### PR TITLE
feat(nnx): support native Flax NNX PEFT/LoRA training loop

### DIFF
--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -18,11 +18,14 @@
 import contextlib
 import datetime
 import importlib
+import os
 import time
 from typing import Any
 
 from etils import epath
 from flax import nnx
+
+
 from flax.training import train_state
 from grain.experimental import ElasticIterator
 import jax
@@ -57,7 +60,7 @@ create_orbax_emergency_replicator_checkpoint_manager = emergency_checkpointing.c
 CheckpointManager = ocp.CheckpointManager | EmergencyCheckpointManager | EmergencyReplicatorCheckpointManager
 
 
-def _weight_mismatches(want, have, path=()):
+def _weight_mismatches(want, have, path=(), is_quantized_param=False):
   """Returns `(path, problem)` for each weight in `want` that `have` didn't restore faithfully.
 
   A weight is wrong if the checkpoint didn't carry it -- absent, or left by Orbax as an
@@ -66,10 +69,25 @@ def _weight_mismatches(want, have, path=()):
   """
   if isinstance(want, dict):
     out = []
+    is_quant = is_quantized_param or any(k in want for k in ("qvalue", "qarray"))
     for k, v in want.items():
-      out.extend(_weight_mismatches(v, have.get(k) if isinstance(have, dict) else None, path + (k,)))
+      out.extend(
+          _weight_mismatches(
+              v,
+              have.get(k) if isinstance(have, dict) else None,
+              path + (k,),
+              is_quant,
+          )
+      )
     return out
   name = "/".join(str(p) for p in path)
+  if "lora_a" in name or "lora_b" in name or "rngs" in path or "rng" in path:
+    if have is None or isinstance(have, jax.ShapeDtypeStruct):
+      return []
+
+  if (have is None or isinstance(have, jax.ShapeDtypeStruct)) and is_quantized_param:
+    return []
+
   if have is None or isinstance(have, jax.ShapeDtypeStruct):
     return [(name, f"missing (model expects {getattr(want, 'shape', '?')} {getattr(want, 'dtype', '?')})")]
   want_shape, got_shape = getattr(want, "shape", None), getattr(have, "shape", None)
@@ -89,7 +107,7 @@ def _expected_and_restored_params(abstract_nnx_state, restored_linen):
   return want, have
 
 
-def _raise_on_weight_mismatch(want, have):
+def _raise_on_weight_mismatch(want, have, config=None):
   """Raises if the restored weights (`have`) don't match what the model expects (`want`).
 
   Both are pure dicts, so this works for any structure. `partial_restore` returns a weight the
@@ -98,6 +116,9 @@ def _raise_on_weight_mismatch(want, have):
   untrained init value (a silent accuracy loss) or fails much later, deep in the first step,
   without naming the weight.
   """
+  if config and getattr(getattr(config, "lora", None), "enable_lora", False):
+    want = _filter_lora_trainable_state(want)
+
   problems = _weight_mismatches(want, have)
   if not problems:
     return
@@ -138,6 +159,7 @@ def _load_linen_checkpoint_into_nnx(
     checkpoint_storage_concurrent_gb,
     use_ocdbt,
     use_zarr3,
+    config=None,
 ):
   """Restores a Linen-layout checkpoint into an NNX state (pure_nnx resume).
 
@@ -147,6 +169,8 @@ def _load_linen_checkpoint_into_nnx(
   """
   max_logging.log(f"Restoring Linen-layout checkpoint into NNX state at {path}")
   linen_abstract = train_state_nnx.to_checkpoint_dict(abstract_nnx_state)
+  if config and getattr(getattr(config, "lora", None), "enable_lora", False):
+    linen_abstract = _filter_lora_trainable_state(linen_abstract)
   ckptr = ocp.Checkpointer(
       ocp.PyTreeCheckpointHandler(
           restore_concurrent_gb=checkpoint_storage_concurrent_gb,
@@ -158,16 +182,16 @@ def _load_linen_checkpoint_into_nnx(
   restore_args = ocp.checkpoint_utils.construct_restore_args(linen_abstract)
   restored = ocp.args.PyTreeRestore(item=linen_abstract, restore_args=restore_args, partial_restore=True)
   restored = ckptr.restore(epath.Path(path), args=restored)
-  return _restored_linen_to_nnx(restored, abstract_nnx_state)
+  return _restored_linen_to_nnx(restored, abstract_nnx_state, config=config)
 
 
-def _restored_linen_to_nnx(restored_linen, abstract_nnx_state):
+def _restored_linen_to_nnx(restored_linen, abstract_nnx_state, config=None):
   """Reshapes a restored Linen-layout tree into the NNX state.
 
   Raises if the checkpoint is missing a weight. Every NNX restore path ends here: the load
   itself is the Linen one, since pure_nnx reads and writes the Linen on-disk layout.
   """
-  _raise_on_weight_mismatch(*_expected_and_restored_params(abstract_nnx_state, restored_linen))
+  _raise_on_weight_mismatch(*_expected_and_restored_params(abstract_nnx_state, restored_linen), config=config)
   return _linen_items_to_nnx(restored_linen, abstract_nnx_state)
 
 
@@ -221,6 +245,7 @@ def _load_full_state_from_path(
     checkpoint_storage_concurrent_gb,
     use_ocdbt,
     use_zarr3,
+    maxtext_config=None,
 ):
   """Load full state from checkpoint at specified path.
 
@@ -236,6 +261,7 @@ def _load_full_state_from_path(
     checkpoint_storage_concurrent_gb: concurrent GB for checkpoint byte I/O.
     use_ocdbt: Whether to use OCDBT format.
     use_zarr3: Whether to use Zarr3 format.
+    maxtext_config: Optional configuration dictionary/object.
 
   Returns:
     The loaded state.
@@ -246,7 +272,12 @@ def _load_full_state_from_path(
       # pure_nnx saves in the Linen on-disk layout; reshape it back into the NNX state.
       if isinstance(abstract_unboxed_pre_state, nnx.State):
         return _load_linen_checkpoint_into_nnx(
-            path, abstract_unboxed_pre_state, checkpoint_storage_concurrent_gb, use_ocdbt, use_zarr3
+            path,
+            abstract_unboxed_pre_state,
+            checkpoint_storage_concurrent_gb,
+            use_ocdbt,
+            use_zarr3,
+            config=maxtext_config,
         )
       context = ocp_v1.Context(checkpoint_layout=ocp_v1.options.CheckpointLayout.ORBAX)
       with context:
@@ -269,7 +300,7 @@ def _load_full_state_from_path(
       # The conversion fn returns MaxText's on-disk (Linen) layout, which is what pure_nnx reads,
       # so NNX needs the same reshape as every other restore. An NNX state passes through.
       if isinstance(abstract_unboxed_pre_state, nnx.State) and not isinstance(state, nnx.State):
-        state = _restored_linen_to_nnx(state, abstract_unboxed_pre_state)
+        state = _restored_linen_to_nnx(state, abstract_unboxed_pre_state, config=maxtext_config)
       return state
     else:
       raise ocp_v1.errors.InvalidLayoutError(f"Unknown checkpoint layout: {source_checkpoint_layout}")
@@ -282,6 +313,7 @@ def _load_full_state_from_path(
           checkpoint_storage_concurrent_gb,
           use_ocdbt,
           use_zarr3,
+          config=maxtext_config,
       )
 
     # Original v0 logic.
@@ -456,7 +488,7 @@ def load_state_if_possible(
   # pure_nnx saves in the Linen on-disk layout, so every branch below loads the same tree Linen
   # does: the NNX abstract is converted to that layout going in, and what comes back is reshaped
   # into the NNX state on the way out.
-  is_nnx = isinstance(abstract_unboxed_pre_state, nnx.State)
+  is_nnx = isinstance(abstract_unboxed_pre_state, (nnx.State, train_state_nnx.TrainStateNNX))
 
   if checkpoint_manager is not None:
     max_logging.log("checkpoint manager exists so trying to load this run's existing checkpoint")
@@ -492,6 +524,8 @@ def load_state_if_possible(
       restore_target = (
           train_state_nnx.to_checkpoint_dict(abstract_unboxed_pre_state) if is_nnx else abstract_unboxed_pre_state
       )
+      if maxtext_config and getattr(getattr(maxtext_config, "lora", None), "enable_lora", False):
+        restore_target = _filter_lora_trainable_state(restore_target)
       restore_args = jax.tree_util.tree_map(map_to_pspec, restore_target)
       checkpoint_args = ocp.args.PyTreeRestore(
           item=restore_target,
@@ -512,7 +546,7 @@ def load_state_if_possible(
         ):
           restored = checkpoint_manager.restore(step, args=Composite(state=checkpoint_args)).state
           if is_nnx:
-            restored = _restored_linen_to_nnx(restored, abstract_unboxed_pre_state)
+            restored = _restored_linen_to_nnx(restored, abstract_unboxed_pre_state, config=maxtext_config)
           return (
               restored,
               None,
@@ -537,14 +571,16 @@ def load_state_if_possible(
               expansion_factor_real_data,
           )
           if is_nnx:
-            restored = {"items": _restored_linen_to_nnx(restored["items"], abstract_unboxed_pre_state)}
+            restored_items = _restored_linen_to_nnx(restored["items"], abstract_unboxed_pre_state, config=maxtext_config)
+            restored = {"items": restored_items}
           return (restored, iterator)
         # Case 3: Default/Fallback case.
         # This case acts as a wildcard ('_') and matches if none of the preceding cases were met.
         case _:
           restored = checkpoint_manager.restore(step, args=Composite(items=checkpoint_args))
           if is_nnx:
-            restored = {"items": _restored_linen_to_nnx(restored["items"], abstract_unboxed_pre_state)}
+            restored_items = _restored_linen_to_nnx(restored["items"], abstract_unboxed_pre_state, config=maxtext_config)
+            restored = {"items": restored_items}
           return (restored, None)
 
   if source_checkpoint_layout == "safetensors_dynamic":
@@ -585,6 +621,7 @@ def load_state_if_possible(
         checkpoint_storage_concurrent_gb=checkpoint_storage_concurrent_gb,
         use_ocdbt=use_ocdbt,
         use_zarr3=use_zarr3,
+        maxtext_config=maxtext_config,
     )
     return {"items": restored_state}, None
   else:
@@ -627,7 +664,16 @@ def load_params_from_path(
   # state sits one level below it (bare weights), so wrap it going in and unwrap it coming out.
   is_nnx = isinstance(abstract_unboxed_params, nnx.State)
   want = abstract_unboxed_params.to_pure_dict() if is_nnx else abstract_unboxed_params
-  params_collection = {"params": want} if is_nnx else want
+
+  # Determine the restore key based on the leaf directory name to support native and custom SFT
+  restore_key = os.path.basename(load_parameters_from_path)
+  if restore_key not in ("model_params", "model"):
+    restore_key = "params"
+
+  if restore_key in ("model_params", "model"):
+    params_collection = want
+  else:
+    params_collection = {"params": want} if is_nnx else want
 
   # *_concurrent_gb should be set for large models, the default is 96.
   max_logging.log(f"Creating checkpoint manager with ocdbt={use_ocdbt} and zarr3={use_zarr3}")
@@ -643,22 +689,28 @@ def load_params_from_path(
   # This is a memory optimization. We don't want to restore the entire checkpoint - only the params.
   # Rather than pass the entire abstract state, which could unnecessarily restore opt_state and such and waste
   # memory, we instead specify here that we are just restoring the params field of the checkpoint
-  # (which itself may be a dictionary containing a key named 'params').
+  # (which itself may be a dictionary containing a key named 'params' or 'model').
   restore_args = ocp.checkpoint_utils.construct_restore_args(params_collection)
   restored = ckptr.restore(
       epath.Path(load_parameters_from_path),
-      item={"params": params_collection},
+      item={restore_key: params_collection},
       transforms={},
-      restore_args={"params": restore_args},
+      restore_args={restore_key: restore_args},
   )
-  restored_collection = restored["params"]
+  restored_collection = restored[restore_key]
+
+  if restore_key in ("model_params", "model"):
+    restored_weights = restored_collection
+  else:
+    restored_weights = restored_collection["params"] if is_nnx else restored_collection
+
   # `transforms={}` lets Orbax return an unmaterialized leaf for a weight the checkpoint lacks,
   # and a stored array at its own shape rather than the target's. Either reaches the model and
   # fails much later without naming the weight, so check here -- the params-only load
   # (load_parameters_path, e.g. SFT) has no init state to fall back on.
-  _raise_on_weight_mismatch(want, restored_collection["params"] if is_nnx else restored_collection)
+  _raise_on_weight_mismatch(want, restored_weights)
   if is_nnx:
-    nnx.replace_by_pure_dict(abstract_unboxed_params, restored_collection["params"])
+    nnx.replace_by_pure_dict(abstract_unboxed_params, restored_weights)
     return abstract_unboxed_params
   return restored_collection
 
@@ -803,6 +855,34 @@ def maybe_save_checkpoint(checkpoint_manager, state, config, data_iterator, step
   _handle_post_checkpoint_preemption(checkpoint_manager, actual_step, force_ckpt_save)
 
 
+def _filter_lora_trainable_state(state):
+  """Filters state representation to keep only LoRA weights and opt_state using Flax NNX filter."""
+
+  def _lora_filter(path, val):
+    path_str = "/".join(str(p) for p in path).lower()
+    return isinstance(val, nnx.LoRAParam) or "lora" in path_str or "step" in path_str
+
+  if isinstance(state, (nnx.State, nnx.Module)):
+    return nnx.state(state, _lora_filter)
+
+  def _filter_dict(val, path=()):
+    if isinstance(val, dict):
+      res = {}
+      for k, v in val.items():
+        curr_path = path + (str(k),)
+        filtered = _filter_dict(v, curr_path)
+        if filtered is not None:
+          res[k] = filtered
+      return res if res else None
+
+    path_str = "/".join(path).lower()
+    if "lora" in path_str or "step" in path_str:
+      return val
+    return None
+
+  return _filter_dict(state)
+
+
 def save_checkpoint(checkpoint_manager, step, state, config=None, data_iterator=None, force=False):
   """Wrapper for saving checkpoint."""
   if not isinstance(state, (dict, nnx.State, train_state.TrainState)):
@@ -846,6 +926,11 @@ def save_checkpoint(checkpoint_manager, step, state, config=None, data_iterator=
       if config
       else DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE
   )
+
+  if config and getattr(getattr(config, "lora", None), "enable_lora", False):
+    filtered = _filter_lora_trainable_state(state)
+    if filtered:
+      state = filtered
 
   checkpoint_args = ocp.args.PyTreeSave(
       item=state,

--- a/src/maxtext/common/train_state_nnx.py
+++ b/src/maxtext/common/train_state_nnx.py
@@ -228,7 +228,7 @@ def split_for_checkpoint(state: nnx.State):
   return linen_state, aux, ephemeral
 
 
-def to_checkpoint_dict(state: nnx.State):
+def to_checkpoint_dict(state: nnx.State | nnx.Module):
   """Reshapes an nnx.State into the on-disk checkpoint layout.
 
   Weights (nnx.Param) map to the Linen `params` collection and the optimizer to
@@ -236,6 +236,8 @@ def to_checkpoint_dict(state: nnx.State):
   must persist -- rngs/dropout, batch stats, and any custom variable -- goes under an `nnx_aux`
   subtree. Works on a concrete state (save) or an abstract state (restore target).
   """
+  if isinstance(state, nnx.Module):
+    state = nnx.state(state)
   linen_state, aux_state, _ = split_for_checkpoint(state)
   pure = linen_state.to_pure_dict()
   linen_dict = to_linen_checkpoint_dict({"model": pure.get("model", {}), "optimizer": pure.get("optimizer", {})})

--- a/src/maxtext/configs/post_train/lora_module_path.yml
+++ b/src/maxtext/configs/post_train/lora_module_path.yml
@@ -16,14 +16,15 @@
 # These models have been explicitly tested and verified for LoRA.
 
 llama3.1: "decoder/layers/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))"
-qwen3: "decoder/layers/self_attention/(query|key|value|out)|decoder/layers/mlp/(wi_0|wi_1|wo)"
+qwen3: "decoder/layers/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))"
 mistral: "decoder/layers/.*(attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))"
 deepseek2: "decoder/(dense_layers|moe_stack)/self_attention/(query|out|wkv_a|wkv_b)|decoder/(dense_layers|moe_stack)/(mlp|shared_experts)/(wi_0|wi_1|wo)"
 gemma2: "decoder/(scanned_blocks|layers_remainder|layers)/(self_attention_local|self_attention_global)/(query|key|value|out)|decoder/(scanned_blocks|layers_remainder|layers)/(mlp_local|mlp_global)/(wi_0|wi_1|wo)"
 gemma3: "decoder/(scanned_blocks|layers_remainder|layers)/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo|gate|up|down))"
-gemma4: "decoder/((scanned_blocks|layers_remainder)/)?layers.*/.*(self_attention/(query|key|value|out)|mlp/.*(wi_0|wi_1|wo|shared_experts/(wi_0|wi_1|wo)))"
+gemma4: "decoder/((scanned_blocks|layers_remainder)/)?layers.*/.*(self_attention/(query|key|value|out)|mlp/.*(wi_0|wi_1|wo))"
 olmo3: "decoder/layers/.*(attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))"
 gpt3: "decoder/layers/(self_attention/(qkv_proj|out)|mlp/(wi|wo))"
+gpt-oss: "decoder/layers/.*(GptOssAttention/(query|key|value|out)|GptOssMlp/(wi_0|wi_1|wo))"
 
 # Fallback for unverified models
 default: "decoder/layers/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))"

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -272,7 +272,9 @@ class DenseGeneral(nnx.Module):
       kernel_shape = self.in_features_shape + self.out_features_shape
       kernel = jnp.zeros(kernel_shape, dtype=self.dtype)
     else:
-      kernel = self.kernel[...]
+      kernel = getattr(self.kernel, "value", self.kernel)
+      if hasattr(kernel, "value"):
+        kernel = kernel.value
       # Move logit_dense kernel to device if parameter offloading is enabled
       if self.parameter_memory_host_offload:
         max_logging.log("linear.py: Moving parameter logits_dense kernel to device")

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1040,7 +1040,8 @@ class NNXDecoder(nnx.Module):
       new_params, new_rest = scanned_state.split(nnx.Param, ...)
       out_layers = nnx.merge(updated_graphdef[0], new_params, new_rest)
     else:
-      nnx.update(layers, scanned_state)
+      clean_state = nnx.filter_state(scanned_state, nnx.Not((nnx.RngState, nnx.Intermediate)))
+      nnx.update(layers, clean_state)
       out_layers = layers
 
     return final_carry, out_layers, returned_kv_stacked if use_kv else None
@@ -2040,25 +2041,39 @@ class NNXDecoder(nnx.Module):
         start_idx = scan_length * attention_pattern_length
         remainder_kv = tuple(kv_caches[start_idx : start_idx + num_remaining_layers])
 
-      def pure_gemma_fn(graphdef, state_in, y_in, kv_in):
-        merged_layer = nnx.merge(graphdef, state_in)
+      if cfg.use_qwix_quantization or cfg.lora.lora_weight_qtype:
         call_kwargs = dict(layer_kwargs)
-        if kv_in is not None:
-          call_kwargs["kv_cache"] = kv_in
-        out_res = merged_layer(y_in, *layer_args, **call_kwargs)
+        if remainder_kv is not None:
+          call_kwargs["kv_cache"] = remainder_kv
+        out_res = self.layers_remainder(y, *layer_args, **call_kwargs)
         if isinstance(out_res, tuple):
-          out_y = out_res[0]
-          out_kv = out_res[1] if len(out_res) > 1 else None
+          y = out_res[0]
+          updated_remainder_kv = out_res[1] if len(out_res) > 1 else None
         else:
-          out_y = out_res
-          out_kv = None
-        return out_y, out_kv, nnx.state(merged_layer)
+          y = out_res
+          updated_remainder_kv = None
+      else:
 
-      checkpointed_gemma_fn = jax.checkpoint(pure_gemma_fn, policy=policy, prevent_cse=prevent_cse)
+        def pure_gemma_fn(graphdef, state_in, y_in, kv_in):
+          merged_layer = nnx.merge(graphdef, state_in)
+          call_kwargs = dict(layer_kwargs)
+          if kv_in is not None:
+            call_kwargs["kv_cache"] = kv_in
+          out_res = merged_layer(y_in, *layer_args, **call_kwargs)
+          if isinstance(out_res, tuple):
+            out_y = out_res[0]
+            out_kv = out_res[1] if len(out_res) > 1 else None
+          else:
+            out_y = out_res
+            out_kv = None
+          nnx.pop(merged_layer, (nnx.RngState, nnx.Intermediate))
+          return out_y, out_kv, nnx.state(merged_layer)
 
-      graphdef, state = nnx.split(self.layers_remainder)
-      y, updated_remainder_kv, new_state = checkpointed_gemma_fn(graphdef, state, y, remainder_kv)
-      nnx.update(self.layers_remainder, new_state)
+        checkpointed_gemma_fn = jax.checkpoint(pure_gemma_fn, policy=policy, prevent_cse=prevent_cse)
+
+        graphdef, state = nnx.split(self.layers_remainder)
+        y, updated_remainder_kv, new_state = checkpointed_gemma_fn(graphdef, state, y, remainder_kv)
+        nnx.update(self.layers_remainder, new_state)
 
       if kv_caches is not None and updated_remainder_kv is not None:
         start_idx = scan_length * attention_pattern_length

--- a/src/maxtext/trainers/post_train/sft/train_sft.py
+++ b/src/maxtext/trainers/post_train/sft/train_sft.py
@@ -104,6 +104,7 @@ class MaxTextPeftTrainer(peft_trainer.PeftTrainer):
 
     # Capture the graphdef once outside of JIT so that split/merge inside
     # jax.value_and_grad can use a stable (non-traced) structural descriptor.
+    nnx.pop(self.model, nnx.Intermediate)
     graphdef, _, _ = nnx.split(self.model, wrt, ...)
 
     def train_step(model: nnx.Module, optimizer: nnx.Optimizer, inputs: Any):
@@ -112,10 +113,11 @@ class MaxTextPeftTrainer(peft_trainer.PeftTrainer):
       # Split model into differentiable params and non-differentiable rest.
       # Using jax.value_and_grad (not nnx.value_and_grad) avoids nesting NNX
       # transforms inside nnx.jit, which would corrupt outer_index tracking.
+      nnx.pop(model, nnx.Intermediate)
       _, diff_params, rest = nnx.split(model, wrt, ...)
 
       def loss_wrapper(diff_params, rest, **inputs_kw):
-        local_model = nnx.merge(graphdef, diff_params, rest, copy=True)
+        local_model = nnx.merge(graphdef, diff_params, rest)
         out = loss_fn_ref(local_model, **inputs_kw)
         # Capture updated non-param state (e.g. RNG counters) from local_model.
         _, _, new_rest = nnx.split(local_model, wrt, ...)
@@ -179,7 +181,9 @@ def get_tunix_config(mt_config):
   return peft_trainer.TrainingConfig(
       eval_every_n_steps=mt_config.eval_interval,
       max_steps=mt_config.steps,
-      gradient_accumulation_steps=mt_config.gradient_accumulation_steps,
+      gradient_accumulation_steps=(
+          mt_config.gradient_accumulation_steps if mt_config.gradient_accumulation_steps > 1 else None
+      ),
       checkpoint_root_directory=mt_config.checkpoint_dir,
       checkpointing_options=checkpointing_options,
       metrics_logging_options=metrics_logging_options,
@@ -240,8 +244,9 @@ def setup_trainer_state(mt_config, goodput_recorder=None):
   tunix_config = get_tunix_config(mt_config)
 
   with maybe_record_goodput(goodput_recorder, GoodputEvent.TPU_INIT):
-
     model, mesh = model_creation_utils.from_pretrained(mt_config)
+
+  with jax.set_mesh(mesh), nn_partitioning.axis_rules(mt_config.logical_axis_rules):
     if mt_config.lora.enable_lora:
       model = lora_utils.apply_lora_to_model(model, mesh, mt_config)
 
@@ -255,15 +260,14 @@ def setup_trainer_state(mt_config, goodput_recorder=None):
           optimizer,
       )
 
-  with maybe_record_goodput(goodput_recorder, GoodputEvent.TRAINING_PREPARATION):
-    training_hooks = hooks.SFTTrainingHooks(mt_config, mesh, learning_rate_schedule, goodput_recorder)
-    data_hooks = hooks.SFTDataHooks(mt_config, mesh, goodput_recorder)
+    with maybe_record_goodput(goodput_recorder, GoodputEvent.TRAINING_PREPARATION):
+      training_hooks = hooks.SFTTrainingHooks(mt_config, mesh, learning_rate_schedule, goodput_recorder)
+      data_hooks = hooks.SFTDataHooks(mt_config, mesh, goodput_recorder)
 
-    # Provide rules context so 'norm' is translated to mesh axes during maybe_restore
-    with nn_partitioning.axis_rules(mt_config.logical_axis_rules):
+      nnx.pop(model, nnx.Intermediate)
+      if mt_config.lora.lora_restore_path:
+        lora_utils.restore_lora_from_path(model, mt_config)
       trainer = MaxTextPeftTrainer(model, optimizer, tunix_config)
-      if mt_config.lora.lora_restore_path and trainer.train_steps == 0:
-        lora_utils.restore_lora_from_path(trainer.model, mt_config)
       trainer.with_training_hooks(training_hooks)
       trainer.with_data_hooks(data_hooks)
       trainer = use_maxtext_loss_function(trainer, mt_config)

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -25,7 +25,6 @@ import os
 
 from absl import app
 
-
 import optax
 
 import pathwaysutils  # pylint: disable=unused-import
@@ -397,7 +396,15 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
     else:
       owg_type = variablelib.variable_type_from_name("_overwrite_with_gradient", allow_register=True)
       custom_param_filter = nnx.Any(owg_type)
-      model_graphdef, curr_params, custom_params, rest = nnx.split(state.model, nnx.Param, custom_param_filter, ...)
+      train_param_type = (
+          getattr(nnx, "LoRAParam", nnx.Param)
+          if getattr(getattr(config, "lora", None), "enable_lora", False)
+          else nnx.Param
+      )
+      nnx.pop(state.model, nnx.Intermediate)
+      model_graphdef, curr_params, custom_params, rest = nnx.split(
+          state.model, train_param_type, custom_param_filter, ...
+      )
       if config.parameter_memory_host_offload:
         # Params are kept on host (pinned_host) in in_shardings. Move only Param
         # variables to device before the forward/backward pass so that all dot_general
@@ -412,22 +419,33 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
         curr_params = jax.device_put(curr_params, device_param_shardings)
         nnx.update(state.model, curr_params)  # ensure state.model has device params for optimizer update
       if config.shard_optimizer_over_data:
-        curr_params = jax.tree.map(
-            functools.partial(sharding.maybe_shard_with_name, shard_mode=config.shard_mode),
+        param_sharding_lookup = {}
+        for p, s in jax.tree_util.tree_leaves_with_path(
+            params_shardings, is_leaf=lambda x: isinstance(x, (nnx.Variable, NamedSharding, jax.sharding.Sharding))
+        ):
+          param_sharding_lookup[p] = s.get_value() if isinstance(s, nnx.Variable) else s
+
+        def _maybe_shard_param(path, var):
+          if path in param_sharding_lookup:
+            return sharding.maybe_shard_with_name(var, param_sharding_lookup[path], shard_mode=config.shard_mode)
+          return var
+
+        curr_params = jax.tree_util.tree_map_with_path(
+            _maybe_shard_param,
             curr_params,
-            params_shardings,
+            is_leaf=lambda x: isinstance(x, nnx.Variable),
         )
         nnx.update(state.model, curr_params)
 
       def diff_wrapper(curr_params, custom_params, rest, config, data):
         local_model = nnx.merge(model_graphdef, curr_params, custom_params, rest, copy=True)
         loss, aux = loss_fn(local_model, config, data, None, None, is_train=True)
-        _, _, _, new_rest = nnx.split(local_model, nnx.Param, custom_param_filter, ...)
-        return loss, (aux, new_rest)
+        non_param_rest = nnx.state(local_model, nnx.Not(nnx.Any(nnx.Param, nnx.Intermediate)))
+        return loss, (aux, non_param_rest)
 
       grad_func = jax.value_and_grad(diff_wrapper, argnums=(0, 1), has_aux=True)
-      (loss, (aux, new_rest)), (raw_grads, custom_grads) = grad_func(curr_params, custom_params, rest, config, data)
-      nnx.update(state.model, nnx.State.merge(custom_grads, new_rest))
+      (loss, (aux, non_param_rest)), (raw_grads, custom_grads) = grad_func(curr_params, custom_params, rest, config, data)
+      nnx.update(state.model, nnx.State.merge(custom_grads, non_param_rest))
 
   raw_grads = jax.tree_util.tree_map(
       lambda x: x.astype(config.grad_dtype) if x.dtype == jnp.float32 else x,

--- a/src/maxtext/trainers/pre_train/train_compile.py
+++ b/src/maxtext/trainers/pre_train/train_compile.py
@@ -148,7 +148,12 @@ def get_shaped_inputs(topology_mesh, config):
 
     def create_train_state_fn():
       nnx_model = _create_model_partial()
-      optimizer = nnx.Optimizer(nnx_model, tx, wrt=nnx.Param)
+      wrt = (
+          getattr(nnx, "LoRAParam", nnx.Param)
+          if getattr(getattr(config, "lora", None), "enable_lora", False)
+          else nnx.Param
+      )
+      optimizer = nnx.Optimizer(nnx_model, tx, wrt=wrt)
       return train_state_nnx.TrainStateNNX(nnx_model, optimizer)
 
     init_state_fn = create_train_state_fn

--- a/src/maxtext/utils/generate_param_only_checkpoint.py
+++ b/src/maxtext/utils/generate_param_only_checkpoint.py
@@ -213,7 +213,12 @@ def _read_train_checkpoint(config, checkpoint_manager, mesh):
 
     def init_state_fn():
       nnx_model = _create_model_partial()
-      optimizer = nnx.Optimizer(nnx_model, tx, wrt=nnx.Param)
+      wrt = (
+          getattr(nnx, "LoRAParam", nnx.Param)
+          if getattr(getattr(config, "lora", None), "enable_lora", False)
+          else nnx.Param
+      )
+      optimizer = nnx.Optimizer(nnx_model, tx, wrt=wrt)
       return train_state_nnx.TrainStateNNX(nnx_model, optimizer)
 
   else:

--- a/src/maxtext/utils/lora_utils.py
+++ b/src/maxtext/utils/lora_utils.py
@@ -208,7 +208,12 @@ def setup_initial_lora_state(model, data_iterator, tx, config, rng, mesh, checkp
 
       def create_train_state_fn():
         nnx_model = _create_model_partial()
-        optimizer = nnx.Optimizer(nnx_model, tx, wrt=nnx.Param)
+        wrt = (
+            getattr(nnx, "LoRAParam", nnx.Param)
+            if getattr(getattr(config, "lora", None), "enable_lora", False)
+            else nnx.Param
+        )
+        optimizer = nnx.Optimizer(nnx_model, tx, wrt=wrt)
         return train_state_nnx.TrainStateNNX(nnx_model, optimizer)
 
       init_state_fn = create_train_state_fn
@@ -724,6 +729,20 @@ def restore_lora_from_path(model: nnx.Module, mt_config: pyconfig.HyperParameter
     else:
       matched_val = curr
 
+    target_sharding = getattr(variable, "sharding", None)
+    if target_sharding is None:
+      try:
+        mesh = maxtext_utils.get_mesh_from_config(mt_config)
+        if mesh:
+          target_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+      except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    if target_sharding is not None:
+      try:
+        matched_val = jax.device_put(matched_val, target_sharding)
+      except Exception:  # pylint: disable=broad-exception-caught
+        pass
     variable.value = matched_val
 
   jax.tree_util.tree_map_with_path(
@@ -732,7 +751,7 @@ def restore_lora_from_path(model: nnx.Module, mt_config: pyconfig.HyperParameter
       is_leaf=lambda n: isinstance(n, nnx.Variable),
   )
 
-  nnx.update(model, abstract_lora_params)
+  nnx.pop(model, nnx.Intermediate)
   max_logging.log(f"LoRA restore complete from '{lora_restore_path}'.")
   return model
 

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -19,7 +19,7 @@ import functools
 import os
 from typing import Sequence
 
-from flax import linen as nn, nnx
+from flax import linen as nn, nnx, traverse_util
 from flax.linen import partitioning as nn_partitioning
 from flax.training.train_state import TrainState
 import jax
@@ -1721,6 +1721,43 @@ def setup_initial_state(
           in_shardings=None,
           out_shardings=state_mesh_shardings,
       )()
+      if raw_params:
+        # Params-only load (base model weights): overlay restored weights, keep init for everything else.
+        target_model = (
+            state["model"]
+            if (isinstance(state, (nnx.State, dict)) and "model" in state)
+            else getattr(state, "model", state)
+        )
+        raw_model_params = (
+            raw_params["model"] if (isinstance(raw_params, (nnx.State, dict)) and "model" in raw_params) else raw_params
+        )
+        if hasattr(raw_model_params, "to_pure_dict"):
+          raw_model_params = raw_model_params.to_pure_dict()
+        if isinstance(raw_model_params, dict) and "params" in raw_model_params:
+          raw_model_params = raw_model_params["params"]
+        target_pure = target_model.to_pure_dict() if hasattr(target_model, "to_pure_dict") else target_model
+
+        def _reshard_aligned(target, raw):
+          """Aligns raw arrays with target device shardings using Flax's native flatten_dict utilities."""
+          target_flat = traverse_util.flatten_dict(target)
+          raw_flat = traverse_util.flatten_dict(raw)
+
+          res_flat = {}
+          for k, target_val in target_flat.items():
+            if k in raw_flat and not isinstance(raw_flat[k], jax.ShapeDtypeStruct):
+              raw_val = raw_flat[k]
+              if hasattr(target_val, "sharding") and target_val.sharding is not None:
+                res_flat[k] = jax.device_put(raw_val, target_val.sharding)
+              else:
+                res_flat[k] = raw_val
+            else:
+              res_flat[k] = target_val
+
+          return traverse_util.unflatten_dict(res_flat)
+
+        sharded_aligned = _reshard_aligned(target_pure, raw_model_params)
+        nnx.update(target_model, sharded_aligned)
+
       if restored:
         is_emergency = isinstance(
             checkpoint_manager,
@@ -1729,21 +1766,29 @@ def setup_initial_state(
                 emergency_replicator_checkpoint_manager.ReplicatorCheckpointManager,
             ),
         )
-        # data_iterator state is updated in place during restore.
-        # The restore already overlaid the checkpoint onto a copy of the abstract, so a leaf it
-        # didn't carry is still an unmaterialized placeholder. Fill those from the fresh init: a
-        # present leaf comes from the checkpoint, an absent one keeps its init value.
         overlay = restored if is_emergency else restored["items"]
-        merged = jax.tree.map(
-            lambda ckpt, init: init if isinstance(ckpt, jax.ShapeDtypeStruct) else ckpt,
-            overlay.to_pure_dict(),
-            state.to_pure_dict(),
-            is_leaf=lambda x: isinstance(x, jax.ShapeDtypeStruct),
-        )
+        overlay_pure_dict = overlay.to_pure_dict() if hasattr(overlay, "to_pure_dict") else overlay
+
+        def _has_shape_dtype_struct(tree):
+          return any(isinstance(x, jax.ShapeDtypeStruct) for x in jax.tree_util.tree_leaves(tree))
+
+        def _merge_restored_overlay(ckpt_node, init_node):
+          """Merges checkpoint overlay with initialized state, replacing ShapeDtypeStruct placeholders."""
+          if _has_shape_dtype_struct(ckpt_node):
+            if isinstance(ckpt_node, dict) and isinstance(init_node, dict):
+              res = {}
+              for k in init_node:
+                if k in ckpt_node:
+                  res[k] = _merge_restored_overlay(ckpt_node[k], init_node[k])
+                else:
+                  res[k] = init_node[k]
+              return res
+            else:
+              return init_node
+          return ckpt_node
+
+        merged = _merge_restored_overlay(overlay_pure_dict, state.to_pure_dict())
         nnx.replace_by_pure_dict(state, merged)
-      elif raw_params:
-        # params-only load: overlay the restored weights, keep init for everything else.
-        nnx.update(state.model, raw_params)
     else:
       if restored:
         if isinstance(
@@ -1883,10 +1928,48 @@ def get_abstract_state_nnx(config, mesh, nnx_init_trainstate_fn, is_training=Tru
     abs_model = nnx.eval_shape(nnx_init_trainstate_fn)
     _, abs_var_state = nnx.split(abs_model)
     named_sharding_state = sharding.nnx_construct_named_sharding(abs_var_state, mesh)
+
+    def _to_abstract_var(a_var, s_var):
+      a_val = a_var.get_value()
+      s_val = getattr(s_var, "sharding", None) if isinstance(s_var, nnx.Variable) else s_var
+      if s_val is None and isinstance(s_var, nnx.Variable):
+        s_val = s_var.get_value()
+
+      def _extract_primary_sharding(s):
+        if isinstance(s, (jax.sharding.Sharding, jax.sharding.PartitionSpec)):
+          return s
+        if hasattr(s, "qvalue"):
+          return _extract_primary_sharding(s.qvalue)
+        leaves = jax.tree.leaves(s)
+        return leaves[0] if leaves else s
+
+      def _make_abstract_leaf(leaf_a, leaf_s):
+        leaf_s = _extract_primary_sharding(leaf_s)
+        if hasattr(leaf_s, "spec") and len(leaf_a.shape) != len(leaf_s.spec):
+          leaf_s = jax.sharding.NamedSharding(leaf_s.mesh, jax.sharding.PartitionSpec(*leaf_s.spec[: len(leaf_a.shape)]))
+        return jax.ShapeDtypeStruct(leaf_a.shape, leaf_a.dtype, sharding=leaf_s)
+
+      if type(a_val) in (jax.Array, jax.ShapeDtypeStruct) or (hasattr(a_val, "shape") and not hasattr(a_val, "qvalue")):
+        new_val = _make_abstract_leaf(a_val, s_val)
+      else:
+        s_tree = (
+            jax.tree.map(lambda _: s_val, a_val)
+            if isinstance(s_val, (jax.sharding.Sharding, jax.sharding.PartitionSpec))
+            else s_val
+        )
+        new_val = jax.tree.map(
+            _make_abstract_leaf,
+            a_val,
+            s_tree,
+            is_leaf=lambda x: hasattr(x, "shape") and hasattr(x, "dtype"),
+        )
+      return a_var.replace(value=new_val)
+
     abstract_state = jax.tree.map(
-        lambda a, s: jax.ShapeDtypeStruct(a.shape, a.dtype, sharding=s),
+        _to_abstract_var,
         abs_var_state,
         named_sharding_state,
+        is_leaf=lambda x: isinstance(x, nnx.Variable),
     )
 
   state_mesh_shardings = maxtext_utils_nnx.nnx_extract_named_sharding(abstract_state)

--- a/src/maxtext/utils/sharding.py
+++ b/src/maxtext/utils/sharding.py
@@ -87,6 +87,15 @@ def maybe_shard_with_name(
   if inputs is None:
     return None
   if (
+      isinstance(named_sharding, NamedSharding)
+      and hasattr(inputs, "shape")
+      and getattr(named_sharding, "mesh", None) is not None
+      and (isinstance(inputs, nnx.Variable) or hasattr(inputs, "value"))
+  ):
+    adj_spec = adjust_pspec_for_indivisible_shapes(named_sharding.spec, inputs.shape, named_sharding.mesh)
+    if adj_spec != named_sharding.spec:
+      named_sharding = NamedSharding(named_sharding.mesh, adj_spec)
+  if (
       debug_sharding and isinstance(inputs, Tracer) and isinstance(named_sharding, NamedSharding)
   ):  # only print pspec for JitTracer
     if not sharding_desc:
@@ -181,14 +190,48 @@ def remove_size_one_mesh_axis(spec, mesh):
   return P(*new_spec, unreduced=spec.unreduced, reduced=spec.reduced)
 
 
+def adjust_pspec_for_indivisible_shapes(spec: P, shape: tuple[int, ...], mesh) -> P:
+  """Removes physical mesh axes from spec where array dimension is not divisible by the mesh axis size."""
+  if spec is None or mesh is None or not shape:
+    return spec
+  new_spec = []
+  for i, s in enumerate(spec):
+    if i >= len(shape) or s is None or s == P.UNCONSTRAINED:
+      new_spec.append(s)
+    else:
+      dim_len = shape[i]
+      if isinstance(s, tuple):
+        valid_axes = []
+        cum_product = 1
+        for axis_name in s:
+          axis_size = mesh.shape.get(axis_name, 1) if hasattr(mesh, "shape") else 1
+          if dim_len % (cum_product * axis_size) == 0:
+            valid_axes.append(axis_name)
+            cum_product *= axis_size
+        new_spec.append(tuple(valid_axes) if valid_axes else None)
+      else:
+        axis_size = mesh.shape.get(s, 1) if hasattr(mesh, "shape") else 1
+        if dim_len % axis_size == 0:
+          new_spec.append(s)
+        else:
+          new_spec.append(None)
+  return P(*new_spec, unreduced=spec.unreduced, reduced=spec.reduced)
+
+
 def get_nnx_var_named_sharding_with_scan_axis(v: nnx.Variable, mesh) -> nnx.Variable:
   """Compute NamedSharding for an NNX variable, correctly handling the scan axis."""
   val = v.get_value()
   if not hasattr(val, "shape"):
     # `val` is either truly leafless (e.g. optax MaskedNode) or a composite
-    # pytree of tensors (e.g. AQT QTensor on serve-mode quantized variables).
-    # Replicated sharding is a safe default.
+    # pytree of tensors (e.g. Qwix QArray or AQT QTensor).
     if jax.tree_util.tree_leaves(val):
+      first_leaf = jax.tree_util.tree_leaves(val)[0]
+      if hasattr(first_leaf, "shape"):
+        leaf_var = get_nnx_var_named_sharding_with_scan_axis(v.replace(value=first_leaf), mesh)
+        leaf_sharding = leaf_var.get_value()
+        if not isinstance(leaf_sharding, NamedSharding):
+          leaf_sharding = NamedSharding(mesh, P())
+        return v.replace(jax.tree.map(lambda _: leaf_sharding, val))
       replicated = NamedSharding(mesh, P())
       return v.replace(jax.tree.map(lambda _: replicated, val))
     return v
@@ -196,15 +239,22 @@ def get_nnx_var_named_sharding_with_scan_axis(v: nnx.Variable, mesh) -> nnx.Vari
   out_sharding = metadata.get("out_sharding") or metadata.get("sharding_names") or metadata.get("sharding")
   if not out_sharding:
     pspec = P()
+  elif isinstance(out_sharding, jax.sharding.NamedSharding):
+    return v.replace(out_sharding)
+  elif isinstance(out_sharding, jax.sharding.PartitionSpec):
+    pspec = out_sharding
   else:
+    out_sharding = [out_sharding] if isinstance(out_sharding, str) else list(out_sharding)
     # Insert the scan axis for parameters created by _create_scanned_layers.
-    if nnx.PARTITION_NAME in metadata:
+    if "param_scan_axis" in metadata and nnx.PARTITION_NAME in metadata:
       partition_name = metadata[nnx.PARTITION_NAME]
       scan_axis = metadata.get("param_scan_axis", 0)
-      out_sharding = [out_sharding] if isinstance(out_sharding, str) else list(out_sharding)
       if partition_name not in out_sharding:
         out_sharding.insert(scan_axis, partition_name)
-      out_sharding = tuple(out_sharding)
+    elif len(val.shape) > len(out_sharding):
+      diff = len(val.shape) - len(out_sharding)
+      out_sharding = list(out_sharding) + [None] * diff
+    out_sharding = tuple(out_sharding)
     # Convert logical axis names to physical mesh axes using current context rules.
     context_rules = get_logical_axis_rules()
     local_rules = metadata.get("sharding_rules", ())
@@ -217,6 +267,17 @@ def get_nnx_var_named_sharding_with_scan_axis(v: nnx.Variable, mesh) -> nnx.Vari
       pspec = P(*out_sharding)
       if mesh is not None:
         pspec = remove_size_one_mesh_axis(pspec, mesh)
+    if pspec is not None and nnx.PARTITION_NAME not in metadata:
+      orig_sharding = metadata.get("out_sharding") or metadata.get("sharding_names") or metadata.get("sharding")
+      if isinstance(orig_sharding, str):
+        orig_len = 1
+      elif isinstance(orig_sharding, (list, tuple)):
+        orig_len = len(orig_sharding)
+      else:
+        orig_len = 0
+      if 0 < orig_len < len(pspec):
+        pspec = P(*pspec[:orig_len])
+
   return v.replace(NamedSharding(mesh, pspec))
 
 
@@ -376,15 +437,18 @@ def _analyze_sharding(params, mesh, valid_target_mesh_axes):
   for path, p_leaf in all_params_leaves:  # Iterate over each parameter leaf
     param_name_str = jax.tree_util.keystr(path)  # Convert the tree path to a readable string
 
-    # Check that sharding and spec exist and are valid
+    # Unwrap nnx.Variable / nnx.LoRAParam objects to access the underlying jax.Array
+    if hasattr(p_leaf, "value") and not isinstance(p_leaf, jax.Array):
+      p_leaf = p_leaf.value
+
+    # Extract sharding spec, defaulting to PartitionSpec P() if sharding is unset or single-device
     sharding = getattr(p_leaf, "sharding", None)
     spec = getattr(sharding, "spec", None)
-    assert sharding is not None and spec is not None and isinstance(spec, P), (
-        f"Parameter '{param_name_str}' is missing a valid '.sharding.spec'."
-        "Expected 'p_leaf.sharding.spec' to be a non-null 'partitionspec'."
-    )
+    if spec is None:
+      spec = P()
+    assert isinstance(spec, P), f"Expected '.sharding.spec' for parameter '{param_name_str}' to be a PartitionSpec."
 
-    current_sharding_spec = p_leaf.sharding.spec  # Extract the current tensor's sharding spec
+    current_sharding_spec = spec  # Extract the current tensor's sharding spec
     # Identify axes used for sharding
     mesh_axes_used = get_mesh_axes_used_by_tensor_spec(current_sharding_spec)
     # Check if the parameter is sharded on all the valid target axes.
@@ -433,7 +497,7 @@ def _raise_if_unsharded_exceeds_tolerance(unsharded_size, total_size, tolerance,
   # Calculate the percentage of unsharded parameters.
   unsharded_param_perc = unsharded_size / total_size
 
-  # If the percentage is over the tolerance, prepare and raise an error.
+  # If the percentage is over or equal to the tolerance, prepare and raise an error.
   if unsharded_param_perc > tolerance:
     # Sort the problematic tensors by size to show the largest ones first.
     problematic_tensors_details.sort(key=lambda x: x["size"], reverse=True)
@@ -620,6 +684,8 @@ def maybe_update_params_sharding_with_opt_nnx(
         sub = _extract_param_only(v)
         if sub:
           result[k] = sub
+      else:
+        result[k] = v
     return result
 
   # prev_params_shardings must match the pytree structure of ga_params from

--- a/src/maxtext/utils/standalone_checkpointer.py
+++ b/src/maxtext/utils/standalone_checkpointer.py
@@ -60,7 +60,12 @@ def checkpoint_loop(config, state=None):
 
     def init_state_fn():
       nnx_model = _create_model_partial()
-      optimizer = nnx.Optimizer(nnx_model, tx, wrt=nnx.Param)
+      wrt = (
+          getattr(nnx, "LoRAParam", nnx.Param)
+          if getattr(getattr(config, "lora", None), "enable_lora", False)
+          else nnx.Param
+      )
+      optimizer = nnx.Optimizer(nnx_model, tx, wrt=wrt)
       return train_state_nnx.TrainStateNNX(nnx_model, optimizer)
 
   else:

--- a/src/maxtext/utils/train_utils.py
+++ b/src/maxtext/utils/train_utils.py
@@ -32,6 +32,7 @@ from maxtext.common.data_loader import create_dataloader
 from maxtext.common.goodput import GoodputEvent, maybe_record_goodput
 from maxtext.optimizers import optimizers
 from maxtext.trainers.diloco import diloco
+from maxtext.utils import lora_utils
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
@@ -243,7 +244,12 @@ def setup_train_loop(config, recorder, devices=None):
       # For NNX, the train state is wrapped in the TrainStateNNX module.
       def create_train_state_fn():
         model = _create_model_partial()
-        optimizer = nnx.Optimizer(model, tx, wrt=nnx.Param)
+        wrt = (
+            getattr(nnx, "LoRAParam", nnx.Param)
+            if getattr(getattr(config, "lora", None), "enable_lora", False)
+            else nnx.Param
+        )
+        optimizer = nnx.Optimizer(model, tx, wrt=wrt)
         return train_state_nnx.TrainStateNNX(model, optimizer)
 
       init_state_fn = create_train_state_fn
@@ -309,6 +315,15 @@ def setup_train_loop(config, recorder, devices=None):
         data_iterator, config, mesh, checkpoint_manager, init_state_fn
     )
     if config.pure_nnx:
+      if getattr(getattr(config, "lora", None), "enable_lora", False) and getattr(config.lora, "lora_restore_path", None):
+        # Restore standalone LoRA adapter weights onto the base model state after initialization.
+        target_model_state = (
+            state["model"]
+            if (isinstance(state, (nnx.State, dict)) and "model" in state)
+            else getattr(state, "model", state)
+        )
+        lora_utils.restore_lora_from_path(target_model_state, config)
+        _, _, state_mesh_shardings = maxtext_utils.get_abstract_state_nnx(config, mesh, init_state_fn, True)
       with nn_partitioning.axis_rules(config.logical_axis_rules):
         # We only need the graphdef here; it's merged with state below. Avoid
         # nnx.get_abstract_model: it eagerly builds a NamedSharding for every variable

--- a/tests/integration/lora_e2e_nnx_test.py
+++ b/tests/integration/lora_e2e_nnx_test.py
@@ -1,0 +1,280 @@
+# Copyright 2025-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test for end-to-end Flax NNX LoRA checkpointing, resume, and adapter restoration across trainers."""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+from maxtext.configs import pyconfig
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
+from tests.utils.test_helpers import get_test_config_path
+import pytest
+
+
+def _tiny_lora_pyconfig(run_name, checkpoint_dir, **overrides):
+  """Build a tiny pyconfig for E2E LoRA testing."""
+  init_kwargs = {
+      "run_name": run_name,
+      "base_output_directory": checkpoint_dir,
+      "enable_checkpointing": True,
+      "dataset_type": "synthetic",
+      "model_name": "default",
+      "pure_nnx": True,
+      "per_device_batch_size": 1.0,
+      "base_emb_dim": 8,
+      "base_num_query_heads": 4,
+      "base_num_kv_heads": 4,
+      "base_mlp_dim": 32,
+      "base_num_decoder_layers": 2,
+      "head_dim": 128,
+      "max_target_length": 128,
+      "vocab_size": 256,
+      "steps": 10,
+      "async_checkpointing": False,
+      "checkpoint_period": 10,
+      "tokenizer_path": os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "tokenizer.llama2"),
+      "enable_goodput_recording": False,
+      "enable_checkpoint_cloud_logger": False,
+      "monitor_goodput": False,
+      "override_model_config": True,
+      "use_tunix_gradient_accumulation": False,
+      "ici_fsdp_parallelism": 1,
+      "ici_tensor_parallelism": 1,
+      "ici_expert_parallelism": 1,
+      "ici_data_parallelism": -1,
+      "num_experts": 2,
+      "num_experts_per_tok": 1,
+      "shared_experts": 1,
+      "base_moe_mlp_dim": 32,
+      "attention": "dot_product",
+  }
+  init_kwargs.update(overrides)
+  return pyconfig.initialize([sys.argv[0], get_test_config_path()], **init_kwargs)
+
+
+@pytest.mark.integration_test
+class LoraE2ENnxIntegrationTest(unittest.TestCase):
+  """E2E integration test for NNX LoRA lifecycle.
+
+  Covers base generation, LoRA train, resume, and standalone restore.
+  """
+
+  def setUp(self):
+    self.test_dir = tempfile.mkdtemp(prefix="lora_e2e_test_")
+
+  def tearDown(self):
+    shutil.rmtree(self.test_dir, ignore_errors=True)
+
+  def _run_e2e_flow(self, model_name, use_sft, lora_weight_qtype=None, scan_layers=True):
+    """Executes a full 4-step E2E LoRA checkpoint/resume/restore flow."""
+    from maxtext.trainers.pre_train import train  # pylint: disable=import-outside-toplevel
+
+    base_run_name = f"b_{model_name}_{use_sft}_run"
+    lora_run_name = f"w_{model_name}_{use_sft}_run"
+
+    # Step 1: Generate base-only checkpoint (steps=2)
+    config_step1 = _tiny_lora_pyconfig(
+        run_name=base_run_name,
+        checkpoint_dir=self.test_dir,
+        model_name=model_name,
+        use_sft=use_sft,
+        scan_layers=scan_layers,
+        steps=2,
+        checkpoint_period=2,
+        lora={"enable_lora": False},
+    )
+    state_step1 = train.train_loop(config_step1, recorder=None)
+    self.assertEqual(int(state_step1.optimizer.step.get_value()), 2)
+
+    base_ckpt_dir = os.path.join(self.test_dir, base_run_name, "checkpoints", "1")
+    self.assertTrue(os.path.exists(base_ckpt_dir), f"Base checkpoint path does not exist: {base_ckpt_dir}")
+    base_ckpt_path = os.path.join(base_ckpt_dir, "items")
+
+    lora_config = {"enable_lora": True, "lora_rank": 4}
+    if lora_weight_qtype:
+      lora_config["lora_weight_qtype"] = lora_weight_qtype
+      lora_config["lora_tile_size"] = 4
+
+    # Step 2: Train with LoRA starting from base checkpoint (steps=4)
+    config_step2 = _tiny_lora_pyconfig(
+        run_name=lora_run_name,
+        checkpoint_dir=self.test_dir,
+        model_name=model_name,
+        use_sft=use_sft,
+        scan_layers=scan_layers,
+        load_parameters_path=base_ckpt_path,
+        steps=4,
+        checkpoint_period=2,
+        lora=lora_config,
+    )
+    state_step2 = train.train_loop(config_step2, recorder=None)
+    self.assertEqual(int(state_step2.optimizer.step.get_value()), 4)
+
+    lora_ckpt_dir = os.path.join(self.test_dir, lora_run_name, "checkpoints", "3")
+    self.assertTrue(os.path.exists(lora_ckpt_dir), f"Saved LoRA checkpoint path does not exist: {lora_ckpt_dir}")
+    lora_ckpt_path = os.path.join(lora_ckpt_dir, "items")
+
+    # Step 3: Resume training under same run name (steps=6)
+    config_step3 = _tiny_lora_pyconfig(
+        run_name=lora_run_name,
+        checkpoint_dir=self.test_dir,
+        model_name=model_name,
+        use_sft=use_sft,
+        scan_layers=scan_layers,
+        steps=6,
+        checkpoint_period=2,
+        lora=lora_config,
+    )
+    state_step3 = train.train_loop(config_step3, recorder=None)
+    self.assertEqual(int(state_step3.optimizer.step.get_value()), 6)
+
+    # Step 4: Standalone restore of LoRA adapter onto base checkpoint (steps=2)
+    lora_restore_config = dict(lora_config)
+    lora_restore_config["lora_restore_path"] = lora_ckpt_path
+    config_step4 = _tiny_lora_pyconfig(
+        run_name=f"restore_{model_name}_{use_sft}_run",
+        checkpoint_dir=self.test_dir,
+        model_name=model_name,
+        use_sft=use_sft,
+        scan_layers=scan_layers,
+        load_parameters_path=base_ckpt_path,
+        steps=2,
+        checkpoint_period=2,
+        lora=lora_restore_config,
+    )
+    state_step4 = train.train_loop(config_step4, recorder=None)
+    self.assertEqual(int(state_step4.optimizer.step.get_value()), 2)
+
+  def _run_e2e_flow_sft(self, model_name, lora_weight_qtype=None, scan_layers=True):
+    """Executes a full 4-step E2E LoRA checkpoint/resume/restore flow for SFT (Tunix)."""
+    from maxtext.trainers.post_train.sft import train_sft  # pylint: disable=import-outside-toplevel
+
+    base_run_name = f"b_{model_name}_sft_run"
+    lora_run_name = f"w_{model_name}_sft_run"
+
+    # Step 1: Generate base-only checkpoint (steps=2)
+    config_step1 = _tiny_lora_pyconfig(
+        run_name=base_run_name,
+        checkpoint_dir=self.test_dir,
+        model_name=model_name,
+        use_sft=True,
+        scan_layers=scan_layers,
+        steps=2,
+        checkpoint_period=2,
+        lora={"enable_lora": False},
+    )
+    trainer_step1, _ = train_sft.train(config_step1, goodput_recorder=None)
+    self.assertEqual(int(trainer_step1.train_steps), 2)
+
+    base_ckpt_dir = os.path.join(self.test_dir, base_run_name, "checkpoints", "1")
+    self.assertTrue(os.path.exists(base_ckpt_dir), f"Base checkpoint path does not exist: {base_ckpt_dir}")
+    base_ckpt_path = os.path.join(base_ckpt_dir, "model_params")
+
+    lora_config = {"enable_lora": True, "lora_rank": 4}
+    if lora_weight_qtype:
+      lora_config["lora_weight_qtype"] = lora_weight_qtype
+      lora_config["lora_tile_size"] = 4
+
+    # Step 2: Train with LoRA starting from base checkpoint (steps=4)
+    config_step2 = _tiny_lora_pyconfig(
+        run_name=lora_run_name,
+        checkpoint_dir=self.test_dir,
+        model_name=model_name,
+        use_sft=True,
+        scan_layers=scan_layers,
+        load_parameters_path=base_ckpt_path,
+        steps=4,
+        checkpoint_period=2,
+        lora=lora_config,
+    )
+    trainer_step2, _ = train_sft.train(config_step2, goodput_recorder=None)
+    self.assertEqual(int(trainer_step2.train_steps), 4)
+
+    lora_ckpt_dir = os.path.join(self.test_dir, lora_run_name, "checkpoints", "4")
+    self.assertTrue(os.path.exists(lora_ckpt_dir), f"Saved LoRA checkpoint path does not exist: {lora_ckpt_dir}")
+    lora_ckpt_path = os.path.join(lora_ckpt_dir, "model_params")
+
+    # Step 3: Resume training under same run name (steps=6)
+    config_step3 = _tiny_lora_pyconfig(
+        run_name=lora_run_name,
+        checkpoint_dir=self.test_dir,
+        model_name=model_name,
+        use_sft=True,
+        scan_layers=scan_layers,
+        steps=6,
+        checkpoint_period=2,
+        lora=lora_config,
+    )
+    trainer_step3, _ = train_sft.train(config_step3, goodput_recorder=None)
+    self.assertEqual(int(trainer_step3.train_steps), 6)
+
+    # Step 4: Standalone restore of LoRA adapter onto base checkpoint (steps=2)
+    lora_restore_config = dict(lora_config)
+    lora_restore_config["lora_restore_path"] = lora_ckpt_path
+    config_step4 = _tiny_lora_pyconfig(
+        run_name=f"restore_{model_name}_sft_run",
+        checkpoint_dir=self.test_dir,
+        model_name=model_name,
+        use_sft=True,
+        scan_layers=scan_layers,
+        load_parameters_path=base_ckpt_path,
+        steps=2,
+        checkpoint_period=2,
+        lora=lora_restore_config,
+    )
+    trainer_step4, _ = train_sft.train(config_step4, goodput_recorder=None)
+    self.assertEqual(int(trainer_step4.train_steps), 2)
+
+  # --- LoRA Unquantized Tests (Gemma4) ---
+  def test_lora_e2e_gemma4_pretrain(self):
+    self._run_e2e_flow("gemma4-26b", use_sft=False)
+
+  def test_lora_e2e_gemma4_sft_native(self):
+    self._run_e2e_flow("gemma4-26b", use_sft=True)
+
+  @pytest.mark.post_training
+  def test_lora_e2e_gemma4_sft(self):
+    self._run_e2e_flow_sft("gemma4-26b")
+
+  # --- QLoRA NF4 Tests (Gemma4, Qwen3, GPT-OSS) ---
+  def test_qlora_e2e_gemma4_pretrain_nf4(self):
+    self._run_e2e_flow("gemma4-26b", use_sft=False, lora_weight_qtype="nf4")
+
+  def test_qlora_e2e_gemma4_sft_native_nf4(self):
+    self._run_e2e_flow("gemma4-26b", use_sft=True, lora_weight_qtype="nf4")
+
+  @pytest.mark.post_training
+  def test_qlora_e2e_gemma4_sft_nf4(self):
+    self._run_e2e_flow_sft("gemma4-26b", lora_weight_qtype="nf4")
+
+  def test_qlora_e2e_qwen3_pretrain_nf4(self):
+    self._run_e2e_flow("qwen3-4b", use_sft=False, lora_weight_qtype="nf4")
+
+  def test_qlora_e2e_qwen3_sft_native_nf4(self):
+    self._run_e2e_flow("qwen3-4b", use_sft=True, lora_weight_qtype="nf4")
+
+  @pytest.mark.post_training
+  def test_qlora_e2e_qwen3_sft_nf4(self):
+    self._run_e2e_flow_sft("qwen3-4b", lora_weight_qtype="nf4")
+
+  def test_qlora_e2e_gptoss_unscanned_nf4(self):
+    self._run_e2e_flow("gpt-oss-20b", use_sft=False, lora_weight_qtype="nf4", scan_layers=False)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/post_training/unit/lora_utils_test.py
+++ b/tests/post_training/unit/lora_utils_test.py
@@ -96,7 +96,7 @@ class LoraUtilsTest(unittest.TestCase):
     self.assertEqual(
         path,
         "decoder/((scanned_blocks|layers_remainder)/)?layers.*/.*"
-        "(self_attention/(query|key|value|out)|mlp/.*(wi_0|wi_1|wo|shared_experts/(wi_0|wi_1|wo)))",
+        "(self_attention/(query|key|value|out)|mlp/.*(wi_0|wi_1|wo))",
     )
 
     mock_config.model_name = "unknown_model"
@@ -292,6 +292,7 @@ class LoraUtilsTest(unittest.TestCase):
             "lora_restore_path": "some/path",
             "lora_rank": 4,
             "lora_alpha": 8.0,
+            "lora_module_path": ".*mlp/wi_.*",
         },
         scan_layers=False,
     )
@@ -300,8 +301,8 @@ class LoraUtilsTest(unittest.TestCase):
 
     restored_state = nnx.state(model, nnx.LoRAParam)
 
-    with mock.patch("orbax.checkpoint.PyTreeCheckpointer.restore", return_value=restored_state) as mock_restore:
-      with mock.patch("flax.nnx.update") as mock_update:
+    with mock.patch("maxtext.utils.lora_utils.sync_lora_metadata"):
+      with mock.patch("orbax.checkpoint.PyTreeCheckpointer.restore", return_value=restored_state) as mock_restore:
         lora_utils.restore_lora_from_path(model, cfg)
         mock_restore.assert_called_once()
         args, kwargs = mock_restore.call_args
@@ -311,7 +312,6 @@ class LoraUtilsTest(unittest.TestCase):
           self.assertTrue(kwargs["partial_restore"])
         elif "args" in kwargs and hasattr(kwargs["args"], "partial_restore"):
           self.assertTrue(kwargs["args"].partial_restore)
-        mock_update.assert_called_once()
 
   def test_sync_lora_metadata_default_syncs(self):
     """Test that default lora rank/alpha are successfully synced from checkpoint metadata."""
@@ -420,7 +420,8 @@ class LoraUtilsTest(unittest.TestCase):
 
       # Use save_checkpoint wrapper with a simple state
       dummy_state = {"weight": jnp.array([1.0, 2.0])}
-      checkpointing.save_checkpoint(manager, step=0, state=dummy_state, config=cfg_save)
+      dummy_iterator = checkpointing.PlaceHolderDataIterator(cfg_save, None)
+      checkpointing.save_checkpoint(manager, step=0, state=dummy_state, config=cfg_save, data_iterator=dummy_iterator)
       checkpointing.wait_until_finished(manager)
 
       # Now verify that the saved checkpoint contains metadata on disk

--- a/tests/unit/lora_utils_nnx_test.py
+++ b/tests/unit/lora_utils_nnx_test.py
@@ -16,6 +16,8 @@
 Linen regression block at the end."""
 
 import unittest
+from dataclasses import dataclass
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -288,6 +290,38 @@ class TestLinenLoraRegression(unittest.TestCase):
         np.asarray(base["params"]["decoder"]["layers"]["self_attention"]["out"]["kernel"]),
         np.asarray(base_orig["params"]["decoder"]["layers"]["self_attention"]["out"]["kernel"]),
     )
+
+
+class TestGetLoraAnnotations(unittest.TestCase):
+  """Unit test for get_lora_annotations handling of None or non-sharded leaves."""
+
+  def test_get_lora_annotations_handles_none_and_non_sharded(self):
+    @dataclass
+    class ShardedLeaf:
+
+      class MockSharding:
+        spec = ("data", "model")
+
+      sharding: Any = MockSharding()
+
+    class NonShardedLeaf:
+      pass
+
+    # A PyTree containing a mixture of sharded, non-sharded, and None leaves
+    lora_abstract_params = {
+        "sharded_leaf": ShardedLeaf(),
+        "non_sharded_leaf": NonShardedLeaf(),
+        "none_leaf": None,
+    }
+
+    mapped = jax.tree_util.tree_map(
+        lambda x: x.sharding.spec if getattr(x, "sharding", None) is not None else None,
+        lora_abstract_params,
+    )
+
+    self.assertEqual(mapped["sharded_leaf"], ("data", "model"))
+    self.assertIsNone(mapped["non_sharded_leaf"])
+    self.assertIsNone(mapped["none_leaf"])
 
 
 if __name__ == "__main__":

--- a/tests/unit/maxtext_utils_nnx_test.py
+++ b/tests/unit/maxtext_utils_nnx_test.py
@@ -24,6 +24,7 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
 from jax.experimental import mesh_utils
 
 from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TRAIN
+from flax import traverse_util
 from maxtext.utils import maxtext_utils_nnx
 
 
@@ -264,6 +265,128 @@ class TestScanAxisMetadata(unittest.TestCase):
     out_sharding = result["kernel"].get_metadata().get("out_sharding")
     # The unfixed code inserts the literal "layers" here.
     self.assertEqual(tuple(out_sharding), ("dense_layers", "embed", "mlp"))
+
+
+class TestMergeRestoredOverlay(unittest.TestCase):
+  """Unit test verifying that ShapeDtypeStruct placeholders in restored checkpoints are replaced by init state."""
+
+  def test_merge_restored_overlay_replaces_shape_dtype_struct(self):
+    init_state = {
+        "model": {
+            "decoder": {
+                "layers": {
+                    "self_attention": {
+                        "query": {"kernel": jnp.ones((8, 16))},
+                        "lora_a": {"kernel": jnp.ones((8, 4))},
+                    }
+                }
+            }
+        }
+    }
+    ckpt_overlay = {
+        "model": {
+            "decoder": {
+                "layers": {
+                    "self_attention": {
+                        "query": {"kernel": jnp.zeros((8, 16))},
+                        "lora_a": {"kernel": jax.ShapeDtypeStruct((8, 4), jnp.float32)},
+                    }
+                }
+            }
+        }
+    }
+
+    def _has_shape_dtype_struct(tree):
+      return any(isinstance(x, jax.ShapeDtypeStruct) for x in jax.tree_util.tree_leaves(tree))
+
+    def _merge_restored_overlay(ckpt_node, init_node):
+      if _has_shape_dtype_struct(ckpt_node):
+        if isinstance(ckpt_node, dict) and isinstance(init_node, dict):
+          res = {}
+          for k in init_node:
+            if k in ckpt_node:
+              res[k] = _merge_restored_overlay(ckpt_node[k], init_node[k])
+            else:
+              res[k] = init_node[k]
+          return res
+        else:
+          return init_node
+      return ckpt_node
+
+    merged = _merge_restored_overlay(ckpt_overlay, init_state)
+
+    # Restored weights (query) should come from checkpoint (zeros)
+    query_kernel = merged["model"]["decoder"]["layers"]["self_attention"]["query"]["kernel"]
+    self.assertTrue(jnp.array_equal(query_kernel, jnp.zeros((8, 16))))
+    # Unrestored weights (lora_a ShapeDtypeStruct) should fall back to init_state (ones)
+    lora_a_kernel = merged["model"]["decoder"]["layers"]["self_attention"]["lora_a"]["kernel"]
+    self.assertTrue(jnp.array_equal(lora_a_kernel, jnp.ones((8, 4))))
+
+
+class TestReshardAligned(unittest.TestCase):
+  """Unit test for the _reshard_aligned utility in maxtext_utils.py."""
+
+  def test_reshard_aligned_replaces_and_shards(self):
+    devices = jax.devices()
+    mesh = Mesh(mesh_utils.create_device_mesh((1, len(devices))), ("data", "model"))
+    sharding = NamedSharding(mesh, P("data", "model"))
+
+    # Create dummy array with custom sharding
+    @dataclass
+    class ShardedValue:
+      sharding: Any
+
+    target = {
+        "decoder": {
+            "layers": {
+                "self_attention": {
+                    "query": {"kernel": ShardedValue(sharding=sharding)},
+                    "lora_a": {"kernel": ShardedValue(sharding=sharding)},
+                }
+            }
+        }
+    }
+
+    raw = {
+        "decoder": {
+            "layers": {
+                "self_attention": {
+                    "query": {"kernel": jnp.ones((8, 16))},
+                    "lora_a": {"kernel": jax.ShapeDtypeStruct((8, 4), jnp.float32)},
+                }
+            }
+        }
+    }
+
+    # Extract our setup_initial_state inner function or mock/simulate its behavior:
+
+    def _reshard_aligned(target, raw):
+      target_flat = traverse_util.flatten_dict(target)
+      raw_flat = traverse_util.flatten_dict(raw)
+
+      res_flat = {}
+      for k, target_val in target_flat.items():
+        if k in raw_flat and not isinstance(raw_flat[k], jax.ShapeDtypeStruct):
+          raw_val = raw_flat[k]
+          if hasattr(target_val, "sharding") and target_val.sharding is not None:
+            res_flat[k] = jax.device_put(raw_val, target_val.sharding)
+          else:
+            res_flat[k] = raw_val
+        else:
+          res_flat[k] = target_val
+
+      return traverse_util.unflatten_dict(res_flat)
+
+    res = _reshard_aligned(target, raw)
+
+    # Query kernel should be converted into a JAX array with the target sharding
+    query_kernel = res["decoder"]["layers"]["self_attention"]["query"]["kernel"]
+    self.assertEqual(query_kernel.sharding, sharding)
+    self.assertTrue(jnp.array_equal(query_kernel, jnp.ones((8, 16))))
+
+    # lora_a kernel should retain target/ShardedValue object (ignoring the ShapeDtypeStruct)
+    lora_a_kernel = res["decoder"]["layers"]["self_attention"]["lora_a"]["kernel"]
+    self.assertIsInstance(lora_a_kernel, ShardedValue)
 
 
 if __name__ == "__main__":

--- a/tests/utils/reference_hlo_deepseek3.txt
+++ b/tests/utils/reference_hlo_deepseek3.txt
@@ -11,25 +11,25 @@ StackFrames
 
 %fused_computation.1355 (param_0.3835: s32[1,128]) -> s32[1,1,128] {
   %param_0.3835 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %constant.1719.clone.154 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %broadcast.4423 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1719.clone.154), dimensions={}, metadata={op_name="broadcast.370"}
-  %lt.832 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.3835, %broadcast.4423), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
-  %constant.1731.clone.1 = s32[]{:T(128)} constant(129280)
-  %add.3653 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1731.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %constant.1679.clone.154 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %broadcast.4414 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1679.clone.154), dimensions={}, metadata={op_name="broadcast.364"}
+  %lt.832 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.3835, %broadcast.4414), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
+  %constant.1691.clone.1 = s32[]{:T(128)} constant(129280)
+  %add.3653 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1691.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %add.3589 = s32[1,128]{1,0:T(1,128)} add(%param_0.3835, %add.3653), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %select_n.2272 = s32[1,128]{1,0:T(1,128)} select(%lt.832, %add.3589, %param_0.3835), metadata={op_name="jit(train_step)/jvp()/select_n" stack_frame_id=0}
   ROOT %bitcast.1928 = s32[1,1,128]{2,1,0:T(1,128)S(1)} bitcast(%select_n.2272)
 }
 
 %fused_computation.1133 (param_0.3323: s32[512]) -> s32[1024] {
-  %constant.4122 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.4269 = s32[1024]{0:T(1024)} broadcast(%constant.4122), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.4080 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.4260 = s32[1024]{0:T(1024)} broadcast(%constant.4080), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %param_0.3323 = s32[512]{0:T(512)S(1)} parameter(0)
-  %constant.4128 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %pad.332 = s32[1024]{0:T(1024)} pad(%param_0.3323, %constant.4128), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %constant.4111 = s32[] constant(129279), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.4258 = s32[1024]{0:T(1024)} broadcast(%constant.4111), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  ROOT %clamp.60 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4269, %pad.332, %broadcast.4258), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.4086 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %pad.332 = s32[1024]{0:T(1024)} pad(%param_0.3323, %constant.4086), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.4069 = s32[] constant(129279), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.4249 = s32[1024]{0:T(1024)} broadcast(%constant.4069), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  ROOT %clamp.60 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4260, %pad.332, %broadcast.4249), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
 %fused_computation.6 (param_0.20: bf16[129280,128], param_1.121: s32[1024]) -> bf16[512,128] {
@@ -37,11 +37,11 @@ StackFrames
   %param_1.121 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.18 = s32[1024]{0:T(1024)} custom-call(%param_1.121), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %slice.1057 = s32[512]{0:T(512)} slice(%custom-call.18), slice={[0:512]}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %reshape.4326 = s32[4,128]{1,0:T(4,128)} reshape(%slice.1057), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %transpose.891 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.4326), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %reshape.4290 = s32[4,128]{1,0:T(4,128)} reshape(%slice.1057), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %transpose.891 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.4290), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %gather.226 = bf16[4,128,128]{2,1,0:T(8,128)(2,1)} gather(%param_0.20, %transpose.891), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %transpose.890 = bf16[4,128,128]{2,1,0:T(8,128)(2,1)} transpose(%gather.226), dimensions={0,1,2}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  ROOT %reshape.4325 = bf16[512,128]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.890), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  ROOT %reshape.4289 = bf16[512,128]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.890), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
 %fused_computation.1432 (param_0.4405: f32[512,3]) -> bf16[3,512] {
@@ -53,8 +53,8 @@ StackFrames
 %fused_computation.1122 (param_0.3211: f32[1536,3], param_1.3571: s32[]) -> bf16[3,384] {
   %param_0.3211 = f32[1536,3]{0,1:T(4,128)S(1)} parameter(0)
   %param_1.3571 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1719.clone.47 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %dynamic-slice.424 = bf16[384,3]{0,1:T(4,128)(2,1)} dynamic-slice(%param_0.3211, %param_1.3571, %constant.1719.clone.47), dynamic_slice_sizes={384,3}, metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294965375","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1679.clone.47 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %dynamic-slice.424 = bf16[384,3]{0,1:T(4,128)(2,1)} dynamic-slice(%param_0.3211, %param_1.3571, %constant.1679.clone.47), dynamic_slice_sizes={384,3}, metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294965375","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
   ROOT %bitcast.1876 = bf16[3,384]{1,0:T(4,128)(2,1)} bitcast(%dynamic-slice.424), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
@@ -79,8 +79,8 @@ StackFrames
 %fused_computation.1256 (param_0.3509: f32[512,3], param_1.3939: s32[]) -> bf16[3,128] {
   %param_0.3509 = f32[512,3]{0,1:T(4,128)S(1)} parameter(0)
   %param_1.3939 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1719.clone.59 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %dynamic-slice.442 = bf16[128,3]{0,1:T(4,128)(2,1)} dynamic-slice(%param_0.3509, %param_1.3939, %constant.1719.clone.59), dynamic_slice_sizes={128,3}, metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294966911","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1679.clone.59 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %dynamic-slice.442 = bf16[128,3]{0,1:T(4,128)(2,1)} dynamic-slice(%param_0.3509, %param_1.3939, %constant.1679.clone.59), dynamic_slice_sizes={128,3}, metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294966911","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
   ROOT %bitcast.1907 = bf16[3,128]{1,0:T(4,128)(2,1)} bitcast(%dynamic-slice.442), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
@@ -91,31 +91,31 @@ StackFrames
 }
 
 %fused_computation.1395 () -> f32[32] {
-  %constant.1736.clone.1 = f32[]{:T(128)} constant(10000)
-  %broadcast.4415 = f32[32]{0:T(128)} broadcast(%constant.1736.clone.1), dimensions={}, metadata={op_name="broadcast.1660"}
+  %constant.1695.clone.1 = f32[]{:T(128)} constant(10000)
+  %broadcast.4406 = f32[32]{0:T(128)} broadcast(%constant.1695.clone.1), dimensions={}, metadata={op_name="broadcast.1657"}
   %iota.346 = f32[32]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/iota" stack_frame_id=0}
-  %constant.1737.clone.1 = f32[]{:T(128)} constant(0.03125)
-  %div.2470 = f32[32]{0:T(128)} broadcast(%constant.1737.clone.1), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %constant.1696.clone.1 = f32[]{:T(128)} constant(0.03125)
+  %div.2470 = f32[32]{0:T(128)} broadcast(%constant.1696.clone.1), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
   %div.2443 = f32[32]{0:T(128)} multiply(%iota.346, %div.2470), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
   %pow.47 = f32[32]{0:T(128)} negate(%div.2443), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
-  %pow.46 = f32[32]{0:T(128)} power(%broadcast.4415, %pow.47), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
-  %constant.1738.clone.1 = f32[]{:T(128)} constant(0.025)
-  %broadcast.4414 = f32[32]{0:T(128)} broadcast(%constant.1738.clone.1), dimensions={}, metadata={op_name="broadcast.1662"}
-  %div.2442 = f32[32]{0:T(128)} multiply(%pow.46, %broadcast.4414), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %constant.1718.clone.11 = f32[]{:T(128)} constant(1)
-  %broadcast.4413 = f32[32]{0:T(128)} broadcast(%constant.1718.clone.11), dimensions={}, metadata={op_name="broadcast.1663"}
-  %constant.1730.clone.96 = f32[]{:T(128)} constant(0)
-  %max.96 = f32[32]{0:T(128)} broadcast(%constant.1730.clone.96), dimensions={}, metadata={op_name="jit(train_step)/jit(clip)/max" stack_frame_id=0}
+  %pow.46 = f32[32]{0:T(128)} power(%broadcast.4406, %pow.47), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
+  %constant.1697.clone.1 = f32[]{:T(128)} constant(0.025)
+  %broadcast.4405 = f32[32]{0:T(128)} broadcast(%constant.1697.clone.1), dimensions={}, metadata={op_name="broadcast.1659"}
+  %div.2442 = f32[32]{0:T(128)} multiply(%pow.46, %broadcast.4405), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %constant.1678.clone.11 = f32[]{:T(128)} constant(1)
+  %broadcast.4404 = f32[32]{0:T(128)} broadcast(%constant.1678.clone.11), dimensions={}, metadata={op_name="broadcast.1660"}
+  %constant.1690.clone.96 = f32[]{:T(128)} constant(0)
+  %max.96 = f32[32]{0:T(128)} broadcast(%constant.1690.clone.96), dimensions={}, metadata={op_name="jit(train_step)/jit(clip)/max" stack_frame_id=0}
   %iota.345 = f32[32]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/iota" stack_frame_id=0}
-  %constant.1739.clone.1 = f32[]{:T(128)} constant(-10)
-  %broadcast.4412 = f32[32]{0:T(128)} broadcast(%constant.1739.clone.1), dimensions={}, metadata={op_name="broadcast.1666"}
-  %sub.875 = f32[32]{0:T(128)} add(%iota.345, %broadcast.4412), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
-  %constant.1740.clone.1 = f32[]{:T(128)} constant(0.0769230798)
-  %broadcast.4411 = f32[32]{0:T(128)} broadcast(%constant.1740.clone.1), dimensions={}, metadata={op_name="broadcast.1667"}
-  %div.2441 = f32[32]{0:T(128)} multiply(%sub.875, %broadcast.4411), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %min.42 = f32[32]{0:T(128)} clamp(%max.96, %div.2441, %broadcast.4413), metadata={op_name="jit(train_step)/jit(clip)/min" stack_frame_id=0}
-  %sub.874 = f32[32]{0:T(128)} subtract(%broadcast.4413, %min.42), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
-  %sub.873 = f32[32]{0:T(128)} subtract(%broadcast.4413, %sub.874), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
+  %constant.1698.clone.1 = f32[]{:T(128)} constant(-10)
+  %broadcast.4403 = f32[32]{0:T(128)} broadcast(%constant.1698.clone.1), dimensions={}, metadata={op_name="broadcast.1663"}
+  %sub.875 = f32[32]{0:T(128)} add(%iota.345, %broadcast.4403), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
+  %constant.1699.clone.1 = f32[]{:T(128)} constant(0.0769230798)
+  %broadcast.4402 = f32[32]{0:T(128)} broadcast(%constant.1699.clone.1), dimensions={}, metadata={op_name="broadcast.1664"}
+  %div.2441 = f32[32]{0:T(128)} multiply(%sub.875, %broadcast.4402), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %min.42 = f32[32]{0:T(128)} clamp(%max.96, %div.2441, %broadcast.4404), metadata={op_name="jit(train_step)/jit(clip)/min" stack_frame_id=0}
+  %sub.874 = f32[32]{0:T(128)} subtract(%broadcast.4404, %min.42), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
+  %sub.873 = f32[32]{0:T(128)} subtract(%broadcast.4404, %sub.874), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
   %mul.4547 = f32[32]{0:T(128)} multiply(%div.2442, %sub.873), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %mul.4546 = f32[32]{0:T(128)} multiply(%pow.46, %sub.874), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   ROOT %add.3632 = f32[32]{0:T(128)S(1)} add(%mul.4547, %mul.4546), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
@@ -126,14 +126,14 @@ StackFrames
   %param_0.4495 = f32[32]{0:T(128)S(1)} parameter(0)
   %mul.3700 = f32[163840,32]{1,0:T(8,128)} broadcast(%param_0.4495), dimensions={1}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %mul.3606 = f32[163840,32]{1,0:T(8,128)} multiply(%mul.3607, %mul.3700), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %constant.1730.clone.95 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2546 = f32[163840,32]{1,0:T(8,128)} broadcast(%constant.1730.clone.95), dimensions={}, metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
+  %constant.1690.clone.95 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2546 = f32[163840,32]{1,0:T(8,128)} broadcast(%constant.1690.clone.95), dimensions={}, metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
   %exp.480 = pred[163840,32]{1,0:T(8,128)(4,1)} compare(%mul.3606, %convert_element_type.2546), direction=EQ, metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
   %mul.3587 = f32[163840,32]{1,0:T(8,128)} multiply(%mul.3606, %convert_element_type.2546), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %exp.473 = f32[163840,32]{1,0:T(8,128)} exponential(%mul.3587), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %constant.1741.clone.1 = f32[]{:T(128)} constant(inf)
-  %broadcast.4090 = f32[163840,32]{1,0:T(8,128)} broadcast(%constant.1741.clone.1), dimensions={}, metadata={op_name="broadcast.373"}
-  %exp.472 = pred[163840,32]{1,0:T(8,128)(4,1)} compare(%exp.473, %broadcast.4090), direction=EQ, metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %constant.1700.clone.1 = f32[]{:T(128)} constant(inf)
+  %broadcast.4081 = f32[163840,32]{1,0:T(8,128)} broadcast(%constant.1700.clone.1), dimensions={}, metadata={op_name="broadcast.367"}
+  %exp.472 = pred[163840,32]{1,0:T(8,128)(4,1)} compare(%exp.473, %broadcast.4081), direction=EQ, metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
   %exp.460 = f32[163840,32]{1,0:T(8,128)} sine(%mul.3606), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
   %exp.459 = f32[163840,32]{1,0:T(8,128)} multiply(%exp.473, %exp.460), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
   %exp.458 = f32[163840,32]{1,0:T(8,128)} multiply(%exp.459, %exp.473), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
@@ -148,25 +148,25 @@ StackFrames
 
 %fused_computation.1356 (param_0.3839: s32[1,128]) -> s32[128] {
   %param_0.3839 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %constant.1719.clone.92 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %broadcast.4422 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1719.clone.92), dimensions={}, metadata={op_name="broadcast.370"}
-  %lt.834 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.3839, %broadcast.4422), direction=LT, metadata={op_name="jit(train_step)/lt" stack_frame_id=0}
-  %constant.1742.clone.2 = s32[]{:T(128)} constant(163840)
-  %broadcast.4410 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1742.clone.2), dimensions={}, metadata={op_name="broadcast.361"}
-  %add.3591 = s32[1,128]{1,0:T(1,128)} add(%param_0.3839, %broadcast.4410), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %constant.1679.clone.92 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %broadcast.4413 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1679.clone.92), dimensions={}, metadata={op_name="broadcast.364"}
+  %lt.834 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.3839, %broadcast.4413), direction=LT, metadata={op_name="jit(train_step)/lt" stack_frame_id=0}
+  %constant.1701.clone.2 = s32[]{:T(128)} constant(163840)
+  %broadcast.4401 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1701.clone.2), dimensions={}, metadata={op_name="broadcast.355"}
+  %add.3591 = s32[1,128]{1,0:T(1,128)} add(%param_0.3839, %broadcast.4401), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
   %select_n.2274 = s32[1,128]{1,0:T(1,128)} select(%lt.834, %add.3591, %param_0.3839), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
   ROOT %bitcast.1929 = s32[128]{0:T(128)S(1)} bitcast(%select_n.2274), metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
 }
 
 %fused_computation.1132 (param_0.3322: s32[128]) -> s32[1024] {
-  %constant.4112 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.4268 = s32[1024]{0:T(1024)} broadcast(%constant.4112), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.4070 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.4259 = s32[1024]{0:T(1024)} broadcast(%constant.4070), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %param_0.3322 = s32[128]{0:T(128)S(1)} parameter(0)
-  %constant.4127 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %pad.331 = s32[1024]{0:T(1024)} pad(%param_0.3322, %constant.4127), padding=0_896, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %constant.4110 = s32[] constant(163839), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %broadcast.4257 = s32[1024]{0:T(1024)} broadcast(%constant.4110), dimensions={}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  ROOT %clamp.59 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4268, %pad.331, %broadcast.4257), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %constant.4085 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %pad.331 = s32[1024]{0:T(1024)} pad(%param_0.3322, %constant.4085), padding=0_896, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %constant.4068 = s32[] constant(163839), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %broadcast.4248 = s32[1024]{0:T(1024)} broadcast(%constant.4068), dimensions={}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  ROOT %clamp.59 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4259, %pad.331, %broadcast.4248), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
 }
 
 %fused_computation.7 (param_0.23: f32[163840,32], param_1.123: s32[1024]) -> f32[128,32] {
@@ -174,11 +174,11 @@ StackFrames
   %param_1.123 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.20 = s32[1024]{0:T(1024)} custom-call(%param_1.123), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
   %slice.1059 = s32[128]{0:T(128)} slice(%custom-call.20), slice={[0:128]}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %reshape.4334 = s32[128]{0:T(128)} reshape(%slice.1059), metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.897 = s32[128]{0:T(128)} transpose(%reshape.4334), dimensions={0}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %reshape.4298 = s32[128]{0:T(128)} reshape(%slice.1059), metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.897 = s32[128]{0:T(128)} transpose(%reshape.4298), dimensions={0}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
   %gather.228 = f32[128,32]{1,0:T(8,128)} gather(%param_0.23, %transpose.897), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
   %transpose.896 = f32[128,32]{1,0:T(8,128)} transpose(%gather.228), dimensions={0,1}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  ROOT %reshape.4333 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.896), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  ROOT %reshape.4297 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.896), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
 }
 
 %fused_computation.8 (param_0.26: f32[163840,32], param_1.125: s32[1024]) -> f32[128,32] {
@@ -186,11 +186,11 @@ StackFrames
   %param_1.125 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.22 = s32[1024]{0:T(1024)} custom-call(%param_1.125), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
   %slice.1061 = s32[128]{0:T(128)} slice(%custom-call.22), slice={[0:128]}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %reshape.4342 = s32[128]{0:T(128)} reshape(%slice.1061), metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.903 = s32[128]{0:T(128)} transpose(%reshape.4342), dimensions={0}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %reshape.4306 = s32[128]{0:T(128)} reshape(%slice.1061), metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.903 = s32[128]{0:T(128)} transpose(%reshape.4306), dimensions={0}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
   %gather.230 = f32[128,32]{1,0:T(8,128)} gather(%param_0.26, %transpose.903), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
   %transpose.902 = f32[128,32]{1,0:T(8,128)} transpose(%gather.230), dimensions={0,1}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  ROOT %reshape.4341 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.902), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  ROOT %reshape.4305 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.902), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
 }
 
 %fused_computation.621 (param_0.1794: f32[128,3,128,128]) -> bf16[3,128,128,128] {
@@ -222,29 +222,29 @@ StackFrames
   %param_2.4298 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %bitcast.2534 = bf16[1,1,128,512]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.4298), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/broadcast_in_dim" stack_frame_id=0}
   %param_1.5447 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.42 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-update-slice.65 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.4838, %bitcast.2534, %param_1.5447, %constant.1492.clone.42, %constant.1492.clone.42, /*index=5*/%constant.1492.clone.42), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1452.clone.42 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-update-slice.65 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.4838, %bitcast.2534, %param_1.5447, %constant.1452.clone.42, %constant.1452.clone.42, /*index=5*/%constant.1452.clone.42), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.129.clone.1 (param_0.4870: bf16[3,128,128,128], param_1.5468: s32[]) -> bf16[1,128,128,128] {
   %param_0.4870 = bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.5468 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.50 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.532 = bf16[1,128,128,128]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4870, %param_1.5468, %constant.1492.clone.50, %constant.1492.clone.50, %constant.1492.clone.50), dynamic_slice_sizes={1,128,128,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1452.clone.50 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.532 = bf16[1,128,128,128]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4870, %param_1.5468, %constant.1452.clone.50, %constant.1452.clone.50, %constant.1452.clone.50), dynamic_slice_sizes={1,128,128,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.99.clone.1 (param_0.4864: bf16[3,384,128,192], param_1.5463: s32[]) -> bf16[1,384,128,192] {
   %param_0.4864 = bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)} parameter(0)
   %param_1.5463 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.49 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.531 = bf16[1,384,128,192]{2,1,3,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4864, %param_1.5463, %constant.1492.clone.49, %constant.1492.clone.49, %constant.1492.clone.49), dynamic_slice_sizes={1,384,128,192}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1452.clone.49 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.531 = bf16[1,384,128,192]{2,1,3,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4864, %param_1.5463, %constant.1452.clone.49, %constant.1452.clone.49, %constant.1452.clone.49), dynamic_slice_sizes={1,384,128,192}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.140.clone.1 (param_0.4859: bf16[3,128,1536], param_1.5460: s32[]) -> bf16[1,128,1536] {
   %param_0.4859 = bf16[3,128,1536]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.5460 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.48 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.530 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4859, %param_1.5460, %constant.1492.clone.48, %constant.1492.clone.48), dynamic_slice_sizes={1,128,1536}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1452.clone.48 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.530 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4859, %param_1.5460, %constant.1452.clone.48, %constant.1452.clone.48), dynamic_slice_sizes={1,128,1536}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %region_2.3 (reduce_sum.9: f32[], reduce_sum.13: f32[]) -> f32[] {
@@ -257,18 +257,18 @@ StackFrames
   %param_0.4841 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.3009 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4841), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.699 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.3009, %convert_element_type.3009), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.1493.clone.19 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.880 = f32[128]{0:T(128)S(1)} reduce(%square.699, %constant.1493.clone.19), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.1453.clone.19 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.880 = f32[128]{0:T(128)S(1)} reduce(%square.699, %constant.1453.clone.19), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.205.clone.1 (param_0.4842: f32[128]) -> f32[128] {
   %param_0.4842 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1494.clone.11 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4707 = f32[128]{0:T(128)} broadcast(%constant.1494.clone.11), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.2870 = f32[128]{0:T(128)} multiply(%param_0.4842, %broadcast.4707), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.1495.clone.13 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4706 = f32[128]{0:T(128)} broadcast(%constant.1495.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3967 = f32[128]{0:T(128)} add(%div.2870, %broadcast.4706), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.1454.clone.11 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4698 = f32[128]{0:T(128)} broadcast(%constant.1454.clone.11), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.2870 = f32[128]{0:T(128)} multiply(%param_0.4842, %broadcast.4698), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.1455.clone.13 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4697 = f32[128]{0:T(128)} broadcast(%constant.1455.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3967 = f32[128]{0:T(128)} add(%div.2870, %broadcast.4697), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.366 = f32[128]{0:T(128)S(1)} rsqrt(%add.3967), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
@@ -287,13 +287,13 @@ StackFrames
 %fused_computation.197.clone.1 (param_0.4839: bf16[3,512], param_1.5448: s32[], param_2.4299: bf16[3,512]) -> (bf16[512], bf16[512]) {
   %param_0.4839 = bf16[3,512]{1,0:T(4,128)(2,1)} parameter(0)
   %param_1.5448 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.43 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.628 = bf16[1,512]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.4839, %param_1.5448, %constant.1492.clone.43), dynamic_slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %constant.4256 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %reduce.879 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%dynamic_slice.628, %constant.4256), dimensions={0}, to_apply=%convert_element_type.2195.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.1452.clone.43 = s32[]{:T(128)} constant(0)
+  %dynamic_slice.376 = bf16[1,512]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.4839, %param_1.5448, %constant.1452.clone.43), dynamic_slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.4214 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %reduce.879 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%dynamic_slice.376, %constant.4214), dimensions={0}, to_apply=%convert_element_type.2195.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %param_2.4299 = bf16[3,512]{1,0:T(4,128)(2,1)} parameter(2)
-  %dynamic_slice.614.clone.3 = bf16[1,512]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.4299, %param_1.5448, %constant.1492.clone.43), dynamic_slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %reduce.682.clone.3 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%dynamic_slice.614.clone.3, %constant.4256), dimensions={0}, to_apply=%convert_element_type.2198.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %dynamic_slice.362.clone.3 = bf16[1,512]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.4299, %param_1.5448, %constant.1452.clone.43), dynamic_slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %reduce.682.clone.3 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%dynamic_slice.362.clone.3, %constant.4214), dimensions={0}, to_apply=%convert_element_type.2198.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   ROOT %tuple.862 = (bf16[512]{0:T(512)(128)(2,1)S(1)}, bf16[512]{0:T(512)(128)(2,1)S(1)}) tuple(%reduce.879, %reduce.682.clone.3)
 }
 
@@ -335,27 +335,27 @@ StackFrames
   %convert_element_type.2255.clone.3 = f32[128,1536]{1,0:T(8,128)} convert(%convolution.91.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %bitcast.695.clone.3 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} bitcast(%convert_element_type.2255.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.701 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%bitcast.695.clone.3, %bitcast.695.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.1493.clone.22 = f32[]{:T(128)} constant(0)
-  %reduce.882 = f32[128]{0:T(128)S(1)} reduce(%square.701, %constant.1493.clone.22), dimensions={0,2}, to_apply=%region_3.4, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.1453.clone.22 = f32[]{:T(128)} constant(0)
+  %reduce.882 = f32[128]{0:T(128)S(1)} reduce(%square.701, %constant.1453.clone.22), dimensions={0,2}, to_apply=%region_3.4, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
   ROOT %tuple.866 = (f32[128]{0:T(128)S(1)}, f32[1,128,1536]{2,1,0:T(8,128)S(1)}) tuple(%reduce.882, %bitcast.695.clone.3)
 }
 
 %fused_computation.204.clone.1 (param_0.4863: f32[128]) -> f32[128] {
   %param_0.4863 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1496.clone.7 = f32[]{:T(128)} constant(0.000651041686)
-  %broadcast.4711 = f32[128]{0:T(128)} broadcast(%constant.1496.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %div.2872 = f32[128]{0:T(128)} multiply(%param_0.4863, %broadcast.4711), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.1495.clone.15 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4710 = f32[128]{0:T(128)} broadcast(%constant.1495.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3970 = f32[128]{0:T(128)} add(%div.2872, %broadcast.4710), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.1456.clone.7 = f32[]{:T(128)} constant(0.000651041686)
+  %broadcast.4702 = f32[128]{0:T(128)} broadcast(%constant.1456.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %div.2872 = f32[128]{0:T(128)} multiply(%param_0.4863, %broadcast.4702), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.1455.clone.15 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4701 = f32[128]{0:T(128)} broadcast(%constant.1455.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3970 = f32[128]{0:T(128)} add(%div.2872, %broadcast.4701), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.368 = f32[128]{0:T(128)S(1)} rsqrt(%add.3970), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
 %fused_computation.200.clone.1 (param_0.4858: bf16[3,384], param_1.5459: s32[]) -> bf16[1,384] {
   %param_0.4858 = bf16[3,384]{1,0:T(4,128)(2,1)} parameter(0)
   %param_1.5459 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.47 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.529 = bf16[1,384]{1,0:T(2,128)(2,1)S(1)} dynamic-slice(%param_0.4858, %param_1.5459, %constant.1492.clone.47), dynamic_slice_sizes={1,384}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1452.clone.47 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.529 = bf16[1,384]{1,0:T(2,128)(2,1)S(1)} dynamic-slice(%param_0.4858, %param_1.5459, %constant.1452.clone.47), dynamic_slice_sizes={1,384}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %all-gather.290.reduce_sub_computation (lhs.16: bf16[], rhs.16: bf16[]) -> bf16[] {
@@ -409,20 +409,20 @@ StackFrames
   %param_0.4868 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.3021 = f32[1,128,128,32,1]{3,1,2,4,0:T(8,128)} convert(%param_0.4868), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %bitcast.2553 = f32[1,128,128,32]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.3021), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %constant.1493.clone.23 = f32[]{:T(128)} constant(0)
-  %convert_element_type.3023 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1493.clone.23), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.1453.clone.23 = f32[]{:T(128)} constant(0)
+  %convert_element_type.3023 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1453.clone.23), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %mul.5154 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.2553, %convert_element_type.3023), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %add.3971 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%bitcast.2554, %mul.5154), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   %param_3.2902 = f32[128,32]{1,0:T(8,128)S(1)} parameter(3)
-  %broadcast_in_dim.1648 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.2902), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %mul.5153 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3971, %broadcast_in_dim.1648), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %broadcast_in_dim.1576 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.2902), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %mul.5153 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3971, %broadcast_in_dim.1576), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %param_2.4309 = f32[128,32]{1,0:T(8,128)S(1)} parameter(2)
-  %broadcast_in_dim.1647 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.4309), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %mul.5152 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.2553, %broadcast_in_dim.1647), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %broadcast_in_dim.1575 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.4309), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %mul.5152 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.2553, %broadcast_in_dim.1575), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %mul.5151 = f32[1,128,128,32]{3,1,2,0:T(8,128)} subtract(%mul.5153, %mul.5152), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %convert.675 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.5151), metadata={op_name="convert.317"}
-  %mul.3131.clone.3 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3971, %broadcast_in_dim.1647), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %mul.3130.clone.3 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.2553, %broadcast_in_dim.1648), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %mul.3131.clone.3 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3971, %broadcast_in_dim.1575), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %mul.3130.clone.3 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.2553, %broadcast_in_dim.1576), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %mul.3129.clone.3 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%mul.3131.clone.3, %mul.3130.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %convert.518.clone.3 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.3129.clone.3), metadata={op_name="convert.318"}
   ROOT %tuple.868 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.675, %convert.518.clone.3)
@@ -430,19 +430,19 @@ StackFrames
 
 %fused_computation.119.clone.1 (param_0.4869: bf16[1,128,128,32], param_1.5467: bf16[1,128,128,32], param_2.4310: bf16[1,128,128,128]) -> bf16[128,128,192] {
   %param_2.4310 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(2)
-  %constant.4259 = bf16[]{:T(256)} constant(-inf)
-  %pad.463 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.4310, %constant.4259), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %constant.4217 = bf16[]{:T(256)} constant(-inf)
+  %pad.463 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.4310, %constant.4217), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.1051 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.463)
   %param_1.5467 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %pad.462 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.5467, %constant.4259), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.462 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.5467, %constant.4217), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.1052 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.462)
   %maximum.100 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1051, %convert.1052), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_0.4869 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.461 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.4869, %constant.4259), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.461 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.4869, %constant.4217), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.1053 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.461)
   %maximum.99 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%maximum.100, %convert.1053), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %constant.1497.clone.7 = bf16[]{:T(256)} constant(0.1348)
-  %mul.5156 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1497.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %constant.1457.clone.7 = bf16[]{:T(256)} constant(0.1348)
+  %mul.5156 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1457.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %convert.1054 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%mul.5156)
   %mul.5155 = f32[1,128,128,192]{3,1,2,0:T(8,128)} multiply(%maximum.99, %convert.1054), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.1055 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%mul.5155)
@@ -452,8 +452,8 @@ StackFrames
 %fused_computation.155.clone.1 (param_0.4843: bf16[3,128,576], param_1.5450: s32[]) -> bf16[1,128,576] {
   %param_0.4843 = bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %param_1.5450 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.45 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.527 = bf16[1,128,576]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4843, %param_1.5450, %constant.1492.clone.45, %constant.1492.clone.45), dynamic_slice_sizes={1,128,576}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1452.clone.45 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.527 = bf16[1,128,576]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4843, %param_1.5450, %constant.1452.clone.45, %constant.1452.clone.45), dynamic_slice_sizes={1,128,576}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.170.clone.clone.1 (param_0.4845: bf16[1,128,512], param_1.5451: f32[128], param_2.4300: bf16[512]) -> bf16[128,512] {
@@ -502,8 +502,8 @@ StackFrames
   %param_2.4304 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} parameter(2)
   %convert_element_type.3015 = f32[1,128,1,32,1]{3,1,4,2,0:T(8,128)} convert(%param_2.4304), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %bitcast.2544 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%convert_element_type.3015), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %constant.1493.clone.21 = f32[]{:T(128)} constant(0)
-  %convert_element_type.3017 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1493.clone.21), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.1453.clone.21 = f32[]{:T(128)} constant(0)
+  %convert_element_type.3017 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1453.clone.21), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %mul.5146 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%bitcast.2544, %convert_element_type.3017), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %add.3969 = f32[1,128,32]{2,1,0:T(8,128)} add(%bitcast.2545, %mul.5146), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   %param_1.5456 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} parameter(1)
@@ -523,11 +523,11 @@ StackFrames
 
 %fused_computation.191.clone.1 (param_0.4856: bf16[1,128,32], param_1.5457: bf16[1,128,32]) -> bf16[128,64] {
   %param_1.5457 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.4257 = bf16[]{:T(256)} constant(-inf)
-  %pad.458 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.5457, %constant.4257), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %constant.4215 = bf16[]{:T(256)} constant(-inf)
+  %pad.458 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.5457, %constant.4215), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.1056 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.458)
   %param_0.4856 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.457 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.4856, %constant.4257), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.457 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.4856, %constant.4215), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.1057 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.457)
   %maximum.97 = f32[1,128,64]{2,1,0:T(8,128)} maximum(%convert.1056, %convert.1057), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","64"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.1058 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} convert(%maximum.97)
@@ -537,8 +537,8 @@ StackFrames
 %fused_computation.110.clone.1 (param_0.4849: bf16[3,128,128,256], param_1.5453: s32[]) -> bf16[1,128,128,256] {
   %param_0.4849 = bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.5453 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.46 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.528 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4849, %param_1.5453, %constant.1492.clone.46, %constant.1492.clone.46, %constant.1492.clone.46), dynamic_slice_sizes={1,128,128,256}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1452.clone.46 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.528 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4849, %param_1.5453, %constant.1452.clone.46, %constant.1452.clone.46, %constant.1452.clone.46), dynamic_slice_sizes={1,128,128,256}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %region_4.5 (reduce_sum.21: f32[], reduce_sum.22: f32[]) -> f32[] {
@@ -552,26 +552,26 @@ StackFrames
   %slice.1436 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_0.4847), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/split" stack_frame_id=0}
   %convert_element_type.3012 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1436), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.700 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.3012, %convert_element_type.3012), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.1493.clone.20 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.881 = f32[128]{0:T(128)S(1)} reduce(%square.700, %constant.1493.clone.20), dimensions={0,2}, to_apply=%region_4.5, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.1453.clone.20 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.881 = f32[128]{0:T(128)S(1)} reduce(%square.700, %constant.1453.clone.20), dimensions={0,2}, to_apply=%region_4.5, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.203.clone.1 (param_0.4848: f32[128]) -> f32[128] {
   %param_0.4848 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1494.clone.12 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4709 = f32[128]{0:T(128)} broadcast(%constant.1494.clone.12), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.2871 = f32[128]{0:T(128)} multiply(%param_0.4848, %broadcast.4709), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.1495.clone.14 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4708 = f32[128]{0:T(128)} broadcast(%constant.1495.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3968 = f32[128]{0:T(128)} add(%div.2871, %broadcast.4708), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.1454.clone.12 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4700 = f32[128]{0:T(128)} broadcast(%constant.1454.clone.12), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.2871 = f32[128]{0:T(128)} multiply(%param_0.4848, %broadcast.4700), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.1455.clone.14 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4699 = f32[128]{0:T(128)} broadcast(%constant.1455.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3968 = f32[128]{0:T(128)} add(%div.2871, %broadcast.4699), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.367 = f32[128]{0:T(128)S(1)} rsqrt(%add.3968), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
 %fused_computation.201.clone.1 (param_0.4840: bf16[3,128], param_1.5449: s32[]) -> bf16[1,128] {
   %param_0.4840 = bf16[3,128]{1,0:T(4,128)(2,1)S(1)} parameter(0)
   %param_1.5449 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.44 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.526 = bf16[1,128]{1,0:T(2,128)(2,1)S(1)} dynamic-slice(%param_0.4840, %param_1.5449, %constant.1492.clone.44), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1452.clone.44 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.526 = bf16[1,128]{1,0:T(2,128)(2,1)S(1)} dynamic-slice(%param_0.4840, %param_1.5449, %constant.1452.clone.44), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %all-gather.293.reduce_sub_computation (lhs.18: bf16[], rhs.18: bf16[]) -> bf16[] {
@@ -623,11 +623,11 @@ StackFrames
 
 %fused_computation.120.clone.1 (param_0.4857: bf16[1,128,128,64], param_1.5458: bf16[1,128,128,128]) -> bf16[128,128,192] {
   %param_1.5458 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.4258 = bf16[]{:T(256)} constant(-inf)
-  %pad.460 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.5458, %constant.4258), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %constant.4216 = bf16[]{:T(256)} constant(-inf)
+  %pad.460 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.5458, %constant.4216), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.1059 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.460)
   %param_0.4857 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.459 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.4857, %constant.4258), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.459 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.4857, %constant.4216), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.1060 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.459)
   %maximum.98 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1059, %convert.1060), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.1061 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.98)
@@ -663,8 +663,8 @@ StackFrames
   %add.3136.clone.3 = f32[1,128,512]{2,1,0:T(8,128)} add(%convert.1062, %convert.1063), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.3024 = f32[1,128,512]{2,1,0:T(8,128)} convert(%add.3136.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.702 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.3024, %convert_element_type.3024), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.1493.clone.24 = f32[]{:T(128)} constant(0)
-  %reduce.883 = f32[128]{0:T(128)S(1)} reduce(%square.702, %constant.1493.clone.24), dimensions={0,2}, to_apply=%region_5.7, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.1453.clone.24 = f32[]{:T(128)} constant(0)
+  %reduce.883 = f32[128]{0:T(128)S(1)} reduce(%square.702, %constant.1453.clone.24), dimensions={0,2}, to_apply=%region_5.7, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
   %convert.1064 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.3136.clone.3)
   ROOT %tuple.869 = (f32[128]{0:T(128)S(1)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.883, %convert.1064)
 }
@@ -672,32 +672,32 @@ StackFrames
 %fused_computation.115.clone.1 (param_0.4880: bf16[3,18432,128], param_1.5474: s32[]) -> bf16[1,18432,128] {
   %param_0.4880 = bf16[3,18432,128]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.5474 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.53 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.535 = bf16[1,18432,128]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4880, %param_1.5474, %constant.1492.clone.53, %constant.1492.clone.53), dynamic_slice_sizes={1,18432,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1452.clone.53 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.535 = bf16[1,18432,128]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4880, %param_1.5474, %constant.1452.clone.53, %constant.1452.clone.53), dynamic_slice_sizes={1,18432,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.116.clone.1 (param_0.4879: bf16[3,128,18432], param_1.5473: s32[]) -> bf16[1,128,18432] {
   %param_0.4879 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.5473 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.52 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.534 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4879, %param_1.5473, %constant.1492.clone.52, %constant.1492.clone.52), dynamic_slice_sizes={1,128,18432}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1452.clone.52 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.534 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4879, %param_1.5473, %constant.1452.clone.52, %constant.1452.clone.52), dynamic_slice_sizes={1,128,18432}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.117.clone.1 (param_0.4875: bf16[3,128,18432], param_1.5470: s32[]) -> bf16[1,128,18432] {
   %param_0.4875 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.5470 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1492.clone.51 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.533 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4875, %param_1.5470, %constant.1492.clone.51, %constant.1492.clone.51), dynamic_slice_sizes={1,128,18432}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1452.clone.51 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.533 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4875, %param_1.5470, %constant.1452.clone.51, %constant.1452.clone.51), dynamic_slice_sizes={1,128,18432}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.202.clone.1 (param_0.4874: f32[128]) -> f32[128] {
   %param_0.4874 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1494.clone.13 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4713 = f32[128]{0:T(128)} broadcast(%constant.1494.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.2873 = f32[128]{0:T(128)} multiply(%param_0.4874, %broadcast.4713), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.1495.clone.16 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4712 = f32[128]{0:T(128)} broadcast(%constant.1495.clone.16), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3972 = f32[128]{0:T(128)} add(%div.2873, %broadcast.4712), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.1454.clone.13 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4704 = f32[128]{0:T(128)} broadcast(%constant.1454.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.2873 = f32[128]{0:T(128)} multiply(%param_0.4874, %broadcast.4704), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.1455.clone.16 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4703 = f32[128]{0:T(128)} broadcast(%constant.1455.clone.16), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3972 = f32[128]{0:T(128)} add(%div.2873, %broadcast.4703), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.369 = f32[128]{0:T(128)S(1)} rsqrt(%add.3972), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
@@ -757,8 +757,8 @@ StackFrames
 %fused_computation.114.clone.clone.clone.clone.clone.clone.clone.1 (param_0.4884: bf16[1,512,18432], param_1.5476: bf16[1,128,18432], param_2.4315: bf16[1,128,512], param_3.2904: f32[128], param_4.2205: bf16[512]) -> bf16[128,18432] {
   %param_1.5476 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %convert.1047 = f32[1,128,18432]{2,1,0:T(8,128)} convert(%param_1.5476)
-  %constant.1498.clone.10 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.98 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)} broadcast(%constant.1498.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)" stack_frame_id=0}
+  %constant.1458.clone.10 = bf16[]{:T(256)} constant(1)
+  %jit_silu_.98 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)} broadcast(%constant.1458.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)" stack_frame_id=0}
   %convert.1048 = f32[1,128,18432]{2,1,0:T(8,128)} convert(%jit_silu_.98)
   %neg.274 = f32[1,128,18432]{2,1,0:T(8,128)} negate(%convert.1047), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %exp.567 = f32[1,128,18432]{2,1,0:T(8,128)} exponential(%neg.274), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
@@ -821,216 +821,144 @@ StackFrames
   ROOT %slice.1496 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} slice(%param_0.4955), slice={[12582912:16777216]}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%wide.region_1.8_spmd.sunk.clone.clone.clone.sunk (wide.param.5: (s32[], bf16[1,128,512], u32[3], u32[3,4], u32[3], /*index=5*/u32[3,4], u32[3], u32[3,4], u32[3], u32[3,4], /*index=10*/u32[3], u32[3,4], u32[3], u32[3,4], u32[3], /*index=15*/u32[3,4], u32[3], u32[3,4], u32[3], u32[3,4], /*index=20*/bf16[3,1,128,512], bf16[3,512], bf16[3,384], bf16[3,512], bf16[3,128,1536], /*index=25*/bf16[3,384,128,192], bf16[3,128], bf16[3,128,576], bf16[3,128,128,256], f32[1,128,1,32], /*index=30*/f32[1,128,1,32], bf16[3,128,128,128], bf16[3,128,18432], bf16[3,128,18432], bf16[3,18432,128], /*index=35*/u32[3], u32[3,4], u32[3], u32[3,4], u32[3], /*index=40*/u32[3,4], u32[3], u32[3,4], u32[3], u32[3,4], /*index=45*/u32[3], u32[3,4], u32[3], u32[3,4], u32[3], /*index=50*/u32[3,4], u32[3], u32[3,4], f32[128,32], f32[128,32], /*index=55*/s32[128], s32[], s8[1,1,1], s8[1,1,1], bf16[])) -> (s32[], bf16[1,128,512], u32[3], u32[3,4], u32[3], /*index=5*/u32[3,4], u32[3], u32[3,4], u32[3], u32[3,4], /*index=10*/u32[3], u32[3,4], u32[3], u32[3,4], u32[3], /*index=15*/u32[3,4], u32[3], u32[3,4], u32[3], u32[3,4], /*index=20*/bf16[3,1,128,512], bf16[3,512], bf16[3,384], bf16[3,512], bf16[3,128,1536], /*index=25*/bf16[3,384,128,192], bf16[3,128], bf16[3,128,576], bf16[3,128,128,256], f32[1,128,1,32], /*index=30*/f32[1,128,1,32], bf16[3,128,128,128], bf16[3,128,18432], bf16[3,128,18432], bf16[3,18432,128], /*index=35*/u32[3], u32[3,4], u32[3], u32[3,4], u32[3], /*index=40*/u32[3,4], u32[3], u32[3,4], u32[3], u32[3,4], /*index=45*/u32[3], u32[3,4], u32[3], u32[3,4], u32[3], /*index=50*/u32[3,4], u32[3], u32[3,4], f32[128,32], f32[128,32], /*index=55*/s32[128], s32[], s8[1,1,1], s8[1,1,1], bf16[]) {
-  %constant.1752.clone..sunk.7 = s32[]{:T(128)} constant(1)
-  %constant.4192..sunk.1 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %wide.param.5 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=5*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, /*index=10*/u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=15*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, /*index=20*/bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, /*index=25*/bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, /*index=30*/f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, /*index=35*/u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=40*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, /*index=45*/u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=50*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, f32[128,32]{1,0:T(8,128)S(1)}, f32[128,32]{1,0:T(8,128)S(1)}, /*index=55*/s32[128]{0:T(128)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) parameter(0)
-  %get-tuple-element.8821 = s32[]{:T(128)} get-tuple-element(%wide.param.5), index=0
-  %copy.1644 = s32[]{:T(128)S(6)} copy(%get-tuple-element.8821), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add.3975 = s32[]{:T(128)} add(%copy.1644, %constant.1752.clone..sunk.7), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8841 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=20
-  %get-tuple-element.8822 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.5), index=1
-  %bitcast_dynamic-update-slice_fusion.17 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} fusion(%get-tuple-element.8841, %copy.1644, %get-tuple-element.8822), kind=kLoop, calls=%fused_computation.171.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
-  %get-tuple-element.8912 = bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=31
-  %dynamic-slice_convert_fusion.40 = bf16[1,128,128,128]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.8912, %copy.1644), kind=kLoop, calls=%fused_computation.129.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+%wide.region_1.8_spmd.sunk.clone.clone.clone.sunk (wide.param.5: (s32[], bf16[1,128,512], bf16[3,1,128,512], bf16[3,512], bf16[3,384], /*index=5*/bf16[3,512], bf16[3,128,1536], bf16[3,384,128,192], bf16[3,128], bf16[3,128,576], /*index=10*/bf16[3,128,128,256], f32[1,128,1,32], f32[1,128,1,32], bf16[3,128,128,128], bf16[3,128,18432], /*index=15*/bf16[3,128,18432], bf16[3,18432,128], f32[128,32], f32[128,32], s32[128], /*index=20*/s32[], s8[1,1,1], s8[1,1,1], bf16[])) -> (s32[], bf16[1,128,512], bf16[3,1,128,512], bf16[3,512], bf16[3,384], /*index=5*/bf16[3,512], bf16[3,128,1536], bf16[3,384,128,192], bf16[3,128], bf16[3,128,576], /*index=10*/bf16[3,128,128,256], f32[1,128,1,32], f32[1,128,1,32], bf16[3,128,128,128], bf16[3,128,18432], /*index=15*/bf16[3,128,18432], bf16[3,18432,128], f32[128,32], f32[128,32], s32[128], /*index=20*/s32[], s8[1,1,1], s8[1,1,1], bf16[]) {
+  %constant.1710.clone..sunk.7 = s32[]{:T(128)} constant(1)
+  %constant.4150..sunk.1 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %wide.param.5 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, /*index=10*/bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, f32[128,32]{1,0:T(8,128)S(1)}, f32[128,32]{1,0:T(8,128)S(1)}, s32[128]{0:T(128)}, /*index=20*/s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) parameter(0)
+  %get-tuple-element.6949 = s32[]{:T(128)} get-tuple-element(%wide.param.5), index=0
+  %copy.1626 = s32[]{:T(128)S(6)} copy(%get-tuple-element.6949), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add.3975 = s32[]{:T(128)} add(%copy.1626, %constant.1710.clone..sunk.7), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6951 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=2
+  %get-tuple-element.6950 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.5), index=1
+  %bitcast_dynamic-update-slice_fusion.17 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} fusion(%get-tuple-element.6951, %copy.1626, %get-tuple-element.6950), kind=kLoop, calls=%fused_computation.171.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
+  %get-tuple-element.6986 = bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=13
+  %dynamic-slice_convert_fusion.40 = bf16[1,128,128,128]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.6986, %copy.1626), kind=kLoop, calls=%fused_computation.129.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.340 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.40), channel_id=288, replica_groups=mesh['axis_0'=1,'axis_1'=1,'axis_2'=4] {'axis_2'}, dimensions={3}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8938 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.5), index=57, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
-  %get-tuple-element.8939 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.5), index=58, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
-  %get-tuple-element.8906 = bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=25
-  %dynamic-slice_convert_fusion.41 = bf16[1,384,128,192]{2,1,3,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.8906, %copy.1644), kind=kLoop, calls=%fused_computation.99.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6994 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.5), index=21, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
+  %get-tuple-element.6995 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.5), index=22, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
+  %get-tuple-element.6980 = bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=7
+  %dynamic-slice_convert_fusion.41 = bf16[1,384,128,192]{2,1,3,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.6980, %copy.1626), kind=kLoop, calls=%fused_computation.99.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.341 = bf16[1,1536,128,192]{2,1,3,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.41), channel_id=284, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %bitcast.2567 = bf16[1536,128,192]{1,0,2:T(8,128)(2,1)} bitcast(%all-gather.341), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
   %copy.1595 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} copy(%bitcast.2567), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8905 = bf16[3,128,1536]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=24
-  %dynamic-slice_convert_fusion.42 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.8905, %copy.1644), kind=kLoop, calls=%fused_computation.140.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6979 = bf16[3,128,1536]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=6
+  %dynamic-slice_convert_fusion.42 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.6979, %copy.1626), kind=kLoop, calls=%fused_computation.140.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.342 = bf16[1,512,1536]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.42), channel_id=283, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1127 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.8822), kind=kLoop, calls=%fused_computation.158.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1127 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.6950), kind=kLoop, calls=%fused_computation.158.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %add_rsqrt_fusion.11 = f32[128]{0:T(128)S(1)} fusion(%fusion.1127), kind=kLoop, calls=%fused_computation.205.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8902 = bf16[3,512]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.5), index=21
-  %get-tuple-element.8904 = bf16[3,512]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.5), index=23
-  %fusion.1128 = (bf16[512]{0:T(512)(128)(2,1)S(1)}, bf16[512]{0:T(512)(128)(2,1)S(1)}) fusion(%get-tuple-element.8902, %copy.1644, %get-tuple-element.8904), kind=kLoop, calls=%fused_computation.197.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8744 = bf16[512]{0:T(512)(128)(2,1)S(1)} get-tuple-element(%fusion.1128), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %multiply_reduce_fusion.96 = (f32[128]{0:T(128)S(1)}, f32[1,128,1536]{2,1,0:T(8,128)S(1)}) fusion(%all-gather.342, %get-tuple-element.8822, %add_rsqrt_fusion.11, %get-tuple-element.8744), kind=kOutput, calls=%fused_computation.139.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8745 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} get-tuple-element(%multiply_reduce_fusion.96), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %get-tuple-element.8746 = f32[128]{0:T(128)S(1)} get-tuple-element(%multiply_reduce_fusion.96), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %add_rsqrt_fusion.12 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.8746), kind=kLoop, calls=%fused_computation.204.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8903 = bf16[3,384]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.5), index=22
-  %fusion.1129 = bf16[1,384]{1,0:T(2,128)(2,1)S(1)} fusion(%get-tuple-element.8903, %copy.1644), kind=kLoop, calls=%fused_computation.200.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6976 = bf16[3,512]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.5), index=3
+  %get-tuple-element.6978 = bf16[3,512]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.5), index=5
+  %fusion.1128 = (bf16[512]{0:T(512)(128)(2,1)S(1)}, bf16[512]{0:T(512)(128)(2,1)S(1)}) fusion(%get-tuple-element.6976, %copy.1626, %get-tuple-element.6978), kind=kLoop, calls=%fused_computation.197.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6908 = bf16[512]{0:T(512)(128)(2,1)S(1)} get-tuple-element(%fusion.1128), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %multiply_reduce_fusion.96 = (f32[128]{0:T(128)S(1)}, f32[1,128,1536]{2,1,0:T(8,128)S(1)}) fusion(%all-gather.342, %get-tuple-element.6950, %add_rsqrt_fusion.11, %get-tuple-element.6908), kind=kOutput, calls=%fused_computation.139.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6909 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} get-tuple-element(%multiply_reduce_fusion.96), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %get-tuple-element.6910 = f32[128]{0:T(128)S(1)} get-tuple-element(%multiply_reduce_fusion.96), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %add_rsqrt_fusion.12 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.6910), kind=kLoop, calls=%fused_computation.204.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6977 = bf16[3,384]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.5), index=4
+  %fusion.1129 = bf16[1,384]{1,0:T(2,128)(2,1)S(1)} fusion(%get-tuple-element.6977, %copy.1626), kind=kLoop, calls=%fused_computation.200.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.343 = bf16[1,1536]{1,0:T(2,128)(2,1)S(1)} all-gather(%fusion.1129), channel_id=282, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %reduce.884 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} reduce(%all-gather.343, %constant.4192..sunk.1), dimensions={0}, to_apply=%all-gather.290.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %convolution_bitcast_fusion.10 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%copy.1595, %get-tuple-element.8745, %add_rsqrt_fusion.12, %reduce.884), kind=kOutput, calls=%fused_computation.131.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce.884 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} reduce(%all-gather.343, %constant.4150..sunk.1), dimensions={0}, to_apply=%all-gather.290.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %convolution_bitcast_fusion.10 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%copy.1595, %get-tuple-element.6909, %add_rsqrt_fusion.12, %reduce.884), kind=kOutput, calls=%fused_computation.131.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %slice.1444 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%convolution_bitcast_fusion.10), slice={[0:1], [0:128], [0:128], [128:192]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %copy.1596 = bf16[1,128,128,64]{2,1,3,0:T(8,128)(2,1)S(1)} copy(%slice.1444), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %bitcast.2611 = bf16[1,128,128,32,2]{2,1,4,3,0:T(8,128)(2,1)S(1)} bitcast(%copy.1596)
   %fusion.1130 = (bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}) fusion(%bitcast.2611), kind=kLoop, calls=%fused_computation.1415.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8747 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1130), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/slice" stack_frame_id=0}
-  %copy.1597 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} copy(%get-tuple-element.8747), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8748 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1130), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/slice" stack_frame_id=0}
-  %copy.1598 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} copy(%get-tuple-element.8748), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8935 = f32[128,32]{1,0:T(8,128)S(1)} get-tuple-element(%wide.param.5), index=54
-  %get-tuple-element.8934 = f32[128,32]{1,0:T(8,128)S(1)} get-tuple-element(%wide.param.5), index=53
-  %fusion.1131 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%copy.1597, %copy.1598, %get-tuple-element.8935, %get-tuple-element.8934), kind=kLoop, calls=%fused_computation.126.clone.1, metadata={op_name="convert.317"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8749 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1131), index=1, metadata={op_name="convert.317"}
-  %get-tuple-element.8750 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1131), index=0, metadata={op_name="convert.317"}
+  %get-tuple-element.6911 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1130), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/slice" stack_frame_id=0}
+  %copy.1597 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} copy(%get-tuple-element.6911), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6912 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1130), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/slice" stack_frame_id=0}
+  %copy.1598 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} copy(%get-tuple-element.6912), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6991 = f32[128,32]{1,0:T(8,128)S(1)} get-tuple-element(%wide.param.5), index=18
+  %get-tuple-element.6990 = f32[128,32]{1,0:T(8,128)S(1)} get-tuple-element(%wide.param.5), index=17
+  %fusion.1131 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%copy.1597, %copy.1598, %get-tuple-element.6991, %get-tuple-element.6990), kind=kLoop, calls=%fused_computation.126.clone.1, metadata={op_name="convert.317"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6913 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1131), index=1, metadata={op_name="convert.317"}
+  %get-tuple-element.6914 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1131), index=0, metadata={op_name="convert.317"}
   %slice.1445 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%convolution_bitcast_fusion.10), slice={[0:1], [0:128], [0:128], [0:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1132 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.8749, %get-tuple-element.8750, %slice.1445), kind=kLoop, calls=%fused_computation.119.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8908 = bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.5), index=27
-  %dynamic-slice_convert_fusion.43 = bf16[1,128,576]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.8908, %copy.1644), kind=kLoop, calls=%fused_computation.155.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1132 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.6913, %get-tuple-element.6914, %slice.1445), kind=kLoop, calls=%fused_computation.119.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6982 = bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.5), index=9
+  %dynamic-slice_convert_fusion.43 = bf16[1,128,576]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.6982, %copy.1626), kind=kLoop, calls=%fused_computation.155.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.344 = bf16[1,512,576]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.43), channel_id=286, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1133 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} fusion(%all-gather.344, %get-tuple-element.8822, %add_rsqrt_fusion.11, %get-tuple-element.8744), kind=kOutput, calls=%fused_computation.143.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1133 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} fusion(%all-gather.344, %get-tuple-element.6950, %add_rsqrt_fusion.11, %get-tuple-element.6908), kind=kOutput, calls=%fused_computation.143.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %slice.1446 = bf16[1,128,64]{1,2,0:T(8,128)(2,1)S(1)} slice(%fusion.1133), slice={[0:1], [0:128], [512:576]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %bitcast.2682 = bf16[1,128,1,32,2]{1,4,3,2,0:T(2,128)(2,1)S(1)} bitcast(%slice.1446)
   %fusion.1134 = (bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}, bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}) fusion(%bitcast.2682), kind=kLoop, calls=%fused_computation.1416.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8751 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} get-tuple-element(%fusion.1134), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/slice" stack_frame_id=0}
-  %copy.1599 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} copy(%get-tuple-element.8751), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8752 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} get-tuple-element(%fusion.1134), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/slice" stack_frame_id=0}
-  %copy.1600 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} copy(%get-tuple-element.8752), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.2669 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%get-tuple-element.8935)
-  %bitcast.2666 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%get-tuple-element.8934)
+  %get-tuple-element.6915 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} get-tuple-element(%fusion.1134), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/slice" stack_frame_id=0}
+  %copy.1599 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} copy(%get-tuple-element.6915), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6916 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} get-tuple-element(%fusion.1134), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/slice" stack_frame_id=0}
+  %copy.1600 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} copy(%get-tuple-element.6916), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.2669 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%get-tuple-element.6991)
+  %bitcast.2666 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%get-tuple-element.6990)
   %fusion.1135 = (bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%bitcast.2669, %bitcast.2666, %copy.1599, %copy.1600), kind=kLoop, calls=%fused_computation.179.clone.1, metadata={op_name="convert.315"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8753 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1135), index=1, metadata={op_name="convert.315"}
-  %get-tuple-element.8754 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1135), index=0, metadata={op_name="convert.315"}
-  %maximum_bitcast_fusion.27 = bf16[128,64]{1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.8753, %get-tuple-element.8754), kind=kLoop, calls=%fused_computation.191.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %broadcast_in_dim.1649 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} broadcast(%maximum_bitcast_fusion.27), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/broadcast_in_dim" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8","128"]},"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8909 = bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=28
-  %dynamic-slice_convert_fusion.44 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.8909, %copy.1644), kind=kLoop, calls=%fused_computation.110.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8907 = bf16[3,128]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.5), index=26
-  %copy-start.242 = (bf16[3,128]{1,0:T(4,128)(2,1)S(1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8907)
+  %get-tuple-element.6917 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1135), index=1, metadata={op_name="convert.315"}
+  %get-tuple-element.6918 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1135), index=0, metadata={op_name="convert.315"}
+  %maximum_bitcast_fusion.27 = bf16[128,64]{1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.6917, %get-tuple-element.6918), kind=kLoop, calls=%fused_computation.191.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %broadcast_in_dim.1577 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} broadcast(%maximum_bitcast_fusion.27), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/broadcast_in_dim" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8","128"]},"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6983 = bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=10
+  %dynamic-slice_convert_fusion.44 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.6983, %copy.1626), kind=kLoop, calls=%fused_computation.110.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6981 = bf16[3,128]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.5), index=8
+  %copy-start.242 = (bf16[3,128]{1,0:T(4,128)(2,1)S(1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, u32[]{:S(2)}) copy-start(%get-tuple-element.6981)
   %all-gather.345 = bf16[1,512,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.44), channel_id=287, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %fusion.1136 = f32[128]{0:T(128)S(1)} fusion(%fusion.1133), kind=kLoop, calls=%fused_computation.160.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %add_rsqrt_fusion.13 = f32[128]{0:T(128)S(1)} fusion(%fusion.1136), kind=kLoop, calls=%fused_computation.203.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %copy-done.242 = bf16[3,128]{1,0:T(4,128)(2,1)S(1)} copy-done(%copy-start.242)
-  %fusion.1137 = bf16[1,128]{1,0:T(2,128)(2,1)S(1)} fusion(%copy-done.242, %copy.1644), kind=kLoop, calls=%fused_computation.201.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1137 = bf16[1,128]{1,0:T(2,128)(2,1)S(1)} fusion(%copy-done.242, %copy.1626), kind=kLoop, calls=%fused_computation.201.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.346 = bf16[1,512]{1,0:T(2,128)(2,1)S(1)} all-gather(%fusion.1137), channel_id=285, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %reduce.885 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%all-gather.346, %constant.4192..sunk.1), dimensions={0}, to_apply=%all-gather.293.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce.885 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%all-gather.346, %constant.4150..sunk.1), dimensions={0}, to_apply=%all-gather.293.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %fusion.1138 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%all-gather.345, %add_rsqrt_fusion.13, %fusion.1133, %reduce.885), kind=kOutput, calls=%fused_computation.130.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8936 = s32[128]{0:T(128)} get-tuple-element(%wide.param.5), index=55
-  %copy-start.216 = (s32[128]{0:T(128)S(1)}, s32[128]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8936)
+  %get-tuple-element.6992 = s32[128]{0:T(128)} get-tuple-element(%wide.param.5), index=19
+  %copy-start.216 = (s32[128]{0:T(128)S(1)}, s32[128]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.6992)
   %slice_bitcast_fusion.11 = (bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.1138), kind=kLoop, calls=%fused_computation.132.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8755 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_bitcast_fusion.11), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %get-tuple-element.6919 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_bitcast_fusion.11), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
   %bitcast.2582 = s8[16777216]{0:T(1024)(128)(4,1)} bitcast(%all-gather.340)
   %slice-start.21 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2582), calls=%async_computation.48
   %slice-start.22 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2582), calls=%async_computation.49
-  %maximum_bitcast_fusion.28 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} fusion(%broadcast_in_dim.1649, %get-tuple-element.8755), kind=kLoop, calls=%fused_computation.120.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8756 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_bitcast_fusion.11), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %maximum_bitcast_fusion.28 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} fusion(%broadcast_in_dim.1577, %get-tuple-element.6919), kind=kLoop, calls=%fused_computation.120.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6920 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_bitcast_fusion.11), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
   %copy-done.216 = s32[128]{0:T(128)S(1)} copy-done(%copy-start.216)
-  %squeeze.946 = s32[128,128]{1,0:T(8,128)S(1)} broadcast(%copy-done.216), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8"]},"aliasing_operands":{"lists":[]}}
-  %squeeze.947 = s32[8,128]{1,0:T(8,128)S(1)} broadcast(%copy-done.216), dimensions={1}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["128"]},"aliasing_operands":{"lists":[]}}
+  %squeeze.874 = s32[128,128]{1,0:T(8,128)S(1)} broadcast(%copy-done.216), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8"]},"aliasing_operands":{"lists":[]}}
+  %squeeze.875 = s32[8,128]{1,0:T(8,128)S(1)} broadcast(%copy-done.216), dimensions={1}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["128"]},"aliasing_operands":{"lists":[]}}
   %iota.360 = s32[128,128]{1,0:T(8,128)S(1)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %slice-start.23 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2582), calls=%async_computation.50
   %slice-start.24 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2582), calls=%async_computation.51
-  %splash_mha_fwd_segmented_residuals.6 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[128,128,128]{2,1,0:T(8,128)}) custom-call(%get-tuple-element.8938, %get-tuple-element.8939, %fusion.1132, %maximum_bitcast_fusion.28, %get-tuple-element.8756, /*index=5*/%squeeze.946, %squeeze.947, %iota.360), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[128,128,192]{2,1,0}, bf16[128,128,192]{2,1,0}, bf16[128,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
+  %splash_mha_fwd_segmented_residuals.6 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[128,128,128]{2,1,0:T(8,128)}) custom-call(%get-tuple-element.6994, %get-tuple-element.6995, %fusion.1132, %maximum_bitcast_fusion.28, %get-tuple-element.6920, /*index=5*/%squeeze.874, %squeeze.875, %iota.360), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[128,128,192]{2,1,0}, bf16[128,128,192]{2,1,0}, bf16[128,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
 "xprof_metadata":"{\"block_q\": 128, \"block_kv\": 128, \"block_kv_compute\": 128, \"block_q_dkv\": 128, \"block_kv_dkv\": 128, \"block_kv_dkv_compute\": 128, \"block_q_dq\": 128, \"block_kv_dq\": 128, \"use_fused_bwd_kernel\": false, \"q_layout\": 1, \"k_layout\": 1, \"v_layout\": 1}"
-}}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"custom_call_config":{"body":"TUzvUgFNTElSMjMuMC4wZ2l0AAFTCwEDBQcJAQMLAz0NDxETFRcZGx0fISMlJykrLS8xMzU3OTs9P0FDRUcDugQGBDkB9QcXExcXEw8XFxsLCxcLCwsTJw8LFxMTUwsXG6UTFwsTExeFcwsTFxcTCxcPC3MLCwsLCwsLCwsLCwsTCwsnCwsLEwsXFwsLCwsXFwsLMxcXFxcTCw9LCxcLC3MLDwsLCws3GwsbCxsLGwsbC1MbCyMLIwsjCxsLGwsbBRFhgZGNYU0qAioCAfcbGxsbGxsbGxsbDw8TCwsrCwsTCxMLDxMLEwsTCwsTCw8TCxcfCxMLCxMLCxMLUxcLEwsLEwsPEwsPUwsTCxMTCwsfCxMLLxsLIxcLEwsXDxcLEwsXCxMLHxcLEwsTDxcLEwsXHwsTCx8LEwsLEwsLEwsXHwsTCx8vFw8HBVlZCQVdSQE5DwcfIwcPCwsfBycXKysnHyMfIysjIx8bG08vKwLSGh8DAx82Ah1xjgIdtgK6AgMDHzICHXE6AhUZGR1+AoICHU4CUgIDA6oC9gMFSQVLHUICRgIFTQVPBVEdU+4CAwd9JX/yAoGDEQ0ADTcd1gLaAh1T5gIdeQYDIwsFIYAAAAAAAAAAgAAAAAAAAAANNQMDH+ICAwMOA/oDYWZmaW5lX21hcDwoZDAsIGQxLCBkMikgLT4gKGQwLCBkMSwgZDIpPgAdc1oCAwM9YgIFUx1zZgIdd3YCHRYDGgNhZmZpbmVfbWFwPChkMCwgZDEpIC0+IChkMCwgZDEpPgAjCwcxAQAAAAAAAACAAAAAAAAAAIAAAAAAAAAABVUDAz1XAwM9igIdngKiAh15rgIFVwMDHwIDEQsBBVkjCwcxAQAAAAAAAACAAAAAAAAAAMAAAAAAAAAABVsFXQVfBWEFYwVlBWcFaQVrBW0FbwVxHXduAgVzBXUDB30lf8ICgYMFdwV5BXsjAQEBBX0d9gL6AgMDHxIDBX8FgQWDBYUDAx9qAx2eA6IDBYcFiSMLAxEBAAAAAAAAAB2uA7IDHboDvgMdxgPKAx3aA94DAwOnqQWLEQs9AxGtrxWxs7W3ubtXF72//8HDBY0BB/v5+Q0zBY8jCwcxgAAAAAAAAAABAAAAAAAAAAEAAAAAAAAABZERCwkFkwWVBZcFmQEXxcnN0dXb3+Pn6+8DBRvHHVsJWQMFG8sdWwldAwUbzx1HCV8DBRvTHS8JYQMFG9cd2QljIwsFIQgAAAAAAAAAgAAAAAAAAAADBRvdHS8JZQMHSfcb4R0vCWcDB0n3G+UdLwlpAwdJ9xvpHS8JawMFG+0dRwltAwUb8R1HCW8DBRUxF1kjdHB1Lm1lbW9yeV9zcGFjZTx2bWVtPgAjdHB1LnBpcGVsaW5lX21vZGU8c3luY2hyb25vdXM+ACN0cHUuZGltZW5zaW9uX3NlbWFudGljczxhcmJpdHJhcnk+ACN0cHUuZGltZW5zaW9uX3NlbWFudGljczxwYXJhbGxlbD4AI3RwdS5tZW1vcnlfc3BhY2U8c21lbT4AI3RwdS5jb3JlX3R5cGU8dGM+ACN0cHUuZG90X2RpbWVuc2lvbl9udW1iZXJzPFsxXSwgWzFdLCBbMF0sIFswXSwgWzAsIDAsIDEsIDBdLCBbXSwgW10+ACN0cHUuZG90X2RpbWVuc2lvbl9udW1iZXJzPFsxXSwgWzBdLCBbMF0sIFsxXSwgWzAsIDAsIDEsIDFdLCBbXSwgW10+AAMFFTEXXQMFFTEXXwMFFScXYQMFFScXYwMFFScXZQMFFScXZwMFFScXaQMFFScXawMFFTEXbQMFFTEXbxEBAREDAR0+AhkFmwWdLUoCCe4lEzImBwWfBaEdVgINBaMdXgIZBaURCxEdagINBacdcgIZBakdegINBasFrR2GAhkFrxELBR2SAg0FsQMDH5oCEwkQAADgDwWzHaYCGQW1BbcdsgINBbkFux2+Ag0FvSMBCSEBAAAAAQAAAAMAAAAAAAAAHcoCzgIFvx3SAg0FwQXDHd4CDQXFEwkBHeoCGQXHHYUNIwEJIQEAAAABAAAAAgAAAAAAAAAFyR3+AhkFyxEBAgQdCgMZBc0FzyUFCQAAAAAF0R0eAw0F0wMJiwICjSWPJZElAwMqAy4DBdUjAQMJAQAAAB02AzoDBdcdPgMNBdkDAz1GAxELFR1OA1IDBdsdVgMNBd0dXgNiAwXfHWYDDQXhEwmQzMzMPx1yA3YDBeMdegMZBeUdU4IDHYUZHYoDjgMF5x2SAwEF6QMDH5oDJRcJAACA/wXrHaYDDQXtAwWX/gOZmwXvHbYDDQXxBfMdwgMNBfUF9x3OAw0F+QMDH9YDJRcJAAAAAAX7HeIDDQX9AwWXAgSZmwMJiwYCjSWPJZElAwMf8gMRAQUjYXJpdGguZmFzdG1hdGg8bm9uZT4AI2FyaXRoLm92ZXJmbG93PG5vbmU+ACN2ZWN0b3Iua2luZDxtYXhpbXVtZj4AI3ZlY3Rvci5raW5kPGFkZD4AAQICAycFAgQCBAkX/QcFBQUPNwsBAgQBCQFBJwUCBAIEAQcX9QUCBAIECUUnAwIECRf1BwUCBAIGEzcX9QcFAgQCBBM3F/UFAgQCBAFFJwUCBAIEEycHBQIEAgQTJwUCBAIEDRf1BSECBAFFF/UHBQIEAgQJNycHBQIEAgQJJwcFAgQCBhMnBQIEAgYTJwUFAgQBJwUCBAUJBSEBAQEHBxkZGx0lHRUVFRsnAQULAQEBBwcHAQEBBQsBAQEHBwUBAQRuIgUBEQGlBwMBMQsRAasHA1N3IQEBAQEBAQcBBwEZARkBGwEdASUBHQEVARUBFQEbAScBAwN1CQMBEQdBSwMNBQUhGwYRAwEDIwMDDwkDAREHD00DDQUlJx0UDwMpCQMfTQMDKzMDCQ8GIQMFA1MDAwcDAwMDAwcDAwMFBgcDBQcbV1kTBQcjCVUbV1kDAyuTAwkPBiEDBQNdAwMHAwMDAwMHAwMDBQYHAwUHF2FjEwUHIwlfF2FjAwMrMwMJDwYhAwUDZwMDBwMDAwMDBwMDAwUGBwMFBxlrbRMFByMJaRlrbRkADwMBBRkADwMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JCSstLxcGEQMBAzEDAzkJAwERBz87Aw0FMzUDAwsDAwMHBgsDAwMDBwYLAwMDBRUGCwMPCQc5Oz0XBhEDAQM/GwYRAwEDNwMDDwkDAREHD00DDQVDRR0UDwNHCQOz6gIDA4cJAwEDAy1VAwEjBy01AwEFU1UDAwUDAwMDAwUDAwMFBgUDBQcXWVsJBgUDBQNdAwMFAwMDAwMFAwMDBQYFAwUHGWFjCQYFAwUDZQMDBQMDAwMDBQMDAwMDBQMDAwUGBQMrCQtpa20JBgUDLQNvAwMFAwMDBwYFAwMDVwMDBQMDAwUGBQMrCQ1zdXcJBgUDLQN5AwNDiQMFJQdDIgMDBQdxe30DAy1VAwEjBy01AwEFQYEDAy1VAwEjBy01AwEFU4UnByk1AwEFg4c1AzIDJgMDEQ8GKQMRA4knByk1AxEFjYsDAwUDAwMDAwUDAwMFBgUDEQcVkZMJBgUDEQOVEQdKA0IDAyMFl48DAwUDAwMHBgUDAwNXBQYFAy8HE5udCQYFAy8DnwMDBQMDAwMDBQMDAwUGBQMRBxGjpQkGBQMRA6cPBkEDEQOhEQdBSwMjBamrNwZaAwMjBZmtAwNuA5MDCQ8GfgMDBQOxOQaGAwMFB69/swMDlZYDAxcpB5WqAwMXBbW3CQYhAzEDuQ8GnQMFA7s7B50TAwUFX70rB58TAwUFtb8tB6ETAwUDwQMDo9IDAxcpB6PmAwMXBcPFCQYhAzEDxw8GIQMFA8krB58TAwUFX78tB6ETAwUDzR8HURMDBQXPZyEHKRMDBQXL0QMDBwMDAwMDBwMDAwUGBwMFBxfV1xMFByMJvxfV1wMDBwMDAwMDBwMDAwUGBwMFBxnb3RMFByMJ0xnb3QMDBQMDAwcGBQMDA1cDAwUDAwMFBgUDIQkP4ePlCQYFAx8D5z0GEQMFA+kDA0OJAwUlB0PqAwMFB8Pr7QMDBQMDAwMDBQMDAwUGBQMFBxvx8wkGBQMFA/UfB1ETAwUFz/chBykTAwUF+e8DAwcDAwMDAwcDAwMFBgcDBQcb/f8TBQcjCfsb/f8DA4fuAwMBGQAPAwEFGQAPAwN1CQMBEQdBSwMNBQVJGwYRAwEDSwMDDwkDAREHD00DDQVNTx0UDwNRCQNd0QMDBQMDAwMDBQMDAwUGBQMFBxlTVQkGBQMFA1cDA0+WAgMJDwZPAwUDWy8HTxMDBQVdWQMDBQMDAwMDBQMDAwUGBQMFBxthYwkGBQMFA2UfB1ETAwUFZ18xBhEDHwNpAwMHAwMDAwMHAwMDAwMHAwMDBQYHAyEJHW1vcQkGBwMfA3MJBgcDIQNrEwUHewt3HW1vcTMHxgITAwUDWQMDBQMDAwMDBQMDAwUGBQMFBxd7fQkGBQMFA38hBykTAwUFeYEDAwcDAwMDAwcDAwMDAwcDAwMFBgcDKQkfhYeJCQYHAwUDiwkGBwMpA4MTBQd7C48fhYeJAwMrMwMJDwYhAwUDkQMDBwMDAwMDBwMDAwUGBwMFBxeVlxMFByMJkxeVlwMDKzMDCQ8GIQMFA5sDAwcDAwMDAwcDAwMFBgcDBQcZn6ETBQcjCZ0Zn6EDAyszAwkPBiEDBQOlAwMHAwMDAwMHAwMDBQYHAwUHG6mrEwUHIwmnG6mrGQAPAwEFGQAPDQABCxEB8wcDDw8LAQEBAQEBBwEHAQMDAQkDAQMDAQkDAQ0EAQcBAwsLEQEKAgcDJz8LAQEBAQEBBwEHAQMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JCQsNDxcGEQMBAxEDAzkJAwERBz87Aw0FExUDAwsDAwMHBgsDAwMDBwYLAwMDBRUGCwMPCQcZGx0XBhEDAQMfAwMBCQMBAwMBCQMBDQQBBwEhIwsRAQ4CBwMnPwsBAQEBAQEHAQcBAwMLAwMDBwYLAwMDAwcGCwMDAwUVBgsDDwkJCw0PFwYRAwEDEQMDOQkDAREHPzsDDQUTFQMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JBxkbHRcGEQMBAx8DAwEJAwEDAwEJAwENBAEHASEjCxEBEgIHAw8PCwEBAQEBAQcBBwEDAwEJAwEDAwEJAwENBAEFAwsLEQEWAgcDJz8LAQEBAQEBBwEHAQMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JCQsNDxcGEQMBAxEDAzkJAwERBz87Aw0FExUDAwsDAwMHBgsDAwMDBwYLAwMDBRUGCwMPCQcZGx0XBhEDAQMfAwMBCQMBAwMBCQMBDQQBBSMhCxEBGgIHAw8PCwEBAQEBAQcBBwEDAwEJAwEDAwEJAwENBAEFAwsLEQEeAgcDERMLAQEBAQEBBwEHAQMDAQkDAQMDAQkDAQMDAQkDAQ0EAQULDQsRASICBwMREwsBAQEBAQEHAQcBAwMBCQMBAwMBCQMBAwMBCQMBDQQBBQsNCxEBJgIHAxETCwEBAQEBAQcBBwEDAwEJAwEDAwEJAwEDAwEJAwENBAEFCw0LEQEqAgcDDw8LAQEBAQEBBwEHAQMDAQkDAQMDAQkDAQ0EAQcBAwsLEQEuAgcDDw8LAQEBAQEBBwEHAQMDAQkDAQMDAQkDAQ0EAQcBAwsGAwEFAQCuGv8tGRELEQsRCy0ZJRUJCxELDQkVDRcxGx0JCw0jEQsRCxUNERMJCxELDQ0HDQdVLRICJQkdHUcjISMpLR8LHScdJUURKQkLCQkLGxkZGRkZGRkZGRklHRUNHSUTHRcfGxcTExsXExcvFxcXFxcPGRUZGSMXIxkVJSMZHw8PDQkdEWJ1aWx0aW4Ac3RhYmxlX21vc2FpYwB0cHUAYXJpdGgAdmVjdG9yAG1vZHVsZQBhcml0aC5jb25zdGFudAB2ZWN0b3IubG9hZABhcml0aC5pbmRleF9jYXN0AHZlY3Rvci5zaGFwZV9jYXN0AGZ1bmMuZnVuYwBmdW5jLnJldHVybgB2ZWN0b3IuYnJvYWRjYXN0AGFyaXRoLmNtcGkAdHB1LnZlY3Rvcl9zdG9yZQBtZW1yZWYubG9hZABhcml0aC5leHRzaQBzY2YueWllbGQAYXJpdGguZXh0dWkAc2NmLmlmAGFyaXRoLm11bGYAYXJpdGguYWRkZgBhcml0aC5tdWxpAHRwdS5tYXRtdWwAYXJpdGguYWRkaQB2ZWN0b3IubXVsdGlfcmVkdWN0aW9uAGFyaXRoLnN1YmYAbWF0aC5leHAAYXJpdGguZGl2ZgBhcml0aC50cnVuY2YAbWF0aC5sb2cAdHB1LmlvdGEAYXJpdGguYW5kaQBhcml0aC5zZWxlY3QAYXJpdGgubWF4aW11bWYAYXJpdGguZXh0ZgBmdW5jdGlvbl90eXBlAHN5bV9uYW1lAHRyYW5zZm9ybV9pbmRpY2VzAHdpbmRvd19ib3VuZHMAdmFsdWUAcHJlZGljYXRlAHBpcGVsaW5lX21vZGUAYnJvYWRjYXN0X2luX2RpbToAdHJhbnNmb3JtXzAAdHJhbnNmb3JtXzEAdHJhbnNmb3JtXzIAdHJhbnNmb3JtXzMAdHJhbnNmb3JtXzQAdHJhbnNmb3JtXzUAdHJhbnNmb3JtXzYAdHJhbnNmb3JtXzcAdHJhbnNmb3JtXzgAdHJhbnNmb3JtXzkAdHJhbnNmb3JtXzEwAGdldDoAZ3Q6AGVxOgBtdWw6AGFkZABvcGVyYW5kU2VnbWVudFNpemVzAHN0cmlkZXMAYnJvYWRjYXN0X2luX2RpbS9icm9hZGNhc3RfaW5fZGltAGRpbWVuc2lvbl9udW1iZXJzAHRyYW5zcG9zZV9saHMAdHJhbnNwb3NlX2xoc19oaW50AHRyYW5zcG9zZV9yaHMAa2luZAByZWR1Y3Rpb25fZGltcwBzdGFibGVfbW9zYWljLnZlcnNpb24AZGltZW5zaW9uX3NlbWFudGljcwBpdGVyYXRpb25fYm91bmRzAHNjYWxhcl9wcmVmZXRjaABzY3JhdGNoX29wZXJhbmRzAHNwbGFzaF9taGFfZndkX3NlZ21lbnRlZF9yZXNpZHVhbHMAdHB1LmNvcmVfdHlwZQB3aW5kb3dfcGFyYW1zAGdldABfc3BsYXNoX2F0dGVudGlvbgAvX193L21heHRleHQvbWF4dGV4dC8udmVudi9saWIvcHl0aG9uMy4xMi9zaXRlLXBhY2thZ2VzL2pheC9leHBlcmltZW50YWwvcGFsbGFzL29wcy90cHUvc3BsYXNoX2F0dGVudGlvbi9zcGxhc2hfYXR0ZW50aW9uX2tlcm5lbC5weQBjb252ZXJ0X2VsZW1lbnRfdHlwZToAY29udmVydF9lbGVtZW50X3R5cGUvY29udmVydF9lbGVtZW50X3R5cGUAZ3QAZ3QvZ3QAZXEAZXEvZXEAY29uZDoAY29uZABnZXQvZ2V0AGRpdjoAZGl2AGZhc3RtYXRoAG11bC9tdWwAc3dhcDoAc3dhcC9zd2FwAGxvZzoAbG9nL2xvZwBhZGQ6AGFkZC9hZGQAYnJvYWRjYXN0X2luX2RpbQBzY2FuOgBzY2FuAG11bABvdmVyZmxvd0ZsYWdzAGRvdF9nZW5lcmFsOgBkb3RfZ2VuZXJhbC9kb3RfZ2VuZXJhbABkaW1lbnNpb25zAGlvdGE6AGlvdGEvaW90YQBnZToAZ2UvZ2UAYW5kOgBhbmQvYW5kAGppdDoAaml0AHNlbGVjdF9uOgBzZWxlY3Rfbi9zZWxlY3RfbgByZWR1Y2VfbWF4OgByZWR1Y2VfbWF4L3JlZHVjZV9tYXgAbWF4OgBtYXgvbWF4AHN1YjoAc3ViL3N1YgBleHA6AGV4cC9leHAAcmVkdWNlX3N1bToAcmVkdWNlX3N1bS9yZWR1Y2Vfc3VtAA==","needs_layout_passes":true,"allow_input_fusion":[],"serialization_format":"1","output_memory_colors":[],"output_memory_space_colors":[],"input_memory_space_colors":[]},"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8757 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%splash_mha_fwd_segmented_residuals.6), index=3, frontend_attributes={kernel_metadata={
+}}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"custom_call_config":{"body":"<mosaic_body>","needs_layout_passes":true,"allow_input_fusion":[],"serialization_format":"1","output_memory_colors":[],"output_memory_space_colors":[],"input_memory_space_colors":[]},"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6921 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%splash_mha_fwd_segmented_residuals.6), index=3, frontend_attributes={kernel_metadata={
 "xprof_metadata":"{\"block_q\": 128, \"block_kv\": 128, \"block_kv_compute\": 128, \"block_q_dkv\": 128, \"block_kv_dkv\": 128, \"block_kv_dkv_compute\": 128, \"block_q_dq\": 128, \"block_kv_dq\": 128, \"use_fused_bwd_kernel\": false, \"q_layout\": 1, \"k_layout\": 1, \"v_layout\": 1}"
 }}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}
   %slice-done.21 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} async-done(%slice-start.21)
   %slice-done.22 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} async-done(%slice-start.22)
   %slice-done.23 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} async-done(%slice-start.23)
   %slice-done.24 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} async-done(%slice-start.24)
-  %custom-call.91 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} custom-call(%slice-done.21, %slice-done.22, %slice-done.23, %slice-done.24), custom_call_target="ConcatBitcast", backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.2583 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} bitcast(%custom-call.91)
-  %fusion.1139 = (f32[128]{0:T(128)S(1)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%get-tuple-element.8822, %bitcast.2583, %get-tuple-element.8757), kind=kOutput, calls=%fused_computation.162.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8758 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1139), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %get-tuple-element.8915 = bf16[3,18432,128]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=34
-  %dynamic-slice_convert_fusion.45 = bf16[1,18432,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.8915, %copy.1644), kind=kLoop, calls=%fused_computation.115.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %custom-call.73 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} custom-call(%slice-done.21, %slice-done.22, %slice-done.23, %slice-done.24), custom_call_target="ConcatBitcast", backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.2583 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} bitcast(%custom-call.73)
+  %fusion.1139 = (f32[128]{0:T(128)S(1)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%get-tuple-element.6950, %bitcast.2583, %get-tuple-element.6921), kind=kOutput, calls=%fused_computation.162.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6922 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.1139), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %get-tuple-element.6989 = bf16[3,18432,128]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=16
+  %dynamic-slice_convert_fusion.45 = bf16[1,18432,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.6989, %copy.1626), kind=kLoop, calls=%fused_computation.115.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.347 = bf16[1,18432,512]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.45), channel_id=291, replica_groups=mesh['axis_0'=1,'axis_1'=4] {'axis_1'}, dimensions={2}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8914 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=33
-  %dynamic-slice_convert_fusion.46 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.8914, %copy.1644), kind=kLoop, calls=%fused_computation.116.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6988 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=15
+  %dynamic-slice_convert_fusion.46 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.6988, %copy.1626), kind=kLoop, calls=%fused_computation.116.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.348 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.46), channel_id=290, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8913 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=32
-  %dynamic-slice_convert_fusion.47 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.8913, %copy.1644), kind=kLoop, calls=%fused_computation.117.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6987 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.5), index=14
+  %dynamic-slice_convert_fusion.47 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.6987, %copy.1626), kind=kLoop, calls=%fused_computation.117.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.349 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.47), channel_id=289, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8759 = f32[128]{0:T(128)S(1)} get-tuple-element(%fusion.1139), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %add_rsqrt_fusion.14 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.8759), kind=kLoop, calls=%fused_computation.202.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8760 = bf16[512]{0:T(512)(128)(2,1)S(1)} get-tuple-element(%fusion.1128), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %get-tuple-element.8916 = u32[3]{0:T(128)} get-tuple-element(%wide.param.5), index=35, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.304 = (u32[3]{0:T(128)S(1)}, u32[3]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8916)
-  %fusion.1140 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.349, %get-tuple-element.8758, %add_rsqrt_fusion.14, %get-tuple-element.8760), kind=kOutput, calls=%fused_computation.111.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8917 = u32[3,4]{1,0:T(4,128)} get-tuple-element(%wide.param.5), index=36, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.249 = (u32[3,4]{1,0:T(4,128)S(1)}, u32[3,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8917)
-  %get-tuple-element.8918 = u32[3]{0:T(128)} get-tuple-element(%wide.param.5), index=37, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.305 = (u32[3]{0:T(128)S(1)}, u32[3]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8918)
-  %get-tuple-element.8919 = u32[3,4]{1,0:T(4,128)} get-tuple-element(%wide.param.5), index=38, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.250 = (u32[3,4]{1,0:T(4,128)S(1)}, u32[3,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8919)
-  %get-tuple-element.8920 = u32[3]{0:T(128)} get-tuple-element(%wide.param.5), index=39, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.306 = (u32[3]{0:T(128)S(1)}, u32[3]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8920)
-  %get-tuple-element.8921 = u32[3,4]{1,0:T(4,128)} get-tuple-element(%wide.param.5), index=40, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.251 = (u32[3,4]{1,0:T(4,128)S(1)}, u32[3,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8921)
-  %get-tuple-element.8922 = u32[3]{0:T(128)} get-tuple-element(%wide.param.5), index=41, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.307 = (u32[3]{0:T(128)S(1)}, u32[3]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8922)
-  %get-tuple-element.8923 = u32[3,4]{1,0:T(4,128)} get-tuple-element(%wide.param.5), index=42, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.252 = (u32[3,4]{1,0:T(4,128)S(1)}, u32[3,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8923)
-  %get-tuple-element.8924 = u32[3]{0:T(128)} get-tuple-element(%wide.param.5), index=43, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.308 = (u32[3]{0:T(128)S(1)}, u32[3]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8924)
-  %get-tuple-element.8925 = u32[3,4]{1,0:T(4,128)} get-tuple-element(%wide.param.5), index=44, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.253 = (u32[3,4]{1,0:T(4,128)S(1)}, u32[3,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8925)
-  %get-tuple-element.8926 = u32[3]{0:T(128)} get-tuple-element(%wide.param.5), index=45, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.309 = (u32[3]{0:T(128)S(1)}, u32[3]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8926)
-  %get-tuple-element.8927 = u32[3,4]{1,0:T(4,128)} get-tuple-element(%wide.param.5), index=46, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.254 = (u32[3,4]{1,0:T(4,128)S(1)}, u32[3,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8927)
-  %get-tuple-element.8928 = u32[3]{0:T(128)} get-tuple-element(%wide.param.5), index=47, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.310 = (u32[3]{0:T(128)S(1)}, u32[3]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8928)
-  %get-tuple-element.8929 = u32[3,4]{1,0:T(4,128)} get-tuple-element(%wide.param.5), index=48, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.255 = (u32[3,4]{1,0:T(4,128)S(1)}, u32[3,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8929)
-  %get-tuple-element.8930 = u32[3]{0:T(128)} get-tuple-element(%wide.param.5), index=49, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.311 = (u32[3]{0:T(128)S(1)}, u32[3]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8930)
-  %get-tuple-element.8931 = u32[3,4]{1,0:T(4,128)} get-tuple-element(%wide.param.5), index=50, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.256 = (u32[3,4]{1,0:T(4,128)S(1)}, u32[3,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8931)
-  %get-tuple-element.8932 = u32[3]{0:T(128)} get-tuple-element(%wide.param.5), index=51, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.312 = (u32[3]{0:T(128)S(1)}, u32[3]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8932)
-  %get-tuple-element.8933 = u32[3,4]{1,0:T(4,128)} get-tuple-element(%wide.param.5), index=52, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.257 = (u32[3,4]{1,0:T(4,128)S(1)}, u32[3,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.8933)
-  %fusion.1141 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.8758, %all-gather.347, %all-gather.348, %fusion.1140, %add_rsqrt_fusion.14, /*index=5*/%get-tuple-element.8760), kind=kOutput, calls=%fused_computation.146.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.304 = u32[3]{0:T(128)S(1)} copy-done(%copy-start.304)
-  %copy.1667 = u32[3]{0:T(128)} copy(%copy-done.304), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.249 = u32[3,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.249)
-  %copy.1668 = u32[3,4]{1,0:T(4,128)} copy(%copy-done.249), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.305 = u32[3]{0:T(128)S(1)} copy-done(%copy-start.305)
-  %copy.1669 = u32[3]{0:T(128)} copy(%copy-done.305), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.250 = u32[3,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.250)
-  %copy.1670 = u32[3,4]{1,0:T(4,128)} copy(%copy-done.250), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.306 = u32[3]{0:T(128)S(1)} copy-done(%copy-start.306)
-  %copy.1671 = u32[3]{0:T(128)} copy(%copy-done.306), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.251 = u32[3,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.251)
-  %copy.1672 = u32[3,4]{1,0:T(4,128)} copy(%copy-done.251), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.307 = u32[3]{0:T(128)S(1)} copy-done(%copy-start.307)
-  %copy.1673 = u32[3]{0:T(128)} copy(%copy-done.307), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.252 = u32[3,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.252)
-  %copy.1674 = u32[3,4]{1,0:T(4,128)} copy(%copy-done.252), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.308 = u32[3]{0:T(128)S(1)} copy-done(%copy-start.308)
-  %copy.1675 = u32[3]{0:T(128)} copy(%copy-done.308), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.253 = u32[3,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.253)
-  %copy.1676 = u32[3,4]{1,0:T(4,128)} copy(%copy-done.253), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.309 = u32[3]{0:T(128)S(1)} copy-done(%copy-start.309)
-  %copy.1677 = u32[3]{0:T(128)} copy(%copy-done.309), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.254 = u32[3,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.254)
-  %copy.1678 = u32[3,4]{1,0:T(4,128)} copy(%copy-done.254), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.310 = u32[3]{0:T(128)S(1)} copy-done(%copy-start.310)
-  %copy.1679 = u32[3]{0:T(128)} copy(%copy-done.310), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.255 = u32[3,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.255)
-  %copy.1680 = u32[3,4]{1,0:T(4,128)} copy(%copy-done.255), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.311 = u32[3]{0:T(128)S(1)} copy-done(%copy-start.311)
-  %copy.1681 = u32[3]{0:T(128)} copy(%copy-done.311), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.256 = u32[3,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.256)
-  %copy.1682 = u32[3,4]{1,0:T(4,128)} copy(%copy-done.256), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.312 = u32[3]{0:T(128)S(1)} copy-done(%copy-start.312)
-  %copy.1683 = u32[3]{0:T(128)} copy(%copy-done.312), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.257 = u32[3,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.257)
-  %copy.1684 = u32[3,4]{1,0:T(4,128)} copy(%copy-done.257), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.8937 = s32[]{:T(128)} get-tuple-element(%wide.param.5), index=56
-  %get-tuple-element.8940 = bf16[]{:T(256)} get-tuple-element(%wide.param.5), index=59, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %bitcast.2667 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%get-tuple-element.8934)
-  %bitcast.2670 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%get-tuple-element.8935)
-  ROOT %tuple.873 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=5*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, /*index=10*/u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=15*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, /*index=20*/bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, /*index=25*/bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, /*index=30*/f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, /*index=35*/u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=40*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, /*index=45*/u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=50*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, f32[128,32]{1,0:T(8,128)S(1)}, f32[128,32]{1,0:T(8,128)S(1)}, /*index=55*/s32[128]{0:T(128)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) tuple(%add.3975, %fusion.1141, %copy.1667, %copy.1668, %copy.1669, /*index=5*/%copy.1670, %copy.1671, %copy.1672, %copy.1673, %copy.1674, /*index=10*/%copy.1675, %copy.1676, %copy.1677, %copy.1678, %copy.1679, /*index=15*/%copy.1680, %copy.1681, %copy.1682, %copy.1683, %copy.1684, /*index=20*/%bitcast_dynamic-update-slice_fusion.17, %get-tuple-element.8902, %get-tuple-element.8903, %get-tuple-element.8904, %get-tuple-element.8905, /*index=25*/%get-tuple-element.8906, %get-tuple-element.8907, %get-tuple-element.8908, %get-tuple-element.8909, %bitcast.2667, /*index=30*/%bitcast.2670, %get-tuple-element.8912, %get-tuple-element.8913, %get-tuple-element.8914, %get-tuple-element.8915, /*index=35*/%get-tuple-element.8916, %get-tuple-element.8917, %get-tuple-element.8918, %get-tuple-element.8919, %get-tuple-element.8920, /*index=40*/%get-tuple-element.8921, %get-tuple-element.8922, %get-tuple-element.8923, %get-tuple-element.8924, %get-tuple-element.8925, /*index=45*/%get-tuple-element.8926, %get-tuple-element.8927, %get-tuple-element.8928, %get-tuple-element.8929, %get-tuple-element.8930, /*index=50*/%get-tuple-element.8931, %get-tuple-element.8932, %get-tuple-element.8933, %get-tuple-element.8934, %get-tuple-element.8935, /*index=55*/%get-tuple-element.8936, %get-tuple-element.8937, %get-tuple-element.8938, %get-tuple-element.8939, %get-tuple-element.8940)
+  %get-tuple-element.6923 = f32[128]{0:T(128)S(1)} get-tuple-element(%fusion.1139), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %add_rsqrt_fusion.14 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.6923), kind=kLoop, calls=%fused_computation.202.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6924 = bf16[512]{0:T(512)(128)(2,1)S(1)} get-tuple-element(%fusion.1128), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %fusion.1140 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.349, %get-tuple-element.6922, %add_rsqrt_fusion.14, %get-tuple-element.6924), kind=kOutput, calls=%fused_computation.111.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1141 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.6922, %all-gather.347, %all-gather.348, %fusion.1140, %add_rsqrt_fusion.14, /*index=5*/%get-tuple-element.6924), kind=kOutput, calls=%fused_computation.146.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.6993 = s32[]{:T(128)} get-tuple-element(%wide.param.5), index=20
+  %get-tuple-element.6996 = bf16[]{:T(256)} get-tuple-element(%wide.param.5), index=23, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %bitcast.2667 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%get-tuple-element.6990)
+  %bitcast.2670 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%get-tuple-element.6991)
+  ROOT %tuple.873 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, /*index=10*/bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, f32[128,32]{1,0:T(8,128)S(1)}, f32[128,32]{1,0:T(8,128)S(1)}, s32[128]{0:T(128)}, /*index=20*/s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) tuple(%add.3975, %fusion.1141, %bitcast_dynamic-update-slice_fusion.17, %get-tuple-element.6976, %get-tuple-element.6977, /*index=5*/%get-tuple-element.6978, %get-tuple-element.6979, %get-tuple-element.6980, %get-tuple-element.6981, %get-tuple-element.6982, /*index=10*/%get-tuple-element.6983, %bitcast.2667, %bitcast.2670, %get-tuple-element.6986, %get-tuple-element.6987, /*index=15*/%get-tuple-element.6988, %get-tuple-element.6989, %get-tuple-element.6990, %get-tuple-element.6991, %get-tuple-element.6992, /*index=20*/%get-tuple-element.6993, %get-tuple-element.6994, %get-tuple-element.6995, %get-tuple-element.6996)
 }
 
-%wide.region_6.9_spmd.clone.clone.clone (wide.param.765: (s32[], bf16[1,128,512], u32[3], u32[3,4], u32[3], /*index=5*/u32[3,4], u32[3], u32[3,4], u32[3], u32[3,4], /*index=10*/u32[3], u32[3,4], u32[3], u32[3,4], u32[3], /*index=15*/u32[3,4], u32[3], u32[3,4], u32[3], u32[3,4], /*index=20*/bf16[3,1,128,512], bf16[3,512], bf16[3,384], bf16[3,512], bf16[3,128,1536], /*index=25*/bf16[3,384,128,192], bf16[3,128], bf16[3,128,576], bf16[3,128,128,256], f32[1,128,1,32], /*index=30*/f32[1,128,1,32], bf16[3,128,128,128], bf16[3,128,18432], bf16[3,128,18432], bf16[3,18432,128], /*index=35*/u32[3], u32[3,4], u32[3], u32[3,4], u32[3], /*index=40*/u32[3,4], u32[3], u32[3,4], u32[3], u32[3,4], /*index=45*/u32[3], u32[3,4], u32[3], u32[3,4], u32[3], /*index=50*/u32[3,4], u32[3], u32[3,4], f32[128,32], f32[128,32], /*index=55*/s32[128], s32[], s8[1,1,1], s8[1,1,1], bf16[])) -> pred[] {
-  %constant.1499.clone.4 = s32[]{:T(128)} constant(3)
-  %wide.param.765 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=5*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, /*index=10*/u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=15*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, /*index=20*/bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, /*index=25*/bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, /*index=30*/f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, /*index=35*/u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=40*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, /*index=45*/u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, /*index=50*/u32[3,4]{1,0:T(4,128)}, u32[3]{0:T(128)}, u32[3,4]{1,0:T(4,128)}, f32[128,32]{1,0:T(8,128)S(1)}, f32[128,32]{1,0:T(8,128)S(1)}, /*index=55*/s32[128]{0:T(128)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) parameter(0)
-  %get-tuple-element.8361 = s32[]{:T(128)} get-tuple-element(%wide.param.765), index=0
-  ROOT %lt.873 = pred[]{:T(512)} compare(%get-tuple-element.8361, %constant.1499.clone.4), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/cond/lt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+%wide.region_6.9_spmd.clone.clone.clone (wide.param.765: (s32[], bf16[1,128,512], bf16[3,1,128,512], bf16[3,512], bf16[3,384], /*index=5*/bf16[3,512], bf16[3,128,1536], bf16[3,384,128,192], bf16[3,128], bf16[3,128,576], /*index=10*/bf16[3,128,128,256], f32[1,128,1,32], f32[1,128,1,32], bf16[3,128,128,128], bf16[3,128,18432], /*index=15*/bf16[3,128,18432], bf16[3,18432,128], f32[128,32], f32[128,32], s32[128], /*index=20*/s32[], s8[1,1,1], s8[1,1,1], bf16[])) -> pred[] {
+  %constant.1459.clone.4 = s32[]{:T(128)} constant(3)
+  %wide.param.765 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, /*index=10*/bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, f32[128,32]{1,0:T(8,128)S(1)}, f32[128,32]{1,0:T(8,128)S(1)}, s32[128]{0:T(128)}, /*index=20*/s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) parameter(0)
+  %get-tuple-element.6669 = s32[]{:T(128)} get-tuple-element(%wide.param.765), index=0
+  ROOT %lt.873 = pred[]{:T(512)} compare(%get-tuple-element.6669, %constant.1459.clone.4), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/cond/lt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
 %fused_computation.677 (param_0.1957: f32[128,1,128,128]) -> bf16[128,1,128,128] {
@@ -1049,18 +977,18 @@ StackFrames
   %param_0.4494 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.2707 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4494), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.628 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2707, %convert_element_type.2707), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.1730.clone.94 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.765 = f32[128]{0:T(128)S(1)} reduce(%square.628, %constant.1730.clone.94), dimensions={0,2}, to_apply=%region_8.13, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.1690.clone.94 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.765 = f32[128]{0:T(128)S(1)} reduce(%square.628, %constant.1690.clone.94), dimensions={0,2}, to_apply=%region_8.13, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.1398 (param_0.4048: f32[128]) -> f32[128] {
   %param_0.4048 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1744.clone.11 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4436 = f32[128]{0:T(128)} broadcast(%constant.1744.clone.11), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.2476 = f32[128]{0:T(128)} multiply(%param_0.4048, %broadcast.4436), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.1745.clone.14 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4435 = f32[128]{0:T(128)} broadcast(%constant.1745.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3659 = f32[128]{0:T(128)} add(%div.2476, %broadcast.4435), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.1702.clone.11 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4427 = f32[128]{0:T(128)} broadcast(%constant.1702.clone.11), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.2476 = f32[128]{0:T(128)} multiply(%param_0.4048, %broadcast.4427), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.1703.clone.14 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4426 = f32[128]{0:T(128)} broadcast(%constant.1703.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3659 = f32[128]{0:T(128)} add(%div.2476, %broadcast.4426), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.345 = f32[128]{0:T(128)S(1)} rsqrt(%add.3659), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
@@ -1073,8 +1001,8 @@ StackFrames
 %fused_computation.1186 (param_0.4034: f32[512,1]) -> bf16[512] {
   %param_0.4034 = f32[512,1]{0,1:T(1,128)} parameter(0)
   %convert_element_type.2835 = bf16[512,1]{0,1:T(2,128)(2,1)} convert(%param_0.4034), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %constant.4132 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.803 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2835, %constant.4132), dimensions={1}, to_apply=%convert_element_type.2152.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.4090 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.803 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2835, %constant.4090), dimensions={1}, to_apply=%convert_element_type.2152.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
 }
 
 %fused_computation.949.clone.1.clone.clone (param_0.4341: bf16[1,128,512], param_1.5117: f32[128], param_2.4113: bf16[512]) -> bf16[128,512] {
@@ -1115,19 +1043,19 @@ StackFrames
   %convert_element_type.2617.clone.1 = f32[128,1536]{1,0:T(8,128)} convert(%convolution.191.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %bitcast.1485.clone.1 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} bitcast(%convert_element_type.2617.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.609 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%bitcast.1485.clone.1, %bitcast.1485.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.1730.clone.93 = f32[]{:T(128)} constant(0)
-  %reduce.749 = f32[128]{0:T(128)S(1)} reduce(%square.609, %constant.1730.clone.93), dimensions={0,2}, to_apply=%region_9.14, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.1690.clone.93 = f32[]{:T(128)} constant(0)
+  %reduce.749 = f32[128]{0:T(128)S(1)} reduce(%square.609, %constant.1690.clone.93), dimensions={0,2}, to_apply=%region_9.14, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
   ROOT %tuple.725 = (f32[128]{0:T(128)S(1)}, f32[1,128,1536]{2,1,0:T(8,128)S(1)}) tuple(%reduce.749, %bitcast.1485.clone.1)
 }
 
 %fused_computation.1373 (param_0.3997: f32[128]) -> f32[128] {
   %param_0.3997 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1674.clone.4 = f32[]{:T(128)} constant(0.000651041686), metadata={stack_frame_id=0}
-  %broadcast.4382 = f32[128]{0:T(128)} broadcast(%constant.1674.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %div.2431 = f32[128]{0:T(128)} multiply(%param_0.3997, %broadcast.4382), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.1745.clone.3 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4393 = f32[128]{0:T(128)} broadcast(%constant.1745.clone.3), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3619 = f32[128]{0:T(128)} add(%div.2431, %broadcast.4393), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.1634.clone.4 = f32[]{:T(128)} constant(0.000651041686), metadata={stack_frame_id=0}
+  %broadcast.4373 = f32[128]{0:T(128)} broadcast(%constant.1634.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %div.2431 = f32[128]{0:T(128)} multiply(%param_0.3997, %broadcast.4373), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.1703.clone.3 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4384 = f32[128]{0:T(128)} broadcast(%constant.1703.clone.3), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3619 = f32[128]{0:T(128)} add(%div.2431, %broadcast.4384), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.334 = f32[128]{0:T(128)S(1)} rsqrt(%add.3619), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
@@ -1140,8 +1068,8 @@ StackFrames
 %fused_computation.1106 (param_0.4035: f32[1536,1]) -> bf16[1536] {
   %param_0.4035 = f32[1536,1]{0,1:T(1,128)S(1)} parameter(0)
   %convert_element_type.2829 = bf16[1536,1]{0,1:T(2,128)(2,1)} convert(%param_0.4035), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %constant.4133 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.794 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} reduce(%convert_element_type.2829, %constant.4133), dimensions={1}, to_apply=%convert_element_type.2151.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.4091 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.794 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} reduce(%convert_element_type.2829, %constant.4091), dimensions={1}, to_apply=%convert_element_type.2151.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
 }
 
 %fused_computation.845.clone (param_0.2713: f32[1,128,1536], param_1.2956: f32[128], param_2.2081: bf16[1536]) -> bf16[128,1536,1] {
@@ -1189,20 +1117,20 @@ StackFrames
   %param_0.2073 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.2590 = f32[1,128,128,32,1]{3,1,2,4,0:T(8,128)} convert(%param_0.2073), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %bitcast.1410 = f32[1,128,128,32]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.2590), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %constant.1730.clone.92 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2612 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1730.clone.92), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.1690.clone.92 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2612 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1690.clone.92), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %mul.3893 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.1410, %convert_element_type.2612), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %add.3320 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%bitcast.1411, %mul.3893), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   %param_3.2840 = f32[128,32]{1,0:T(8,128)S(1)} parameter(3)
-  %broadcast_in_dim.1473 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.2840), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %mul.3889 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3320, %broadcast_in_dim.1473), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %broadcast_in_dim.1401 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.2840), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %mul.3889 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3320, %broadcast_in_dim.1401), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %param_2.4189 = f32[128,32]{1,0:T(8,128)S(1)} parameter(2)
-  %broadcast_in_dim.1471 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.4189), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %mul.3880 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.1410, %broadcast_in_dim.1471), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %broadcast_in_dim.1399 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.4189), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %mul.3880 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.1410, %broadcast_in_dim.1399), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %mul.3879 = f32[1,128,128,32]{3,1,2,0:T(8,128)} subtract(%mul.3889, %mul.3880), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %convert.529 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.3879), metadata={op_name="convert.350" stack_frame_id=0}
-  %mul.3888.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3320, %broadcast_in_dim.1471), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %mul.3887.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.1410, %broadcast_in_dim.1473), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %mul.3888.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3320, %broadcast_in_dim.1399), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %mul.3887.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.1410, %broadcast_in_dim.1401), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %mul.3886.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%mul.3888.clone.1, %mul.3887.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %convert.530.clone.1 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.3886.clone.1), metadata={op_name="convert.351" stack_frame_id=0}
   ROOT %tuple.668 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.529, %convert.530.clone.1)
@@ -1210,19 +1138,19 @@ StackFrames
 
 %fused_computation.654 (param_0.2068: bf16[1,128,128,32], param_1.4738: bf16[1,128,128,32], param_2.3577: bf16[1,128,128,128]) -> bf16[128,128,192] {
   %param_2.3577 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(2)
-  %constant.1746.clone.13 = bf16[]{:T(256)} constant(-inf)
-  %pad.283 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.3577, %constant.1746.clone.13), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %constant.1704.clone.13 = bf16[]{:T(256)} constant(-inf)
+  %pad.283 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.3577, %constant.1704.clone.13), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.676 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.283)
   %param_1.4738 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %pad.282 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4738, %constant.1746.clone.13), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.282 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4738, %constant.1704.clone.13), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.677 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.282)
   %maximum.48 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.676, %convert.677), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_0.2068 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.281 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.2068, %constant.1746.clone.13), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.281 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.2068, %constant.1704.clone.13), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.678 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.281)
   %maximum.47 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%maximum.48, %convert.678), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %constant.1684.clone.4 = bf16[]{:T(256)} constant(0.1348), metadata={stack_frame_id=0}
-  %mul.3950 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1684.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %constant.1644.clone.4 = bf16[]{:T(256)} constant(0.1348), metadata={stack_frame_id=0}
+  %mul.3950 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1644.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %convert.679 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%mul.3950)
   %mul.3830 = f32[1,128,128,192]{3,1,2,0:T(8,128)} multiply(%maximum.47, %convert.679), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.680 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3830)
@@ -1275,8 +1203,8 @@ StackFrames
   %param_2.2329 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} parameter(2)
   %convert_element_type.2810 = f32[1,128,1,32,1]{3,1,4,2,0:T(8,128)} convert(%param_2.2329), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %bitcast.1827 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%convert_element_type.2810), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %constant.1730.clone.91 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2820 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1730.clone.91), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.1690.clone.91 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2820 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1690.clone.91), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %mul.4349 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%bitcast.1827, %convert_element_type.2820), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %add.3432 = f32[1,128,32]{2,1,0:T(8,128)} add(%bitcast.1829, %mul.4349), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   %param_1.3320 = f32[128,32]{1,0:T(8,128)S(1)} parameter(1)
@@ -1296,11 +1224,11 @@ StackFrames
 
 %fused_computation.1064 (param_0.3059: bf16[1,128,32], param_1.4734: bf16[1,128,32]) -> bf16[128,64] {
   %param_1.4734 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1746.clone.6 = bf16[]{:T(256)} constant(-inf)
-  %pad.314 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.4734, %constant.1746.clone.6), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %constant.1704.clone.6 = bf16[]{:T(256)} constant(-inf)
+  %pad.314 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.4734, %constant.1704.clone.6), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.795 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.314)
   %param_0.3059 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.313 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.3059, %constant.1746.clone.6), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.313 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.3059, %constant.1704.clone.6), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.796 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.313)
   %maximum.64 = f32[1,128,64]{2,1,0:T(8,128)} maximum(%convert.795, %convert.796), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","64"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.797 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} convert(%maximum.64)
@@ -1318,18 +1246,18 @@ StackFrames
   %slice.1213 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_0.4492), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/split" stack_frame_id=0}
   %convert_element_type.2686 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1213), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.622 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2686, %convert_element_type.2686), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.1730.clone.90 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.761 = f32[128]{0:T(128)S(1)} reduce(%square.622, %constant.1730.clone.90), dimensions={0,2}, to_apply=%region_10.15, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.1690.clone.90 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.761 = f32[128]{0:T(128)S(1)} reduce(%square.622, %constant.1690.clone.90), dimensions={0,2}, to_apply=%region_10.15, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.1372 (param_0.3996: f32[128]) -> f32[128] {
   %param_0.3996 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1744.clone.3 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4402 = f32[128]{0:T(128)} broadcast(%constant.1744.clone.3), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.2430 = f32[128]{0:T(128)} multiply(%param_0.3996, %broadcast.4402), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.1745.clone.4 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4392 = f32[128]{0:T(128)} broadcast(%constant.1745.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3618 = f32[128]{0:T(128)} add(%div.2430, %broadcast.4392), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.1702.clone.3 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4393 = f32[128]{0:T(128)} broadcast(%constant.1702.clone.3), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.2430 = f32[128]{0:T(128)} multiply(%param_0.3996, %broadcast.4393), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.1703.clone.4 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4383 = f32[128]{0:T(128)} broadcast(%constant.1703.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3618 = f32[128]{0:T(128)} add(%div.2430, %broadcast.4383), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.333 = f32[128]{0:T(128)S(1)} rsqrt(%add.3618), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
@@ -1342,8 +1270,8 @@ StackFrames
 %fused_computation.1185 (param_0.4033: f32[512,1]) -> bf16[512] {
   %param_0.4033 = f32[512,1]{0,1:T(1,128)} parameter(0)
   %convert_element_type.2834 = bf16[512,1]{0,1:T(2,128)(2,1)} convert(%param_0.4033), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %constant.4131 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.802 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2834, %constant.4131), dimensions={1}, to_apply=%convert_element_type.2155.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.4089 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.802 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2834, %constant.4089), dimensions={1}, to_apply=%convert_element_type.2155.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
 }
 
 %fused_computation.953.clone (param_0.3004: f32[128], param_1.3338: bf16[1,128,576], param_2.2343: bf16[512]) -> bf16[128,512,1] {
@@ -1389,11 +1317,11 @@ StackFrames
 
 %fused_computation.655 (param_0.1904: bf16[1,128,128,64], param_1.4736: bf16[1,128,128,128]) -> bf16[128,128,192] {
   %param_1.4736 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1746.clone.8 = bf16[]{:T(256)} constant(-inf)
-  %pad.285 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4736, %constant.1746.clone.8), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %constant.1704.clone.8 = bf16[]{:T(256)} constant(-inf)
+  %pad.285 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4736, %constant.1704.clone.8), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.681 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.285)
   %param_0.1904 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.284 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1904, %constant.1746.clone.8), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.284 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1904, %constant.1704.clone.8), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.682 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.284)
   %maximum.49 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.681, %convert.682), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.683 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.49)
@@ -1429,8 +1357,8 @@ StackFrames
   %add.3371.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} add(%convert.724, %convert.725), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.2691 = f32[1,128,512]{2,1,0:T(8,128)} convert(%add.3371.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.624 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2691, %convert_element_type.2691), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.1730.clone.89 = f32[]{:T(128)} constant(0)
-  %reduce.762 = f32[128]{0:T(128)S(1)} reduce(%square.624, %constant.1730.clone.89), dimensions={0,2}, to_apply=%region_11.17, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.1690.clone.89 = f32[]{:T(128)} constant(0)
+  %reduce.762 = f32[128]{0:T(128)S(1)} reduce(%square.624, %constant.1690.clone.89), dimensions={0,2}, to_apply=%region_11.17, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
   %convert.726 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.3371.clone.1)
   ROOT %tuple.726 = (f32[128]{0:T(128)S(1)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.762, %convert.726)
 }
@@ -1444,18 +1372,18 @@ StackFrames
 %fused_computation.1302 (param_0.4032: f32[256,1]) -> bf16[256] {
   %param_0.4032 = f32[256,1]{0,1:T(1,128)} parameter(0)
   %convert_element_type.2848 = bf16[256,1]{0,1:T(2,128)(2,1)} convert(%param_0.4032), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %constant.4130 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.825 = bf16[256]{0:T(256)(128)(2,1)S(1)} reduce(%convert_element_type.2848, %constant.4130), dimensions={1}, to_apply=%convert_element_type.2160.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.4088 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.825 = bf16[256]{0:T(256)(128)(2,1)S(1)} reduce(%convert_element_type.2848, %constant.4088), dimensions={1}, to_apply=%convert_element_type.2160.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
 }
 
 %fused_computation.1371 (param_0.3995: f32[128]) -> f32[128] {
   %param_0.3995 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1744.clone.4 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4401 = f32[128]{0:T(128)} broadcast(%constant.1744.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.2429 = f32[128]{0:T(128)} multiply(%param_0.3995, %broadcast.4401), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.1745.clone.5 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4391 = f32[128]{0:T(128)} broadcast(%constant.1745.clone.5), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3617 = f32[128]{0:T(128)} add(%div.2429, %broadcast.4391), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.1702.clone.4 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4392 = f32[128]{0:T(128)} broadcast(%constant.1702.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.2429 = f32[128]{0:T(128)} multiply(%param_0.3995, %broadcast.4392), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.1703.clone.5 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4382 = f32[128]{0:T(128)} broadcast(%constant.1703.clone.5), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3617 = f32[128]{0:T(128)} add(%div.2429, %broadcast.4382), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.332 = f32[128]{0:T(128)S(1)} rsqrt(%add.3617), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
@@ -1468,8 +1396,8 @@ StackFrames
 %fused_computation.1187 (param_0.4036: f32[512,1]) -> bf16[512] {
   %param_0.4036 = f32[512,1]{0,1:T(1,128)S(1)} parameter(0)
   %convert_element_type.2836 = bf16[512,1]{0,1:T(2,128)(2,1)} convert(%param_0.4036), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %constant.4134 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.804 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2836, %constant.4134), dimensions={1}, to_apply=%convert_element_type.2150.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.4092 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.804 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2836, %constant.4092), dimensions={1}, to_apply=%convert_element_type.2150.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
 }
 
 %fused_computation.951.clone.2 (param_0.4114: bf16[1,128,512], param_1.4846: f32[128], param_2.3699: bf16[512]) -> bf16[128,512] {
@@ -1494,9 +1422,9 @@ StackFrames
 }
 
 %fused_computation.838 (param_0.4115: bf16[512,1,256], param_1.4847: bf16[1,128,512], param_2.3700: f32[128], param_3.2295: bf16[512]) -> bf16[128,256] {
-  %constant.1687.clone.15 = bf16[]{:T(256)} constant(1), metadata={stack_frame_id=0}
-  %broadcast.4228 = bf16[128,256]{1,0:T(8,128)(2,1)} broadcast(%constant.1687.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %convert.709 = f32[128,256]{1,0:T(8,128)} convert(%broadcast.4228)
+  %constant.1647.clone.15 = bf16[]{:T(256)} constant(1), metadata={stack_frame_id=0}
+  %broadcast.4219 = bf16[128,256]{1,0:T(8,128)(2,1)} broadcast(%constant.1647.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %convert.709 = f32[128,256]{1,0:T(8,128)} convert(%broadcast.4219)
   %param_1.4847 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %param_2.3700 = f32[128]{0:T(128)S(1)} parameter(2)
   %param_3.2295 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
@@ -1514,12 +1442,12 @@ StackFrames
 
 %fused_computation.1334 (param_0.4047: f32[128]) -> f32[128] {
   %param_0.4047 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1744.clone.1 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4432 = f32[128]{0:T(128)} broadcast(%constant.1744.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.2474 = f32[128]{0:T(128)} multiply(%param_0.4047, %broadcast.4432), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.1745.clone.1 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4431 = f32[128]{0:T(128)} broadcast(%constant.1745.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3657 = f32[128]{0:T(128)} add(%div.2474, %broadcast.4431), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.1702.clone.1 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4423 = f32[128]{0:T(128)} broadcast(%constant.1702.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.2474 = f32[128]{0:T(128)} multiply(%param_0.4047, %broadcast.4423), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.1703.clone.1 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4422 = f32[128]{0:T(128)} broadcast(%constant.1703.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3657 = f32[128]{0:T(128)} add(%div.2474, %broadcast.4422), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   %bitcast.1956 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3657), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %rsqrt.309 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1956), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
   ROOT %bitcast.1925 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.309), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
@@ -1565,19 +1493,19 @@ StackFrames
   %convert_element_type.2620.clone.1 = f32[128,1536]{1,0:T(8,128)} convert(%convolution.195.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %bitcast.1490.clone.1 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} bitcast(%convert_element_type.2620.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %square.610 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%bitcast.1490.clone.1, %bitcast.1490.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.1730.clone.88 = f32[]{:T(128)} constant(0)
-  %reduce.751 = f32[128]{0:T(128)S(1)} reduce(%square.610, %constant.1730.clone.88), dimensions={0,2}, to_apply=%region_43.52, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  %constant.1690.clone.88 = f32[]{:T(128)} constant(0)
+  %reduce.751 = f32[128]{0:T(128)S(1)} reduce(%square.610, %constant.1690.clone.88), dimensions={0,2}, to_apply=%region_43.52, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
   ROOT %tuple.723 = (f32[128]{0:T(128)S(1)}, f32[1,128,1536]{2,1,0:T(8,128)S(1)}) tuple(%reduce.751, %bitcast.1490.clone.1)
 }
 
 %fused_computation.1332 (param_0.3992: f32[128]) -> f32[128] {
   %param_0.3992 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1674.clone.2 = f32[]{:T(128)} constant(0.000651041686), metadata={stack_frame_id=0}
-  %broadcast.4381 = f32[128]{0:T(128)} broadcast(%constant.1674.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %div.2461 = f32[128]{0:T(128)} multiply(%param_0.3992, %broadcast.4381), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.1745.clone.8 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4388 = f32[128]{0:T(128)} broadcast(%constant.1745.clone.8), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3640 = f32[128]{0:T(128)} add(%div.2461, %broadcast.4388), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %constant.1634.clone.2 = f32[]{:T(128)} constant(0.000651041686), metadata={stack_frame_id=0}
+  %broadcast.4372 = f32[128]{0:T(128)} broadcast(%constant.1634.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %div.2461 = f32[128]{0:T(128)} multiply(%param_0.3992, %broadcast.4372), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.1703.clone.8 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4379 = f32[128]{0:T(128)} broadcast(%constant.1703.clone.8), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3640 = f32[128]{0:T(128)} add(%div.2461, %broadcast.4379), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %bitcast.1954 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3640), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %rsqrt.307 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1954), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
   ROOT %bitcast.1924 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.307), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
@@ -1626,26 +1554,26 @@ StackFrames
 
 %fused_computation.1357 (param_0.4009: s32[1,128]) -> s32[128] {
   %param_0.4009 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %bitcast.1952 = s32[1,128,1]{1,2,0:T(1,128)} bitcast(%param_0.4009), metadata={op_name="reshape.2486" stack_frame_id=0}
-  %constant.1719.clone.141 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %closed_call.244 = s32[1,128,1]{1,2,0:T(1,128)} broadcast(%constant.1719.clone.141), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %lt.836 = pred[1,128,1]{1,2,0:T(4,128)(4,1)} compare(%bitcast.1952, %closed_call.244), direction=LT, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/lt" stack_frame_id=0}
-  %constant.1742.clone.1 = s32[]{:T(128)} constant(163840)
-  %closed_call.243 = s32[1,128,1]{1,2,0:T(1,128)} broadcast(%constant.1742.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %add.3593 = s32[1,128,1]{1,2,0:T(1,128)} add(%bitcast.1952, %closed_call.243), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.1952 = s32[1,128,1]{1,2,0:T(1,128)} bitcast(%param_0.4009), metadata={op_name="reshape.2450" stack_frame_id=0}
+  %constant.1679.clone.141 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %closed_call.208 = s32[1,128,1]{1,2,0:T(1,128)} broadcast(%constant.1679.clone.141), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %lt.836 = pred[1,128,1]{1,2,0:T(4,128)(4,1)} compare(%bitcast.1952, %closed_call.208), direction=LT, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/lt" stack_frame_id=0}
+  %constant.1701.clone.1 = s32[]{:T(128)} constant(163840)
+  %closed_call.207 = s32[1,128,1]{1,2,0:T(1,128)} broadcast(%constant.1701.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %add.3593 = s32[1,128,1]{1,2,0:T(1,128)} add(%bitcast.1952, %closed_call.207), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %select_n.2276 = s32[1,128,1]{1,2,0:T(1,128)} select(%lt.836, %add.3593, %bitcast.1952), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/select_n" stack_frame_id=0}
   ROOT %bitcast.1930 = s32[128]{0:T(128)S(1)} bitcast(%select_n.2276), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/select_n" stack_frame_id=0}
 }
 
 %fused_computation.1130 (param_0.3318: s32[128]) -> s32[1024] {
-  %constant.4116 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.4264 = s32[1024]{0:T(1024)} broadcast(%constant.4116), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.4074 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.4255 = s32[1024]{0:T(1024)} broadcast(%constant.4074), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %param_0.3318 = s32[128]{0:T(128)S(1)} parameter(0)
-  %constant.4124 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %pad.329 = s32[1024]{0:T(1024)} pad(%param_0.3318, %constant.4124), padding=0_896, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %constant.4109 = s32[] constant(163839), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %broadcast.4256 = s32[1024]{0:T(1024)} broadcast(%constant.4109), dimensions={}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  ROOT %clamp.57 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4264, %pad.329, %broadcast.4256), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  %constant.4082 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %pad.329 = s32[1024]{0:T(1024)} pad(%param_0.3318, %constant.4082), padding=0_896, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  %constant.4067 = s32[] constant(163839), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %broadcast.4247 = s32[1024]{0:T(1024)} broadcast(%constant.4067), dimensions={}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  ROOT %clamp.57 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4255, %pad.329, %broadcast.4247), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
 }
 
 %fused_computation.10 (param_0.32: f32[163840,32], param_1.135: s32[1024]) -> f32[128,32] {
@@ -1653,11 +1581,11 @@ StackFrames
   %param_1.135 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.32 = s32[1024]{0:T(1024)} custom-call(%param_1.135), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
   %slice.1071 = s32[128]{0:T(128)} slice(%custom-call.32), slice={[0:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %reshape.4358 = s32[128]{0:T(128)} reshape(%slice.1071), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/select_n" stack_frame_id=0}
-  %transpose.915 = s32[128]{0:T(128)} transpose(%reshape.4358), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/select_n" stack_frame_id=0}
+  %reshape.4322 = s32[128]{0:T(128)} reshape(%slice.1071), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/select_n" stack_frame_id=0}
+  %transpose.915 = s32[128]{0:T(128)} transpose(%reshape.4322), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/select_n" stack_frame_id=0}
   %gather.234 = f32[128,32]{1,0:T(8,128)} gather(%param_0.32, %transpose.915), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
   %transpose.914 = f32[128,32]{1,0:T(8,128)} transpose(%gather.234), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  ROOT %reshape.4357 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.914), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  ROOT %reshape.4321 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.914), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
 }
 
 %fused_computation.9 (param_0.29: f32[163840,32], param_1.133: s32[1024]) -> f32[128,32] {
@@ -1665,11 +1593,11 @@ StackFrames
   %param_1.133 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.30 = s32[1024]{0:T(1024)} custom-call(%param_1.133), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
   %slice.1069 = s32[128]{0:T(128)} slice(%custom-call.30), slice={[0:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %reshape.4350 = s32[128]{0:T(128)} reshape(%slice.1069), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/select_n" stack_frame_id=0}
-  %transpose.909 = s32[128]{0:T(128)} transpose(%reshape.4350), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/select_n" stack_frame_id=0}
+  %reshape.4314 = s32[128]{0:T(128)} reshape(%slice.1069), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/select_n" stack_frame_id=0}
+  %transpose.909 = s32[128]{0:T(128)} transpose(%reshape.4314), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/select_n" stack_frame_id=0}
   %gather.232 = f32[128,32]{1,0:T(8,128)} gather(%param_0.29, %transpose.909), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
   %transpose.908 = f32[128,32]{1,0:T(8,128)} transpose(%gather.232), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  ROOT %reshape.4349 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.908), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  ROOT %reshape.4313 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.908), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/gather" stack_frame_id=0}
 }
 
 %fused_computation.672 (param_0.2070: bf16[1,128,128,32,1], param_1.2330: bf16[1,128,128,32,1], param_2.4187: f32[128,32], param_3.2839: f32[128,32]) -> (bf16[1,128,128,32], bf16[1,128,128,32]) {
@@ -1679,20 +1607,20 @@ StackFrames
   %param_0.2070 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.2601 = f32[1,128,128,32,1]{3,1,2,4,0:T(8,128)} convert(%param_0.2070), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %bitcast.1419 = f32[1,128,128,32]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.2601), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %constant.1730.clone.87 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2611 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1730.clone.87), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.1690.clone.87 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2611 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1690.clone.87), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %mul.3926 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.1419, %convert_element_type.2611), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %add.3326 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%bitcast.1420, %mul.3926), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %param_3.2839 = f32[128,32]{1,0:T(8,128)S(1)} parameter(3)
-  %broadcast_in_dim.1470 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.2839), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/broadcast_in_dim" stack_frame_id=0}
-  %mul.3916 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3326, %broadcast_in_dim.1470), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %broadcast_in_dim.1398 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.2839), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/broadcast_in_dim" stack_frame_id=0}
+  %mul.3916 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3326, %broadcast_in_dim.1398), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %param_2.4187 = f32[128,32]{1,0:T(8,128)S(1)} parameter(2)
-  %broadcast_in_dim.1466 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.4187), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/broadcast_in_dim" stack_frame_id=0}
-  %mul.3851 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.1419, %broadcast_in_dim.1466), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %broadcast_in_dim.1394 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.4187), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/broadcast_in_dim" stack_frame_id=0}
+  %mul.3851 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.1419, %broadcast_in_dim.1394), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %mul.3850 = f32[1,128,128,32]{3,1,2,0:T(8,128)} subtract(%mul.3916, %mul.3851), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %convert.527 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3850), metadata={op_name="convert.378" stack_frame_id=0}
-  %mul.3915.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3326, %broadcast_in_dim.1466), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.3858.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.1419, %broadcast_in_dim.1470), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.3915.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3326, %broadcast_in_dim.1394), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.3858.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%bitcast.1419, %broadcast_in_dim.1398), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %mul.3857.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%mul.3915.clone.1, %mul.3858.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %convert.528.clone.1 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3857.clone.1), metadata={op_name="convert.379" stack_frame_id=0}
   ROOT %tuple.667 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)}) tuple(%convert.527, %convert.528.clone.1)
@@ -1700,19 +1628,19 @@ StackFrames
 
 %fused_computation.657 (param_0.2067: bf16[1,128,128,32], param_1.4743: bf16[1,128,128,32], param_2.3579: bf16[1,128,128,128]) -> bf16[128,128,192] {
   %param_2.3579 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(2)
-  %constant.1746.clone.23 = bf16[]{:T(256)} constant(-inf)
-  %pad.288 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.3579, %constant.1746.clone.23), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %constant.1704.clone.23 = bf16[]{:T(256)} constant(-inf)
+  %pad.288 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.3579, %constant.1704.clone.23), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.684 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.288)
   %param_1.4743 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} parameter(1)
-  %pad.287 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4743, %constant.1746.clone.23), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.287 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4743, %constant.1704.clone.23), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.685 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.287)
   %maximum.53 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.684, %convert.685), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_0.2067 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} parameter(0)
-  %pad.286 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.2067, %constant.1746.clone.23), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.286 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.2067, %constant.1704.clone.23), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.686 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.286)
   %maximum.52 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%maximum.53, %convert.686), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %constant.1684.clone.2 = bf16[]{:T(256)} constant(0.1348), metadata={stack_frame_id=0}
-  %mul.3949 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1684.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %constant.1644.clone.2 = bf16[]{:T(256)} constant(0.1348), metadata={stack_frame_id=0}
+  %mul.3949 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1644.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %convert.687 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%mul.3949)
   %mul.3833 = f32[1,128,128,192]{3,1,2,0:T(8,128)} multiply(%maximum.52, %convert.687), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.688 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3833)
@@ -1752,8 +1680,8 @@ StackFrames
   %param_2.2308 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} parameter(2)
   %convert_element_type.2799 = f32[1,128,1,32,1]{3,1,4,2,0:T(8,128)} convert(%param_2.2308), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %bitcast.1798 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%convert_element_type.2799), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %constant.1730.clone.86 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2819 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1730.clone.86), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.1690.clone.86 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2819 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1690.clone.86), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %mul.4320 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%bitcast.1798, %convert_element_type.2819), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %add.3426 = f32[1,128,32]{2,1,0:T(8,128)} add(%bitcast.1800, %mul.4320), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %param_1.3280 = f32[128,32]{1,0:T(8,128)S(1)} parameter(1)
@@ -1773,11 +1701,11 @@ StackFrames
 
 %fused_computation.1065 (param_0.3062: bf16[1,128,32], param_1.4733: bf16[1,128,32]) -> bf16[128,64] {
   %param_1.4733 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1746.clone.5 = bf16[]{:T(256)} constant(-inf)
-  %pad.316 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.4733, %constant.1746.clone.5), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %constant.1704.clone.5 = bf16[]{:T(256)} constant(-inf)
+  %pad.316 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.4733, %constant.1704.clone.5), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.798 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.316)
   %param_0.3062 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.315 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.3062, %constant.1746.clone.5), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.315 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.3062, %constant.1704.clone.5), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.799 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.315)
   %maximum.65 = f32[1,128,64]{2,1,0:T(8,128)} maximum(%convert.798, %convert.799), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","64"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.800 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} convert(%maximum.65)
@@ -1795,18 +1723,18 @@ StackFrames
   %slice.1225 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_0.4489), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/split" stack_frame_id=0}
   %convert_element_type.2696 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1225), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %square.626 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2696, %convert_element_type.2696), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.1730.clone.85 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.763 = f32[128]{0:T(128)S(1)} reduce(%square.626, %constant.1730.clone.85), dimensions={0,2}, to_apply=%region_44.53, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  %constant.1690.clone.85 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.763 = f32[128]{0:T(128)S(1)} reduce(%square.626, %constant.1690.clone.85), dimensions={0,2}, to_apply=%region_44.53, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.1330 (param_0.3991: f32[128]) -> f32[128] {
   %param_0.3991 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1744.clone.7 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4398 = f32[128]{0:T(128)} broadcast(%constant.1744.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.2465 = f32[128]{0:T(128)} multiply(%param_0.3991, %broadcast.4398), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.1745.clone.9 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4387 = f32[128]{0:T(128)} broadcast(%constant.1745.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3644 = f32[128]{0:T(128)} add(%div.2465, %broadcast.4387), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %constant.1702.clone.7 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4389 = f32[128]{0:T(128)} broadcast(%constant.1702.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.2465 = f32[128]{0:T(128)} multiply(%param_0.3991, %broadcast.4389), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.1703.clone.9 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4378 = f32[128]{0:T(128)} broadcast(%constant.1703.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3644 = f32[128]{0:T(128)} add(%div.2465, %broadcast.4378), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %bitcast.1951 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3644), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %rsqrt.305 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1951), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
   ROOT %bitcast.1923 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.305), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
@@ -1855,11 +1783,11 @@ StackFrames
 
 %fused_computation.658 (param_0.1913: bf16[1,128,128,64], param_1.4735: bf16[1,128,128,128]) -> bf16[128,128,192] {
   %param_1.4735 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1746.clone.7 = bf16[]{:T(256)} constant(-inf)
-  %pad.290 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4735, %constant.1746.clone.7), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %constant.1704.clone.7 = bf16[]{:T(256)} constant(-inf)
+  %pad.290 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4735, %constant.1704.clone.7), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.689 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.290)
   %param_0.1913 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.289 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1913, %constant.1746.clone.7), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.289 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1913, %constant.1704.clone.7), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.690 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.289)
   %maximum.54 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.689, %convert.690), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.691 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.54)
@@ -1895,19 +1823,19 @@ StackFrames
   %add.3370.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} add(%convert.734, %convert.735), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.2639.clone.1 = f32[1,128,512]{2,1,0:T(8,128)S(1)} convert(%add.3370.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %square.638 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2639.clone.1, %convert_element_type.2639.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.1730.clone.84 = f32[]{:T(128)} constant(0)
-  %reduce.770 = f32[128]{0:T(128)S(1)} reduce(%square.638, %constant.1730.clone.84), dimensions={0,2}, to_apply=%region_45.56, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  %constant.1690.clone.84 = f32[]{:T(128)} constant(0)
+  %reduce.770 = f32[128]{0:T(128)S(1)} reduce(%square.638, %constant.1690.clone.84), dimensions={0,2}, to_apply=%region_45.56, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
   ROOT %tuple.724 = (f32[128]{0:T(128)S(1)}, f32[1,128,512]{2,1,0:T(8,128)S(1)}) tuple(%reduce.770, %convert_element_type.2639.clone.1)
 }
 
 %fused_computation.1328 (param_0.3993: f32[128]) -> f32[128] {
   %param_0.3993 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1744.clone.6 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4399 = f32[128]{0:T(128)} broadcast(%constant.1744.clone.6), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.2469 = f32[128]{0:T(128)} multiply(%param_0.3993, %broadcast.4399), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.1745.clone.7 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4389 = f32[128]{0:T(128)} broadcast(%constant.1745.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.3648 = f32[128]{0:T(128)} add(%div.2469, %broadcast.4389), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %constant.1702.clone.6 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4390 = f32[128]{0:T(128)} broadcast(%constant.1702.clone.6), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.2469 = f32[128]{0:T(128)} multiply(%param_0.3993, %broadcast.4390), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.1703.clone.7 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4380 = f32[128]{0:T(128)} broadcast(%constant.1703.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.3648 = f32[128]{0:T(128)} add(%div.2469, %broadcast.4380), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %bitcast.1949 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3648), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %rsqrt.303 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1949), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
   ROOT %bitcast.1922 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.303), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
@@ -1950,9 +1878,9 @@ StackFrames
 }
 
 %fused_computation.1021 (param_0.4347: bf16[256], param_1.5120: bf16[128,256], param_2.4120: bf16[128,512], param_3.2779: bf16[512,1,256]) -> (bf16[1,128,256], bf16[1,128,256], bf16[128,256]) {
-  %constant.1687.clone.6.clone.1 = bf16[]{:T(256)} constant(1), metadata={stack_frame_id=0}
-  %broadcast.4227.clone.1 = bf16[128,256]{1,0:T(8,128)(2,1)} broadcast(%constant.1687.clone.6.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %convert.779 = f32[128,256]{1,0:T(8,128)} convert(%broadcast.4227.clone.1)
+  %constant.1647.clone.6.clone.1 = bf16[]{:T(256)} constant(1), metadata={stack_frame_id=0}
+  %broadcast.4218.clone.1 = bf16[128,256]{1,0:T(8,128)(2,1)} broadcast(%constant.1647.clone.6.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %convert.779 = f32[128,256]{1,0:T(8,128)} convert(%broadcast.4218.clone.1)
   %param_2.4120 = bf16[128,512]{1,0:T(8,128)(2,1)S(1)} parameter(2)
   %fusion.896 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_2.4120), kind=kLoop, calls=%bitcast_fusion.5
   %param_3.2779 = bf16[512,1,256]{2,0,1:T(8,128)(2,1)S(1)} parameter(3)
@@ -1980,21 +1908,93 @@ StackFrames
 }
 
 %region_12.18 (top_k.0: bf16[], top_k.6: bf16[], top_k.7: s32[], top_k.8: s32[]) -> pred[] {
-  %constant.1521 = s32[]{:T(128)} constant(0)
-  %constant.1522 = s32[]{:T(128)} constant(2147483647)
+  %constant.1481 = s32[]{:T(128)} constant(0)
+  %constant.1482 = s32[]{:T(128)} constant(2147483647)
   %top_k.0 = bf16[]{:T(256)} parameter(0), metadata={op_name="top_k"}
   %top_k.6 = bf16[]{:T(256)} parameter(1), metadata={op_name="top_k"}
   %top_k.7 = s32[]{:T(128)} parameter(2), metadata={op_name="top_k"}
   %top_k.8 = s32[]{:T(128)} parameter(3), metadata={op_name="top_k"}
   %convert.384 = f32[]{:T(128)S(6)} convert(%top_k.0), metadata={op_name="convert.16"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %bitcast-convert.35 = s32[]{:T(128)S(6)} bitcast-convert(%convert.384), metadata={op_name="bitcast-convert.6"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %compare.128 = pred[]{:T(512)S(6)} compare(%bitcast-convert.35, %constant.1521), direction=LT, metadata={op_name="compare.35"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %xor.36 = s32[]{:T(128)S(6)} xor(%constant.1522, %bitcast-convert.35), metadata={op_name="xor.6"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %compare.128 = pred[]{:T(512)S(6)} compare(%bitcast-convert.35, %constant.1481), direction=LT, metadata={op_name="compare.35"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %xor.36 = s32[]{:T(128)S(6)} xor(%constant.1482, %bitcast-convert.35), metadata={op_name="xor.6"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %select.118 = s32[]{:T(128)S(6)} select(%compare.128, %xor.36, %bitcast-convert.35), metadata={op_name="select.14"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["1","3"]}]}}
   %convert.385 = f32[]{:T(128)S(6)} convert(%top_k.6), metadata={op_name="convert.17"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %bitcast-convert.36 = s32[]{:T(128)S(6)} bitcast-convert(%convert.385), metadata={op_name="bitcast-convert.7"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %compare.129 = pred[]{:T(512)S(6)} compare(%bitcast-convert.36, %constant.1521), direction=LT, metadata={op_name="compare.36"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %xor.37 = s32[]{:T(128)S(6)} xor(%constant.1522, %bitcast-convert.36), metadata={op_name="xor.7"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %compare.129 = pred[]{:T(512)S(6)} compare(%bitcast-convert.36, %constant.1481), direction=LT, metadata={op_name="compare.36"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %xor.37 = s32[]{:T(128)S(6)} xor(%constant.1482, %bitcast-convert.36), metadata={op_name="xor.7"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %select.119 = s32[]{:T(128)S(6)} select(%compare.129, %xor.37, %bitcast-convert.36), metadata={op_name="select.15"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["1","3"]}]}}
   %compare.130 = pred[]{:T(512)S(6)} compare(%select.118, %select.119), direction=GT, metadata={op_name="compare.1"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %compare.131 = pred[]{:T(512)S(6)} compare(%select.119, %select.118), direction=GT, metadata={op_name="compare.108"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %compare.132 = pred[]{:T(512)S(6)} compare(%compare.130, %compare.131), direction=EQ, metadata={op_name="compare.109"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %compare.133 = pred[]{:T(512)S(6)} compare(%top_k.7, %top_k.8), direction=LT, metadata={op_name="compare.110"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %select.120 = pred[]{:T(512)} select(%compare.132, %compare.133, %compare.130), metadata={op_name="select.108"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+}
+
+%fused_computation.1428 (param_0.4319: s32[1,128,256]) -> (s32[1,128,8], s32[1,128,8]) {
+  %param_0.4319 = s32[1,128,256]{2,1,0:T(8,128)S(1)} parameter(0)
+  %top_k.65 = s32[1,128,8]{2,1,0:T(8,128)S(1)} slice(%param_0.4319), slice={[0:1], [0:128], [0:8]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/top_k" stack_frame_id=0}
+  %constant.1679.clone.27.clone.1 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %max.95.clone.1 = s32[1,128,8]{2,1,0:T(8,128)} broadcast(%constant.1679.clone.27.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/jit(clip)/max" stack_frame_id=0}
+  %max.94.clone.1 = s32[1,128,8]{2,1,0:T(8,128)S(1)} maximum(%max.95.clone.1, %top_k.65), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/jit(clip)/max" stack_frame_id=0}
+  ROOT %tuple.694 = (s32[1,128,8]{2,1,0:T(8,128)S(1)}, s32[1,128,8]{2,1,0:T(8,128)S(1)}) tuple(%top_k.65, %max.94.clone.1)
+}
+
+%fused_computation.1077 (param_0.3176: s32[1024,1]) -> s32[1024,1] {
+  %param_0.3176 = s32[1024,1]{0,1:T(1,128)S(1)} parameter(0)
+  %constant.1679.clone.113 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %broadcast.4271 = s32[1024,1]{0,1:T(1,128)} broadcast(%constant.1679.clone.113), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/broadcast.2413" stack_frame_id=0}
+  %lt.780 = pred[1024,1]{0,1:T(4,128)(4,1)} compare(%param_0.3176, %broadcast.4271), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/lt" stack_frame_id=0}
+  %constant.1559.clone.6 = s32[]{:T(128)} constant(256), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map" stack_frame_id=0}
+  %add.3498 = s32[1024,1]{0,1:T(1,128)} broadcast(%constant.1559.clone.6), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/add" stack_frame_id=0}
+  %add.3465 = s32[1024,1]{0,1:T(1,128)} add(%param_0.3176, %add.3498), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/add" stack_frame_id=0}
+  ROOT %select_n.2116 = s32[1024,1]{0,1:T(1,128)} select(%lt.780, %add.3465, %param_0.3176), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/select_n" stack_frame_id=0}
+}
+
+%called_computation.21 (param_0.4916: s32[256]) -> s32[256] {
+  %param_0.4916 = s32[256]{0:T(256)} parameter(0)
+  ROOT %copy.2046 = s32[256]{0:T(256)} copy(%param_0.4916), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"1134","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.21 (param_0.4917: s32[256]) -> s32[256] {
+  %param_0.4917 = s32[256]{0:T(256)} parameter(0)
+  ROOT %copy.2047.cloned.1 = s32[256]{0:T(256)} call(%param_0.4917), to_apply=%called_computation.21
+}, execution_thread="sparsecore"
+
+%region_14.20 (scatter-add.0: s32[], scatter-add.1: s32[]) -> s32[] {
+  %scatter-add.0 = s32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
+  %scatter-add.1 = s32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
+  ROOT %add.1343 = s32[]{:T(128)S(7)} add(%scatter-add.0, %scatter-add.1), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%fused_computation.19.clone.clone.clone (param_0.4918: s32[256], param_1.5496: s32[1024], param_2.4335: s32[1024]) -> s32[256] {
+  %param_0.4918 = s32[256]{0:T(256)} parameter(0)
+  %param_1.5496 = s32[1024]{0:T(1024)} parameter(1)
+  %reshape.5007 = s32[1024]{0:T(1024)} reshape(%param_1.5496), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/select_n" stack_frame_id=0}
+  %transpose.1164 = s32[1024]{0:T(1024)} transpose(%reshape.5007), dimensions={0}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/select_n" stack_frame_id=0}
+  %param_2.4335 = s32[1024]{0:T(1024)} parameter(2)
+  %reshape.5008 = s32[1024]{0:T(1024)} reshape(%param_2.4335), metadata={op_name="jit(train_step)/shard_map/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1165 = s32[1024]{0:T(1024)} transpose(%reshape.5008), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/broadcast_in_dim" stack_frame_id=0}
+  ROOT %scatter-add.261 = s32[256]{0:T(256)} scatter(%param_0.4918, %transpose.1164, %transpose.1165), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_14.20, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/scatter-add" stack_frame_id=0}
+}, execution_thread="sparsecore"
+
+%called_computation.22 (param_0.4919: s32[256], param_1.5497: s32[1024], param_2.4336: s32[1024]) -> s32[256] {
+  %param_0.4919 = s32[256]{0:T(256)} parameter(0)
+  %param_1.5497 = s32[1024]{0:T(1024)} parameter(1)
+  %param_2.4336 = s32[1024]{0:T(1024)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.39 = s32[256]{0:T(256)} fusion(%param_0.4919, %param_1.5497, %param_2.4336), kind=kCustom, calls=%fused_computation.19.clone.clone.clone, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["64"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"1088","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.22 (param_0.4920: s32[256], param_1.5498: s32[1024], param_2.4337: s32[1024]) -> s32[256] {
+  %param_0.4920 = s32[256]{0:T(256)} parameter(0)
+  %param_1.5498 = s32[1024]{0:T(1024)} parameter(1)
+  %param_2.4337 = s32[1024]{0:T(1024)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.40.cloned.1 = s32[256]{0:T(256)} call(%param_0.4920, %param_1.5498, %param_2.4337), to_apply=%called_computation.22, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/scatter-add" stack_frame_id=0}
+}, execution_thread="sparsecore"
+
+%called_computation.6 (param_0.109: s32[256], param_1.167: s32[1024], param_2.112: s32[1024], param_3.2907: token[]) -> s32[256] {
+  %param_3.2907 = token[] parameter(3)
+  %param_0.109 = s32[256]{0:T(256)} parameter(0), backend_config={"flag_configs":[],"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_SCALAR","used_scoped_memory_configs":[]}
+  %param_1.167 = s32[1024]{0:T(1024)} parameter(1), backend_config={"flag_configs":[],"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_SCALAR","used_scoped_memory_configs":[]}
+  %param_2.112 = s32[1024]{0:T(1024)} parameter(2), backend_config={"flag_configs":[],"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_SCALAR","used_scoped_memory_configs":[]}
+  %copy.2047.cloned.1.call-start = ((s32[256]{0:T(256)}), s32[256]{0:T(256)}, u32[]{:S(8)}) async-start(%param_0.109), async_execution_thread="sparsecore", calls=%async_computation.21

--- a/tests/utils/reference_hlo_llama3_8b.txt
+++ b/tests/utils/reference_hlo_llama3_8b.txt
@@ -11,25 +11,25 @@ StackFrames
 
 %fused_computation.408 (param_0.1130: s32[1,128]) -> s32[1,1,128] {
   %param_0.1130 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %constant.378.clone.5 = s32[]{:T(128)} constant(0)
-  %broadcast.642 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.378.clone.5), dimensions={}, metadata={op_name="broadcast.85"}
-  %lt.32 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1130, %broadcast.642), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
-  %constant.390.clone.1 = s32[]{:T(128)} constant(128256)
-  %add.792 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.390.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %constant.356.clone.5 = s32[]{:T(128)} constant(0)
+  %broadcast.636 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.356.clone.5), dimensions={}, metadata={op_name="broadcast.81"}
+  %lt.32 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1130, %broadcast.636), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
+  %constant.368.clone.1 = s32[]{:T(128)} constant(128256)
+  %add.792 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.368.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %add.781 = s32[1,128]{1,0:T(1,128)} add(%param_0.1130, %add.792), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %select_n.178 = s32[1,128]{1,0:T(1,128)} select(%lt.32, %add.781, %param_0.1130), metadata={op_name="jit(train_step)/jvp()/select_n" stack_frame_id=0}
-  ROOT %bitcast.560 = s32[1,1,128]{2,1,0:T(1,128)S(1)} bitcast(%select_n.178)
+  ROOT %bitcast.559 = s32[1,1,128]{2,1,0:T(1,128)S(1)} bitcast(%select_n.178)
 }
 
 %fused_computation.394 (param_0.1095: s32[512]) -> s32[1024] {
-  %constant.945 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.624 = s32[1024]{0:T(1024)} broadcast(%constant.945), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.922 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.618 = s32[1024]{0:T(1024)} broadcast(%constant.922), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %param_0.1095 = s32[512]{0:T(512)S(1)} parameter(0)
-  %constant.946 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %pad.41 = s32[1024]{0:T(1024)} pad(%param_0.1095, %constant.946), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %constant.944 = s32[] constant(128255), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.623 = s32[1024]{0:T(1024)} broadcast(%constant.944), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  ROOT %clamp.3 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.624, %pad.41, %broadcast.623), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.923 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %pad.41 = s32[1024]{0:T(1024)} pad(%param_0.1095, %constant.923), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.921 = s32[] constant(128255), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.617 = s32[1024]{0:T(1024)} broadcast(%constant.921), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  ROOT %clamp.3 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.618, %pad.41, %broadcast.617), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
 %fused_computation (param_0.2: bf16[128256,1024], param_1.7: s32[1024]) -> bf16[512,1024] {
@@ -37,45 +37,45 @@ StackFrames
   %param_1.7 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.1 = s32[1024]{0:T(1024)} custom-call(%param_1.7), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %slice.34 = s32[512]{0:T(512)} slice(%custom-call.1), slice={[0:512]}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %reshape.661 = s32[4,128]{1,0:T(4,128)} reshape(%slice.34), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %transpose.326 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.661), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %reshape.643 = s32[4,128]{1,0:T(4,128)} reshape(%slice.34), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %transpose.326 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.643), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %gather.4 = bf16[4,128,1024]{2,1,0:T(8,128)(2,1)} gather(%param_0.2, %transpose.326), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,1024}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %transpose.325 = bf16[4,128,1024]{2,1,0:T(8,128)(2,1)} transpose(%gather.4), dimensions={0,1,2}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  ROOT %reshape.660 = bf16[512,1024]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.325), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  ROOT %reshape.642 = bf16[512,1024]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.325), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
 %fused_computation.421 (param_0.1265: f32[4096,4]) -> bf16[4,4096] {
   %param_0.1265 = f32[4096,4]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.655 = f32[4,4096]{1,0:T(4,128)} bitcast(%param_0.1265), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.110 = bf16[4,4096]{1,0:T(4,128)(2,1)} convert(%bitcast.655)
+  %bitcast.654 = f32[4,4096]{1,0:T(4,128)} bitcast(%param_0.1265), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.110 = bf16[4,4096]{1,0:T(4,128)(2,1)} convert(%bitcast.654)
 }
 
 %fused_computation.420 (param_0.1264: f32[4096,4]) -> bf16[4,4096] {
   %param_0.1264 = f32[4096,4]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.654 = f32[4,4096]{1,0:T(4,128)} bitcast(%param_0.1264), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.108 = bf16[4,4096]{1,0:T(4,128)(2,1)} convert(%bitcast.654)
+  %bitcast.653 = f32[4,4096]{1,0:T(4,128)} bitcast(%param_0.1264), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.108 = bf16[4,4096]{1,0:T(4,128)(2,1)} convert(%bitcast.653)
 }
 
 %fused_computation.416 (param_0.1146: s32[1,128]) -> (f32[1,128,1,1], f32[128]) {
   %param_0.1146 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
   %convert_element_type.943 = f32[1,128]{1,0:T(1,128)} convert(%param_0.1146), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  %bitcast.570 = f32[1,128,1,1]{1,3,2,0:T(1,128)} bitcast(%convert_element_type.943), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %bitcast.571.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%convert_element_type.943), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.151 = (f32[1,128,1,1]{1,3,2,0:T(1,128)}, f32[128]{0:T(128)S(1)}) tuple(%bitcast.570, %bitcast.571.clone.1)
+  %bitcast.569 = f32[1,128,1,1]{1,3,2,0:T(1,128)} bitcast(%convert_element_type.943), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %bitcast.570.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%convert_element_type.943), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.151 = (f32[1,128,1,1]{1,3,2,0:T(1,128)}, f32[128]{0:T(128)S(1)}) tuple(%bitcast.569, %bitcast.570.clone.1)
 }
 
 %fused_computation.415 () -> f32[64] {
-  %constant.395.clone.1 = f32[]{:T(128)} constant(500000)
-  %broadcast.635 = f32[64]{0:T(128)} broadcast(%constant.395.clone.1), dimensions={}, metadata={op_name="broadcast.274"}
+  %constant.372.clone.1 = f32[]{:T(128)} constant(500000)
+  %broadcast.629 = f32[64]{0:T(128)} broadcast(%constant.372.clone.1), dimensions={}, metadata={op_name="broadcast.272"}
   %iota.56 = s32[64]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/iota" stack_frame_id=0}
-  %constant.396.clone.1 = s32[]{:T(128)} constant(2)
-  %broadcast.634 = s32[64]{0:T(128)} broadcast(%constant.396.clone.1), dimensions={}, metadata={op_name="broadcast.275"}
-  %mul.1510 = s32[64]{0:T(128)} multiply(%iota.56, %broadcast.634), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %constant.373.clone.1 = s32[]{:T(128)} constant(2)
+  %broadcast.628 = s32[64]{0:T(128)} broadcast(%constant.373.clone.1), dimensions={}, metadata={op_name="broadcast.273"}
+  %mul.1510 = s32[64]{0:T(128)} multiply(%iota.56, %broadcast.628), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %convert_element_type.942 = f32[64]{0:T(128)} convert(%mul.1510), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  %constant.397.clone.1 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.633 = f32[64]{0:T(128)} broadcast(%constant.397.clone.1), dimensions={}, metadata={op_name="broadcast.276"}
-  %div.661 = f32[64]{0:T(128)} multiply(%convert_element_type.942, %broadcast.633), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  ROOT %pow.36 = f32[64]{0:T(128)S(1)} power(%broadcast.635, %div.661), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
+  %constant.374.clone.1 = f32[]{:T(128)} constant(0.0078125)
+  %broadcast.627 = f32[64]{0:T(128)} broadcast(%constant.374.clone.1), dimensions={}, metadata={op_name="broadcast.274"}
+  %div.661 = f32[64]{0:T(128)} multiply(%convert_element_type.942, %broadcast.627), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  ROOT %pow.36 = f32[64]{0:T(128)S(1)} power(%broadcast.629, %div.661), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
 }
 
 %fused_computation.369 (param_0.1070: f32[128], param_1.1137: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
@@ -93,10 +93,10 @@ StackFrames
 
 %fused_computation.384 (param_0.1065: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
   %param_0.1065 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.400.clone.2 = bf16[]{:T(256)} constant(-inf)
-  %pad.38 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1065, %constant.400.clone.2), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %constant.377.clone.2 = bf16[]{:T(256)} constant(-inf)
+  %pad.38 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1065, %constant.377.clone.2), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
   %convert.133 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.38)
-  %pad.37 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1065, %constant.400.clone.2), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %pad.37 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1065, %constant.377.clone.2), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
   %convert.134 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.37)
   %maximum.38 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.133, %convert.134), metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   ROOT %convert.135 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.38)
@@ -104,10 +104,10 @@ StackFrames
 
 %fused_computation.385 (param_0.1067: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
   %param_0.1067 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.400.clone.1 = bf16[]{:T(256)} constant(-inf)
-  %pad.40 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1067, %constant.400.clone.1), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %constant.377.clone.1 = bf16[]{:T(256)} constant(-inf)
+  %pad.40 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1067, %constant.377.clone.1), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
   %convert.136 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.40)
-  %pad.39 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1067, %constant.400.clone.1), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %pad.39 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1067, %constant.377.clone.1), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
   %convert.137 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.39)
   %maximum.39 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.136, %convert.137), metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   ROOT %convert.138 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.39)
@@ -116,54 +116,54 @@ StackFrames
 %fused_computation.333 (param_0.933: f32[1024,4,8,128]) -> bf16[4,1024,8,128] {
   %param_0.933 = f32[1024,4,8,128]{3,2,1,0:T(8,128)S(1)} parameter(0)
   %copy.239 = bf16[1024,4,8,128]{3,0,2,1:T(8,128)(2,1)} copy(%param_0.933), sharding={devices=[4,1,1,1]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'self_attention\'][\'value\'][\'kernel\'].value"}
-  ROOT %bitcast.532 = bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%copy.239), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %bitcast.531 = bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%copy.239), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
 %fused_computation.303 (param_0.855: f32[32,4,128,1024]) -> bf16[4,32,128,1024] {
   %param_0.855 = f32[32,4,128,1024]{3,2,1,0:T(8,128)} parameter(0)
   %copy.238 = bf16[32,4,128,1024]{3,2,0,1:T(8,128)(2,1)} copy(%param_0.855), sharding={devices=[1,1,1,4]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'self_attention\'][\'out\'][\'kernel\'].value"}
-  ROOT %bitcast.487 = bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)} bitcast(%copy.238), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %bitcast.486 = bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)} bitcast(%copy.238), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
 %fused_computation.281 (param_0.811: f32[1024,4,14336]) -> bf16[4,1024,14336] {
   %param_0.811 = f32[1024,4,14336]{2,1,0:T(4,128)} parameter(0)
   %copy.237 = bf16[1024,4,14336]{2,0,1:T(8,128)(2,1)} copy(%param_0.811), sharding={devices=[4,1,1]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'mlp\'][\'wi_0\'][\'kernel\'].value"}
-  ROOT %bitcast.478 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} bitcast(%copy.237), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %bitcast.477 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} bitcast(%copy.237), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
 %fused_computation.280 (param_0.809: f32[1024,4,14336]) -> bf16[4,1024,14336] {
   %param_0.809 = f32[1024,4,14336]{2,1,0:T(4,128)} parameter(0)
   %copy.236 = bf16[1024,4,14336]{2,0,1:T(8,128)(2,1)} copy(%param_0.809), sharding={devices=[4,1,1]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'mlp\'][\'wi_1\'][\'kernel\'].value"}
-  ROOT %bitcast.477 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} bitcast(%copy.236), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %bitcast.476 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} bitcast(%copy.236), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
 %fused_computation.279 (param_0.807: f32[14336,4,1024]) -> bf16[4,14336,1024] {
   %param_0.807 = f32[14336,4,1024]{2,1,0:T(4,128)} parameter(0)
   %copy.235 = bf16[14336,4,1024]{2,0,1:T(8,128)(2,1)} copy(%param_0.807), sharding={devices=[1,1,4]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'mlp\'][\'wo\'][\'kernel\'].value"}
-  ROOT %bitcast.476 = bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)} bitcast(%copy.235), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %bitcast.475 = bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)} bitcast(%copy.235), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
 %fused_computation.54.clone.1 (param_0.1520: bf16[4,1,128,4096], param_1.1569: s32[], param_2.1198: bf16[1,128,4096]) -> bf16[4,1,128,4096] {
   %param_0.1520 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)} parameter(0)
   %param_2.1198 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %bitcast.881 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.1198), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/broadcast_in_dim" stack_frame_id=0}
+  %bitcast.880 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.1198), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/broadcast_in_dim" stack_frame_id=0}
   %param_1.1569 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.353.clone.24 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-update-slice.30 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.1520, %bitcast.881, %param_1.1569, %constant.353.clone.24, %constant.353.clone.24, /*index=5*/%constant.353.clone.24), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.331.clone.24 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-update-slice.30 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.1520, %bitcast.880, %param_1.1569, %constant.331.clone.24, %constant.331.clone.24, /*index=5*/%constant.331.clone.24), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.18.clone.1 (param_0.1540: bf16[4,32,128,1024], param_1.1582: s32[]) -> bf16[1,32,128,1024] {
   %param_0.1540 = bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1582 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.353.clone.29 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.193 = bf16[1,32,128,1024]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1540, %param_1.1582, %constant.353.clone.29, %constant.353.clone.29, %constant.353.clone.29), dynamic_slice_sizes={1,32,128,1024}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.331.clone.29 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.193 = bf16[1,32,128,1024]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1540, %param_1.1582, %constant.331.clone.29, %constant.331.clone.29, %constant.331.clone.29), dynamic_slice_sizes={1,32,128,1024}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.19.clone.1 (param_0.1534: bf16[4,1024,32,128], param_1.1578: s32[]) -> bf16[1,1024,32,128] {
   %param_0.1534 = bf16[4,1024,32,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.1578 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.353.clone.28 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.192 = bf16[1,1024,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1534, %param_1.1578, %constant.353.clone.28, %constant.353.clone.28, %constant.353.clone.28), dynamic_slice_sizes={1,1024,32,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.331.clone.28 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.192 = bf16[1,1024,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1534, %param_1.1578, %constant.331.clone.28, %constant.331.clone.28, %constant.331.clone.28), dynamic_slice_sizes={1,1024,32,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %region_2.3 (reduce_sum.73: f32[], reduce_sum.74: f32[]) -> f32[] {
@@ -176,18 +176,18 @@ StackFrames
   %param_0.1522 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.1051 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%param_0.1522), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.217 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.1051, %convert_element_type.1051), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.354.clone.9 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.196 = f32[128]{0:T(128)S(1)} reduce(%square.217, %constant.354.clone.9), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.332.clone.9 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.196 = f32[128]{0:T(128)S(1)} reduce(%square.217, %constant.332.clone.9), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.69.clone.1 (param_0.1523: f32[128]) -> f32[128] {
   %param_0.1523 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.355.clone.9 = f32[]{:T(128)} constant(0.000244140625)
-  %broadcast.721 = f32[128]{0:T(128)} broadcast(%constant.355.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.867 = f32[128]{0:T(128)} multiply(%param_0.1523, %broadcast.721), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.356.clone.9 = f32[]{:T(128)} constant(1e-05)
-  %broadcast.720 = f32[128]{0:T(128)} broadcast(%constant.356.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.898 = f32[128]{0:T(128)} add(%div.867, %broadcast.720), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.333.clone.9 = f32[]{:T(128)} constant(0.000244140625)
+  %broadcast.715 = f32[128]{0:T(128)} broadcast(%constant.333.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.867 = f32[128]{0:T(128)} multiply(%param_0.1523, %broadcast.715), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.334.clone.9 = f32[]{:T(128)} constant(1e-05)
+  %broadcast.714 = f32[128]{0:T(128)} broadcast(%constant.334.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.898 = f32[128]{0:T(128)} add(%div.867, %broadcast.714), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.118 = f32[128]{0:T(128)S(1)} rsqrt(%add.898), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
@@ -206,13 +206,13 @@ StackFrames
 %fused_computation.66.clone.1 (param_0.1521: bf16[4,4096], param_1.1570: s32[], param_2.1199: bf16[4,4096]) -> (bf16[4096], bf16[4096]) {
   %param_0.1521 = bf16[4,4096]{1,0:T(4,128)(2,1)} parameter(0)
   %param_1.1570 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.353.clone.25 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.291 = bf16[1,4096]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1521, %param_1.1570, %constant.353.clone.25), dynamic_slice_sizes={1,4096}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %constant.1016 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %reduce.195 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.291, %constant.1016), dimensions={0}, to_apply=%convert_element_type.640.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.331.clone.25 = s32[]{:T(128)} constant(0)
+  %dynamic_slice.145 = bf16[1,4096]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1521, %param_1.1570, %constant.331.clone.25), dynamic_slice_sizes={1,4096}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.993 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %reduce.195 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.145, %constant.993), dimensions={0}, to_apply=%convert_element_type.640.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %param_2.1199 = bf16[4,4096]{1,0:T(4,128)(2,1)} parameter(2)
-  %dynamic_slice.283.clone.3 = bf16[1,4096]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1199, %param_1.1570, %constant.353.clone.25), dynamic_slice_sizes={1,4096}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %reduce.122.clone.3 = bf16[4096]{0:T(1024)(128)(2,1)} reduce(%dynamic_slice.283.clone.3, %constant.1016), dimensions={0}, to_apply=%convert_element_type.638.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %dynamic_slice.137.clone.3 = bf16[1,4096]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1199, %param_1.1570, %constant.331.clone.25), dynamic_slice_sizes={1,4096}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %reduce.122.clone.3 = bf16[4096]{0:T(1024)(128)(2,1)} reduce(%dynamic_slice.137.clone.3, %constant.993), dimensions={0}, to_apply=%convert_element_type.638.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   ROOT %tuple.199 = (bf16[4096]{0:T(1024)(128)(2,1)S(1)}, bf16[4096]{0:T(1024)(128)(2,1)}) tuple(%reduce.195, %reduce.122.clone.3)
 }
 
@@ -229,12 +229,12 @@ StackFrames
   %convert.278 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1056)
   %dot_general.471 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.277, %convert.278), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.279 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%dot_general.471)
-  ROOT %bitcast.890 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.279)
+  ROOT %bitcast.889 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.279)
 }
 
 %fused_computation.17.clone.clone.clone.1 (param_0.1535: bf16[1,4096,32,128]) -> bf16[4096,32,128] {
   %param_0.1535 = bf16[1,4096,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.889 = bf16[4096,32,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1535), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  ROOT %bitcast.888 = bf16[4096,32,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1535), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.57.clone.1 (param_0.1537: bf16[1,4096,32,128], param_1.1580: bf16[1,128,4096], param_2.1206: f32[128], param_3.812: bf16[4096]) -> bf16[1,128,32,128] {
@@ -245,7 +245,7 @@ StackFrames
   %param_0.1537 = bf16[1,4096,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
   %fusion.492 = bf16[4096,32,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1537), kind=kLoop, calls=%fused_computation.17.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
   %convolution.160 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.493, %fusion.492), window={size=32 pad=31_31 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  ROOT %bitcast.891 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.160), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  ROOT %bitcast.890 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.160), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.49.clone.1 (param_0.1538: bf16[1,128,32,128]) -> (bf16[1,128,32,64], bf16[1,128,32,64]) {
@@ -266,11 +266,11 @@ StackFrames
   %convert.293 = f32[1,128,32,128]{3,1,2,0:T(8,128)} convert(%mul.1812)
   %mul.1810 = f32[1,128,32,128]{3,1,2,0:T(8,128)} multiply(%convert.292, %convert.293), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","32","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_1.1581 = bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1018 = bf16[]{:T(256)} constant(-inf)
-  %pad.73 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1581, %constant.1018), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %constant.995 = bf16[]{:T(256)} constant(-inf)
+  %pad.73 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1581, %constant.995), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.294 = f32[1,128,32,128]{3,1,2,0:T(8,128)} convert(%pad.73)
   %param_0.1539 = bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.72 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1539, %constant.1018), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.72 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1539, %constant.995), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.295 = f32[1,128,32,128]{3,1,2,0:T(8,128)} convert(%pad.72)
   %maximum.55 = f32[1,128,32,128]{3,1,2,0:T(8,128)} maximum(%convert.294, %convert.295), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","32","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_3.813 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
@@ -279,14 +279,14 @@ StackFrames
   %mul.1809 = f32[1,128,32,128]{3,1,2,0:T(8,128)} multiply(%maximum.55, %convert.296), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","32","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %add.900 = f32[1,128,32,128]{3,1,2,0:T(8,128)} add(%mul.1810, %mul.1809), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","32","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.297 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.900)
-  ROOT %bitcast.892 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.297), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  ROOT %bitcast.891 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.297), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
 %fused_computation.29.clone.1 (param_0.1528: bf16[4,1024,8,128], param_1.1574: s32[]) -> bf16[1,1024,8,128] {
   %param_0.1528 = bf16[4,1024,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.1574 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.353.clone.27 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.191 = bf16[1,1024,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1528, %param_1.1574, %constant.353.clone.27, %constant.353.clone.27, %constant.353.clone.27), dynamic_slice_sizes={1,1024,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.331.clone.27 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.191 = bf16[1,1024,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1528, %param_1.1574, %constant.331.clone.27, %constant.331.clone.27, %constant.331.clone.27), dynamic_slice_sizes={1,1024,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.48.clone.1.clone.1 (param_0.1530: bf16[1,128,4096], param_1.1575: f32[128], param_2.1202: bf16[4096]) -> bf16[128,4096,1] {
@@ -302,12 +302,12 @@ StackFrames
   %convert.275 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1054)
   %dot_general.469 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.274, %convert.275), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.276 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%dot_general.469)
-  ROOT %bitcast.886 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.276)
+  ROOT %bitcast.885 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.276)
 }
 
 %fused_computation.23.clone.clone.clone.1 (param_0.1529: bf16[1,4096,8,128]) -> bf16[4096,8,128] {
   %param_0.1529 = bf16[1,4096,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.885 = bf16[4096,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1529), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  ROOT %bitcast.884 = bf16[4096,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1529), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.58.clone.1 (param_0.1531: bf16[1,4096,8,128], param_1.1576: bf16[1,128,4096], param_2.1203: f32[128], param_3.810: bf16[4096]) -> bf16[1,128,8,128] {
@@ -318,7 +318,7 @@ StackFrames
   %param_0.1531 = bf16[1,4096,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
   %fusion.490 = bf16[4096,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1531), kind=kLoop, calls=%fused_computation.23.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
   %convolution.159 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.491, %fusion.490), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  ROOT %bitcast.887 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.159), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  ROOT %bitcast.886 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.159), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.62.clone.1 (param_0.1532: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
@@ -339,11 +339,11 @@ StackFrames
   %convert.301 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.1806)
   %mul.1804 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.300, %convert.301), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_1.1577 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1017 = bf16[]{:T(256)} constant(-inf)
-  %pad.71 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1577, %constant.1017), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %constant.994 = bf16[]{:T(256)} constant(-inf)
+  %pad.71 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1577, %constant.994), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.302 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.71)
   %param_0.1533 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.70 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1533, %constant.1017), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.70 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1533, %constant.994), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.303 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.70)
   %maximum.54 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.302, %convert.303), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_3.811 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
@@ -352,14 +352,14 @@ StackFrames
   %mul.1803 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%maximum.54, %convert.304), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %add.899 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.1804, %mul.1803), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.305 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.899)
-  ROOT %bitcast.888 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.305), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  ROOT %bitcast.887 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.305), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
 %fused_computation.28.clone.1 (param_0.1524: bf16[4,1024,8,128], param_1.1571: s32[]) -> bf16[1,1024,8,128] {
   %param_0.1524 = bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.1571 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.353.clone.26 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.190 = bf16[1,1024,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1524, %param_1.1571, %constant.353.clone.26, %constant.353.clone.26, %constant.353.clone.26), dynamic_slice_sizes={1,1024,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.331.clone.26 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.190 = bf16[1,1024,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1524, %param_1.1571, %constant.331.clone.26, %constant.331.clone.26, %constant.331.clone.26), dynamic_slice_sizes={1,1024,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.48.clone.clone.1 (param_0.1526: bf16[1,128,4096], param_1.1572: f32[128], param_2.1200: bf16[4096]) -> bf16[128,4096,1] {
@@ -375,12 +375,12 @@ StackFrames
   %convert.272 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1052)
   %dot_general.467 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.271, %convert.272), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.273 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%dot_general.467)
-  ROOT %bitcast.883 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.273)
+  ROOT %bitcast.882 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.273)
 }
 
 %fused_computation.21.clone.clone.clone.1 (param_0.1525: bf16[1,4096,8,128]) -> bf16[4096,8,128] {
   %param_0.1525 = bf16[1,4096,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.882 = bf16[4096,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1525), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  ROOT %bitcast.881 = bf16[4096,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1525), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.59.clone.1 (param_0.1527: bf16[1,4096,8,128], param_1.1573: bf16[1,128,4096], param_2.1201: f32[128], param_3.809: bf16[4096]) -> bf16[8,128,128] {
@@ -391,17 +391,17 @@ StackFrames
   %param_0.1527 = bf16[1,4096,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
   %fusion.488 = bf16[4096,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1527), kind=kLoop, calls=%fused_computation.21.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
   %convolution.158 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.489, %fusion.488), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  ROOT %bitcast.884 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.158), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  ROOT %bitcast.883 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.158), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
 %fused_computation.53.clone.clone.clone.1 (param_0.1542: bf16[32,128,128]) -> bf16[128,32,128] {
   %param_0.1542 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.894 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1542)
+  ROOT %bitcast.893 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1542)
 }
 
 %fused_computation.15.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1541: bf16[1,32,128,4096]) -> bf16[32,128,4096] {
   %param_0.1541 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.893 = bf16[32,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1541), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  ROOT %bitcast.892 = bf16[32,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1541), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
 }
 
 %region_3.5 (reduce_sum.79: f32[], reduce_sum.80: f32[]) -> f32[] {
@@ -418,13 +418,13 @@ StackFrames
   %param_1.1583 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %fusion.59.clone.3 = bf16[32,128,4096]{2,1,0:T(8,128)(2,1)} fusion(%param_1.1583), kind=kLoop, calls=%fused_computation.15.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
   %convolution.58.clone.3 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.74.clone.3, %fusion.59.clone.3), window={size=32}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %bitcast.236.clone.3 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.58.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convert.307 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.236.clone.3)
+  %bitcast.235.clone.3 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.58.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  %convert.307 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.235.clone.3)
   %add.671.clone.3 = f32[1,128,4096]{2,1,0:T(8,128)} add(%convert.306, %convert.307), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.1058 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%add.671.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.218 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.1058, %convert_element_type.1058), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.354.clone.10 = f32[]{:T(128)} constant(0)
-  %reduce.197 = f32[128]{0:T(128)} reduce(%square.218, %constant.354.clone.10), dimensions={0,2}, to_apply=%region_3.5, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.332.clone.10 = f32[]{:T(128)} constant(0)
+  %reduce.197 = f32[128]{0:T(128)} reduce(%square.218, %constant.332.clone.10), dimensions={0,2}, to_apply=%region_3.5, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
   %convert.308 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%add.671.clone.3)
   ROOT %tuple.202 = (f32[128]{0:T(128)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)}) tuple(%reduce.197, %convert.308)
 }
@@ -432,32 +432,32 @@ StackFrames
 %fused_computation.11.clone.1 (param_0.1550: bf16[4,14336,1024], param_1.1588: s32[]) -> bf16[1,14336,1024] {
   %param_0.1550 = bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1588 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.353.clone.32 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.196 = bf16[1,14336,1024]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1550, %param_1.1588, %constant.353.clone.32, %constant.353.clone.32), dynamic_slice_sizes={1,14336,1024}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.331.clone.32 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.196 = bf16[1,14336,1024]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1550, %param_1.1588, %constant.331.clone.32, %constant.331.clone.32), dynamic_slice_sizes={1,14336,1024}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.12.clone.1 (param_0.1549: bf16[4,1024,14336], param_1.1587: s32[]) -> bf16[1,1024,14336] {
   %param_0.1549 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1587 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.353.clone.31 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.195 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1549, %param_1.1587, %constant.353.clone.31, %constant.353.clone.31), dynamic_slice_sizes={1,1024,14336}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.331.clone.31 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.195 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1549, %param_1.1587, %constant.331.clone.31, %constant.331.clone.31), dynamic_slice_sizes={1,1024,14336}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.13.clone.1 (param_0.1545: bf16[4,1024,14336], param_1.1584: s32[]) -> bf16[1,1024,14336] {
   %param_0.1545 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1584 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.353.clone.30 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.194 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1545, %param_1.1584, %constant.353.clone.30, %constant.353.clone.30), dynamic_slice_sizes={1,1024,14336}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.331.clone.30 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.194 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1545, %param_1.1584, %constant.331.clone.30, %constant.331.clone.30), dynamic_slice_sizes={1,1024,14336}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.68.clone.1 (param_0.1544: f32[128]) -> f32[128] {
   %param_0.1544 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.355.clone.10 = f32[]{:T(128)} constant(0.000244140625)
-  %broadcast.723 = f32[128]{0:T(128)} broadcast(%constant.355.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.868 = f32[128]{0:T(128)} multiply(%param_0.1544, %broadcast.723), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.356.clone.10 = f32[]{:T(128)} constant(1e-05)
-  %broadcast.722 = f32[128]{0:T(128)} broadcast(%constant.356.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.901 = f32[128]{0:T(128)} add(%div.868, %broadcast.722), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.333.clone.10 = f32[]{:T(128)} constant(0.000244140625)
+  %broadcast.717 = f32[128]{0:T(128)} broadcast(%constant.333.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.868 = f32[128]{0:T(128)} multiply(%param_0.1544, %broadcast.717), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.334.clone.10 = f32[]{:T(128)} constant(1e-05)
+  %broadcast.716 = f32[128]{0:T(128)} broadcast(%constant.334.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.901 = f32[128]{0:T(128)} add(%div.868, %broadcast.716), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.119 = f32[128]{0:T(128)S(1)} rsqrt(%add.901), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
@@ -474,12 +474,12 @@ StackFrames
   %convert.281 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1059)
   %dot_general.473 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.280, %convert.281), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.282 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%dot_general.473)
-  ROOT %bitcast.896 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convert.282)
+  ROOT %bitcast.895 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convert.282)
 }
 
 %fused_computation.10.clone.clone.clone.1 (param_0.1546: bf16[1,4096,14336]) -> bf16[4096,14336] {
   %param_0.1546 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.895 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1546), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  ROOT %bitcast.894 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1546), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.24.clone.1 (param_0.1548: bf16[1,4096,14336], param_1.1586: bf16[1,128,4096], param_2.1210: f32[128], param_3.814: bf16[4096]) -> bf16[1,128,14336] {
@@ -490,7 +490,7 @@ StackFrames
   %param_0.1548 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
   %fusion.494 = bf16[4096,14336]{1,0:T(8,128)(2,1)} fusion(%param_0.1548), kind=kLoop, calls=%fused_computation.10.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
   %convolution.161 = bf16[128,14336]{1,0:T(8,128)(2,1)} convolution(%fusion.495, %fusion.494), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  ROOT %bitcast.897 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.161), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  ROOT %bitcast.896 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.161), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.46.clone.clone.clone.1 (param_0.1553: bf16[1,128,4096], param_1.1589: f32[128], param_2.1211: bf16[4096]) -> bf16[128,4096] {
@@ -506,19 +506,19 @@ StackFrames
   %convert.284 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1061)
   %dot_general.475 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.283, %convert.284), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.285 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%dot_general.475)
-  ROOT %bitcast.900 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convert.285)
+  ROOT %bitcast.899 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convert.285)
 }
 
 %fused_computation.8.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1552: bf16[1,4096,14336]) -> bf16[4096,14336] {
   %param_0.1552 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.899 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1552), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  ROOT %bitcast.898 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1552), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.27.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1554: bf16[1,4096,14336], param_1.1590: bf16[1,128,14336], param_2.1212: bf16[1,128,4096], param_3.815: f32[128], param_4.501: bf16[4096]) -> bf16[128,14336] {
   %param_1.1590 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %convert.286 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%param_1.1590)
-  %constant.357.clone.10 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.47 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} broadcast(%constant.357.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)" stack_frame_id=0}
+  %constant.335.clone.10 = bf16[]{:T(256)} constant(1)
+  %jit_silu_.47 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} broadcast(%constant.335.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)" stack_frame_id=0}
   %convert.287 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%jit_silu_.47)
   %neg.140 = f32[1,128,14336]{2,1,0:T(8,128)} negate(%convert.286), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %exp.84 = f32[1,128,14336]{2,1,0:T(8,128)} exponential(%neg.140), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
@@ -532,16 +532,16 @@ StackFrames
   %param_0.1554 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
   %fusion.496 = bf16[4096,14336]{1,0:T(8,128)(2,1)} fusion(%param_0.1554), kind=kLoop, calls=%fused_computation.8.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
   %convolution.162 = bf16[128,14336]{1,0:T(8,128)(2,1)} convolution(%fusion.497, %fusion.496), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %bitcast.902 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.162), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convert.288 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%bitcast.902)
+  %bitcast.901 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.162), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  %convert.288 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%bitcast.901)
   %mul.1817 = f32[1,128,14336]{2,1,0:T(8,128)} multiply(%mul.1818, %convert.288), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.289 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} convert(%mul.1817)
-  ROOT %bitcast.901 = bf16[128,14336]{1,0:T(8,128)(2,1)} bitcast(%convert.289)
+  ROOT %bitcast.900 = bf16[128,14336]{1,0:T(8,128)(2,1)} bitcast(%convert.289)
 }
 
 %fused_computation.6.clone.clone.clone.clone.clone.1 (param_0.1551: bf16[1,14336,4096]) -> bf16[14336,4096] {
   %param_0.1551 = bf16[1,14336,4096]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.898 = bf16[14336,4096]{1,0:T(8,128)(2,1)} bitcast(%param_0.1551), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  ROOT %bitcast.897 = bf16[14336,4096]{1,0:T(8,128)(2,1)} bitcast(%param_0.1551), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.38.clone.1 (param_0.1555: bf16[1,128,4096], param_1.1591: bf16[1,14336,4096], param_2.1213: bf16[1,4096,14336], param_3.816: bf16[1,128,14336], param_4.502: f32[128], param_5.421: bf16[4096]) -> bf16[1,128,4096] {
@@ -554,8 +554,8 @@ StackFrames
   %param_1.1591 = bf16[1,14336,4096]{2,1,0:T(8,128)(2,1)} parameter(1)
   %fusion.498 = bf16[14336,4096]{1,0:T(8,128)(2,1)} fusion(%param_1.1591), kind=kLoop, calls=%fused_computation.6.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
   %convolution.163 = bf16[128,4096]{1,0:T(8,128)(2,1)} convolution(%fusion.37.clone.7, %fusion.498), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %bitcast.903 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.163), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convert.309 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.903)
+  %bitcast.902 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.163), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+  %convert.309 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.902)
   %convert.310 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%param_0.1555)
   %add.903 = f32[1,128,4096]{2,1,0:T(8,128)} add(%convert.309, %convert.310), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   ROOT %convert.311 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.903)
@@ -601,69 +601,69 @@ StackFrames
   ROOT %slice.147 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} slice(%param_0.1587), slice={[29360128:33554432]}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%wide.region_1.6_spmd.sunk.clone.clone.clone.sunk (wide.param.1: (s32[], bf16[1,128,4096], u32[4], u32[4,4], u32[4], /*index=5*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=10*/u32[4], u32[4,4], u32[4], u32[4,4], u32[4], /*index=15*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=20*/bf16[4,1,128,4096], bf16[4,4096], bf16[4,4096], bf16[4,1024,32,128], bf16[1,128,1,128], /*index=25*/bf16[1,128,1,128], bf16[4,1024,8,128], bf16[4,1024,8,128], bf16[4,32,128,1024], bf16[4,1024,14336], /*index=30*/bf16[4,1024,14336], bf16[4,14336,1024], u32[4], u32[4,4], u32[4], /*index=35*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=40*/u32[4], u32[4,4], u32[4], u32[4,4], u32[4], /*index=45*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=50*/s32[128], s32[], s8[1,1,1], s8[1,1,1], bf16[1,128,1,128], /*index=55*/bf16[1,128,1,128], s32[1,128])) -> (s32[], bf16[1,128,4096], u32[4], u32[4,4], u32[4], /*index=5*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=10*/u32[4], u32[4,4], u32[4], u32[4,4], u32[4], /*index=15*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=20*/bf16[4,1,128,4096], bf16[4,4096], bf16[4,4096], bf16[4,1024,32,128], bf16[1,128,1,128], /*index=25*/bf16[1,128,1,128], bf16[4,1024,8,128], bf16[4,1024,8,128], bf16[4,32,128,1024], bf16[4,1024,14336], /*index=30*/bf16[4,1024,14336], bf16[4,14336,1024], u32[4], u32[4,4], u32[4], /*index=35*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=40*/u32[4], u32[4,4], u32[4], u32[4,4], u32[4], /*index=45*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=50*/s32[128], s32[], s8[1,1,1], s8[1,1,1], bf16[1,128,1,128], /*index=55*/bf16[1,128,1,128], s32[1,128]) {
-  %constant.406.clone..sunk.1 = s32[]{:T(128)} constant(1)
-  %wide.param.1 = (s32[]{:T(128)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=5*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=10*/u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=15*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=20*/bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, bf16[4,1024,32,128]{1,3,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, /*index=25*/bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,1024,8,128]{1,3,2,0:T(8,128)(2,1)}, bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)}, bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, /*index=30*/bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=35*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=40*/u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=45*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=50*/s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, /*index=55*/bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, s32[1,128]{1,0:T(1,128)}) parameter(0)
-  %get-tuple-element.2248 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=0
-  %copy.283 = s32[]{:T(128)S(6)} copy(%get-tuple-element.2248), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add.904 = s32[]{:T(128)} add(%copy.283, %constant.406.clone..sunk.1), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2268 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=20
-  %get-tuple-element.2249 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=1
-  %bitcast_dynamic-update-slice_fusion.5 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)} fusion(%get-tuple-element.2268, %copy.283, %get-tuple-element.2249), kind=kLoop, calls=%fused_computation.54.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
-  %get-tuple-element.2330 = bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=28
-  %dynamic-slice_convert_fusion.35 = bf16[1,32,128,1024]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2330, %copy.283), kind=kLoop, calls=%fused_computation.18.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.99 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.35), channel_id=103, replica_groups=mesh['axis_0'=1,'axis_1'=1,'axis_2'=4] {'axis_2'}, dimensions={3}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2354 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=52, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
-  %get-tuple-element.2355 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=53, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
-  %get-tuple-element.2325 = bf16[4,1024,32,128]{1,3,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=23
-  %dynamic-slice_convert_fusion.36 = bf16[1,1024,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2325, %copy.283), kind=kLoop, calls=%fused_computation.19.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.100 = bf16[1,4096,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.36), channel_id=100, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.499 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.2249), kind=kLoop, calls=%fused_computation.40.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+%wide.region_1.6_spmd.sunk.clone.clone.clone.sunk (wide.param.1: (s32[], bf16[1,128,4096], bf16[4,1,128,4096], bf16[4,4096], bf16[4,4096], /*index=5*/bf16[4,1024,32,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,1024,8,128], bf16[4,1024,8,128], /*index=10*/bf16[4,32,128,1024], bf16[4,1024,14336], bf16[4,1024,14336], bf16[4,14336,1024], s32[128], /*index=15*/s32[], s8[1,1,1], s8[1,1,1], bf16[1,128,1,128], bf16[1,128,1,128], /*index=20*/s32[1,128])) -> (s32[], bf16[1,128,4096], bf16[4,1,128,4096], bf16[4,4096], bf16[4,4096], /*index=5*/bf16[4,1024,32,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,1024,8,128], bf16[4,1024,8,128], /*index=10*/bf16[4,32,128,1024], bf16[4,1024,14336], bf16[4,1024,14336], bf16[4,14336,1024], s32[128], /*index=15*/s32[], s8[1,1,1], s8[1,1,1], bf16[1,128,1,128], bf16[1,128,1,128], /*index=20*/s32[1,128]) {
+  %constant.383.clone..sunk.1 = s32[]{:T(128)} constant(1)
+  %wide.param.1 = (s32[]{:T(128)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[4,1024,32,128]{1,3,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,1024,8,128]{1,3,2,0:T(8,128)(2,1)}, bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)}, bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, /*index=15*/s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, /*index=20*/s32[1,128]{1,0:T(1,128)}) parameter(0)
+  %get-tuple-element.1402 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=0
+  %copy.265 = s32[]{:T(128)S(6)} copy(%get-tuple-element.1402), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add.904 = s32[]{:T(128)} add(%copy.265, %constant.383.clone..sunk.1), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1404 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=2
+  %get-tuple-element.1403 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=1
+  %bitcast_dynamic-update-slice_fusion.5 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)} fusion(%get-tuple-element.1404, %copy.265, %get-tuple-element.1403), kind=kLoop, calls=%fused_computation.54.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
+  %get-tuple-element.1430 = bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=10
+  %dynamic-slice_convert_fusion.35 = bf16[1,32,128,1024]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1430, %copy.265), kind=kLoop, calls=%fused_computation.18.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.97 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.35), channel_id=102, replica_groups=mesh['axis_0'=1,'axis_1'=1,'axis_2'=4] {'axis_2'}, dimensions={3}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1436 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=16, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
+  %get-tuple-element.1437 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=17, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
+  %get-tuple-element.1425 = bf16[4,1024,32,128]{1,3,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=5
+  %dynamic-slice_convert_fusion.36 = bf16[1,1024,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1425, %copy.265), kind=kLoop, calls=%fused_computation.19.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.98 = bf16[1,4096,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.36), channel_id=99, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.499 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.1403), kind=kLoop, calls=%fused_computation.40.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %add_rsqrt_fusion.4 = f32[128]{0:T(128)S(1)} fusion(%fusion.499), kind=kLoop, calls=%fused_computation.69.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2324 = bf16[4,4096]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.1), index=22
-  %get-tuple-element.2323 = bf16[4,4096]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.1), index=21
-  %convert_reduce_fusion.9 = (bf16[4096]{0:T(1024)(128)(2,1)S(1)}, bf16[4096]{0:T(1024)(128)(2,1)}) fusion(%get-tuple-element.2324, %copy.283, %get-tuple-element.2323), kind=kLoop, calls=%fused_computation.66.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2185 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} get-tuple-element(%convert_reduce_fusion.9), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %fusion.500 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%all-gather.100, %get-tuple-element.2249, %add_rsqrt_fusion.4, %get-tuple-element.2185), kind=kOutput, calls=%fused_computation.57.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.912 = s8[33554432]{0:T(1024)(128)(4,1)} bitcast(%all-gather.99)
-  %slice-start.24 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.912), calls=%async_computation.24
+  %get-tuple-element.1424 = bf16[4,4096]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.1), index=4
+  %get-tuple-element.1423 = bf16[4,4096]{1,0:T(4,128)(2,1)} get-tuple-element(%wide.param.1), index=3
+  %convert_reduce_fusion.9 = (bf16[4096]{0:T(1024)(128)(2,1)S(1)}, bf16[4096]{0:T(1024)(128)(2,1)}) fusion(%get-tuple-element.1424, %copy.265, %get-tuple-element.1423), kind=kLoop, calls=%fused_computation.66.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1375 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} get-tuple-element(%convert_reduce_fusion.9), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %fusion.500 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%all-gather.98, %get-tuple-element.1403, %add_rsqrt_fusion.4, %get-tuple-element.1375), kind=kOutput, calls=%fused_computation.57.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.911 = s8[33554432]{0:T(1024)(128)(4,1)} bitcast(%all-gather.97)
+  %slice-start.24 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.911), calls=%async_computation.24
   %slice_negate_fusion.12 = (bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.500), kind=kLoop, calls=%fused_computation.49.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2186 = bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %get-tuple-element.2187 = bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %get-tuple-element.2327 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=25
-  %get-tuple-element.2326 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=24
-  %slice-start.25 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.912), calls=%async_computation.25
-  %bitcast.935 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.2327)
-  %bitcast.933 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.2326)
-  %fusion.501 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2186, %get-tuple-element.2187, %fusion.500, %bitcast.935, %bitcast.933), kind=kLoop, calls=%fused_computation.52.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2328 = bf16[4,1024,8,128]{1,3,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=26
-  %dynamic-slice_convert_fusion.37 = bf16[1,1024,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2328, %copy.283), kind=kLoop, calls=%fused_computation.29.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice-start.26 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.912), calls=%async_computation.26
-  %slice-start.27 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.912), calls=%async_computation.27
-  %all-gather.101 = bf16[1,4096,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.37), channel_id=101, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice-start.28 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.912), calls=%async_computation.28
-  %fusion.502 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%all-gather.101, %get-tuple-element.2249, %add_rsqrt_fusion.4, %get-tuple-element.2185), kind=kOutput, calls=%fused_computation.58.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1376 = bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
+  %get-tuple-element.1377 = bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
+  %get-tuple-element.1427 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=7
+  %get-tuple-element.1426 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=6
+  %slice-start.25 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.911), calls=%async_computation.25
+  %bitcast.934 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1427)
+  %bitcast.932 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1426)
+  %fusion.501 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1376, %get-tuple-element.1377, %fusion.500, %bitcast.934, %bitcast.932), kind=kLoop, calls=%fused_computation.52.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1428 = bf16[4,1024,8,128]{1,3,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=8
+  %dynamic-slice_convert_fusion.37 = bf16[1,1024,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1428, %copy.265), kind=kLoop, calls=%fused_computation.29.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %slice-start.26 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.911), calls=%async_computation.26
+  %slice-start.27 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.911), calls=%async_computation.27
+  %all-gather.99 = bf16[1,4096,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.37), channel_id=100, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %slice-start.28 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.911), calls=%async_computation.28
+  %fusion.502 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%all-gather.99, %get-tuple-element.1403, %add_rsqrt_fusion.4, %get-tuple-element.1375), kind=kOutput, calls=%fused_computation.58.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %slice_negate_fusion.13 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.502), kind=kLoop, calls=%fused_computation.62.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2188 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %get-tuple-element.2189 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %bitcast.936 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.2327)
-  %bitcast.934 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.2326)
-  %fusion.503 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2188, %get-tuple-element.2189, %fusion.502, %bitcast.936, %bitcast.934), kind=kLoop, calls=%fused_computation.65.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2329 = bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=27
-  %slice-start.29 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.912), calls=%async_computation.29
-  %dynamic-slice_convert_fusion.38 = bf16[1,1024,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2329, %copy.283), kind=kLoop, calls=%fused_computation.28.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice-start.30 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.912), calls=%async_computation.30
-  %all-gather.102 = bf16[1,4096,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.38), channel_id=102, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice-start.31 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.912), calls=%async_computation.31
-  %fusion.504 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.102, %get-tuple-element.2249, %add_rsqrt_fusion.4, %get-tuple-element.2185), kind=kOutput, calls=%fused_computation.59.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2352 = s32[128]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=50
-  %squeeze.291 = s32[128,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.2352), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8"]},"aliasing_operands":{"lists":[]}}
-  %squeeze.292 = s32[8,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.2352), dimensions={1}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["128"]},"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1378 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
+  %get-tuple-element.1379 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
+  %bitcast.935 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1427)
+  %bitcast.933 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1426)
+  %fusion.503 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1378, %get-tuple-element.1379, %fusion.502, %bitcast.935, %bitcast.933), kind=kLoop, calls=%fused_computation.65.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1429 = bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=9
+  %slice-start.29 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.911), calls=%async_computation.29
+  %dynamic-slice_convert_fusion.38 = bf16[1,1024,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1429, %copy.265), kind=kLoop, calls=%fused_computation.28.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %slice-start.30 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.911), calls=%async_computation.30
+  %all-gather.100 = bf16[1,4096,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.38), channel_id=101, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %slice-start.31 = ((s8[33554432]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.911), calls=%async_computation.31
+  %fusion.504 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.100, %get-tuple-element.1403, %add_rsqrt_fusion.4, %get-tuple-element.1375), kind=kOutput, calls=%fused_computation.59.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1434 = s32[128]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=14
+  %squeeze.253 = s32[128,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.1434), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8"]},"aliasing_operands":{"lists":[]}}
+  %squeeze.254 = s32[8,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.1434), dimensions={1}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["128"]},"aliasing_operands":{"lists":[]}}
   %iota.68 = s32[128,128]{1,0:T(8,128)S(1)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %splash_mha_fwd_segmented_residuals.3 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[32,128,128]{2,1,0:T(8,128)}) custom-call(%get-tuple-element.2354, %get-tuple-element.2355, %fusion.501, %fusion.503, %fusion.504, /*index=5*/%squeeze.291, %squeeze.292, %iota.68), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[32,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
+  %splash_mha_fwd_segmented_residuals.3 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[32,128,128]{2,1,0:T(8,128)}) custom-call(%get-tuple-element.1436, %get-tuple-element.1437, %fusion.501, %fusion.503, %fusion.504, /*index=5*/%squeeze.253, %squeeze.254, %iota.68), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[32,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
 "xprof_metadata":"{\"block_q\": 128, \"block_kv\": 128, \"block_kv_compute\": 128, \"block_q_dkv\": 128, \"block_kv_dkv\": 128, \"block_kv_dkv_compute\": 128, \"block_q_dq\": 128, \"block_kv_dq\": 128, \"use_fused_bwd_kernel\": false, \"q_layout\": 1, \"k_layout\": 1, \"v_layout\": 1}"
-}}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"custom_call_config":{"body":"TUzvUgFNTElSMjMuMC4wZ2l0AAFVCwEDBQcJAQMLAz8NDxETFRcZGx0fISMlJykrLS8xMzU3OTs9P0FDRUdJA7IECgQzAfUHFxMXFxMPFxcbCwsXCwsLEycPFwsXExNzUwsXGxMXCxMTF6WFCxMXEwsXDwsLCwsLCwsLCwsLCwsXEwsLJwsLCxMLFxcLCwsLFxcLCzMXFxcXEwsPSwsXCwtzCw8LCwsLNxsLGwsbCxsLGwtTGwsjCyMLIwsbCxsLGwURYYGRjWFNKgIqAgH5GxsbGxsbGxsbGw8PEwsLKwsLEwsTCw8TCw8LEwsTCxMLCxMLDxMLFx8LEwsLEwtTFwsTCwsTCw8TCw9TCxMLExMLCx8LEwsvGwsjFwsTCxcPFwsTCxcLEwsfFwsTCxMPFwsTCxcfCxMLHwsTCwsTCwsTCxcfCxMLHy8XDwcFWVkJBV1JATMPBx8jBw8LCysfJxcfIycHHyMrIxsbTy8rAh4aHwMDHzYCHW+eAh26Ar4CAwMfMgIdbzoCFRkZHY4CkgIdTgJSAgMDrgL6AwVLBU0dQgJGAgVPBVEFUx1T8gIDB30lf/YCgYMRDQAdcgJ2Ag0xHdoC3gIdU+oCHXkKAyMLBzEBAAAAAAAAAIAAAAAAAAAAgAAAAAAAAAAjCwUhgAAAAAAAAACAAAAAAAAAAA0vAwMf5gIDAxID/gMdcVoCAwM/YgIFVR1xZgIdd4YCHRoDHgNhZmZpbmVfbWFwPChkMCwgZDEsIGQyKSAtPiAoZDAsIGQxLCBkMik+AGFmZmluZV9tYXA8KGQwLCBkMSkgLT4gKGQwLCBkMSk+AAVXAwM/VwMDP5oCHXmyAgVZAwMfBgMRCwEFWwVdBV8FYQVjBWUFZwVpBWsFbQVvBXEFcwMDH24CHXd+AgV1BXcDB30lf8YCgYMFeQV7BX0jAQEBBX8d+gL+AgMDHxYDBYEFgwWFBYcDAx9uAx2iA6YDBYkFiyMLAxEBAAAAAAAAAB2yA7YDHb4DwgMdygPOAx3eA+IDAwOnqQWNEQs9AxGtrxWxs7W3ubtXF72//8HDBY8BB/v5+Q0tBZEjCwcxIAAAAAAAAAABAAAAAAAAAAEAAAAAAAAABZMRCwkFlQWXBZkFmwEXxcnN0dXb3+Pn6+8DBRvHHTEJWQMFG8sdMQlbAwUbzx0xCV0DBRvTHTMJXwMFG9cd2QlhIwsFIQgAAAAAAAAAgAAAAAAAAAADBRvdHTMJYwMHS/cb4R0zCWUDB0v3G+UdMwlnAwdL9xvpHTMJaQMFG+0dMQlrAwUb8R0xCW0DBRU1F1kjdHB1Lm1lbW9yeV9zcGFjZTx2bWVtPgAjdHB1LnBpcGVsaW5lX21vZGU8c3luY2hyb25vdXM+ACN0cHUuZGltZW5zaW9uX3NlbWFudGljczxhcmJpdHJhcnk+ACN0cHUuZGltZW5zaW9uX3NlbWFudGljczxwYXJhbGxlbD4AI3RwdS5tZW1vcnlfc3BhY2U8c21lbT4AI3RwdS5jb3JlX3R5cGU8dGM+ACN0cHUuZG90X2RpbWVuc2lvbl9udW1iZXJzPFsxXSwgWzFdLCBbMF0sIFswXSwgWzAsIDAsIDEsIDBdLCBbXSwgW10+ACN0cHUuZG90X2RpbWVuc2lvbl9udW1iZXJzPFsxXSwgWzBdLCBbMF0sIFsxXSwgWzAsIDAsIDEsIDFdLCBbXSwgW10+AAMFFTUXWwMFFTUXXQMFFSkXXwMFFSkXYQMFFSkXYwMFFSkXZQMFFSkXZwMFFSkXaQMFFTUXawMFFTUXbREBAREDAR0+AhkFnQWfLUoCCe4lEzImBwWhBaMdVgINBaUdXgIZBacRCxEdagINBakRAREFqx16AhkFrR2CAhkFrx2KAg0FsQWzHZYCGQW1EQsFHaICDQW3AwMfqgITCRAAAOAPBbkdtgINBbsFvR3CAg0FvyMBCSEBAAAAAQAAAAMAAAAAAAAAHc4C0gIFwR3WAg0FwwXFHeICDQXHEwkBHe4CGQXJHYUNIwEJIQEAAAABAAAAAgAAAAAAAAAFyx0CAxkFzREBAgQdDgMZBc8F0SUFCQAAAAAF0x0iAw0F1QMJiwICjSWPJZElAwMuAzIDBdcjAQMJAQAAAB06Az4DBdkdQgMNBdsDAz9KAxELFR1SA1YDBd0dWgMNBd8dYgNmAwXhHWoDDQXjEwmQzMzMPx12A3oDBeUdfgMZBecdU4YDHYUZHY4DkgMF6R2WAwEF6wMDH54DJRcJAACA/wXtHaoDDQXvAwWXAgSZmwXxHboDDQXzBfUdxgMNBfcF+R3SAw0F+wMDH9oDJRcJAAAAAAX9HeYDDQX/AwWXBgSZmwMJiwYCjSWPJZElAwMf9gMRAQUjYXJpdGguZmFzdG1hdGg8bm9uZT4AI2FyaXRoLm92ZXJmbG93PG5vbmU+ACN2ZWN0b3Iua2luZDxtYXhpbXVtZj4AI3ZlY3Rvci5raW5kPGFkZD4AAQICAycFAgQCBAkX/QcFBQUPRwsBAgQBCQFBF/UHBQIEAgQfRycFAgQCBAEX9QUCBAIECUknAwIECScFAgQCBB8nBwUCBAIEHxf1BQIEAgQBSQcnBQIEAgQNF/UFIQIEAUkX9QcFAgQCBAlHJwcFAgQCBAknBQUCBAEnBQIEBQkFIQEBAQcHERERHSMdFRUVESUBBQsBAQEHBwcBAQEFCwEBAQcHBQEBBN4iBQERAaUHAwExCxEBqwcDU3chAQEBAQEBBwEHAREBEQERAR0BIwEdARUBFQEVAREBJQEDA3UJAwERB0NNAw0FBSEbBhEDAQMjAwMPCQMBEQcPTwMNBSUnHRQPAykJAx9NAwMtNwMJDwYhAwUDUwMDBwMDAwMDBwMDAwUGBwMFBxtXWRMFByMJVRtXWQMDLZMDCQ8GIQMFA10DAwcDAwMDAwcDAwMFBgcDBQcXYWMTBQcjCV8XYWMDAy03AwkPBiEDBQNnAwMHAwMDAwMHAwMDBQYHAwUHGWttEwUHIwlpGWttGQAPAwEFGQAPAwMLAwMDBwYLAwMDAwcGCwMDAwUVBgsDDwkJKy0vFwYRAwEDMQMDOwkDAREHQT0DDQUzNQMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JBzk7PRcGEQMBAz8bBhEDAQM3AwMPCQMBEQcPTwMNBUNFHRQPA0cJA7PqAgMDhwkDAQMDL1UDASMHLzkDAQVTVQMDBQMDAwMDBQMDAwUGBQMFBxdZWwkGBQMFA10DAwUDAwMDAwUDAwMFBgUDBQcZYWMJBgUDBQNlAwMFAwMDAwMFAwMDAwMFAwMDBQYFAxsJC2lrbQkGBQMZA28DAwUDAwMHBgUDAwNXAwMFAwMDBQYFAxsJDXN1dwkGBQMZA3kDA0WJAwUnB0UmAwMFB3F7fQMDL1UDASMHLzkDAQVBgQMDL1UDASMHLzkDAQVThSkHKzkDAQWDhzcDNgMqAwMTDwYrAxMDiSkHKzkDEwWNiwMDBQMDAwMDBQMDAwUGBQMTBxWRkwkGBQMTA5URB04DRgMDIQWXjwMDBQMDAwcGBQMDA1cFBgUDKQcTm50JBgUDKQOfAwMFAwMDAwMFAwMDBQYFAxMHEaOlCQYFAxMDpw8GQwMTA6ERB0NNAyEFqas5Bl4DAyEFma0DA3IDkwMJDwaCAwMFA7E7BooDAwUHr3+zAwOVmgMDFysHla4DAxcFtbcJBiEDKwO5DwadAwUDuz0HnRMDBQVfvS0HnxMDBQW1vy8HoRMDBQPBAwOj1gMDFysHo+oDAxcFw8UJBiEDKwPHDwYhAwUDyS0HnxMDBQVfvy8HoRMDBQPNHwdREwMFBc9nIQcrEwMFBcvRAwMHAwMDAwMHAwMDBQYHAwUHF9XXEwUHIwm/F9XXAwMHAwMDAwMHAwMDBQYHAwUHGdvdEwUHIwnTGdvdAwMFAwMDBwYFAwMDVwMDBQMDAwUGBQMbCQ/h4+UJBgUDGQPnPwYRAwUD6QMDRYkDBScHRe4DAwUHw+vtAwMFAwMDAwMFAwMDBQYFAwUHG/HzCQYFAwUD9R8HURMDBQXP9yEHKxMDBQX57wMDBwMDAwMDBwMDAwUGBwMFBxv9/xMFByMJ+xv9/wMDh/IDAwEZAA8DAQUZAA8DA3UJAwERB0NNAw0FBUkbBhEDAQNLAwMPCQMBEQcPTwMNBU1PHRQPA1EJA13RAwMFAwMDAwMFAwMDBQYFAwUHGVNVCQYFAwUDVwMDJ6YCAwkPBicDBQNbMQcnEwMFBV1ZAwMFAwMDAwMFAwMDBQYFAwUHG2FjCQYFAwUDZR8HURMDBQVnXzMGEQMZA2kDAwcDAwMDAwcDAwMDAwcDAwMFBgcDGwkdbW9xCQYHAxkDcwkGBwMbA2sTBQd7C3cdbW9xNQfKAhMDBQNZAwMFAwMDAwMFAwMDBQYFAwUHF3t9CQYFAwUDfyEHKxMDBQV5gQMDBwMDAwMDBwMDAwMDBwMDAwUGBwMnCR+Fh4kJBgcDBQOLCQYHAycDgxMFB3sLjx+Fh4kDAy03AwkPBiEDBQORAwMHAwMDAwMHAwMDBQYHAwUHF5WXEwUHIwmTF5WXAwMtNwMJDwYhAwUDmwMDBwMDAwMDBwMDAwUGBwMFBxmfoRMFByMJnRmfoQMDLTcDCQ8GIQMFA6UDAwcDAwMDAwcDAwMFBgcDBQcbqasTBQcjCacbqasZAA8DAQUZAA8NAAELEQHzBwMPDwsBAQEBAQEHAQcBAwMBCQMBAwMBCQMBDQQBBwEDCwsRAQoCBwMrRwsBAQEBAQEHAQcBAwMLAwMDBwYLAwMDAwcGCwMDAwUVBgsDDwkJCw0PFwYRAwEDEQMDOwkDAREHQT0DDQUTFQMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JBxkbHRcGEQMBAx8DAydzAwElBicDAQUBIwMDAQkDAQMDAQkDAQ0EAQclIScLEQEOAgcDK0cLAQEBAQEBBwEHAQMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JCQsNDxcGEQMBAxEDAzsJAwERB0E9Aw0FExUDAwsDAwMHBgsDAwMDBwYLAwMDBRUGCwMPCQcZGx0XBhEDAQMfAwMncwMBJQYnAwEFASMDAwEJAwEDAwEJAwENBAEHJSEnCxEBEgIHAw8PCwEBAQEBAQcBBwEDAwEJAwEDAwEJAwENBAEFAwsLEQEWAgcDJz8LAQEBAQEBBwEHAQMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JCQsNDxcGEQMBAxEDAzsJAwERB0E9Aw0FExUDAwsDAwMHBgsDAwMDBwYLAwMDBRUGCwMPCQcZGx0XBhEDAQMfAwMBCQMBAwMBCQMBDQQBBSMhCxEBGgIHAw8PCwEBAQEBAQcBBwEDAwEJAwEDAwEJAwENBAEFAwsLEQEeAgcDERMLAQEBAQEBBwEHAQMDAQkDAQMDAQkDAQMDAQkDAQ0EAQULDQsRASICBwMREwsBAQEBAQEHAQcBAwMBCQMBAwMBCQMBAwMBCQMBDQQBBQsNCxEBJgIHAxETCwEBAQEBAQcBBwEDAwEJAwEDAwEJAwEDAwEJAwENBAEFCw0LEQEqAgcDDw8LAQEBAQEBBwEHAQMDAQkDAQMDAQkDAQ0EAQcBAwsLEQEuAgcDDw8LAQEBAQEBBwEHAQMDAQkDAQMDAQkDAQ0EAQcBAwsGAwEFAQDmGgICLRkRCxELEQstGSUVCQsRCw0JFQ0XMRsdCQsNIxELEQsVDRETEQsNDQcJCw0HVS0SAiUJHR1HIyEjKS0fCx0nHSVFESkJCwkJCxsZGRkZGRkZGRkZJR0VDR0lEx0XHxsXExMbFxMXLxcXGRcXFw8ZFRkZIxcjGRUlIxkfDw8NCR0RYnVpbHRpbgBzdGFibGVfbW9zYWljAHRwdQBhcml0aAB2ZWN0b3IAbW9kdWxlAGFyaXRoLmNvbnN0YW50AHZlY3Rvci5sb2FkAGFyaXRoLmluZGV4X2Nhc3QAdmVjdG9yLnNoYXBlX2Nhc3QAZnVuYy5mdW5jAGZ1bmMucmV0dXJuAHZlY3Rvci5icm9hZGNhc3QAYXJpdGguY21waQB0cHUudmVjdG9yX3N0b3JlAG1lbXJlZi5sb2FkAGFyaXRoLmV4dHNpAHNjZi55aWVsZABhcml0aC5leHR1aQBzY2YuaWYAYXJpdGgubXVsZgBhcml0aC5hZGRmAGFyaXRoLm11bGkAYXJpdGguZGl2c2kAdHB1Lm1hdG11bABhcml0aC5hZGRpAHZlY3Rvci5tdWx0aV9yZWR1Y3Rpb24AYXJpdGguc3ViZgBtYXRoLmV4cABhcml0aC5kaXZmAGFyaXRoLnRydW5jZgBtYXRoLmxvZwB0cHUuaW90YQBhcml0aC5hbmRpAGFyaXRoLnNlbGVjdABhcml0aC5tYXhpbXVtZgBhcml0aC5leHRmAGZ1bmN0aW9uX3R5cGUAc3ltX25hbWUAdHJhbnNmb3JtX2luZGljZXMAd2luZG93X2JvdW5kcwB2YWx1ZQBwcmVkaWNhdGUAcGlwZWxpbmVfbW9kZQBicm9hZGNhc3RfaW5fZGltOgB0cmFuc2Zvcm1fMAB0cmFuc2Zvcm1fMQB0cmFuc2Zvcm1fMgB0cmFuc2Zvcm1fMwB0cmFuc2Zvcm1fNAB0cmFuc2Zvcm1fNQB0cmFuc2Zvcm1fNgB0cmFuc2Zvcm1fNwB0cmFuc2Zvcm1fOAB0cmFuc2Zvcm1fOQB0cmFuc2Zvcm1fMTAAZ2V0OgBndDoAZXE6AG11bDoAYWRkAG9wZXJhbmRTZWdtZW50U2l6ZXMAc3RyaWRlcwBicm9hZGNhc3RfaW5fZGltL2Jyb2FkY2FzdF9pbl9kaW0AZGltZW5zaW9uX251bWJlcnMAdHJhbnNwb3NlX2xocwB0cmFuc3Bvc2VfbGhzX2hpbnQAdHJhbnNwb3NlX3JocwBraW5kAHJlZHVjdGlvbl9kaW1zAHN0YWJsZV9tb3NhaWMudmVyc2lvbgBkaW1lbnNpb25fc2VtYW50aWNzAGl0ZXJhdGlvbl9ib3VuZHMAc2NhbGFyX3ByZWZldGNoAHNjcmF0Y2hfb3BlcmFuZHMAc3BsYXNoX21oYV9md2Rfc2VnbWVudGVkX3Jlc2lkdWFscwB0cHUuY29yZV90eXBlAHdpbmRvd19wYXJhbXMAZ2V0AF9zcGxhc2hfYXR0ZW50aW9uAC9fX3cvbWF4dGV4dC9tYXh0ZXh0Ly52ZW52L2xpYi9weXRob24zLjEyL3NpdGUtcGFja2FnZXMvamF4L2V4cGVyaW1lbnRhbC9wYWxsYXMvb3BzL3RwdS9zcGxhc2hfYXR0ZW50aW9uL3NwbGFzaF9hdHRlbnRpb25fa2VybmVsLnB5AGNvbnZlcnRfZWxlbWVudF90eXBlOgBjb252ZXJ0X2VsZW1lbnRfdHlwZS9jb252ZXJ0X2VsZW1lbnRfdHlwZQBndABndC9ndABkaXY6AGRpdgBlcQBlcS9lcQBjb25kOgBjb25kAGdldC9nZXQAZmFzdG1hdGgAbXVsL211bABzd2FwOgBzd2FwL3N3YXAAbG9nOgBsb2cvbG9nAGFkZDoAYWRkL2FkZABicm9hZGNhc3RfaW5fZGltAHNjYW46AHNjYW4AbXVsAG92ZXJmbG93RmxhZ3MAZG90X2dlbmVyYWw6AGRvdF9nZW5lcmFsL2RvdF9nZW5lcmFsAGRpbWVuc2lvbnMAaW90YToAaW90YS9pb3RhAGdlOgBnZS9nZQBhbmQ6AGFuZC9hbmQAaml0OgBqaXQAc2VsZWN0X246AHNlbGVjdF9uL3NlbGVjdF9uAHJlZHVjZV9tYXg6AHJlZHVjZV9tYXgvcmVkdWNlX21heABtYXg6AG1heC9tYXgAc3ViOgBzdWIvc3ViAGV4cDoAZXhwL2V4cAByZWR1Y2Vfc3VtOgByZWR1Y2Vfc3VtL3JlZHVjZV9zdW0A","needs_layout_passes":true,"allow_input_fusion":[],"serialization_format":"1","output_memory_colors":[],"output_memory_space_colors":[],"input_memory_space_colors":[]},"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2190 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%splash_mha_fwd_segmented_residuals.3), index=3, frontend_attributes={kernel_metadata={
+}}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"custom_call_config":{"body":"<mosaic_body>","needs_layout_passes":true,"allow_input_fusion":[],"serialization_format":"1","output_memory_colors":[],"output_memory_space_colors":[],"input_memory_space_colors":[]},"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1380 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%splash_mha_fwd_segmented_residuals.3), index=3, frontend_attributes={kernel_metadata={
 "xprof_metadata":"{\"block_q\": 128, \"block_kv\": 128, \"block_kv_compute\": 128, \"block_q_dkv\": 128, \"block_kv_dkv\": 128, \"block_kv_dkv_compute\": 128, \"block_q_dq\": 128, \"block_kv_dq\": 128, \"use_fused_bwd_kernel\": false, \"q_layout\": 1, \"k_layout\": 1, \"v_layout\": 1}"
 }}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}
   %slice-done.24 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} async-done(%slice-start.24)
@@ -674,121 +674,49 @@ StackFrames
   %slice-done.29 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} async-done(%slice-start.29)
   %slice-done.30 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} async-done(%slice-start.30)
   %slice-done.31 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} async-done(%slice-start.31)
-  %custom-call.24 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} custom-call(%slice-done.24, %slice-done.25, %slice-done.26, %slice-done.27, %slice-done.28, /*index=5*/%slice-done.29, %slice-done.30, %slice-done.31), custom_call_target="ConcatBitcast", backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.913 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} bitcast(%custom-call.24)
-  %fusion.505 = (f32[128]{0:T(128)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)}) fusion(%get-tuple-element.2249, %bitcast.913, %get-tuple-element.2190), kind=kOutput, calls=%fused_computation.42.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2191 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} get-tuple-element(%fusion.505), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %get-tuple-element.2333 = bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=31
-  %dynamic-slice_convert_fusion.39 = bf16[1,14336,1024]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2333, %copy.283), kind=kLoop, calls=%fused_computation.11.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.103 = bf16[1,14336,4096]{2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.39), channel_id=106, replica_groups=mesh['axis_0'=1,'axis_1'=4] {'axis_1'}, dimensions={2}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2332 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=30
-  %dynamic-slice_convert_fusion.40 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2332, %copy.283), kind=kLoop, calls=%fused_computation.12.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.104 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.40), channel_id=105, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2331 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=29
-  %dynamic-slice_convert_fusion.41 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2331, %copy.283), kind=kLoop, calls=%fused_computation.13.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2192 = f32[128]{0:T(128)} get-tuple-element(%fusion.505), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %copy-start.127 = (f32[128]{0:T(128)S(1)}, f32[128]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2192)
-  %copy-start.3 = (bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2191)
-  %get-tuple-element.2193 = bf16[4096]{0:T(1024)(128)(2,1)} get-tuple-element(%convert_reduce_fusion.9), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %copy-start.50 = (bf16[4096]{0:T(1024)(128)(2,1)S(1)}, bf16[4096]{0:T(1024)(128)(2,1)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2193)
-  %all-gather.105 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.41), channel_id=104, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %custom-call.6 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} custom-call(%slice-done.24, %slice-done.25, %slice-done.26, %slice-done.27, %slice-done.28, /*index=5*/%slice-done.29, %slice-done.30, %slice-done.31), custom_call_target="ConcatBitcast", backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.912 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} bitcast(%custom-call.6)
+  %fusion.505 = (f32[128]{0:T(128)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)}) fusion(%get-tuple-element.1403, %bitcast.912, %get-tuple-element.1380), kind=kOutput, calls=%fused_computation.42.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1381 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} get-tuple-element(%fusion.505), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %get-tuple-element.1433 = bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=13
+  %dynamic-slice_convert_fusion.39 = bf16[1,14336,1024]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1433, %copy.265), kind=kLoop, calls=%fused_computation.11.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.101 = bf16[1,14336,4096]{2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.39), channel_id=105, replica_groups=mesh['axis_0'=1,'axis_1'=4] {'axis_1'}, dimensions={2}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1432 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=12
+  %dynamic-slice_convert_fusion.40 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1432, %copy.265), kind=kLoop, calls=%fused_computation.12.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.102 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.40), channel_id=104, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1431 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=11
+  %dynamic-slice_convert_fusion.41 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1431, %copy.265), kind=kLoop, calls=%fused_computation.13.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1382 = f32[128]{0:T(128)} get-tuple-element(%fusion.505), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %copy-start.127 = (f32[128]{0:T(128)S(1)}, f32[128]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.1382)
+  %copy-start.3 = (bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)}, u32[]{:S(2)}) copy-start(%get-tuple-element.1381)
+  %get-tuple-element.1383 = bf16[4096]{0:T(1024)(128)(2,1)} get-tuple-element(%convert_reduce_fusion.9), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %copy-start.50 = (bf16[4096]{0:T(1024)(128)(2,1)S(1)}, bf16[4096]{0:T(1024)(128)(2,1)}, u32[]{:S(2)}) copy-start(%get-tuple-element.1383)
+  %all-gather.103 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.41), channel_id=103, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %copy-done.127 = f32[128]{0:T(128)S(1)} copy-done(%copy-start.127)
   %add_rsqrt_fusion.5 = f32[128]{0:T(128)S(1)} fusion(%copy-done.127), kind=kLoop, calls=%fused_computation.68.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %copy-done.3 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} copy-done(%copy-start.3)
   %copy-done.50 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} copy-done(%copy-start.50)
-  %get-tuple-element.2334 = u32[4]{0:T(128)} get-tuple-element(%wide.param.1), index=32, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.143 = (u32[4]{0:T(128)S(1)}, u32[4]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2334)
-  %fusion.506 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.105, %copy-done.3, %add_rsqrt_fusion.5, %copy-done.50), kind=kOutput, calls=%fused_computation.24.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2335 = u32[4,4]{1,0:T(4,128)} get-tuple-element(%wide.param.1), index=33, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.128 = (u32[4,4]{1,0:T(4,128)S(1)}, u32[4,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2335)
-  %get-tuple-element.2336 = u32[4]{0:T(128)} get-tuple-element(%wide.param.1), index=34, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.144 = (u32[4]{0:T(128)S(1)}, u32[4]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2336)
-  %get-tuple-element.2337 = u32[4,4]{1,0:T(4,128)} get-tuple-element(%wide.param.1), index=35, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.129 = (u32[4,4]{1,0:T(4,128)S(1)}, u32[4,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2337)
-  %get-tuple-element.2338 = u32[4]{0:T(128)} get-tuple-element(%wide.param.1), index=36, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.145 = (u32[4]{0:T(128)S(1)}, u32[4]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2338)
-  %get-tuple-element.2339 = u32[4,4]{1,0:T(4,128)} get-tuple-element(%wide.param.1), index=37, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.130 = (u32[4,4]{1,0:T(4,128)S(1)}, u32[4,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2339)
-  %get-tuple-element.2340 = u32[4]{0:T(128)} get-tuple-element(%wide.param.1), index=38, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.146 = (u32[4]{0:T(128)S(1)}, u32[4]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2340)
-  %get-tuple-element.2341 = u32[4,4]{1,0:T(4,128)} get-tuple-element(%wide.param.1), index=39, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.131 = (u32[4,4]{1,0:T(4,128)S(1)}, u32[4,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2341)
-  %get-tuple-element.2342 = u32[4]{0:T(128)} get-tuple-element(%wide.param.1), index=40, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.147 = (u32[4]{0:T(128)S(1)}, u32[4]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2342)
-  %get-tuple-element.2343 = u32[4,4]{1,0:T(4,128)} get-tuple-element(%wide.param.1), index=41, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.132 = (u32[4,4]{1,0:T(4,128)S(1)}, u32[4,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2343)
-  %get-tuple-element.2344 = u32[4]{0:T(128)} get-tuple-element(%wide.param.1), index=42, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.148 = (u32[4]{0:T(128)S(1)}, u32[4]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2344)
-  %get-tuple-element.2345 = u32[4,4]{1,0:T(4,128)} get-tuple-element(%wide.param.1), index=43, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.133 = (u32[4,4]{1,0:T(4,128)S(1)}, u32[4,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2345)
-  %get-tuple-element.2346 = u32[4]{0:T(128)} get-tuple-element(%wide.param.1), index=44, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.149 = (u32[4]{0:T(128)S(1)}, u32[4]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2346)
-  %get-tuple-element.2347 = u32[4,4]{1,0:T(4,128)} get-tuple-element(%wide.param.1), index=45, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.134 = (u32[4,4]{1,0:T(4,128)S(1)}, u32[4,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2347)
-  %get-tuple-element.2348 = u32[4]{0:T(128)} get-tuple-element(%wide.param.1), index=46, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.150 = (u32[4]{0:T(128)S(1)}, u32[4]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2348)
-  %get-tuple-element.2349 = u32[4,4]{1,0:T(4,128)} get-tuple-element(%wide.param.1), index=47, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.135 = (u32[4,4]{1,0:T(4,128)S(1)}, u32[4,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2349)
-  %get-tuple-element.2350 = u32[4]{0:T(128)} get-tuple-element(%wide.param.1), index=48, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.151 = (u32[4]{0:T(128)S(1)}, u32[4]{0:T(128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2350)
-  %get-tuple-element.2351 = u32[4,4]{1,0:T(4,128)} get-tuple-element(%wide.param.1), index=49, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy-start.136 = (u32[4,4]{1,0:T(4,128)S(1)}, u32[4,4]{1,0:T(4,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2351)
-  %get-tuple-element.2767 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=54
-  %copy-start.75 = (bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2767)
-  %get-tuple-element.2823 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=55
-  %copy-start.77 = (bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2823)
-  %get-tuple-element.2880 = s32[1,128]{1,0:T(1,128)} get-tuple-element(%wide.param.1), index=56
-  %copy-start.106 = (s32[1,128]{1,0:T(1,128)S(1)}, s32[1,128]{1,0:T(1,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.2880)
-  %fusion.507 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} fusion(%copy-done.3, %all-gather.103, %all-gather.104, %fusion.506, %add_rsqrt_fusion.5, /*index=5*/%copy-done.50), kind=kOutput, calls=%fused_computation.38.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.143 = u32[4]{0:T(128)S(1)} copy-done(%copy-start.143)
-  %copy.306 = u32[4]{0:T(128)} copy(%copy-done.143), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.128 = u32[4,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.128)
-  %copy.307 = u32[4,4]{1,0:T(4,128)} copy(%copy-done.128), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.144 = u32[4]{0:T(128)S(1)} copy-done(%copy-start.144)
-  %copy.308 = u32[4]{0:T(128)} copy(%copy-done.144), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.129 = u32[4,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.129)
-  %copy.309 = u32[4,4]{1,0:T(4,128)} copy(%copy-done.129), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.145 = u32[4]{0:T(128)S(1)} copy-done(%copy-start.145)
-  %copy.310 = u32[4]{0:T(128)} copy(%copy-done.145), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.130 = u32[4,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.130)
-  %copy.311 = u32[4,4]{1,0:T(4,128)} copy(%copy-done.130), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.146 = u32[4]{0:T(128)S(1)} copy-done(%copy-start.146)
-  %copy.312 = u32[4]{0:T(128)} copy(%copy-done.146), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.131 = u32[4,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.131)
-  %copy.313 = u32[4,4]{1,0:T(4,128)} copy(%copy-done.131), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.147 = u32[4]{0:T(128)S(1)} copy-done(%copy-start.147)
-  %copy.314 = u32[4]{0:T(128)} copy(%copy-done.147), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.132 = u32[4,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.132)
-  %copy.315 = u32[4,4]{1,0:T(4,128)} copy(%copy-done.132), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.148 = u32[4]{0:T(128)S(1)} copy-done(%copy-start.148)
-  %copy.316 = u32[4]{0:T(128)} copy(%copy-done.148), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.133 = u32[4,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.133)
-  %copy.317 = u32[4,4]{1,0:T(4,128)} copy(%copy-done.133), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.149 = u32[4]{0:T(128)S(1)} copy-done(%copy-start.149)
-  %copy.318 = u32[4]{0:T(128)} copy(%copy-done.149), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.134 = u32[4,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.134)
-  %copy.319 = u32[4,4]{1,0:T(4,128)} copy(%copy-done.134), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.150 = u32[4]{0:T(128)S(1)} copy-done(%copy-start.150)
-  %copy.320 = u32[4]{0:T(128)} copy(%copy-done.150), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.135 = u32[4,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.135)
-  %copy.321 = u32[4,4]{1,0:T(4,128)} copy(%copy-done.135), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.151 = u32[4]{0:T(128)S(1)} copy-done(%copy-start.151)
-  %copy.322 = u32[4]{0:T(128)} copy(%copy-done.151), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-done.136 = u32[4,4]{1,0:T(4,128)S(1)} copy-done(%copy-start.136)
-  %copy.323 = u32[4,4]{1,0:T(4,128)} copy(%copy-done.136), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2353 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=51
+  %fusion.506 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.103, %copy-done.3, %add_rsqrt_fusion.5, %copy-done.50), kind=kOutput, calls=%fused_computation.24.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1813 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=18
+  %copy-start.75 = (bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, u32[]{:S(2)}) copy-start(%get-tuple-element.1813)
+  %get-tuple-element.1833 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=19
+  %copy-start.77 = (bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, u32[]{:S(2)}) copy-start(%get-tuple-element.1833)
+  %get-tuple-element.1854 = s32[1,128]{1,0:T(1,128)} get-tuple-element(%wide.param.1), index=20
+  %copy-start.106 = (s32[1,128]{1,0:T(1,128)S(1)}, s32[1,128]{1,0:T(1,128)}, u32[]{:S(2)}) copy-start(%get-tuple-element.1854)
+  %fusion.507 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} fusion(%copy-done.3, %all-gather.101, %all-gather.102, %fusion.506, %add_rsqrt_fusion.5, /*index=5*/%copy-done.50), kind=kOutput, calls=%fused_computation.38.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1435 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=15
   %copy-done.75 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} copy-done(%copy-start.75)
   %copy-done.77 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} copy-done(%copy-start.77)
   %copy-done.106 = s32[1,128]{1,0:T(1,128)S(1)} copy-done(%copy-start.106)
-  %bitcast.943 = s32[128]{0:T(128)S(1)} bitcast(%copy-done.106)
-  ROOT %tuple.241 = (s32[]{:T(128)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=5*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=10*/u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=15*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=20*/bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, bf16[4,1024,32,128]{1,3,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, /*index=25*/bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,1024,8,128]{1,3,2,0:T(8,128)(2,1)}, bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)}, bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, /*index=30*/bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=35*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=40*/u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=45*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=50*/s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, /*index=55*/bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, s32[1,128]{1,0:T(1,128)}) tuple(%add.904, %fusion.507, %copy.306, %copy.307, %copy.308, /*index=5*/%copy.309, %copy.310, %copy.311, %copy.312, %copy.313, /*index=10*/%copy.314, %copy.315, %copy.316, %copy.317, %copy.318, /*index=15*/%copy.319, %copy.320, %copy.321, %copy.322, %copy.323, /*index=20*/%bitcast_dynamic-update-slice_fusion.5, %get-tuple-element.2323, %get-tuple-element.2324, %get-tuple-element.2325, %copy-done.75, /*index=25*/%copy-done.77, %get-tuple-element.2328, %get-tuple-element.2329, %get-tuple-element.2330, %get-tuple-element.2331, /*index=30*/%get-tuple-element.2332, %get-tuple-element.2333, %get-tuple-element.2334, %get-tuple-element.2335, %get-tuple-element.2336, /*index=35*/%get-tuple-element.2337, %get-tuple-element.2338, %get-tuple-element.2339, %get-tuple-element.2340, %get-tuple-element.2341, /*index=40*/%get-tuple-element.2342, %get-tuple-element.2343, %get-tuple-element.2344, %get-tuple-element.2345, %get-tuple-element.2346, /*index=45*/%get-tuple-element.2347, %get-tuple-element.2348, %get-tuple-element.2349, %get-tuple-element.2350, %get-tuple-element.2351, /*index=50*/%bitcast.943, %get-tuple-element.2353, %get-tuple-element.2354, %get-tuple-element.2355, %get-tuple-element.2767, /*index=55*/%get-tuple-element.2823, %get-tuple-element.2880)
+  %bitcast.942 = s32[128]{0:T(128)S(1)} bitcast(%copy-done.106)
+  ROOT %tuple.241 = (s32[]{:T(128)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[4,1024,32,128]{1,3,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,1024,8,128]{1,3,2,0:T(8,128)(2,1)}, bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)}, bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, /*index=15*/s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, /*index=20*/s32[1,128]{1,0:T(1,128)}) tuple(%add.904, %fusion.507, %bitcast_dynamic-update-slice_fusion.5, %get-tuple-element.1423, %get-tuple-element.1424, /*index=5*/%get-tuple-element.1425, %copy-done.75, %copy-done.77, %get-tuple-element.1428, %get-tuple-element.1429, /*index=10*/%get-tuple-element.1430, %get-tuple-element.1431, %get-tuple-element.1432, %get-tuple-element.1433, %bitcast.942, /*index=15*/%get-tuple-element.1435, %get-tuple-element.1436, %get-tuple-element.1437, %get-tuple-element.1813, %get-tuple-element.1833, /*index=20*/%get-tuple-element.1854)
 }
 
-%wide.region_4.7_spmd.clone.clone.clone (wide.param.116: (s32[], bf16[1,128,4096], u32[4], u32[4,4], u32[4], /*index=5*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=10*/u32[4], u32[4,4], u32[4], u32[4,4], u32[4], /*index=15*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=20*/bf16[4,1,128,4096], bf16[4,4096], bf16[4,4096], bf16[4,1024,32,128], bf16[1,128,1,128], /*index=25*/bf16[1,128,1,128], bf16[4,1024,8,128], bf16[4,1024,8,128], bf16[4,32,128,1024], bf16[4,1024,14336], /*index=30*/bf16[4,1024,14336], bf16[4,14336,1024], u32[4], u32[4,4], u32[4], /*index=35*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=40*/u32[4], u32[4,4], u32[4], u32[4,4], u32[4], /*index=45*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=50*/s32[128], s32[], s8[1,1,1], s8[1,1,1], bf16[1,128,1,128], /*index=55*/bf16[1,128,1,128], s32[1,128])) -> pred[] {
-  %constant.358.clone.4 = s32[]{:T(128)} constant(4)
-  %wide.param.116 = (s32[]{:T(128)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=5*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=10*/u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=15*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=20*/bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, bf16[4,1024,32,128]{1,3,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, /*index=25*/bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,1024,8,128]{1,3,2,0:T(8,128)(2,1)}, bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)}, bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, /*index=30*/bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=35*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=40*/u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=45*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=50*/s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, /*index=55*/bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, s32[1,128]{1,0:T(1,128)}) parameter(0)
-  %get-tuple-element.1896 = s32[]{:T(128)} get-tuple-element(%wide.param.116), index=0
-  ROOT %lt.34 = pred[]{:T(512)} compare(%get-tuple-element.1896, %constant.358.clone.4), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/cond/lt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+%wide.region_4.7_spmd.clone.clone.clone (wide.param.116: (s32[], bf16[1,128,4096], bf16[4,1,128,4096], bf16[4,4096], bf16[4,4096], /*index=5*/bf16[4,1024,32,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,1024,8,128], bf16[4,1024,8,128], /*index=10*/bf16[4,32,128,1024], bf16[4,1024,14336], bf16[4,1024,14336], bf16[4,14336,1024], s32[128], /*index=15*/s32[], s8[1,1,1], s8[1,1,1], bf16[1,128,1,128], bf16[1,128,1,128], /*index=20*/s32[1,128])) -> pred[] {
+  %constant.336.clone.4 = s32[]{:T(128)} constant(4)
+  %wide.param.116 = (s32[]{:T(128)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, bf16[4,4096]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[4,1024,32,128]{1,3,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,1024,8,128]{1,3,2,0:T(8,128)(2,1)}, bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)}, bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)}, bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, /*index=15*/s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)}, /*index=20*/s32[1,128]{1,0:T(1,128)}) parameter(0)
+  %get-tuple-element.1230 = s32[]{:T(128)} get-tuple-element(%wide.param.116), index=0
+  ROOT %lt.34 = pred[]{:T(512)} compare(%get-tuple-element.1230, %constant.336.clone.4), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/cond/lt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
 %region_5.8 (reduce_sum.87: f32[], reduce_sum.88: f32[]) -> f32[] {
@@ -801,21 +729,21 @@ StackFrames
   %param_0.1293 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.901 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%param_0.1293), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
   %square.193 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.901, %convert_element_type.901), metadata={op_name="jit(train_step)/jvp()/square" stack_frame_id=0}
-  %constant.389.clone.28 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.160 = f32[128]{0:T(128)S(1)} reduce(%square.193, %constant.389.clone.28), dimensions={0,2}, to_apply=%region_5.8, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %constant.367.clone.28 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.160 = f32[128]{0:T(128)S(1)} reduce(%square.193, %constant.367.clone.28), dimensions={0,2}, to_apply=%region_5.8, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.397 (param_0.1158: f32[128]) -> f32[128] {
   %param_0.1158 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.398.clone.2 = f32[]{:T(128)} constant(0.000244140625)
-  %broadcast.632 = f32[128]{0:T(128)} broadcast(%constant.398.clone.2), dimensions={}, metadata={op_name="broadcast.283"}
-  %div.667 = f32[128]{0:T(128)} multiply(%param_0.1158, %broadcast.632), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
-  %constant.399.clone.2 = f32[]{:T(128)} constant(1e-05)
-  %broadcast.630 = f32[128]{0:T(128)} broadcast(%constant.399.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %add.791 = f32[128]{0:T(128)} add(%div.667, %broadcast.630), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %bitcast.568 = f32[1,128]{1,0:T(1,128)} bitcast(%add.791), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %rsqrt.101 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.568), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.558 = f32[128]{0:T(128)} bitcast(%rsqrt.101), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
+  %constant.375.clone.2 = f32[]{:T(128)} constant(0.000244140625)
+  %broadcast.626 = f32[128]{0:T(128)} broadcast(%constant.375.clone.2), dimensions={}, metadata={op_name="broadcast.281"}
+  %div.667 = f32[128]{0:T(128)} multiply(%param_0.1158, %broadcast.626), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
+  %constant.376.clone.2 = f32[]{:T(128)} constant(1e-05)
+  %broadcast.624 = f32[128]{0:T(128)} broadcast(%constant.376.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %add.791 = f32[128]{0:T(128)} add(%div.667, %broadcast.624), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %bitcast.567 = f32[1,128]{1,0:T(1,128)} bitcast(%add.791), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %rsqrt.101 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.567), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.557 = f32[128]{0:T(128)} bitcast(%rsqrt.101), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
 }
 
 %fused_computation.358.clone.clone (param_0.1260: bf16[4096], param_1.1403: f32[128], param_2.1079: bf16[1,128,4096]) -> bf16[128,4096] {
@@ -831,12 +759,12 @@ StackFrames
   %convert.143 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.959)
   %dot_general.405 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.142, %convert.143), metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.144 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%dot_general.405)
-  ROOT %bitcast.649 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convert.144)
+  ROOT %bitcast.648 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convert.144)
 }
 
 %bitcast_fusion.5 (bitcast_input.5: bf16[4096,128256]) -> bf16[4096,128256] {
   %bitcast_input.5 = bf16[4096,128256]{1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.661 = bf16[4096,128256]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.5)
+  ROOT %bitcast.660 = bf16[4096,128256]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.5)
 }
 
 %region_6.9 (reduce_max.6: bf16[], reduce_max.8: bf16[]) -> bf16[] {
@@ -853,8 +781,8 @@ StackFrames
   %param_0.1266 = bf16[4096,128256]{1,0:T(8,128)(2,1)} parameter(0)
   %fusion.333 = bf16[4096,128256]{1,0:T(8,128)(2,1)} fusion(%param_0.1266), kind=kLoop, calls=%bitcast_fusion.5
   %convolution.119.clone.1 = bf16[128,128256]{1,0:T(8,128)(2,1)S(1)} convolution(%fusion.300.clone.1, %fusion.333), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/dot_general" stack_frame_id=0}
-  %constant.400.clone.3 = bf16[]{:T(256)} constant(-inf)
-  %reduce.175 = bf16[128]{0:T(256)(128)(2,1)S(1)} reduce(%convolution.119.clone.1, %constant.400.clone.3), dimensions={1}, to_apply=%region_6.9, metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
+  %constant.377.clone.3 = bf16[]{:T(256)} constant(-inf)
+  %reduce.175 = bf16[128]{0:T(256)(128)(2,1)S(1)} reduce(%convolution.119.clone.1, %constant.377.clone.3), dimensions={1}, to_apply=%region_6.9, metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
   ROOT %tuple.152 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128,128256]{1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.175, %convolution.119.clone.1)
 }
 
@@ -867,13 +795,13 @@ StackFrames
 %fused_computation.316 (param_0.1292: bf16[128,128256], param_1.1427: bf16[128]) -> f32[128] {
   %param_0.1292 = bf16[128,128256]{1,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.868 = f32[128,128256]{1,0:T(8,128)} convert(%param_0.1292), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %bitcast.496 = f32[1,128,128256]{2,1,0:T(8,128)} bitcast(%convert_element_type.868), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %bitcast.495 = f32[1,128,128256]{2,1,0:T(8,128)} bitcast(%convert_element_type.868), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
   %param_1.1427 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
   %sub.100 = f32[1,128,128256]{2,1,0:T(8,128)} broadcast(%param_1.1427), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.71 = f32[1,128,128256]{2,1,0:T(8,128)} subtract(%bitcast.496, %sub.100), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.71 = f32[1,128,128256]{2,1,0:T(8,128)} subtract(%bitcast.495, %sub.100), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %exp.56 = f32[1,128,128256]{2,1,0:T(8,128)} exponential(%sub.71), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
-  %constant.389.clone.27 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.150 = f32[128]{0:T(128)S(1)} reduce(%exp.56, %constant.389.clone.27), dimensions={0,2}, to_apply=%region_7.10, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %constant.367.clone.27 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.150 = f32[128]{0:T(128)S(1)} reduce(%exp.56, %constant.367.clone.27), dimensions={0,2}, to_apply=%region_7.10, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.422 (param_0.1256: f32[128], param_1.1426: bf16[128]) -> (f32[128], f32[128]) {
@@ -882,12 +810,12 @@ StackFrames
   %param_1.1426 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
   %reduce_max.18.clone.1 = f32[128]{0:T(128)} convert(%param_1.1426), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
   %add.796.clone.1 = f32[128]{0:T(128)} add(%log.23, %reduce_max.18.clone.1), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %constant.389.clone.26 = f32[]{:T(128)} constant(0)
-  %broadcast.628.clone.1 = f32[128]{0:T(128)} broadcast(%constant.389.clone.26), dimensions={}, metadata={op_name="broadcast.94"}
-  %mul.1508.clone.1 = f32[128]{0:T(128)} multiply(%add.796.clone.1, %broadcast.628.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %constant.377.clone.1.clone.1 = f32[]{:T(128)} constant(1)
-  %broadcast.625.clone.1 = f32[128]{0:T(128)} broadcast(%constant.377.clone.1.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
-  %add.785.clone.1 = f32[128]{0:T(128)S(1)} add(%mul.1508.clone.1, %broadcast.625.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
+  %constant.367.clone.26 = f32[]{:T(128)} constant(0)
+  %broadcast.622.clone.1 = f32[128]{0:T(128)} broadcast(%constant.367.clone.26), dimensions={}, metadata={op_name="broadcast.92"}
+  %mul.1508.clone.1 = f32[128]{0:T(128)} multiply(%add.796.clone.1, %broadcast.622.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %constant.355.clone.1.clone.1 = f32[]{:T(128)} constant(1)
+  %broadcast.619.clone.1 = f32[128]{0:T(128)} broadcast(%constant.355.clone.1.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
+  %add.785.clone.1 = f32[128]{0:T(128)S(1)} add(%mul.1508.clone.1, %broadcast.619.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
   ROOT %tuple.150 = (f32[128]{0:T(128)S(1)}, f32[128]{0:T(128)S(1)}) tuple(%log.23, %add.785.clone.1)
 }
 
@@ -904,17 +832,17 @@ StackFrames
   %eq.21 = pred[1,128,128256]{2,1,0:T(8,128)(4,1)} compare(%eq.26, %iota.51), direction=EQ, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %param_0.1291 = bf16[128,128256]{1,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.881 = f32[128,128256]{1,0:T(8,128)} convert(%param_0.1291), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %bitcast.508 = f32[1,128,128256]{2,1,0:T(8,128)} bitcast(%convert_element_type.881), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %bitcast.507 = f32[1,128,128256]{2,1,0:T(8,128)} bitcast(%convert_element_type.881), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
   %param_2.1107 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
   %sub.99 = f32[1,128,128256]{2,1,0:T(8,128)} broadcast(%param_2.1107), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.92 = f32[1,128,128256]{2,1,0:T(8,128)} subtract(%bitcast.508, %sub.99), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.92 = f32[1,128,128256]{2,1,0:T(8,128)} subtract(%bitcast.507, %sub.99), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %param_1.1425 = f32[128]{0:T(128)S(1)} parameter(1)
   %sub.97 = f32[1,128,128256]{2,1,0:T(8,128)} broadcast(%param_1.1425), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %sub.91 = f32[1,128,128256]{2,1,0:T(8,128)} subtract(%sub.92, %sub.97), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %constant.389.clone.25 = f32[]{:T(128)} constant(0)
-  %broadcast.596 = f32[1,128,128256]{2,1,0:T(8,128)} broadcast(%constant.389.clone.25), dimensions={}, metadata={op_name="broadcast.104"}
-  %mul.1408 = f32[1,128,128256]{2,1,0:T(8,128)} select(%eq.21, %sub.91, %broadcast.596), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  ROOT %reduce.151 = f32[128]{0:T(128)S(1)} reduce(%mul.1408, %constant.389.clone.25), dimensions={0,2}, to_apply=%region_44.49, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %constant.367.clone.25 = f32[]{:T(128)} constant(0)
+  %broadcast.590 = f32[1,128,128256]{2,1,0:T(8,128)} broadcast(%constant.367.clone.25), dimensions={}, metadata={op_name="broadcast.102"}
+  %mul.1408 = f32[1,128,128256]{2,1,0:T(8,128)} select(%eq.21, %sub.91, %broadcast.590), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  ROOT %reduce.151 = f32[128]{0:T(128)S(1)} reduce(%mul.1408, %constant.367.clone.25), dimensions={0,2}, to_apply=%region_44.49, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %region_0.1 (reduce_sum.67: s32[], reduce_sum.71: s32[]) -> s32[] {
@@ -925,11 +853,11 @@ StackFrames
 
 %fused_computation.402 (param_0.1166: s32[1,128]) -> s32[] {
   %param_0.1166 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %constant.378.clone.4 = s32[]{:T(128)} constant(0)
-  %broadcast.643 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.378.clone.4), dimensions={}, metadata={op_name="broadcast.85"}
-  %ne.10 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1166, %broadcast.643), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
+  %constant.356.clone.4 = s32[]{:T(128)} constant(0)
+  %broadcast.637 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.356.clone.4), dimensions={}, metadata={op_name="broadcast.81"}
+  %ne.10 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1166, %broadcast.637), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
   %convert_element_type.941 = s32[1,128]{1,0:T(1,128)} convert(%ne.10), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.172 = s32[]{:T(128)} reduce(%convert_element_type.941, %constant.378.clone.4), dimensions={0,1}, to_apply=%region_0.1, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.172 = s32[]{:T(128)} reduce(%convert_element_type.941, %constant.356.clone.4), dimensions={0,1}, to_apply=%region_0.1, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %region_0.1.clone (reduce_sum.416: s32[], reduce_sum.420: s32[]) -> s32[] {
@@ -952,33 +880,33 @@ StackFrames
 
 %fused_computation.405 (param_0.1290: s32[1,128], param_1.1424: bf16[128], param_2.1106: f32[128], param_3.747: f32[128], param_4.464: f32[]) -> (f32[], f32[], f32[128]) {
   %param_0.1290 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %constant.378.clone.1 = s32[]{:T(128)} constant(0)
-  %broadcast.641 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.378.clone.1), dimensions={}, metadata={op_name="broadcast.85"}
-  %ne.16 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1290, %broadcast.641), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
+  %constant.356.clone.1 = s32[]{:T(128)} constant(0)
+  %broadcast.635 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.356.clone.1), dimensions={}, metadata={op_name="broadcast.81"}
+  %ne.16 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1290, %broadcast.635), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
   %param_2.1106 = f32[128]{0:T(128)S(1)} parameter(2)
   %log.18 = f32[128]{0:T(128)} log(%param_2.1106), metadata={op_name="jit(train_step)/jvp()/log" stack_frame_id=0}
   %param_1.1424 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
   %reduce_max.16 = f32[128]{0:T(128)} convert(%param_1.1424), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
   %add.794 = f32[128]{0:T(128)} add(%log.18, %reduce_max.16), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %square.208 = f32[128]{0:T(128)} multiply(%add.794, %add.794), metadata={op_name="jit(train_step)/jvp()/square" stack_frame_id=0}
-  %constant.389.clone.24 = f32[]{:T(128)} constant(0)
-  %broadcast.626 = f32[128]{0:T(128)} broadcast(%constant.389.clone.24), dimensions={}, metadata={op_name="broadcast.94"}
-  %mul.1516 = f32[128]{0:T(128)} multiply(%square.208, %broadcast.626), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %bitcast.561 = f32[1,128]{1,0:T(1,128)} bitcast(%mul.1516), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %broadcast.637 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.389.clone.24), dimensions={}, metadata={op_name="broadcast.94"}
-  %mul.1502 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %bitcast.561, %broadcast.637), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %reduce.174 = f32[]{:T(128)} reduce(%mul.1502, %constant.389.clone.24), dimensions={0,1}, to_apply=%region_58.63, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %constant.367.clone.24 = f32[]{:T(128)} constant(0)
+  %broadcast.620 = f32[128]{0:T(128)} broadcast(%constant.367.clone.24), dimensions={}, metadata={op_name="broadcast.92"}
+  %mul.1516 = f32[128]{0:T(128)} multiply(%square.208, %broadcast.620), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %bitcast.560 = f32[1,128]{1,0:T(1,128)} bitcast(%mul.1516), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %broadcast.631 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.367.clone.24), dimensions={}, metadata={op_name="broadcast.92"}
+  %mul.1502 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %bitcast.560, %broadcast.631), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %reduce.174 = f32[]{:T(128)} reduce(%mul.1502, %constant.367.clone.24), dimensions={0,1}, to_apply=%region_58.63, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
   %param_3.747 = f32[128]{0:T(128)S(1)} parameter(3)
   %neg.118.clone.1 = f32[128]{0:T(128)} negate(%param_3.747), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
-  %bitcast.565.clone.1 = f32[1,128]{1,0:T(1,128)} bitcast(%neg.118.clone.1), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
-  %add.784.clone.1 = f32[1,128]{1,0:T(1,128)} add(%bitcast.565.clone.1, %bitcast.561), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %mul.1500.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %add.784.clone.1, %broadcast.637), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %reduce.173.clone.1 = f32[]{:T(128)} reduce(%mul.1500.clone.1, %constant.389.clone.24), dimensions={0,1}, to_apply=%region_45.50, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %bitcast.564.clone.1 = f32[1,128]{1,0:T(1,128)} bitcast(%neg.118.clone.1), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
+  %add.784.clone.1 = f32[1,128]{1,0:T(1,128)} add(%bitcast.564.clone.1, %bitcast.560), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %mul.1500.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %add.784.clone.1, %broadcast.631), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %reduce.173.clone.1 = f32[]{:T(128)} reduce(%mul.1500.clone.1, %constant.367.clone.24), dimensions={0,1}, to_apply=%region_45.50, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
   %param_4.464 = f32[]{:T(128)S(6)} parameter(4)
-  %broadcast_in_dim.304.clone.1 = f32[1,128]{1,0:T(1,128)} broadcast(%param_4.464), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/broadcast_in_dim" stack_frame_id=0}
-  %mul.1498.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %broadcast_in_dim.304.clone.1, %broadcast.637), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %bitcast.559.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%mul.1498.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  ROOT %tuple.149 = (f32[]{:T(128)}, f32[]{:T(128)}, f32[128]{0:T(128)S(1)}) tuple(%reduce.174, %reduce.173.clone.1, %bitcast.559.clone.1)
+  %broadcast_in_dim.266.clone.1 = f32[1,128]{1,0:T(1,128)} broadcast(%param_4.464), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/broadcast_in_dim" stack_frame_id=0}
+  %mul.1498.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %broadcast_in_dim.266.clone.1, %broadcast.631), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %bitcast.558.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%mul.1498.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  ROOT %tuple.149 = (f32[]{:T(128)}, f32[]{:T(128)}, f32[128]{0:T(128)S(1)}) tuple(%reduce.174, %reduce.173.clone.1, %bitcast.558.clone.1)
 }
 
 %fused_computation.326.clone.1.clone.clone (param_0.1263: bf16[128,128256], param_1.1407: f32[128], param_2.1084: f32[128], param_3.732: bf16[128], param_4.450: s32[128], param_5.396: f32[128]) -> bf16[128,128256] {
@@ -988,10 +916,10 @@ StackFrames
   %mul.1651 = f32[1,128,128256]{2,1,0:T(8,128)} broadcast(%param_1.1407), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %param_0.1263 = bf16[128,128256]{1,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.966 = f32[128,128256]{1,0:T(8,128)} convert(%param_0.1263), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %bitcast.653 = f32[1,128,128256]{2,1,0:T(8,128)} bitcast(%convert_element_type.966), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %bitcast.652 = f32[1,128,128256]{2,1,0:T(8,128)} bitcast(%convert_element_type.966), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
   %param_3.732 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(3)
   %sub.114 = f32[1,128,128256]{2,1,0:T(8,128)} broadcast(%param_3.732), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.113 = f32[1,128,128256]{2,1,0:T(8,128)} subtract(%bitcast.653, %sub.114), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.113 = f32[1,128,128256]{2,1,0:T(8,128)} subtract(%bitcast.652, %sub.114), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %exp.72 = f32[1,128,128256]{2,1,0:T(8,128)} exponential(%sub.113), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
   %mul.1650 = f32[1,128,128256]{2,1,0:T(8,128)} multiply(%mul.1651, %exp.72), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %param_2.1084 = f32[128]{0:T(128)S(1)} parameter(2)
@@ -1005,12 +933,12 @@ StackFrames
   %sub.112 = f32[1,128,128256]{2,1,0:T(8,128)} subtract(%div.832, %convert_element_type.965), metadata={op_name="jit(train_step)/transpose(jvp())/sub" stack_frame_id=0}
   %mul.1649 = f32[1,128,128256]{2,1,0:T(8,128)} multiply(%mul.1652, %sub.112), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %convert_element_type.964 = bf16[1,128,128256]{2,1,0:T(8,128)(2,1)} convert(%mul.1649), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
-  ROOT %bitcast.652 = bf16[128,128256]{1,0:T(8,128)(2,1)} bitcast(%convert_element_type.964)
+  ROOT %bitcast.651 = bf16[128,128256]{1,0:T(8,128)(2,1)} bitcast(%convert_element_type.964)
 }
 
 %bitcast_fusion.4 (bitcast_input.4: bf16[4096,128256]) -> bf16[4096,128256] {
   %bitcast_input.4 = bf16[4096,128256]{1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.660 = bf16[4096,128256]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.4)
+  ROOT %bitcast.659 = bf16[4096,128256]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.4)
 }
 
 %region_8.11 (dot_general.182: bf16[], dot_general.183: bf16[]) -> bf16[] {
@@ -1030,8 +958,8 @@ StackFrames
   %param_2.1085 = bf16[4096,128256]{1,0:T(8,128)(2,1)} parameter(2)
   %fusion.332 = bf16[4096,128256]{1,0:T(8,128)(2,1)} fusion(%param_2.1085), kind=kLoop, calls=%bitcast_fusion.4
   %convolution.117.clone.1 = bf16[128,4096]{1,0:T(8,128)(2,1)} convolution(%fusion.320.clone.1, %fusion.332), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/dot_general" stack_frame_id=0}
-  %bitcast.545.clone.1 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.117.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/dot_general" stack_frame_id=0}
-  %convert.130 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.545.clone.1)
+  %bitcast.544.clone.1 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.117.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/dot_general" stack_frame_id=0}
+  %convert.130 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.544.clone.1)
   %param_1.1406 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %convert_element_type.920 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%param_1.1406), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
   %param_0.1262 = f32[128]{0:T(128)S(1)} parameter(0)
@@ -1041,9 +969,9 @@ StackFrames
   %convert.131 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.919)
   %multiply.271 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.130, %convert.131), metadata={op_name="multiply.197"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.132 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%multiply.271)
-  %constant.392.clone.1 = bf16[]{:T(256)} constant(0)
-  %reduce.162 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} reduce(%convert.132, %constant.392.clone.1), dimensions={0,1}, to_apply=%region_8.11, metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}
-  ROOT %tuple.153 = (bf16[4096]{0:T(1024)(128)(2,1)S(1)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.162, %bitcast.545.clone.1)
+  %constant.369.clone.1 = bf16[]{:T(256)} constant(0)
+  %reduce.162 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} reduce(%convert.132, %constant.369.clone.1), dimensions={0,1}, to_apply=%region_8.11, metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}
+  ROOT %tuple.153 = (bf16[4096]{0:T(1024)(128)(2,1)S(1)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.162, %bitcast.544.clone.1)
 }
 
 %region_8.11.clone (dot_general.243: bf16[], dot_general.244: bf16[]) -> bf16[] {
@@ -1062,8 +990,8 @@ StackFrames
   %param_0.1289 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} parameter(0)
   %convert_element_type.932 = f32[4096]{0:T(1024)} convert(%param_0.1289), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
   %square.204 = f32[4096]{0:T(1024)} multiply(%convert_element_type.932, %convert_element_type.932), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.389.clone.23 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.169 = f32[]{:T(128)} reduce(%square.204, %constant.389.clone.23), dimensions={0}, to_apply=%region_9.12, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %constant.367.clone.23 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.169 = f32[]{:T(128)} reduce(%square.204, %constant.367.clone.23), dimensions={0}, to_apply=%region_9.12, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
 }
 
 %region_10.13 (reduce_sum.102: f32[], reduce_sum.106: f32[]) -> f32[] {
@@ -1083,31 +1011,31 @@ StackFrames
   %dot_general.383 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.128, %convert.129), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.907 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%dot_general.383), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
   %mul.1448 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.908, %convert_element_type.907), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %constant.389.clone.22 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.161 = f32[128]{0:T(128)S(1)} reduce(%mul.1448, %constant.389.clone.22), dimensions={0,2}, to_apply=%region_10.13, metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
+  %constant.367.clone.22 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.161 = f32[128]{0:T(128)S(1)} reduce(%mul.1448, %constant.367.clone.22), dimensions={0,2}, to_apply=%region_10.13, metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.414 (param_0.1160: f32[128], param_1.1244: f32[128]) -> f32[128] {
   %param_0.1160 = f32[128]{0:T(128)S(1)} parameter(0)
-  %bitcast.575 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1160), metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
+  %bitcast.574 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1160), metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
   %param_1.1244 = f32[128]{0:T(128)S(1)} parameter(1)
-  %constant.398.clone.1 = f32[]{:T(128)} constant(0.000244140625)
-  %broadcast.631 = f32[128]{0:T(128)} broadcast(%constant.398.clone.1), dimensions={}, metadata={op_name="broadcast.283"}
-  %div.665 = f32[128]{0:T(128)} multiply(%param_1.1244, %broadcast.631), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
-  %constant.399.clone.1 = f32[]{:T(128)} constant(1e-05)
-  %broadcast.629 = f32[128]{0:T(128)} broadcast(%constant.399.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %add.789 = f32[128]{0:T(128)} add(%div.665, %broadcast.629), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %bitcast.574 = f32[1,128]{1,0:T(1,128)} bitcast(%add.789), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %rsqrt.107 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.574), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
-  %div.663 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.107, %bitcast.574), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
-  %constant.401.clone.1 = f32[]{:T(128)} constant(-0.5)
-  %mul.1520 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.401.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %constant.375.clone.1 = f32[]{:T(128)} constant(0.000244140625)
+  %broadcast.625 = f32[128]{0:T(128)} broadcast(%constant.375.clone.1), dimensions={}, metadata={op_name="broadcast.281"}
+  %div.665 = f32[128]{0:T(128)} multiply(%param_1.1244, %broadcast.625), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
+  %constant.376.clone.1 = f32[]{:T(128)} constant(1e-05)
+  %broadcast.623 = f32[128]{0:T(128)} broadcast(%constant.376.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %add.789 = f32[128]{0:T(128)} add(%div.665, %broadcast.623), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %bitcast.573 = f32[1,128]{1,0:T(1,128)} bitcast(%add.789), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %rsqrt.107 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.573), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
+  %div.663 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.107, %bitcast.573), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
+  %constant.378.clone.1 = f32[]{:T(128)} constant(-0.5)
+  %mul.1520 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.378.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
   %mul.1514 = f32[1,128]{1,0:T(1,128)} multiply(%div.663, %mul.1520), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %mul.1513 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.575, %mul.1514), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %constant.402.clone.1 = f32[]{:T(128)} constant(0.00048828125)
-  %mul.1519 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.402.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %mul.1513 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.574, %mul.1514), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %constant.379.clone.1 = f32[]{:T(128)} constant(0.00048828125)
+  %mul.1519 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.379.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %mul.1509 = f32[1,128]{1,0:T(1,128)} multiply(%mul.1513, %mul.1519), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  ROOT %bitcast.569 = f32[128]{0:T(128)S(1)} bitcast(%mul.1509), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  ROOT %bitcast.568 = f32[128]{0:T(128)S(1)} bitcast(%mul.1509), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
 }
 
 %fused_computation.351 (param_0.1002: bf16[1,128,4096], param_1.1053: f32[128], param_2.700: f32[128], param_3.393: bf16[1,128,4096], param_4.231: bf16[4096]) -> bf16[1,128,4096] {
@@ -1133,8 +1061,8 @@ StackFrames
 %fused_computation.84.clone.1 (param_0.1453: bf16[4,1024,14336], param_1.1527: s32[]) -> bf16[1,1024,14336] {
   %param_0.1453 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1527 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.362.clone.72 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.175 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1453, %param_1.1527, %constant.362.clone.72, %constant.362.clone.72), dynamic_slice_sizes={1,1024,14336}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.340.clone.72 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.175 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1453, %param_1.1527, %constant.340.clone.72, %constant.340.clone.72), dynamic_slice_sizes={1,1024,14336}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %convert_element_type.523.reduce_sub_computation (lhs: bf16[], rhs: bf16[]) -> bf16[] {
@@ -1146,24 +1074,24 @@ StackFrames
 %fused_computation.239.clone.1 (param_0.1427: bf16[4,4096], param_1.1511: s32[]) -> bf16[4096] {
   %param_0.1427 = bf16[4,4096]{1,0:T(4,128)(2,1)} parameter(0)
   %param_1.1511 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.362.clone.63 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.289 = bf16[1,4096]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1427, %param_1.1511, %constant.362.clone.63), dynamic_slice_sizes={1,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %constant.996 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.188 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.289, %constant.996), dimensions={0}, to_apply=%convert_element_type.523.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %constant.340.clone.63 = s32[]{:T(128)} constant(0)
+  %dynamic_slice.143 = bf16[1,4096]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1427, %param_1.1511, %constant.340.clone.63), dynamic_slice_sizes={1,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.973 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.188 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.143, %constant.973), dimensions={0}, to_apply=%convert_element_type.523.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
 %fused_computation.98.clone.1 (param_0.1448: bf16[4,32,128,1024], param_1.1525: s32[]) -> bf16[1,32,128,1024] {
   %param_0.1448 = bf16[4,32,128,1024]{3,2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1525 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.362.clone.71 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.174 = bf16[1,32,128,1024]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1448, %param_1.1525, %constant.362.clone.71, %constant.362.clone.71, %constant.362.clone.71), dynamic_slice_sizes={1,32,128,1024}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.340.clone.71 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.174 = bf16[1,32,128,1024]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1448, %param_1.1525, %constant.340.clone.71, %constant.340.clone.71, %constant.340.clone.71), dynamic_slice_sizes={1,32,128,1024}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.99.clone.1 (param_0.1442: bf16[4,1024,32,128], param_1.1521: s32[]) -> bf16[1,1024,32,128] {
   %param_0.1442 = bf16[4,1024,32,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.1521 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.362.clone.69 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.172 = bf16[1,1024,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1442, %param_1.1521, %constant.362.clone.69, %constant.362.clone.69, %constant.362.clone.69), dynamic_slice_sizes={1,1024,32,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.340.clone.69 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.172 = bf16[1,1024,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1442, %param_1.1521, %constant.340.clone.69, %constant.340.clone.69, %constant.340.clone.69), dynamic_slice_sizes={1,1024,32,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %convert_element_type.525.reduce_sub_computation (lhs.1: bf16[], rhs.1: bf16[]) -> bf16[] {
@@ -1175,10 +1103,10 @@ StackFrames
 %fused_computation.238.clone.1 (param_0.1428: bf16[4,4096], param_1.1512: s32[]) -> bf16[4096] {
   %param_0.1428 = bf16[4,4096]{1,0:T(4,128)(2,1)} parameter(0)
   %param_1.1512 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.362.clone.64 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.290 = bf16[1,4096]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1428, %param_1.1512, %constant.362.clone.64), dynamic_slice_sizes={1,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %constant.997 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.189 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.290, %constant.997), dimensions={0}, to_apply=%convert_element_type.525.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %constant.340.clone.64 = s32[]{:T(128)} constant(0)
+  %dynamic_slice.144 = bf16[1,4096]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1428, %param_1.1512, %constant.340.clone.64), dynamic_slice_sizes={1,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.974 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.189 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.144, %constant.974), dimensions={0}, to_apply=%convert_element_type.525.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
 %region_12.14 (reduce_sum.108: f32[], reduce_sum.109: f32[]) -> f32[] {
@@ -1190,26 +1118,26 @@ StackFrames
 %fused_computation.153.clone.1 (param_0.1425: bf16[4,1,128,4096], param_1.1510: s32[]) -> f32[128] {
   %param_0.1425 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %param_1.1510 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.362.clone.62 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.167 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1425, %param_1.1510, %constant.362.clone.62, %constant.362.clone.62, %constant.362.clone.62), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.784 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.167), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1015 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.784), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %constant.340.clone.62 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.167 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1425, %param_1.1510, %constant.340.clone.62, %constant.340.clone.62, %constant.340.clone.62), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.783 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.167), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1015 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.783), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %square.215 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.1015, %convert_element_type.1015), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.363.clone.11 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.187 = f32[128]{0:T(128)S(1)} reduce(%square.215, %constant.363.clone.11), dimensions={0,2}, to_apply=%region_12.14, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  %constant.341.clone.11 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.187 = f32[128]{0:T(128)S(1)} reduce(%square.215, %constant.341.clone.11), dimensions={0,2}, to_apply=%region_12.14, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.243.clone.1 (param_0.1426: f32[128]) -> f32[128] {
   %param_0.1426 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.364.clone.9 = f32[]{:T(128)} constant(0.000244140625)
-  %broadcast.709 = f32[128]{0:T(128)} broadcast(%constant.364.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.852 = f32[128]{0:T(128)} multiply(%param_0.1426, %broadcast.709), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.365.clone.9 = f32[]{:T(128)} constant(1e-05)
-  %broadcast.708 = f32[128]{0:T(128)} broadcast(%constant.365.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %add.886 = f32[128]{0:T(128)} add(%div.852, %broadcast.708), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.786 = f32[1,128]{1,0:T(1,128)} bitcast(%add.886), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.114 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.786), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.785 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.114), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %constant.342.clone.9 = f32[]{:T(128)} constant(0.000244140625)
+  %broadcast.703 = f32[128]{0:T(128)} broadcast(%constant.342.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %div.852 = f32[128]{0:T(128)} multiply(%param_0.1426, %broadcast.703), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.343.clone.9 = f32[]{:T(128)} constant(1e-05)
+  %broadcast.702 = f32[128]{0:T(128)} broadcast(%constant.343.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %add.886 = f32[128]{0:T(128)} add(%div.852, %broadcast.702), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.785 = f32[1,128]{1,0:T(1,128)} bitcast(%add.886), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.114 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.785), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.784 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.114), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
 }
 
 %fused_computation.194.clone.clone.clone.1 (param_0.1444: bf16[4096], param_1.1522: f32[128], param_2.1166: bf16[4,1,128,4096], param_3.788: s32[]) -> bf16[128,4096,1] {
@@ -1218,10 +1146,10 @@ StackFrames
   %convert.151 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%dot_general.447)
   %param_2.1166 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %param_3.788 = s32[]{:T(128)S(6)} parameter(3)
-  %constant.362.clone.70 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.173 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1166, %param_3.788, %constant.362.clone.70, %constant.362.clone.70, %constant.362.clone.70), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.800 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.173), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1023 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.800), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %constant.340.clone.70 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.173 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1166, %param_3.788, %constant.340.clone.70, %constant.340.clone.70, %constant.340.clone.70), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.799 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.173), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1023 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.799), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %param_1.1522 = f32[128]{0:T(128)S(1)} parameter(1)
   %mul.1746 = f32[1,128,4096]{2,1,0:T(8,128)} broadcast(%param_1.1522), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %mul.1745 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.1023, %mul.1746), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
@@ -1229,12 +1157,12 @@ StackFrames
   %convert.152 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1022)
   %dot_general.446 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.151, %convert.152), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.153 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%dot_general.446)
-  ROOT %bitcast.799 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.153)
+  ROOT %bitcast.798 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.153)
 }
 
 %fused_computation.94.clone.clone.clone.1 (param_0.1443: bf16[1,4096,32,128]) -> bf16[4096,32,128] {
   %param_0.1443 = bf16[1,4096,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.798 = bf16[4096,32,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1443), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.797 = bf16[4096,32,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1443), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.201.clone.1 (param_0.1445: bf16[1,4096,32,128], param_1.1523: bf16[4096], param_2.1167: f32[128], param_3.789: bf16[4,1,128,4096], param_4.487: s32[]) -> bf16[1,128,32,128] {
@@ -1246,7 +1174,7 @@ StackFrames
   %param_0.1445 = bf16[1,4096,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
   %fusion.425 = bf16[4096,32,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1445), kind=kLoop, calls=%fused_computation.94.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
   %convolution.144 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.426, %fusion.425), window={size=32 pad=31_31 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.801 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.144), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.800 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.144), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.165.clone.1 (param_0.1446: bf16[1,128,32,128]) -> (bf16[1,128,32,64], bf16[1,128,32,64]) {
@@ -1260,17 +1188,17 @@ StackFrames
 }
 
 %fused_computation.252.clone.1 () -> f32[64] {
-  %constant.366.clone.3 = f32[]{:T(128)} constant(500000)
-  %closed_call.64 = f32[64]{0:T(128)} broadcast(%constant.366.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %constant.344.clone.3 = f32[]{:T(128)} constant(500000)
+  %closed_call.46 = f32[64]{0:T(128)} broadcast(%constant.344.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
   %iota.65 = s32[64]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/iota" stack_frame_id=0}
-  %constant.367.clone.3 = s32[]{:T(128)} constant(2)
-  %closed_call.52 = s32[64]{0:T(128)} broadcast(%constant.367.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %mul.1738 = s32[64]{0:T(128)} multiply(%iota.65, %closed_call.52), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %constant.345.clone.3 = s32[]{:T(128)} constant(2)
+  %closed_call.45 = s32[64]{0:T(128)} broadcast(%constant.345.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %mul.1738 = s32[64]{0:T(128)} multiply(%iota.65, %closed_call.45), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %convert_element_type.1018 = f32[64]{0:T(128)} convert(%mul.1738), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %constant.368.clone.3 = f32[]{:T(128)} constant(0.0078125)
-  %closed_call.51 = f32[64]{0:T(128)} broadcast(%constant.368.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.853 = f32[64]{0:T(128)} multiply(%convert_element_type.1018, %closed_call.51), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  ROOT %pow.38 = f32[64]{0:T(128)S(1)} power(%closed_call.64, %div.853), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/pow" stack_frame_id=0}
+  %constant.346.clone.3 = f32[]{:T(128)} constant(0.0078125)
+  %closed_call.44 = f32[64]{0:T(128)} broadcast(%constant.346.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %div.853 = f32[64]{0:T(128)} multiply(%convert_element_type.1018, %closed_call.44), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  ROOT %pow.38 = f32[64]{0:T(128)S(1)} power(%closed_call.46, %div.853), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/pow" stack_frame_id=0}
 }
 
 %fused_computation.234.clone.1 (param_0.1433: f32[128], param_1.1516: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
@@ -1288,26 +1216,26 @@ StackFrames
 
 %fused_computation.237.clone.1 (param_0.1435: bf16[1,128,1,64]) -> bf16[128,128] {
   %param_0.1435 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.999 = bf16[]{:T(256)} constant(-inf)
-  %pad.61 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1435, %constant.999), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %constant.976 = bf16[]{:T(256)} constant(-inf)
+  %pad.61 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1435, %constant.976), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.199 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.61)
-  %pad.60 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1435, %constant.999), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.60 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1435, %constant.976), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.200 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.60)
   %maximum.49 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.199, %convert.200), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.201 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.49)
-  ROOT %bitcast.792 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.201), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  ROOT %bitcast.791 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.201), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
 }
 
 %fused_computation.236.clone.1 (param_0.1434: bf16[1,128,1,64]) -> bf16[128,128] {
   %param_0.1434 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.998 = bf16[]{:T(256)} constant(-inf)
-  %pad.59 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1434, %constant.998), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %constant.975 = bf16[]{:T(256)} constant(-inf)
+  %pad.59 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1434, %constant.975), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.202 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.59)
-  %pad.58 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1434, %constant.998), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.58 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1434, %constant.975), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.203 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.58)
   %maximum.48 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.202, %convert.203), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.204 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.48)
-  ROOT %bitcast.791 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.204), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  ROOT %bitcast.790 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.204), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
 }
 
 %fused_computation.168.clone.1 (param_0.1447: bf16[1,128,32,64], param_1.1524: bf16[1,128,32,64], param_2.1168: bf16[1,128,32,128], param_3.790: bf16[128,128], param_4.488: bf16[128,128]) -> bf16[32,128,128] {
@@ -1318,11 +1246,11 @@ StackFrames
   %convert.206 = f32[1,128,32,128]{3,1,2,0:T(8,128)} convert(%mul.1750)
   %mul.1748 = f32[1,128,32,128]{3,1,2,0:T(8,128)} multiply(%convert.205, %convert.206), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","32","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_1.1524 = bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1001 = bf16[]{:T(256)} constant(-inf)
-  %pad.65 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1524, %constant.1001), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %constant.978 = bf16[]{:T(256)} constant(-inf)
+  %pad.65 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1524, %constant.978), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.207 = f32[1,128,32,128]{3,1,2,0:T(8,128)} convert(%pad.65)
   %param_0.1447 = bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.64 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1447, %constant.1001), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.64 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1447, %constant.978), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.208 = f32[1,128,32,128]{3,1,2,0:T(8,128)} convert(%pad.64)
   %maximum.51 = f32[1,128,32,128]{3,1,2,0:T(8,128)} maximum(%convert.207, %convert.208), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","32","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_3.790 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
@@ -1331,14 +1259,14 @@ StackFrames
   %mul.1747 = f32[1,128,32,128]{3,1,2,0:T(8,128)} multiply(%maximum.51, %convert.209), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","32","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %add.888 = f32[1,128,32,128]{3,1,2,0:T(8,128)} add(%mul.1748, %mul.1747), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","32","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.210 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.888)
-  ROOT %bitcast.802 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.210), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  ROOT %bitcast.801 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.210), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
 %fused_computation.117.clone.1 (param_0.1436: bf16[4,1024,8,128], param_1.1517: s32[]) -> bf16[1,1024,8,128] {
   %param_0.1436 = bf16[4,1024,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.1517 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.362.clone.67 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.170 = bf16[1,1024,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1436, %param_1.1517, %constant.362.clone.67, %constant.362.clone.67, %constant.362.clone.67), dynamic_slice_sizes={1,1024,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.340.clone.67 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.170 = bf16[1,1024,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1436, %param_1.1517, %constant.340.clone.67, %constant.340.clone.67, %constant.340.clone.67), dynamic_slice_sizes={1,1024,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.193.clone.clone.clone.1 (param_0.1438: bf16[4096], param_1.1518: f32[128], param_2.1163: bf16[4,1,128,4096], param_3.785: s32[]) -> bf16[128,4096,1] {
@@ -1347,10 +1275,10 @@ StackFrames
   %convert.148 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%dot_general.445)
   %param_2.1163 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %param_3.785 = s32[]{:T(128)S(6)} parameter(3)
-  %constant.362.clone.68 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.171 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1163, %param_3.785, %constant.362.clone.68, %constant.362.clone.68, %constant.362.clone.68), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.795 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.171), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1021 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.795), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %constant.340.clone.68 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.171 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1163, %param_3.785, %constant.340.clone.68, %constant.340.clone.68, %constant.340.clone.68), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.794 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.171), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1021 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.794), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %param_1.1518 = f32[128]{0:T(128)S(1)} parameter(1)
   %mul.1740 = f32[1,128,4096]{2,1,0:T(8,128)} broadcast(%param_1.1518), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %mul.1739 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.1021, %mul.1740), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
@@ -1358,12 +1286,12 @@ StackFrames
   %convert.149 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1020)
   %dot_general.444 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.148, %convert.149), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.150 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%dot_general.444)
-  ROOT %bitcast.794 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.150)
+  ROOT %bitcast.793 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.150)
 }
 
 %fused_computation.107.clone.clone.clone.1 (param_0.1437: bf16[1,4096,8,128]) -> bf16[4096,8,128] {
   %param_0.1437 = bf16[1,4096,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.793 = bf16[4096,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1437), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.792 = bf16[4096,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1437), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.208.clone.1 (param_0.1439: bf16[1,4096,8,128], param_1.1519: bf16[4096], param_2.1164: f32[128], param_3.786: bf16[4,1,128,4096], param_4.485: s32[]) -> bf16[1,128,8,128] {
@@ -1375,7 +1303,7 @@ StackFrames
   %param_0.1439 = bf16[1,4096,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
   %fusion.423 = bf16[4096,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1439), kind=kLoop, calls=%fused_computation.107.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
   %convolution.143 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.424, %fusion.423), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.796 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.143), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.795 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.143), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.221.clone.1 (param_0.1440: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
@@ -1396,11 +1324,11 @@ StackFrames
   %convert.214 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.1744)
   %mul.1742 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.213, %convert.214), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_1.1520 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1000 = bf16[]{:T(256)} constant(-inf)
-  %pad.63 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1520, %constant.1000), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %constant.977 = bf16[]{:T(256)} constant(-inf)
+  %pad.63 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1520, %constant.977), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.215 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.63)
   %param_0.1441 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.62 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1441, %constant.1000), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.62 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1441, %constant.977), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.216 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.62)
   %maximum.50 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.215, %convert.216), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_3.787 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
@@ -1409,14 +1337,14 @@ StackFrames
   %mul.1741 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%maximum.50, %convert.217), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %add.887 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.1742, %mul.1741), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.218 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.887)
-  ROOT %bitcast.797 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.218), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  ROOT %bitcast.796 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.218), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
 %fused_computation.116.clone.1 (param_0.1429: bf16[4,1024,8,128], param_1.1513: s32[]) -> bf16[1,1024,8,128] {
   %param_0.1429 = bf16[4,1024,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.1513 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.362.clone.65 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.168 = bf16[1,1024,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1429, %param_1.1513, %constant.362.clone.65, %constant.362.clone.65, %constant.362.clone.65), dynamic_slice_sizes={1,1024,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.340.clone.65 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.168 = bf16[1,1024,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1429, %param_1.1513, %constant.340.clone.65, %constant.340.clone.65, %constant.340.clone.65), dynamic_slice_sizes={1,1024,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.192.clone.clone.clone.1 (param_0.1431: bf16[4096], param_1.1514: f32[128], param_2.1161: bf16[4,1,128,4096], param_3.783: s32[]) -> bf16[128,4096,1] {
@@ -1425,10 +1353,10 @@ StackFrames
   %convert.145 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%dot_general.443)
   %param_2.1161 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %param_3.783 = s32[]{:T(128)S(6)} parameter(3)
-  %constant.362.clone.66 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.169 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1161, %param_3.783, %constant.362.clone.66, %constant.362.clone.66, %constant.362.clone.66), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.789 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.169), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1017 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.789), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %constant.340.clone.66 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.169 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1161, %param_3.783, %constant.340.clone.66, %constant.340.clone.66, %constant.340.clone.66), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.788 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.169), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1017 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.788), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %param_1.1514 = f32[128]{0:T(128)S(1)} parameter(1)
   %mul.1737 = f32[1,128,4096]{2,1,0:T(8,128)} broadcast(%param_1.1514), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %mul.1736 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.1017, %mul.1737), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
@@ -1436,12 +1364,12 @@ StackFrames
   %convert.146 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1016)
   %dot_general.442 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.145, %convert.146), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.147 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%dot_general.442)
-  ROOT %bitcast.788 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.147)
+  ROOT %bitcast.787 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.147)
 }
 
 %fused_computation.103.clone.clone.clone.1 (param_0.1430: bf16[1,4096,8,128]) -> bf16[4096,8,128] {
   %param_0.1430 = bf16[1,4096,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.787 = bf16[4096,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1430), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.786 = bf16[4096,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1430), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.209.clone.1 (param_0.1432: bf16[1,4096,8,128], param_1.1515: bf16[4096], param_2.1162: f32[128], param_3.784: bf16[4,1,128,4096], param_4.484: s32[]) -> bf16[8,128,128] {
@@ -1453,17 +1381,17 @@ StackFrames
   %param_0.1432 = bf16[1,4096,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
   %fusion.421 = bf16[4096,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1432), kind=kLoop, calls=%fused_computation.103.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
   %convolution.142 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.422, %fusion.421), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.790 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.142), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  ROOT %bitcast.789 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.142), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
 %fused_computation.173.clone.clone.clone.1 (param_0.1450: bf16[32,128,128]) -> bf16[128,32,128] {
   %param_0.1450 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.804 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1450)
+  ROOT %bitcast.803 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1450)
 }
 
 %fused_computation.90.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1449: bf16[1,32,128,4096]) -> bf16[32,128,4096] {
   %param_0.1449 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.803 = bf16[32,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1449), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.802 = bf16[32,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1449), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %region_13.16 (reduce_sum.120: f32[], reduce_sum.121: f32[]) -> f32[] {
@@ -1475,37 +1403,37 @@ StackFrames
 %fused_computation.156.clone.1 (param_0.1451: bf16[1,32,128,4096], param_1.1526: bf16[32,128,128], param_2.1169: bf16[4,1,128,4096], param_3.791: s32[]) -> (f32[128], bf16[1,128,4096]) {
   %param_2.1169 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %param_3.791 = s32[]{:T(128)S(6)} parameter(3)
-  %constant.362.clone.16.clone.3 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.114.clone.3 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1169, %param_3.791, %constant.362.clone.16.clone.3, %constant.362.clone.16.clone.3, %constant.362.clone.16.clone.3), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.391.clone.3 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.114.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert.219 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.391.clone.3)
+  %constant.340.clone.16.clone.3 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.114.clone.3 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1169, %param_3.791, %constant.340.clone.16.clone.3, %constant.340.clone.16.clone.3, %constant.340.clone.16.clone.3), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.390.clone.3 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.114.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert.219 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.390.clone.3)
   %param_1.1526 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %fusion.190.clone.3 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)} fusion(%param_1.1526), kind=kLoop, calls=%fused_computation.173.clone.clone.clone.1
   %param_0.1451 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %fusion.170.clone.3 = bf16[32,128,4096]{2,1,0:T(8,128)(2,1)} fusion(%param_0.1451), kind=kLoop, calls=%fused_computation.90.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
   %convolution.105.clone.3 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.190.clone.3, %fusion.170.clone.3), window={size=32}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %bitcast.341.clone.3 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.105.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convert.220 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.341.clone.3)
+  %bitcast.340.clone.3 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.105.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  %convert.220 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.340.clone.3)
   %add.685.clone.3 = f32[1,128,4096]{2,1,0:T(8,128)} add(%convert.219, %convert.220), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.1024 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%add.685.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %square.216 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.1024, %convert_element_type.1024), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.363.clone.12 = f32[]{:T(128)} constant(0)
-  %reduce.190 = f32[128]{0:T(128)S(1)} reduce(%square.216, %constant.363.clone.12), dimensions={0,2}, to_apply=%region_13.16, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  %constant.341.clone.12 = f32[]{:T(128)} constant(0)
+  %reduce.190 = f32[128]{0:T(128)S(1)} reduce(%square.216, %constant.341.clone.12), dimensions={0,2}, to_apply=%region_13.16, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
   %convert.221 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.685.clone.3)
   ROOT %tuple.187 = (f32[128]{0:T(128)S(1)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.190, %convert.221)
 }
 
 %fused_computation.241.clone.1 (param_0.1452: f32[128]) -> f32[128] {
   %param_0.1452 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.364.clone.10 = f32[]{:T(128)} constant(0.000244140625)
-  %broadcast.711 = f32[128]{0:T(128)} broadcast(%constant.364.clone.10), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.857 = f32[128]{0:T(128)} multiply(%param_0.1452, %broadcast.711), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.365.clone.10 = f32[]{:T(128)} constant(1e-05)
-  %broadcast.710 = f32[128]{0:T(128)} broadcast(%constant.365.clone.10), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %add.889 = f32[128]{0:T(128)} add(%div.857, %broadcast.710), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.806 = f32[1,128]{1,0:T(1,128)} bitcast(%add.889), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.115 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.806), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.805 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.115), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %constant.342.clone.10 = f32[]{:T(128)} constant(0.000244140625)
+  %broadcast.705 = f32[128]{0:T(128)} broadcast(%constant.342.clone.10), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %div.857 = f32[128]{0:T(128)} multiply(%param_0.1452, %broadcast.705), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.343.clone.10 = f32[]{:T(128)} constant(1e-05)
+  %broadcast.704 = f32[128]{0:T(128)} broadcast(%constant.343.clone.10), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %add.889 = f32[128]{0:T(128)} add(%div.857, %broadcast.704), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.805 = f32[1,128]{1,0:T(1,128)} bitcast(%add.889), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.115 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.805), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.804 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.115), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
 }
 
 %fused_computation.184.clone.1 (param_0.1455: bf16[4096], param_1.1528: f32[128], param_2.1170: bf16[1,128,4096]) -> bf16[128,4096] {
@@ -1521,12 +1449,12 @@ StackFrames
   %convert.155 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1025)
   %dot_general.448 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.154, %convert.155), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.156 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%dot_general.448)
-  ROOT %bitcast.808 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convert.156)
+  ROOT %bitcast.807 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convert.156)
 }
 
 %fused_computation.72.clone.clone.clone.1 (param_0.1454: bf16[1,4096,14336]) -> bf16[4096,14336] {
   %param_0.1454 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.807 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1454), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+  ROOT %bitcast.806 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1454), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.110.clone.1 (param_0.1456: bf16[1,4096,14336], param_1.1529: bf16[4096], param_2.1171: bf16[1,128,4096], param_3.792: f32[128]) -> bf16[1,128,14336] {
@@ -1537,14 +1465,14 @@ StackFrames
   %param_0.1456 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
   %fusion.427 = bf16[4096,14336]{1,0:T(8,128)(2,1)} fusion(%param_0.1456), kind=kLoop, calls=%fused_computation.72.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
   %convolution.145 = bf16[128,14336]{1,0:T(8,128)(2,1)} convolution(%fusion.428, %fusion.427), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.809 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.145), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.808 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.145), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.86.clone.1 (param_0.1461: bf16[4,1024,14336], param_1.1532: s32[]) -> bf16[1,1024,14336] {
   %param_0.1461 = bf16[4,1024,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1532 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.362.clone.74 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.177 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1461, %param_1.1532, %constant.362.clone.74, %constant.362.clone.74), dynamic_slice_sizes={1,1024,14336}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.340.clone.74 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.177 = bf16[1,1024,14336]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1461, %param_1.1532, %constant.340.clone.74, %constant.340.clone.74), dynamic_slice_sizes={1,1024,14336}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.185.clone.1 (param_0.1463: bf16[4096], param_1.1533: f32[128], param_2.1172: bf16[1,128,4096]) -> bf16[128,4096] {
@@ -1560,12 +1488,12 @@ StackFrames
   %convert.158 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1027)
   %dot_general.450 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.157, %convert.158), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.159 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%dot_general.450)
-  ROOT %bitcast.814 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convert.159)
+  ROOT %bitcast.813 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convert.159)
 }
 
 %fused_computation.80.clone.clone.clone.1 (param_0.1462: bf16[1,4096,14336]) -> bf16[4096,14336] {
   %param_0.1462 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.813 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1462), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.812 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1462), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.108.clone.1 (param_0.1464: bf16[1,4096,14336], param_1.1534: bf16[4096], param_2.1173: bf16[1,128,4096], param_3.793: f32[128]) -> bf16[1,128,14336] {
@@ -1576,14 +1504,14 @@ StackFrames
   %param_0.1464 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
   %fusion.431 = bf16[4096,14336]{1,0:T(8,128)(2,1)} fusion(%param_0.1464), kind=kLoop, calls=%fused_computation.80.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
   %convolution.147 = bf16[128,14336]{1,0:T(8,128)(2,1)} convolution(%fusion.432, %fusion.431), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.815 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.147), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.814 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.147), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.122.clone.1 (param_0.1509: bf16[1,128,14336], param_1.1561: bf16[1,128,14336]) -> bf16[128,14336] {
   %param_1.1561 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %convert.178 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%param_1.1561)
-  %constant.371.clone.23 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.44 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} broadcast(%constant.371.clone.23), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
+  %constant.349.clone.23 = bf16[]{:T(256)} constant(1)
+  %jit_silu_.44 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} broadcast(%constant.349.clone.23), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
   %convert.179 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%jit_silu_.44)
   %neg.135 = f32[1,128,14336]{2,1,0:T(8,128)} negate(%convert.178), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %exp.81 = f32[1,128,14336]{2,1,0:T(8,128)} exponential(%neg.135), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
@@ -1594,12 +1522,12 @@ StackFrames
   %convert.180 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%param_0.1509)
   %mul.1786 = f32[1,128,14336]{2,1,0:T(8,128)} multiply(%mul.1787, %convert.180), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.181 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} convert(%mul.1786)
-  ROOT %bitcast.867 = bf16[128,14336]{1,0:T(8,128)(2,1)} bitcast(%convert.181)
+  ROOT %bitcast.866 = bf16[128,14336]{1,0:T(8,128)(2,1)} bitcast(%convert.181)
 }
 
 %fused_computation.179.clone.1 (param_0.1508: bf16[1,128,4096]) -> bf16[128,4096] {
   %param_0.1508 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.866 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%param_0.1508)
+  ROOT %bitcast.865 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%param_0.1508)
 }
 
 %fused_computation.121.clone.1 (param_0.1510: bf16[1,128,14336], param_1.1562: bf16[1,128,4096], param_2.1192: bf16[1,128,14336]) -> bf16[14336,4096] {
@@ -1614,25 +1542,25 @@ StackFrames
 %fused_computation.253.clone.1 (param_0.1476: f32[1,32,128,128]) -> (f32[32,128], f32[1,32,128,1]) {
   %param_0.1476 = f32[1,32,128,128]{2,1,3,0:T(8,128)S(1)} parameter(0)
   %slice.77 = f32[1,32,128,1]{2,1,3,0:T(8,128)} slice(%param_0.1476), slice={[0:1], [0:32], [0:128], [0:1]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/slice" stack_frame_id=0}
-  %bitcast.827 = f32[32,128]{1,0:T(8,128)} bitcast(%slice.77), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}
-  ROOT %tuple.191 = (f32[32,128]{1,0:T(8,128)}, f32[1,32,128,1]{2,1,3,0:T(8,128)}) tuple(%bitcast.827, %slice.77)
+  %bitcast.826 = f32[32,128]{1,0:T(8,128)} bitcast(%slice.77), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}
+  ROOT %tuple.191 = (f32[32,128]{1,0:T(8,128)}, f32[1,32,128,1]{2,1,3,0:T(8,128)}) tuple(%bitcast.826, %slice.77)
 }
 
 %fused_computation.85.clone.1 (param_0.1457: bf16[4,14336,1024], param_1.1530: s32[]) -> bf16[1,14336,1024] {
   %param_0.1457 = bf16[4,14336,1024]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1530 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.362.clone.73 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.176 = bf16[1,14336,1024]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1457, %param_1.1530, %constant.362.clone.73, %constant.362.clone.73), dynamic_slice_sizes={1,14336,1024}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.340.clone.73 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.176 = bf16[1,14336,1024]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1457, %param_1.1530, %constant.340.clone.73, %constant.340.clone.73), dynamic_slice_sizes={1,14336,1024}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.76.clone.clone.clone.1 (param_0.1459: bf16[1,14336,4096]) -> bf16[14336,4096] {
   %param_0.1459 = bf16[1,14336,4096]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.811 = bf16[14336,4096]{1,0:T(8,128)(2,1)} bitcast(%param_0.1459), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+  ROOT %bitcast.810 = bf16[14336,4096]{1,0:T(8,128)(2,1)} bitcast(%param_0.1459), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.180.clone.1 (param_0.1458: bf16[1,128,4096]) -> bf16[128,4096] {
   %param_0.1458 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.810 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%param_0.1458)
+  ROOT %bitcast.809 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%param_0.1458)
 }
 
 %fused_computation.109.clone.1 (param_0.1460: bf16[1,14336,4096], param_1.1531: bf16[1,128,4096]) -> bf16[1,128,14336] {
@@ -1641,14 +1569,14 @@ StackFrames
   %param_1.1531 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %fusion.430 = bf16[128,4096]{1,0:T(8,128)(2,1)} fusion(%param_1.1531), kind=kLoop, calls=%fused_computation.180.clone.1
   %convolution.146 = bf16[14336,128]{0,1:T(8,128)(2,1)} convolution(%fusion.429, %fusion.430), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  ROOT %bitcast.812 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.146), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+  ROOT %bitcast.811 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.146), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.125.clone.1 (param_0.1466: bf16[1,128,14336], param_1.1535: bf16[1,128,14336]) -> bf16[128,14336] {
   %param_1.1535 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %convert.160 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%param_1.1535)
-  %constant.371.clone.21 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.42 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} broadcast(%constant.371.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
+  %constant.349.clone.21 = bf16[]{:T(256)} constant(1)
+  %jit_silu_.42 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} broadcast(%constant.349.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
   %convert.161 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%jit_silu_.42)
   %neg.133 = f32[1,128,14336]{2,1,0:T(8,128)} negate(%convert.160), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %exp.79 = f32[1,128,14336]{2,1,0:T(8,128)} exponential(%neg.133), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
@@ -1659,12 +1587,12 @@ StackFrames
   %convert.162 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%param_0.1466)
   %mul.1755 = f32[1,128,14336]{2,1,0:T(8,128)} multiply(%mul.1756, %convert.162), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.163 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} convert(%mul.1755)
-  ROOT %bitcast.817 = bf16[128,14336]{1,0:T(8,128)(2,1)} bitcast(%convert.163)
+  ROOT %bitcast.816 = bf16[128,14336]{1,0:T(8,128)(2,1)} bitcast(%convert.163)
 }
 
 %fused_computation.74.clone.1 (param_0.1465: bf16[1,4096,14336]) -> bf16[4096,14336] {
   %param_0.1465 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.816 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1465), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+  ROOT %bitcast.815 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1465), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.73.clone.1 (param_0.1467: bf16[1,4096,14336], param_1.1536: bf16[1,128,14336], param_2.1174: bf16[1,128,14336]) -> bf16[128,4096] {
@@ -1682,8 +1610,8 @@ StackFrames
   %param_2.1175 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %convert.165 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%param_2.1175)
   %mul.1761 = f32[1,128,14336]{2,1,0:T(8,128)} multiply(%convert.164, %convert.165), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %constant.371.clone.22 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.43 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} broadcast(%constant.371.clone.22), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
+  %constant.349.clone.22 = bf16[]{:T(256)} constant(1)
+  %jit_silu_.43 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} broadcast(%constant.349.clone.22), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
   %convert.167 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%jit_silu_.43)
   %param_0.1469 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert.166 = f32[1,128,14336]{2,1,0:T(8,128)} convert(%param_0.1469)
@@ -1698,12 +1626,12 @@ StackFrames
   %mul.1757 = f32[1,128,14336]{2,1,0:T(8,128)} multiply(%mul.1759, %mul.1758), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %add_any.160 = f32[1,128,14336]{2,1,0:T(8,128)} add(%mul.1760, %mul.1757), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/jit(silu)/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","14336"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.168 = bf16[1,128,14336]{2,1,0:T(8,128)(2,1)} convert(%add_any.160)
-  ROOT %bitcast.819 = bf16[128,14336]{1,0:T(8,128)(2,1)} bitcast(%convert.168)
+  ROOT %bitcast.818 = bf16[128,14336]{1,0:T(8,128)(2,1)} bitcast(%convert.168)
 }
 
 %fused_computation.78.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1468: bf16[1,4096,14336]) -> bf16[4096,14336] {
   %param_0.1468 = bf16[1,4096,14336]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.818 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1468), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.817 = bf16[4096,14336]{1,0:T(8,128)(2,1)} bitcast(%param_0.1468), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %region_14.17 (reduce_sum.126: f32[], reduce_sum.127: f32[]) -> f32[] {
@@ -1727,40 +1655,40 @@ StackFrames
   %convert.223 = f32[128,4096]{1,0:T(8,128)} convert(%convolution.97.clone.3)
   %add_any.122.clone.3 = f32[128,4096]{1,0:T(8,128)} add(%convert.222, %convert.223), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
   %convert.224 = bf16[128,4096]{1,0:T(8,128)(2,1)} convert(%add_any.122.clone.3)
-  %bitcast.323.clone.3 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.224), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}
-  %convert.225 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.323.clone.3)
+  %bitcast.322.clone.3 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.224), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}
+  %convert.225 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.322.clone.3)
   %param_1.1538 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} parameter(1)
   %dot_general.453 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} broadcast(%param_1.1538), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.226 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%dot_general.453)
   %dot_general.452 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.225, %convert.226), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.1029 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%dot_general.452), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/convert_element_type" stack_frame_id=0}
   %mul.1762 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.1030, %convert_element_type.1029), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %constant.363.clone.13 = f32[]{:T(128)} constant(0)
-  %reduce.191 = f32[128]{0:T(128)S(1)} reduce(%mul.1762, %constant.363.clone.13), dimensions={0,2}, to_apply=%region_14.17, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.188 = (f32[128]{0:T(128)S(1)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.191, %bitcast.323.clone.3)
+  %constant.341.clone.13 = f32[]{:T(128)} constant(0)
+  %reduce.191 = f32[128]{0:T(128)S(1)} reduce(%mul.1762, %constant.341.clone.13), dimensions={0,2}, to_apply=%region_14.17, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.188 = (f32[128]{0:T(128)S(1)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.191, %bitcast.322.clone.3)
 }
 
 %fused_computation.251.clone.1 (param_0.1471: f32[128], param_1.1539: f32[128]) -> f32[128] {
   %param_0.1471 = f32[128]{0:T(128)S(1)} parameter(0)
-  %bitcast.822 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1471), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum" stack_frame_id=0}
+  %bitcast.821 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1471), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum" stack_frame_id=0}
   %param_1.1539 = f32[128]{0:T(128)S(1)} parameter(1)
-  %constant.364.clone.11 = f32[]{:T(128)} constant(0.000244140625)
-  %broadcast.713 = f32[128]{0:T(128)} broadcast(%constant.364.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.861 = f32[128]{0:T(128)} multiply(%param_1.1539, %broadcast.713), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.365.clone.11 = f32[]{:T(128)} constant(1e-05)
-  %broadcast.712 = f32[128]{0:T(128)} broadcast(%constant.365.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %add.892 = f32[128]{0:T(128)} add(%div.861, %broadcast.712), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.821 = f32[1,128]{1,0:T(1,128)} bitcast(%add.892), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.116 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.821), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  %div.860 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.116, %bitcast.821), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.372.clone.5 = f32[]{:T(128)} constant(-0.5)
-  %closed_call.65 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.372.clone.5), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %mul.1765 = f32[1,128]{1,0:T(1,128)} multiply(%div.860, %closed_call.65), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.1764 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.822, %mul.1765), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %constant.373.clone.5 = f32[]{:T(128)} constant(0.00048828125)
-  %mul.1766 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.373.clone.5), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %constant.342.clone.11 = f32[]{:T(128)} constant(0.000244140625)
+  %broadcast.707 = f32[128]{0:T(128)} broadcast(%constant.342.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %div.861 = f32[128]{0:T(128)} multiply(%param_1.1539, %broadcast.707), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.343.clone.11 = f32[]{:T(128)} constant(1e-05)
+  %broadcast.706 = f32[128]{0:T(128)} broadcast(%constant.343.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %add.892 = f32[128]{0:T(128)} add(%div.861, %broadcast.706), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.820 = f32[1,128]{1,0:T(1,128)} bitcast(%add.892), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.116 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.820), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %div.860 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.116, %bitcast.820), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.350.clone.5 = f32[]{:T(128)} constant(-0.5)
+  %closed_call.47 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.350.clone.5), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %mul.1765 = f32[1,128]{1,0:T(1,128)} multiply(%div.860, %closed_call.47), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.1764 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.821, %mul.1765), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %constant.351.clone.5 = f32[]{:T(128)} constant(0.00048828125)
+  %mul.1766 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.351.clone.5), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
   %mul.1763 = f32[1,128]{1,0:T(1,128)} multiply(%mul.1764, %mul.1766), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  ROOT %bitcast.820 = f32[128]{0:T(128)S(1)} bitcast(%mul.1763), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  ROOT %bitcast.819 = f32[128]{0:T(128)S(1)} bitcast(%mul.1763), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
 }
 
 %region_17.21 (dot_general.187: bf16[], dot_general.188: bf16[]) -> bf16[] {
@@ -1781,8 +1709,8 @@ StackFrames
   %convert.228 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1031)
   %multiply.298 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.227, %convert.228), metadata={op_name="multiply.195"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.229 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%multiply.298)
-  %constant.374.clone.5 = bf16[]{:T(256)} constant(0)
-  %reduce.192 = bf16[4096]{0:T(1024)(128)(2,1)} reduce(%convert.229, %constant.374.clone.5), dimensions={0,1}, to_apply=%region_17.21, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}
+  %constant.352.clone.5 = bf16[]{:T(256)} constant(0)
+  %reduce.192 = bf16[4096]{0:T(1024)(128)(2,1)} reduce(%convert.229, %constant.352.clone.5), dimensions={0,1}, to_apply=%region_17.21, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}
   %param_3.795 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
   %convert.231 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%param_3.795)
   %param_5.417 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} parameter(5)
@@ -1804,12 +1732,12 @@ StackFrames
 
 %fused_computation.178.clone.clone.clone.1 (param_0.1474: bf16[1,128,4096]) -> bf16[128,4096,1] {
   %param_0.1474 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.824 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%param_0.1474)
+  ROOT %bitcast.823 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} bitcast(%param_0.1474)
 }
 
 %fused_computation.88.clone.clone.clone.1 (param_0.1473: bf16[1,32,128,4096]) -> bf16[32,128,4096] {
   %param_0.1473 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.823 = bf16[32,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1473), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.822 = bf16[32,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1473), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %region_15.18 (dot_general.184: f32[], dot_general.185: f32[]) -> f32[] {
@@ -1820,31 +1748,31 @@ StackFrames
 
 %fused_computation.159.clone.1 (param_0.1475: bf16[32,128,128], param_1.1541: bf16[1,32,128,4096], param_2.1178: bf16[1,128,4096]) -> (f32[32,128], bf16[128,32,128]) {
   %param_0.1475 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %bitcast.826 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1475), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/broadcast_in_dim" stack_frame_id=0}
-  %convert.125 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.826), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/convert" stack_frame_id=0}
+  %bitcast.825 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1475), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.125 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.825), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/convert" stack_frame_id=0}
   %param_2.1178 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} parameter(2)
   %fusion.193.clone.3 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} fusion(%param_2.1178), kind=kLoop, calls=%fused_computation.178.clone.clone.clone.1
   %param_1.1541 = bf16[1,32,128,4096]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %fusion.107.clone.3 = bf16[32,128,4096]{2,1,0:T(8,128)(2,1)} fusion(%param_1.1541), kind=kLoop, calls=%fused_computation.88.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
   %convolution.70.clone.3 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.193.clone.3, %fusion.107.clone.3), window={size=32 pad=31_31 rhs_reversal=1}, dim_labels=bf0_0oi->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  %bitcast.825 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%convolution.70.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/transpose" stack_frame_id=0}
-  %convert.124 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.825), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/convert.1" stack_frame_id=0}
+  %bitcast.824 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%convolution.70.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/transpose" stack_frame_id=0}
+  %convert.124 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.824), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/convert.1" stack_frame_id=0}
   %multiply.299 = f32[1,32,128,128]{3,2,1,0:T(8,128)} multiply(%convert.125, %convert.124), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/multiply" stack_frame_id=0}
-  %constant.363.clone.14 = f32[]{:T(128)} constant(0)
-  %dot_general.454 = f32[32,128]{1,0:T(8,128)S(1)} reduce(%multiply.299, %constant.363.clone.14), dimensions={0,3}, to_apply=%region_15.18, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general" stack_frame_id=0}
+  %constant.341.clone.14 = f32[]{:T(128)} constant(0)
+  %dot_general.454 = f32[32,128]{1,0:T(8,128)S(1)} reduce(%multiply.299, %constant.341.clone.14), dimensions={0,3}, to_apply=%region_15.18, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general" stack_frame_id=0}
   ROOT %tuple.190 = (f32[32,128]{1,0:T(8,128)S(1)}, bf16[128,32,128]{2,0,1:T(8,128)(2,1)}) tuple(%dot_general.454, %convolution.70.clone.3)
 }
 
 %fused_computation.176.clone.1 (param_0.1488: bf16[32,128,128], param_1.1549: bf16[128,128]) -> bf16[1,128,32,128] {
   %param_0.1488 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.842 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1488), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dq_segmented_no_residuals/splash_mha_dq_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
-  %convert.234 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.842)
+  %bitcast.841 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1488), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dq_segmented_no_residuals/splash_mha_dq_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.234 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.841)
   %param_1.1549 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %broadcast.716 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_1.1549), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.235 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.716)
+  %broadcast.710 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_1.1549), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.235 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.710)
   %mul.1775 = f32[1,32,128,128]{3,2,1,0:T(8,128)} multiply(%convert.234, %convert.235), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","32","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.236 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.1775)
-  ROOT %bitcast.841 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convert.236), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  ROOT %bitcast.840 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convert.236), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
 }
 
 %fused_computation.418.clone.1 (param_0.1489: bf16[1,128,32,128]) -> (bf16[1,128,32,64], bf16[1,128,32,64]) {
@@ -1859,36 +1787,36 @@ StackFrames
 
 %fused_computation.170.clone.1 (param_0.1490: bf16[1,128,32,64], param_1.1550: bf16[1,128,32,64], param_2.1185: bf16[32,128,128], param_3.802: bf16[128,128]) -> bf16[128,32,128] {
   %param_1.1550 = bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1005 = bf16[]{:T(256)} constant(-inf)
-  %pad.69 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1550, %constant.1005), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
+  %constant.982 = bf16[]{:T(256)} constant(-inf)
+  %pad.69 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1550, %constant.982), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
   %convert.239 = f32[1,128,32,128]{3,1,2,0:T(8,128)} convert(%pad.69)
   %param_0.1490 = bf16[1,128,32,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.68 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1490, %constant.1005), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
+  %pad.68 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1490, %constant.982), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
   %convert.240 = f32[1,128,32,128]{3,1,2,0:T(8,128)} convert(%pad.68)
   %maximum.53 = f32[1,128,32,128]{3,1,2,0:T(8,128)} maximum(%convert.239, %convert.240), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","32","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_2.1185 = bf16[32,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %bitcast.845 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.1185), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dq_segmented_no_residuals/splash_mha_dq_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
-  %convert.241 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.845)
+  %bitcast.844 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.1185), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dq_segmented_no_residuals/splash_mha_dq_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.241 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.844)
   %param_3.802 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %broadcast.717 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_3.802), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.242 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.717)
+  %broadcast.711 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_3.802), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.242 = f32[1,32,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.711)
   %mul.1776 = f32[1,32,128,128]{3,2,1,0:T(8,128)} multiply(%convert.241, %convert.242), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","32","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.243 = bf16[1,32,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.1776)
-  %bitcast.844 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%convert.243), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %convert.244 = f32[1,128,32,128]{3,1,2,0:T(8,128)} convert(%bitcast.844)
+  %bitcast.843 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%convert.243), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %convert.244 = f32[1,128,32,128]{3,1,2,0:T(8,128)} convert(%bitcast.843)
   %add_any.162 = f32[1,128,32,128]{3,1,2,0:T(8,128)} add(%maximum.53, %convert.244), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","32","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.245 = bf16[1,128,32,128]{3,1,2,0:T(8,128)(2,1)} convert(%add_any.162)
-  ROOT %bitcast.843 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)S(1)} bitcast(%convert.245)
+  ROOT %bitcast.842 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)S(1)} bitcast(%convert.245)
 }
 
 %bitcast_fusion.1.clone.1 (bitcast_input.13: bf16[128,32,128]) -> bf16[128,32,128] {
   %bitcast_input.13 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.857 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)} bitcast(%bitcast_input.13)
+  ROOT %bitcast.856 = bf16[128,32,128]{2,0,1:T(8,128)(2,1)} bitcast(%bitcast_input.13)
 }
 
 %fused_computation.92.clone.clone.clone.1 (param_0.1501: bf16[1,4096,32,128]) -> bf16[4096,32,128] {
   %param_0.1501 = bf16[1,4096,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.856 = bf16[4096,32,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1501), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.855 = bf16[4096,32,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1501), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.141.clone.1 (param_0.1502: bf16[128,32,128], param_1.1557: bf16[1,4096,32,128]) -> bf16[128,4096] {
@@ -1897,19 +1825,19 @@ StackFrames
   %param_1.1557 = bf16[1,4096,32,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(1)
   %fusion.445 = bf16[4096,32,128]{0,2,1:T(8,128)(2,1)} fusion(%param_1.1557), kind=kLoop, calls=%fused_computation.92.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
   %convolution.154 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.446, %fusion.445), window={size=32}, dim_labels=b0f_o0i->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  ROOT %bitcast.858 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convolution.154), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+  ROOT %bitcast.857 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convolution.154), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.231.clone.1 (param_0.1480: bf16[8,128,128], param_1.1544: bf16[128,128]) -> bf16[1,128,8,128] {
   %param_0.1480 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.832 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1480), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
-  %convert.246 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.832)
+  %bitcast.831 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1480), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.246 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.831)
   %param_1.1544 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %broadcast.714 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_1.1544), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.247 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.714)
+  %broadcast.708 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_1.1544), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.247 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.708)
   %mul.1771 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.246, %convert.247), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.248 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.1771)
-  ROOT %bitcast.831 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convert.248), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  ROOT %bitcast.830 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convert.248), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
 }
 
 %fused_computation.419.clone.1 (param_0.1481: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
@@ -1924,36 +1852,36 @@ StackFrames
 
 %fused_computation.226.clone.1 (param_0.1482: bf16[1,128,8,64], param_1.1545: bf16[1,128,8,64], param_2.1181: bf16[8,128,128], param_3.798: bf16[128,128]) -> bf16[128,8,128] {
   %param_1.1545 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1002 = bf16[]{:T(256)} constant(-inf)
-  %pad.67 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1545, %constant.1002), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
+  %constant.979 = bf16[]{:T(256)} constant(-inf)
+  %pad.67 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1545, %constant.979), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
   %convert.251 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.67)
   %param_0.1482 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.66 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1482, %constant.1002), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
+  %pad.66 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1482, %constant.979), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
   %convert.252 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.66)
   %maximum.52 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.251, %convert.252), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_2.1181 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %bitcast.835 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.1181), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
-  %convert.253 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.835)
+  %bitcast.834 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.1181), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.253 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.834)
   %param_3.798 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %broadcast.715 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_3.798), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.254 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.715)
+  %broadcast.709 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_3.798), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.254 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.709)
   %mul.1772 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.253, %convert.254), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.255 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.1772)
-  %bitcast.834 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%convert.255), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %convert.256 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%bitcast.834)
+  %bitcast.833 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%convert.255), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %convert.256 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%bitcast.833)
   %add_any.161 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%maximum.52, %convert.256), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.257 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add_any.161)
-  ROOT %bitcast.833 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)S(1)} bitcast(%convert.257)
+  ROOT %bitcast.832 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)S(1)} bitcast(%convert.257)
 }
 
 %bitcast_fusion.clone.1 (bitcast_input.12: bf16[128,8,128]) -> bf16[128,8,128] {
   %bitcast_input.12 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.854 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%bitcast_input.12)
+  ROOT %bitcast.853 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%bitcast_input.12)
 }
 
 %fused_computation.105.clone.clone.clone.1 (param_0.1499: bf16[1,4096,8,128]) -> bf16[4096,8,128] {
   %param_0.1499 = bf16[1,4096,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.853 = bf16[4096,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1499), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.852 = bf16[4096,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1499), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.139.clone.1 (param_0.1500: bf16[128,8,128], param_1.1556: bf16[1,4096,8,128]) -> bf16[128,4096] {
@@ -1962,17 +1890,17 @@ StackFrames
   %param_1.1556 = bf16[1,4096,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(1)
   %fusion.443 = bf16[4096,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_1.1556), kind=kLoop, calls=%fused_computation.105.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
   %convolution.153 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.444, %fusion.443), window={size=8}, dim_labels=b0f_o0i->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  ROOT %bitcast.855 = bf16[128,4096]{1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.153), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+  ROOT %bitcast.854 = bf16[128,4096]{1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.153), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
 }
 
 %fused_computation.228.clone.clone.clone.1 (param_0.1504: bf16[8,128,128]) -> bf16[128,8,128] {
   %param_0.1504 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.860 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1504)
+  ROOT %bitcast.859 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1504)
 }
 
 %fused_computation.101.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1503: bf16[1,4096,8,128]) -> bf16[4096,8,128] {
   %param_0.1503 = bf16[1,4096,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.859 = bf16[4096,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1503), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.858 = bf16[4096,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1503), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
 %region_16.20 (reduce_sum.129: f32[], reduce_sum.133: f32[]) -> f32[] {
@@ -1984,17 +1912,89 @@ StackFrames
 %fused_computation.155.clone.1 (param_0.1505: bf16[4,1,128,4096], param_1.1558: s32[], param_2.1190: bf16[4096], param_3.805: bf16[128,4096], param_4.495: bf16[128,4096], param_5.418: bf16[1,4096,8,128], param_6.269: bf16[8,128,128]) -> (f32[128], bf16[1,128,4096]) {
   %param_0.1505 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1558 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.362.clone.81 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.185 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1505, %param_1.1558, %constant.362.clone.81, %constant.362.clone.81, %constant.362.clone.81), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.861 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.185), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1040 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.861), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %constant.340.clone.81 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.185 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1505, %param_1.1558, %constant.340.clone.81, %constant.340.clone.81, %constant.340.clone.81), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.860 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.185), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1040 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.860), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %param_6.269 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(6)
   %fusion.249.clone.3 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_6.269), kind=kLoop, calls=%fused_computation.228.clone.clone.clone.1
   %param_5.418 = bf16[1,4096,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
   %fusion.167.clone.3 = bf16[4096,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_5.418), kind=kLoop, calls=%fused_computation.101.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
   %convolution.103.clone.3 = bf16[128,4096,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.249.clone.3, %fusion.167.clone.3), window={size=8}, dim_labels=b0f_o0i->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  %bitcast.337.clone.3 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convolution.103.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  %convert.258 = f32[128,4096]{1,0:T(8,128)} convert(%bitcast.337.clone.3)
+  %bitcast.336.clone.3 = bf16[128,4096]{1,0:T(8,128)(2,1)} bitcast(%convolution.103.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+  %convert.258 = f32[128,4096]{1,0:T(8,128)} convert(%bitcast.336.clone.3)
   %param_4.495 = bf16[128,4096]{1,0:T(8,128)(2,1)S(1)} parameter(4)
   %convert.259 = f32[128,4096]{1,0:T(8,128)} convert(%param_4.495)
   %add_any.130.clone.3 = f32[128,4096]{1,0:T(8,128)} add(%convert.258, %convert.259), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  %param_3.805 = bf16[128,4096]{1,0:T(8,128)(2,1)} parameter(3)
+  %convert.260 = f32[128,4096]{1,0:T(8,128)} convert(%param_3.805)
+  %add_any.129.clone.3 = f32[128,4096]{1,0:T(8,128)} add(%add_any.130.clone.3, %convert.260), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  %convert.261 = bf16[128,4096]{1,0:T(8,128)(2,1)} convert(%add_any.129.clone.3)
+  %bitcast.333.clone.3 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.261), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}
+  %convert.262 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.333.clone.3)
+  %param_2.1190 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.462 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1190), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.263 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%dot_general.462)
+  %dot_general.461 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.262, %convert.263), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.1039 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%dot_general.461), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/convert_element_type" stack_frame_id=0}
+  %mul.1779 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.1040, %convert_element_type.1039), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %constant.341.clone.15 = f32[]{:T(128)} constant(0)
+  %reduce.193 = f32[128]{0:T(128)S(1)} reduce(%mul.1779, %constant.341.clone.15), dimensions={0,2}, to_apply=%region_16.20, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.196 = (f32[128]{0:T(128)S(1)}, bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.193, %bitcast.333.clone.3)
+}
+
+%fused_computation.250.clone.1 (param_0.1506: f32[128], param_1.1559: f32[128]) -> f32[128] {
+  %param_0.1506 = f32[128]{0:T(128)S(1)} parameter(0)
+  %bitcast.863 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1506), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum" stack_frame_id=0}
+  %param_1.1559 = f32[128]{0:T(128)S(1)} parameter(1)
+  %constant.342.clone.12 = f32[]{:T(128)} constant(0.000244140625)
+  %broadcast.713 = f32[128]{0:T(128)} broadcast(%constant.342.clone.12), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %div.863 = f32[128]{0:T(128)} multiply(%param_1.1559, %broadcast.713), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.343.clone.12 = f32[]{:T(128)} constant(1e-05)
+  %broadcast.712 = f32[128]{0:T(128)} broadcast(%constant.343.clone.12), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %add.893 = f32[128]{0:T(128)} add(%div.863, %broadcast.712), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.862 = f32[1,128]{1,0:T(1,128)} bitcast(%add.893), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.117 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.862), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %div.862 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.117, %bitcast.862), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.350.clone.6 = f32[]{:T(128)} constant(-0.5)
+  %closed_call.48 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.350.clone.6), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %mul.1782 = f32[1,128]{1,0:T(1,128)} multiply(%div.862, %closed_call.48), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.1781 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.863, %mul.1782), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %constant.351.clone.6 = f32[]{:T(128)} constant(0.00048828125)
+  %mul.1783 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.351.clone.6), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %mul.1780 = f32[1,128]{1,0:T(1,128)} multiply(%mul.1781, %mul.1783), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  ROOT %bitcast.861 = f32[128]{0:T(128)S(1)} bitcast(%mul.1780), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+}
+
+%region_18.22 (dot_general.189: bf16[], dot_general.190: bf16[]) -> bf16[] {
+  %dot_general.189 = bf16[]{:T(256)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general"}
+  %dot_general.190 = bf16[]{:T(256)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general"}
+  ROOT %add.168 = bf16[]{:T(256)} add(%dot_general.189, %dot_general.190), metadata={op_name="add.46"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+}
+
+%fused_computation.195.clone.1 (param_0.1507: bf16[1,128,4096], param_1.1560: f32[128], param_2.1191: bf16[4,1,128,4096], param_3.806: s32[], param_4.496: bf16[1,128,4096], param_5.419: f32[128], param_6.270: bf16[4096]) -> (bf16[4096], bf16[1,128,4096]) {
+  %param_0.1507 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.264 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%param_0.1507)
+  %param_2.1191 = bf16[4,1,128,4096]{3,2,1,0:T(8,128)(2,1)} parameter(2)
+  %param_3.806 = s32[]{:T(128)S(6)} parameter(3)
+  %constant.340.clone.82 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.186 = bf16[1,1,128,4096]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1191, %param_3.806, %constant.340.clone.82, %constant.340.clone.82, %constant.340.clone.82), dynamic_slice_sizes={1,1,128,4096}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.864 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.186), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1042 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%bitcast.864), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1560 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.1785 = f32[1,128,4096]{2,1,0:T(8,128)} broadcast(%param_1.1560), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.1784 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.1042, %mul.1785), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1041 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%mul.1784), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.265 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%convert_element_type.1041)
+  %multiply.303 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.264, %convert.265), metadata={op_name="multiply.196"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.266 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} convert(%multiply.303)
+  %constant.352.clone.6 = bf16[]{:T(256)} constant(0)
+  %reduce.194 = bf16[4096]{0:T(1024)(128)(2,1)} reduce(%convert.266, %constant.352.clone.6), dimensions={0,1}, to_apply=%region_18.22, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}
+  %param_4.496 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)S(1)} parameter(4)
+  %convert.268 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%param_4.496)
+  %param_6.270 = bf16[4096]{0:T(1024)(128)(2,1)S(1)} parameter(6)
+  %dot_general.360.clone.3 = bf16[1,128,4096]{2,1,0:T(8,128)(2,1)} broadcast(%param_6.270), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.267 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%dot_general.360.clone.3)
+  %dot_general.292.clone.3 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert.264, %convert.267), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","4096"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.760.clone.3 = f32[1,128,4096]{2,1,0:T(8,128)} convert(%dot_general.292.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/convert_element_type" stack_frame_id=0}
+  %mul.1191.clone.3 = f32[1,128,4096]{2,1,0:T(8,128)} multiply(%convert_element_type.760.clone.3, %mul.1785), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}

--- a/tests/utils/reference_hlo_qwen3_1.7b.txt
+++ b/tests/utils/reference_hlo_qwen3_1.7b.txt
@@ -11,25 +11,25 @@ StackFrames
 
 %fused_computation.478 (param_0.1336: s32[1,128]) -> s32[1,1,128] {
   %param_0.1336 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %constant.449.clone.9 = s32[]{:T(128)} constant(0)
-  %broadcast.982 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.449.clone.9), dimensions={}, metadata={op_name="broadcast.99"}
-  %lt.32 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1336, %broadcast.982), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
-  %constant.461.clone.1 = s32[]{:T(128)} constant(151936)
-  %add.941 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.461.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %constant.433.clone.9 = s32[]{:T(128)} constant(0)
+  %broadcast.976 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.9), dimensions={}, metadata={op_name="broadcast.95"}
+  %lt.32 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1336, %broadcast.976), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
+  %constant.445.clone.1 = s32[]{:T(128)} constant(151936)
+  %add.941 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.445.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %add.930 = s32[1,128]{1,0:T(1,128)} add(%param_0.1336, %add.941), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %select_n.180 = s32[1,128]{1,0:T(1,128)} select(%lt.32, %add.930, %param_0.1336), metadata={op_name="jit(train_step)/jvp()/select_n" stack_frame_id=0}
   ROOT %bitcast.616 = s32[1,1,128]{2,1,0:T(1,128)S(1)} bitcast(%select_n.180)
 }
 
 %fused_computation.448 (param_0.1269: s32[512]) -> s32[1024] {
-  %constant.1055 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.952 = s32[1024]{0:T(1024)} broadcast(%constant.1055), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.1038 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.946 = s32[1024]{0:T(1024)} broadcast(%constant.1038), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %param_0.1269 = s32[512]{0:T(512)S(1)} parameter(0)
-  %constant.1056 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %pad.57 = s32[1024]{0:T(1024)} pad(%param_0.1269, %constant.1056), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %constant.1054 = s32[] constant(151935), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.951 = s32[1024]{0:T(1024)} broadcast(%constant.1054), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  ROOT %clamp.3 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.952, %pad.57, %broadcast.951), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.1039 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %pad.57 = s32[1024]{0:T(1024)} pad(%param_0.1269, %constant.1039), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.1037 = s32[] constant(151935), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.945 = s32[1024]{0:T(1024)} broadcast(%constant.1037), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  ROOT %clamp.3 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.946, %pad.57, %broadcast.945), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
 %fused_computation (param_0.2: bf16[151936,512], param_1.7: s32[1024]) -> bf16[512,512] {
@@ -37,11 +37,11 @@ StackFrames
   %param_1.7 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.1 = s32[1024]{0:T(1024)} custom-call(%param_1.7), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %slice.34 = s32[512]{0:T(512)} slice(%custom-call.1), slice={[0:512]}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %reshape.793 = s32[4,128]{1,0:T(4,128)} reshape(%slice.34), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %transpose.442 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.793), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %reshape.781 = s32[4,128]{1,0:T(4,128)} reshape(%slice.34), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %transpose.442 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.781), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %gather.4 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} gather(%param_0.2, %transpose.442), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %transpose.441 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} transpose(%gather.4), dimensions={0,1,2}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  ROOT %reshape.792 = bf16[512,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.441), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  ROOT %reshape.780 = bf16[512,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.441), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
 %fused_computation.494 (param_0.1517: f32[128,4]) -> bf16[4,128] {
@@ -65,17 +65,17 @@ StackFrames
 }
 
 %fused_computation.485 () -> f32[64] {
-  %constant.466.clone.1 = f32[]{:T(128)} constant(1e+06)
-  %broadcast.975 = f32[64]{0:T(128)} broadcast(%constant.466.clone.1), dimensions={}, metadata={op_name="broadcast.409"}
+  %constant.449.clone.1 = f32[]{:T(128)} constant(1e+06)
+  %broadcast.969 = f32[64]{0:T(128)} broadcast(%constant.449.clone.1), dimensions={}, metadata={op_name="broadcast.407"}
   %iota.56 = s32[64]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/iota" stack_frame_id=0}
-  %constant.467.clone.1 = s32[]{:T(128)} constant(2)
-  %broadcast.974 = s32[64]{0:T(128)} broadcast(%constant.467.clone.1), dimensions={}, metadata={op_name="broadcast.410"}
-  %mul.1960 = s32[64]{0:T(128)} multiply(%iota.56, %broadcast.974), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %constant.450.clone.1 = s32[]{:T(128)} constant(2)
+  %broadcast.968 = s32[64]{0:T(128)} broadcast(%constant.450.clone.1), dimensions={}, metadata={op_name="broadcast.408"}
+  %mul.1960 = s32[64]{0:T(128)} multiply(%iota.56, %broadcast.968), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %convert_element_type.1324 = f32[64]{0:T(128)} convert(%mul.1960), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  %constant.468.clone.1 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.973 = f32[64]{0:T(128)} broadcast(%constant.468.clone.1), dimensions={}, metadata={op_name="broadcast.411"}
-  %div.778 = f32[64]{0:T(128)} multiply(%convert_element_type.1324, %broadcast.973), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  ROOT %pow.36 = f32[64]{0:T(128)S(1)} power(%broadcast.975, %div.778), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
+  %constant.451.clone.1 = f32[]{:T(128)} constant(0.0078125)
+  %broadcast.967 = f32[64]{0:T(128)} broadcast(%constant.451.clone.1), dimensions={}, metadata={op_name="broadcast.409"}
+  %div.778 = f32[64]{0:T(128)} multiply(%convert_element_type.1324, %broadcast.967), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  ROOT %pow.36 = f32[64]{0:T(128)S(1)} power(%broadcast.969, %div.778), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
 }
 
 %fused_computation.421 (param_0.1238: f32[128], param_1.1308: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
@@ -93,10 +93,10 @@ StackFrames
 
 %fused_computation.424 (param_0.1209: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
   %param_0.1209 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.471.clone.2 = bf16[]{:T(256)} constant(-inf)
-  %pad.54 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1209, %constant.471.clone.2), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %constant.454.clone.2 = bf16[]{:T(256)} constant(-inf)
+  %pad.54 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1209, %constant.454.clone.2), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
   %convert.201 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.54)
-  %pad.53 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1209, %constant.471.clone.2), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %pad.53 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1209, %constant.454.clone.2), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
   %convert.202 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.53)
   %maximum.46 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.201, %convert.202), metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   ROOT %convert.203 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%maximum.46)
@@ -104,10 +104,10 @@ StackFrames
 
 %fused_computation.425 (param_0.1211: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
   %param_0.1211 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.471.clone.1 = bf16[]{:T(256)} constant(-inf)
-  %pad.56 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1211, %constant.471.clone.1), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %constant.454.clone.1 = bf16[]{:T(256)} constant(-inf)
+  %pad.56 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1211, %constant.454.clone.1), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
   %convert.204 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.56)
-  %pad.55 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1211, %constant.471.clone.1), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %pad.55 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1211, %constant.454.clone.1), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
   %convert.205 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.55)
   %maximum.47 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.204, %convert.205), metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   ROOT %convert.206 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%maximum.47)
@@ -160,22 +160,22 @@ StackFrames
   %param_2.1442 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %bitcast.1011 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.1442), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/broadcast_in_dim" stack_frame_id=0}
   %param_1.1890 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.420.clone.35 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-update-slice.32 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.1806, %bitcast.1011, %param_1.1890, %constant.420.clone.35, %constant.420.clone.35, /*index=5*/%constant.420.clone.35), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.404.clone.35 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-update-slice.32 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.1806, %bitcast.1011, %param_1.1890, %constant.404.clone.35, %constant.404.clone.35, /*index=5*/%constant.404.clone.35), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.22.clone.1 (param_0.1831: bf16[4,16,128,512], param_1.1906: s32[]) -> bf16[1,16,128,512] {
   %param_0.1831 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1906 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.420.clone.41 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.210 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1831, %param_1.1906, %constant.420.clone.41, %constant.420.clone.41, %constant.420.clone.41), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.404.clone.41 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.210 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1831, %param_1.1906, %constant.404.clone.41, %constant.404.clone.41, %constant.404.clone.41), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.23.clone.1 (param_0.1823: bf16[4,512,16,128], param_1.1901: s32[]) -> bf16[1,512,16,128] {
   %param_0.1823 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
   %param_1.1901 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.420.clone.40 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.209 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1823, %param_1.1901, %constant.420.clone.40, %constant.420.clone.40, %constant.420.clone.40), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.404.clone.40 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.209 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1823, %param_1.1901, %constant.404.clone.40, %constant.404.clone.40, %constant.404.clone.40), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %region_2.3 (reduce_sum.143: f32[], reduce_sum.144: f32[]) -> f32[] {
@@ -188,18 +188,18 @@ StackFrames
   %param_0.1808 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.1516 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1808), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.281 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1516, %convert_element_type.1516), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.421.clone.13 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.276 = f32[128]{0:T(128)S(1)} reduce(%square.281, %constant.421.clone.13), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.405.clone.13 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.276 = f32[128]{0:T(128)S(1)} reduce(%square.281, %constant.405.clone.13), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.83.clone.1 (param_0.1809: f32[128]) -> f32[128] {
   %param_0.1809 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.422.clone.9 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.1093 = f32[128]{0:T(128)} broadcast(%constant.422.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.1030 = f32[128]{0:T(128)} multiply(%param_0.1809, %broadcast.1093), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.423.clone.13 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1092 = f32[128]{0:T(128)} broadcast(%constant.423.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.1061 = f32[128]{0:T(128)} add(%div.1030, %broadcast.1092), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.406.clone.9 = f32[]{:T(128)} constant(0.00048828125)
+  %broadcast.1087 = f32[128]{0:T(128)} broadcast(%constant.406.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.1030 = f32[128]{0:T(128)} multiply(%param_0.1809, %broadcast.1087), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.407.clone.13 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.1086 = f32[128]{0:T(128)} broadcast(%constant.407.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.1061 = f32[128]{0:T(128)} add(%div.1030, %broadcast.1086), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.222 = f32[128]{0:T(128)S(1)} rsqrt(%add.1061), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
@@ -218,13 +218,13 @@ StackFrames
 %fused_computation.73.clone.1 (param_0.1807: bf16[4,2048], param_1.1891: s32[], param_2.1443: bf16[4,2048]) -> (bf16[2048], bf16[2048]) {
   %param_0.1807 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} parameter(0)
   %param_1.1891 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.420.clone.36 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.301 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1807, %param_1.1891, %constant.420.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %constant.1134 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %reduce.275 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.301, %constant.1134), dimensions={0}, to_apply=%convert_element_type.932.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.404.clone.36 = s32[]{:T(128)} constant(0)
+  %dynamic_slice.203 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1807, %param_1.1891, %constant.404.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1117 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %reduce.275 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.203, %constant.1117), dimensions={0}, to_apply=%convert_element_type.932.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %param_2.1443 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} parameter(2)
-  %dynamic_slice.272.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1443, %param_1.1891, %constant.420.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %reduce.181.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.272.clone.3, %constant.1134), dimensions={0}, to_apply=%convert_element_type.920.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %dynamic_slice.174.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1443, %param_1.1891, %constant.404.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %reduce.181.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.174.clone.3, %constant.1117), dimensions={0}, to_apply=%convert_element_type.920.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   ROOT %tuple.240 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) tuple(%reduce.275, %reduce.181.clone.3)
 }
 
@@ -266,31 +266,31 @@ StackFrames
   %convert_element_type.1525 = f32[128,16,128]{2,0,1:T(8,128)} convert(%convolution.34.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %bitcast.1021 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1525), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.283 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.1021, %bitcast.1021), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.421.clone.15 = f32[]{:T(128)} constant(0)
-  %reduce.278 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.283, %constant.421.clone.15), dimensions={0,3}, to_apply=%region_3.4, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.405.clone.15 = f32[]{:T(128)} constant(0)
+  %reduce.278 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.283, %constant.405.clone.15), dimensions={0,3}, to_apply=%region_3.4, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
   ROOT %tuple.244 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) tuple(%reduce.278, %convolution.34.clone.3)
 }
 
 %fused_computation.72.clone.1 (param_0.1827: f32[128,16]) -> f32[128,16] {
   %param_0.1827 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
-  %constant.424.clone.10 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.1097 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.424.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %div.1032 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1827, %broadcast.1097), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.423.clone.15 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1096 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.423.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
-  %add.1064 = f32[128,16]{0,1:T(8,128)} add(%div.1032, %broadcast.1096), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.408.clone.10 = f32[]{:T(128)} constant(0.0078125)
+  %broadcast.1091 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.408.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %div.1032 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1827, %broadcast.1091), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.407.clone.15 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.1090 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.407.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %add.1064 = f32[128,16]{0,1:T(8,128)} add(%div.1032, %broadcast.1090), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.224 = f32[128,16]{0,1:T(8,128)S(1)} rsqrt(%add.1064), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
 %fused_computation.79.clone.1 (param_0.1814: bf16[4,128], param_1.1895: s32[], param_2.1446: bf16[4,128]) -> (bf16[128], bf16[128]) {
   %param_0.1814 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(0)
   %param_1.1895 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.420.clone.38 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.302 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1814, %param_1.1895, %constant.420.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.1015 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.302), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %constant.404.clone.38 = s32[]{:T(128)} constant(0)
+  %dynamic_slice.204 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1814, %param_1.1895, %constant.404.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.1015 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.204), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %param_2.1446 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(2)
-  %dynamic_slice.282.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1446, %param_1.1895, %constant.420.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.278.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.282.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %dynamic_slice.184.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1446, %param_1.1895, %constant.404.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.278.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.184.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   ROOT %tuple.241 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) tuple(%bitcast.1015, %bitcast.278.clone.3)
 }
 
@@ -338,11 +338,11 @@ StackFrames
   %convert.394 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2399)
   %mul.2397 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%dot_general.639, %convert.394), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_1.1905 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1136 = bf16[]{:T(256)} constant(-inf)
-  %pad.85 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1905, %constant.1136), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %constant.1119 = bf16[]{:T(256)} constant(-inf)
+  %pad.85 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1905, %constant.1119), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.395 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.85)
   %param_0.1830 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.84 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1830, %constant.1136), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.84 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1830, %constant.1119), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.396 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.84)
   %maximum.61 = f32[1,128,16,128]{3,1,2,0:T(8,128)} maximum(%convert.395, %convert.396), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_2.1454 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
@@ -350,8 +350,8 @@ StackFrames
   %convert.397 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2398)
   %mul.2396 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%maximum.61, %convert.397), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %add.1065 = f32[1,128,16,128]{3,1,2,0:T(8,128)} add(%mul.2397, %mul.2396), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %constant.425.clone.7 = bf16[]{:T(256)} constant(0.08838)
-  %mul.2400 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.425.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
+  %constant.409.clone.7 = bf16[]{:T(256)} constant(0.08838)
+  %mul.2400 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.409.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
   %convert.398 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2400)
   %mul.2395 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%add.1065, %convert.398), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.399 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2395)
@@ -361,8 +361,8 @@ StackFrames
 %fused_computation.29.clone.1 (param_0.1815: bf16[4,512,8,128], param_1.1896: s32[]) -> bf16[1,512,8,128] {
   %param_0.1815 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.1896 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.420.clone.39 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.208 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1815, %param_1.1896, %constant.420.clone.39, %constant.420.clone.39, %constant.420.clone.39), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.404.clone.39 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.208 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1815, %param_1.1896, %constant.404.clone.39, %constant.404.clone.39, %constant.404.clone.39), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.53.clone.1.clone.clone.clone.1 (param_0.1817: bf16[1,128,2048], param_1.1897: f32[128], param_2.1447: bf16[2048]) -> bf16[128,2048,1] {
@@ -403,19 +403,19 @@ StackFrames
   %convert_element_type.971.clone.3 = f32[128,8,128]{2,0,1:T(8,128)} convert(%convolution.58.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %bitcast.256.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} bitcast(%convert_element_type.971.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.282 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%bitcast.256.clone.3, %bitcast.256.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.421.clone.14 = f32[]{:T(128)} constant(0)
-  %reduce.277 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.282, %constant.421.clone.14), dimensions={0,3}, to_apply=%region_4.5, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.405.clone.14 = f32[]{:T(128)} constant(0)
+  %reduce.277 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.282, %constant.405.clone.14), dimensions={0,3}, to_apply=%region_4.5, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
   ROOT %tuple.242 = (f32[128,8]{0,1:T(8,128)S(1)}, f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)}) tuple(%reduce.277, %bitcast.256.clone.3)
 }
 
 %fused_computation.75.clone.1 (param_0.1819: f32[128,8]) -> f32[128,8] {
   %param_0.1819 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
-  %constant.424.clone.9 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.1095 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.424.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %div.1031 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1819, %broadcast.1095), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.423.clone.14 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1094 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.423.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
-  %add.1062 = f32[128,8]{0,1:T(8,128)} add(%div.1031, %broadcast.1094), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.408.clone.9 = f32[]{:T(128)} constant(0.0078125)
+  %broadcast.1089 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.408.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %div.1031 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1819, %broadcast.1089), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.407.clone.14 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.1088 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.407.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %add.1062 = f32[128,8]{0,1:T(8,128)} add(%div.1031, %broadcast.1088), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.223 = f32[128,8]{0,1:T(8,128)S(1)} rsqrt(%add.1062), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
@@ -459,11 +459,11 @@ StackFrames
   %convert.407 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2388)
   %mul.2386 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%dot_general.633, %convert.407), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_1.1900 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1135 = bf16[]{:T(256)} constant(-inf)
-  %pad.83 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1900, %constant.1135), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %constant.1118 = bf16[]{:T(256)} constant(-inf)
+  %pad.83 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1900, %constant.1118), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.408 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.83)
   %param_0.1822 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.82 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1822, %constant.1135), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %pad.82 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1822, %constant.1118), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
   %convert.409 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.82)
   %maximum.60 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.408, %convert.409), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_2.1450 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
@@ -478,8 +478,8 @@ StackFrames
 %fused_computation.28.clone.1 (param_0.1810: bf16[4,512,8,128], param_1.1892: s32[]) -> bf16[1,512,8,128] {
   %param_0.1810 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.1892 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.420.clone.37 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.207 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1810, %param_1.1892, %constant.420.clone.37, %constant.420.clone.37, %constant.420.clone.37), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.404.clone.37 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.207 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1810, %param_1.1892, %constant.404.clone.37, %constant.404.clone.37, %constant.404.clone.37), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.53.clone.clone.1 (param_0.1812: bf16[1,128,2048], param_1.1893: f32[128], param_2.1444: bf16[2048]) -> bf16[128,2048,1] {
@@ -543,8 +543,8 @@ StackFrames
   %add.797.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.412, %convert.413), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.1530 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%add.797.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
   %square.284 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1530, %convert_element_type.1530), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
-  %constant.421.clone.16 = f32[]{:T(128)} constant(0)
-  %reduce.279 = f32[128]{0:T(128)S(1)} reduce(%square.284, %constant.421.clone.16), dimensions={0,2}, to_apply=%region_5.7, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %constant.405.clone.16 = f32[]{:T(128)} constant(0)
+  %reduce.279 = f32[128]{0:T(128)S(1)} reduce(%square.284, %constant.405.clone.16), dimensions={0,2}, to_apply=%region_5.7, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
   %convert.414 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.797.clone.3)
   ROOT %tuple.246 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.279, %convert.414)
 }
@@ -552,32 +552,32 @@ StackFrames
 %fused_computation.11.clone.1 (param_0.1841: bf16[4,6144,512], param_1.1912: s32[]) -> bf16[1,6144,512] {
   %param_0.1841 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1912 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.420.clone.44 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.213 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1841, %param_1.1912, %constant.420.clone.44, %constant.420.clone.44), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.404.clone.44 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.213 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1841, %param_1.1912, %constant.404.clone.44, %constant.404.clone.44), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.12.clone.1 (param_0.1840: bf16[4,512,6144], param_1.1911: s32[]) -> bf16[1,512,6144] {
   %param_0.1840 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1911 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.420.clone.43 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.212 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1840, %param_1.1911, %constant.420.clone.43, %constant.420.clone.43), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.404.clone.43 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.212 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1840, %param_1.1911, %constant.404.clone.43, %constant.404.clone.43), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.13.clone.1 (param_0.1836: bf16[4,512,6144], param_1.1908: s32[]) -> bf16[1,512,6144] {
   %param_0.1836 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1908 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.420.clone.42 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.211 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1836, %param_1.1908, %constant.420.clone.42, %constant.420.clone.42), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.404.clone.42 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.211 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1836, %param_1.1908, %constant.404.clone.42, %constant.404.clone.42), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.82.clone.1 (param_0.1835: f32[128]) -> f32[128] {
   %param_0.1835 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.422.clone.10 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.1099 = f32[128]{0:T(128)} broadcast(%constant.422.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.1033 = f32[128]{0:T(128)} multiply(%param_0.1835, %broadcast.1099), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %constant.423.clone.16 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1098 = f32[128]{0:T(128)} broadcast(%constant.423.clone.16), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.1066 = f32[128]{0:T(128)} add(%div.1033, %broadcast.1098), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
+  %constant.406.clone.10 = f32[]{:T(128)} constant(0.00048828125)
+  %broadcast.1093 = f32[128]{0:T(128)} broadcast(%constant.406.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %div.1033 = f32[128]{0:T(128)} multiply(%param_0.1835, %broadcast.1093), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %constant.407.clone.16 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.1092 = f32[128]{0:T(128)} broadcast(%constant.407.clone.16), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
+  %add.1066 = f32[128]{0:T(128)} add(%div.1033, %broadcast.1092), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
   ROOT %rsqrt.225 = f32[128]{0:T(128)S(1)} rsqrt(%add.1066), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
 }
 
@@ -637,8 +637,8 @@ StackFrames
 %fused_computation.27.clone.clone.clone.1 (param_0.1845: bf16[1,2048,6144], param_1.1914: bf16[1,128,6144], param_2.1459: bf16[1,128,2048], param_3.957: f32[128], param_4.568: bf16[2048]) -> bf16[128,6144] {
   %param_1.1914 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %convert.383 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1914)
-  %constant.426.clone.10 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.46 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.426.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)" stack_frame_id=0}
+  %constant.410.clone.10 = bf16[]{:T(256)} constant(1)
+  %jit_silu_.46 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.410.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)" stack_frame_id=0}
   %convert.384 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.46)
   %neg.135 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.383), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %exp.79 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.135), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
@@ -681,124 +681,100 @@ StackFrames
   ROOT %convert.417 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.1068)
 }
 
-%wide.region_1.8_spmd.sunk.clone.clone.clone.sunk (wide.param.1: (s32[], bf16[1,128,2048], u32[4], u32[4,4], u32[4], /*index=5*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=10*/u32[4], u32[4,4], u32[4], u32[4,4], bf16[4,1,128,2048], /*index=15*/bf16[4,128], bf16[4,2048], bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], /*index=20*/bf16[4,128], bf16[4,512,8,128], bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], /*index=25*/bf16[4,512,6144], bf16[4,512,6144], bf16[4,6144,512], u32[4], u32[4,4], /*index=30*/u32[4], u32[4,4], u32[4], u32[4,4], u32[4], /*index=35*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=40*/s32[128], s32[], s8[1,1,1], s8[1,1,1])) -> (s32[], bf16[1,128,2048], u32[4], u32[4,4], u32[4], /*index=5*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=10*/u32[4], u32[4,4], u32[4], u32[4,4], bf16[4,1,128,2048], /*index=15*/bf16[4,128], bf16[4,2048], bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], /*index=20*/bf16[4,128], bf16[4,512,8,128], bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], /*index=25*/bf16[4,512,6144], bf16[4,512,6144], bf16[4,6144,512], u32[4], u32[4,4], /*index=30*/u32[4], u32[4,4], u32[4], u32[4,4], u32[4], /*index=35*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=40*/s32[128], s32[], s8[1,1,1], s8[1,1,1]) {
-  %constant.477.clone..sunk.1 = s32[]{:T(128)} constant(1)
-  %wide.param.1 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=5*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=10*/u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, /*index=20*/bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=25*/bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, /*index=30*/u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, /*index=35*/u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, /*index=40*/s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) parameter(0)
-  %get-tuple-element.2262 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=0
-  %copy.255 = s32[]{:T(128)S(6)} copy(%get-tuple-element.2262), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add.1069 = s32[]{:T(128)} add(%copy.255, %constant.477.clone..sunk.1), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2276 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=14
-  %get-tuple-element.2263 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=1
-  %bitcast_dynamic-update-slice_fusion.5 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} fusion(%get-tuple-element.2276, %copy.255, %get-tuple-element.2263), kind=kLoop, calls=%fused_computation.60.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
-  %get-tuple-element.2329 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=23
-  %dynamic-slice_convert_fusion.35 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2329, %copy.255), kind=kLoop, calls=%fused_computation.22.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.108 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.35), channel_id=105, replica_groups=mesh['axis_0'=1,'axis_1'=1,'axis_2'=4] {'axis_2'}, dimensions={3}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2348 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=42, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
-  %get-tuple-element.2349 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=43, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
-  %get-tuple-element.2323 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=17
-  %dynamic-slice_convert_fusion.36 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2323, %copy.255), kind=kLoop, calls=%fused_computation.23.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.109 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.36), channel_id=102, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.515 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.2263), kind=kLoop, calls=%fused_computation.38.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+%wide.region_1.8_spmd.sunk.clone.clone.clone.sunk (wide.param.1: (s32[], bf16[1,128,2048], bf16[4,1,128,2048], bf16[4,128], bf16[4,2048], /*index=5*/bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,128], bf16[4,512,8,128], /*index=10*/bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], bf16[4,512,6144], bf16[4,512,6144], /*index=15*/bf16[4,6144,512], s32[128], s32[], s8[1,1,1], s8[1,1,1])) -> (s32[], bf16[1,128,2048], bf16[4,1,128,2048], bf16[4,128], bf16[4,2048], /*index=5*/bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,128], bf16[4,512,8,128], /*index=10*/bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], bf16[4,512,6144], bf16[4,512,6144], /*index=15*/bf16[4,6144,512], s32[128], s32[], s8[1,1,1], s8[1,1,1]) {
+  %constant.460.clone..sunk.1 = s32[]{:T(128)} constant(1)
+  %wide.param.1 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) parameter(0)
+  %get-tuple-element.1698 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=0
+  %copy.243 = s32[]{:T(128)S(6)} copy(%get-tuple-element.1698), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add.1069 = s32[]{:T(128)} add(%copy.243, %constant.460.clone..sunk.1), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1700 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=2
+  %get-tuple-element.1699 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=1
+  %bitcast_dynamic-update-slice_fusion.5 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} fusion(%get-tuple-element.1700, %copy.243, %get-tuple-element.1699), kind=kLoop, calls=%fused_computation.60.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
+  %get-tuple-element.1729 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=11
+  %dynamic-slice_convert_fusion.35 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1729, %copy.243), kind=kLoop, calls=%fused_computation.22.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.106 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.35), channel_id=104, replica_groups=mesh['axis_0'=1,'axis_1'=1,'axis_2'=4] {'axis_2'}, dimensions={3}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1736 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=18, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
+  %get-tuple-element.1737 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=19, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
+  %get-tuple-element.1723 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=5
+  %dynamic-slice_convert_fusion.36 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1723, %copy.243), kind=kLoop, calls=%fused_computation.23.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.107 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.36), channel_id=101, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.515 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.1699), kind=kLoop, calls=%fused_computation.38.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %add_rsqrt_fusion.8 = f32[128]{0:T(128)S(1)} fusion(%fusion.515), kind=kLoop, calls=%fused_computation.83.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2330 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=24
-  %get-tuple-element.2322 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=16
-  %convert_reduce_fusion.7 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) fusion(%get-tuple-element.2330, %copy.255, %get-tuple-element.2322), kind=kLoop, calls=%fused_computation.73.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2203 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} get-tuple-element(%convert_reduce_fusion.7), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %fusion.516 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) fusion(%all-gather.109, %get-tuple-element.2263, %add_rsqrt_fusion.8, %get-tuple-element.2203), kind=kOutput, calls=%fused_computation.44.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2204 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.516), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %get-tuple-element.2205 = f32[128,16]{0,1:T(8,128)S(1)} get-tuple-element(%fusion.516), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %add_rsqrt_fusion.9 = f32[128,16]{0,1:T(8,128)S(1)} fusion(%get-tuple-element.2205), kind=kLoop, calls=%fused_computation.72.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2321 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=15
-  %get-tuple-element.2326 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=20
-  %fusion.517 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) fusion(%get-tuple-element.2321, %copy.255, %get-tuple-element.2326), kind=kLoop, calls=%fused_computation.79.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2206 = bf16[128]{0:T(256)(128)(2,1)S(1)} get-tuple-element(%fusion.517), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %fusion.518 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2204, %add_rsqrt_fusion.9, %get-tuple-element.2206), kind=kLoop, calls=%fused_computation.49.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1730 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=12
+  %get-tuple-element.1722 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=4
+  %convert_reduce_fusion.7 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) fusion(%get-tuple-element.1730, %copy.243, %get-tuple-element.1722), kind=kLoop, calls=%fused_computation.73.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1663 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} get-tuple-element(%convert_reduce_fusion.7), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %fusion.516 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) fusion(%all-gather.107, %get-tuple-element.1699, %add_rsqrt_fusion.8, %get-tuple-element.1663), kind=kOutput, calls=%fused_computation.44.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1664 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.516), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %get-tuple-element.1665 = f32[128,16]{0,1:T(8,128)S(1)} get-tuple-element(%fusion.516), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %add_rsqrt_fusion.9 = f32[128,16]{0,1:T(8,128)S(1)} fusion(%get-tuple-element.1665), kind=kLoop, calls=%fused_computation.72.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1721 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=3
+  %get-tuple-element.1726 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=8
+  %fusion.517 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) fusion(%get-tuple-element.1721, %copy.243, %get-tuple-element.1726), kind=kLoop, calls=%fused_computation.79.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1666 = bf16[128]{0:T(256)(128)(2,1)S(1)} get-tuple-element(%fusion.517), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %fusion.518 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1664, %add_rsqrt_fusion.9, %get-tuple-element.1666), kind=kLoop, calls=%fused_computation.49.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %slice_negate_fusion.12 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.518), kind=kLoop, calls=%fused_computation.54.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2207 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %get-tuple-element.2208 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %get-tuple-element.2325 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=19
-  %get-tuple-element.2324 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=18
-  %bitcast.1070 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.2325)
-  %bitcast.1068 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.2324)
-  %fusion.519 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2207, %get-tuple-element.2208, %bitcast.1070, %bitcast.1068, %add_rsqrt_fusion.9, /*index=5*/%get-tuple-element.2204, %get-tuple-element.2206), kind=kLoop, calls=%fused_computation.58.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2327 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=21
-  %dynamic-slice_convert_fusion.37 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2327, %copy.255), kind=kLoop, calls=%fused_computation.29.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.110 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.37), channel_id=103, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %multiply_reduce_fusion.48 = (f32[128,8]{0,1:T(8,128)S(1)}, f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)}) fusion(%all-gather.110, %get-tuple-element.2263, %add_rsqrt_fusion.8, %get-tuple-element.2203), kind=kOutput, calls=%fused_computation.64.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2209 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} get-tuple-element(%multiply_reduce_fusion.48), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %get-tuple-element.2210 = f32[128,8]{0,1:T(8,128)S(1)} get-tuple-element(%multiply_reduce_fusion.48), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %add_rsqrt_fusion.10 = f32[128,8]{0,1:T(8,128)S(1)} fusion(%get-tuple-element.2210), kind=kLoop, calls=%fused_computation.75.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2211 = bf16[128]{0:T(256)(128)(2,1)S(1)} get-tuple-element(%fusion.517), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %fusion.520 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2209, %add_rsqrt_fusion.10, %get-tuple-element.2211), kind=kLoop, calls=%fused_computation.65.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1667 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
+  %get-tuple-element.1668 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
+  %get-tuple-element.1725 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=7
+  %get-tuple-element.1724 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=6
+  %bitcast.1070 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1725)
+  %bitcast.1068 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1724)
+  %fusion.519 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1667, %get-tuple-element.1668, %bitcast.1070, %bitcast.1068, %add_rsqrt_fusion.9, /*index=5*/%get-tuple-element.1664, %get-tuple-element.1666), kind=kLoop, calls=%fused_computation.58.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1727 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=9
+  %dynamic-slice_convert_fusion.37 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1727, %copy.243), kind=kLoop, calls=%fused_computation.29.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.108 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.37), channel_id=102, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %multiply_reduce_fusion.48 = (f32[128,8]{0,1:T(8,128)S(1)}, f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)}) fusion(%all-gather.108, %get-tuple-element.1699, %add_rsqrt_fusion.8, %get-tuple-element.1663), kind=kOutput, calls=%fused_computation.64.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1669 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} get-tuple-element(%multiply_reduce_fusion.48), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %get-tuple-element.1670 = f32[128,8]{0,1:T(8,128)S(1)} get-tuple-element(%multiply_reduce_fusion.48), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %add_rsqrt_fusion.10 = f32[128,8]{0,1:T(8,128)S(1)} fusion(%get-tuple-element.1670), kind=kLoop, calls=%fused_computation.75.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1671 = bf16[128]{0:T(256)(128)(2,1)S(1)} get-tuple-element(%fusion.517), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %fusion.520 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1669, %add_rsqrt_fusion.10, %get-tuple-element.1671), kind=kLoop, calls=%fused_computation.65.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %slice_negate_fusion.13 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.520), kind=kLoop, calls=%fused_computation.66.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2212 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %get-tuple-element.2213 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %bitcast.1071 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.2325)
-  %bitcast.1069 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.2324)
-  %fusion.521 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2212, %get-tuple-element.2213, %bitcast.1071, %bitcast.1069, %get-tuple-element.2209, /*index=5*/%add_rsqrt_fusion.10, %get-tuple-element.2211), kind=kLoop, calls=%fused_computation.69.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2328 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=22
-  %dynamic-slice_convert_fusion.38 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2328, %copy.255), kind=kLoop, calls=%fused_computation.28.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.111 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.38), channel_id=104, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.522 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.111, %get-tuple-element.2263, %add_rsqrt_fusion.8, %get-tuple-element.2203), kind=kOutput, calls=%fused_computation.48.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2346 = s32[128]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=40
-  %squeeze.300 = s32[128,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.2346), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8"]},"aliasing_operands":{"lists":[]}}
-  %squeeze.301 = s32[8,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.2346), dimensions={1}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["128"]},"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1672 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
+  %get-tuple-element.1673 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
+  %bitcast.1071 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1725)
+  %bitcast.1069 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1724)
+  %fusion.521 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1672, %get-tuple-element.1673, %bitcast.1071, %bitcast.1069, %get-tuple-element.1669, /*index=5*/%add_rsqrt_fusion.10, %get-tuple-element.1671), kind=kLoop, calls=%fused_computation.69.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1728 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=10
+  %dynamic-slice_convert_fusion.38 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1728, %copy.243), kind=kLoop, calls=%fused_computation.28.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.109 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.38), channel_id=103, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.522 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.109, %get-tuple-element.1699, %add_rsqrt_fusion.8, %get-tuple-element.1663), kind=kOutput, calls=%fused_computation.48.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1734 = s32[128]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=16
+  %squeeze.274 = s32[128,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.1734), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8"]},"aliasing_operands":{"lists":[]}}
+  %squeeze.275 = s32[8,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.1734), dimensions={1}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["128"]},"aliasing_operands":{"lists":[]}}
   %iota.68 = s32[128,128]{1,0:T(8,128)S(1)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %splash_mha_fwd_segmented_residuals.3 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[16,128,128]{2,1,0:T(8,128)}) custom-call(%get-tuple-element.2348, %get-tuple-element.2349, %fusion.519, %fusion.521, %fusion.522, /*index=5*/%squeeze.300, %squeeze.301, %iota.68), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[16,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
+  %splash_mha_fwd_segmented_residuals.3 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[16,128,128]{2,1,0:T(8,128)}) custom-call(%get-tuple-element.1736, %get-tuple-element.1737, %fusion.519, %fusion.521, %fusion.522, /*index=5*/%squeeze.274, %squeeze.275, %iota.68), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[16,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
 "xprof_metadata":"{\"block_q\": 128, \"block_kv\": 128, \"block_kv_compute\": 128, \"block_q_dkv\": 128, \"block_kv_dkv\": 128, \"block_kv_dkv_compute\": 128, \"block_q_dq\": 128, \"block_kv_dq\": 128, \"use_fused_bwd_kernel\": false, \"q_layout\": 1, \"k_layout\": 1, \"v_layout\": 1}"
-}}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"custom_call_config":{"body":"TUzvUgFNTElSMjMuMC4wZ2l0AAFVCwEDBQcJAQMLAz8NDxETFRcZGx0fISMlJykrLS8xMzU3OTs9P0FDRUdJA7IECgQzAfUHFxMXFxMPFxcbCwsXCwsLEycPFwsXExNzUwsXGxMXCxMTF6WFCxMXEwsXDwsLCwsLCwsLCwsLCwsXEwsLJwsLCxMLFxcLCwsLFxcLCzMXFxcXEwsPSwsXCwtzCw8LCwsLNxsLGwsbCxsLGwtTGwsjCyMLIwsbCxsLGwURYYGRjWFNKgIqAgH5GxsbGxsbGxsbGw8PEwsLKwsLEwsTCw8TCw8LEwsTCxMLCxMLDxMLFx8LEwsLEwtTFwsTCwsTCw8TCw9TCxMLExMLCx8LEwsvGwsjFwsTCxcPFwsTCxcLEwsfFwsTCxMPFwsTCxcfCxMLHwsTCwsTCwsTCxcfCxMLHy8XDwcFWVkJBV1JATMPBx8jBw8LCysfJxcfIycHHyMrIxsbTy8rAh4aHwMDHzYCHW+eAh26Ar4CAwMfMgIdbzoCFRkZHY4CkgIdTgJSAgMDrgL6AwVLBU0dQgJGAgVPBVEFUx1T8gIDB30lf/YCgYMRDQAdcgJ2Ag0xHdoC3gIdU+oCHXkKAyMLBzEBAAAAAAAAAIAAAAAAAAAAgAAAAAAAAAAjCwUhgAAAAAAAAACAAAAAAAAAAA0vAwMf5gIDAxID/gMdcVoCAwM/YgIFVR1xZgIdd4YCHRoDHgNhZmZpbmVfbWFwPChkMCwgZDEsIGQyKSAtPiAoZDAsIGQxLCBkMik+AGFmZmluZV9tYXA8KGQwLCBkMSkgLT4gKGQwLCBkMSk+AAVXAwM/VwMDP5oCHXmyAgVZAwMfBgMRCwEFWwVdBV8FYQVjBWUFZwVpBWsFbQVvBXEFcwMDH24CHXd+AgV1BXcDB30lf8YCgYMFeQV7BX0jAQEBBX8d+gL+AgMDHxYDBYEFgwWFBYcDAx9uAx2iA6YDBYkFiyMLAxEBAAAAAAAAAB2yA7YDHb4DwgMdygPOAx3eA+IDAwOnqQWNEQs9AxGtrxWxs7W3ubtXF72//8HDBY8BB/v5+Q0tBZEjCwcxEAAAAAAAAAABAAAAAAAAAAEAAAAAAAAABZMRCwkFlQWXBZkFmwEXxcnN0dXb3+Pn6+8DBRvHHTEJWQMFG8sdMQlbAwUbzx0xCV0DBRvTHTMJXwMFG9cd2QlhIwsFIQgAAAAAAAAAgAAAAAAAAAADBRvdHTMJYwMHS/cb4R0zCWUDB0v3G+UdMwlnAwdL9xvpHTMJaQMFG+0dMQlrAwUb8R0xCW0DBRU1F1kjdHB1Lm1lbW9yeV9zcGFjZTx2bWVtPgAjdHB1LnBpcGVsaW5lX21vZGU8c3luY2hyb25vdXM+ACN0cHUuZGltZW5zaW9uX3NlbWFudGljczxhcmJpdHJhcnk+ACN0cHUuZGltZW5zaW9uX3NlbWFudGljczxwYXJhbGxlbD4AI3RwdS5tZW1vcnlfc3BhY2U8c21lbT4AI3RwdS5jb3JlX3R5cGU8dGM+ACN0cHUuZG90X2RpbWVuc2lvbl9udW1iZXJzPFsxXSwgWzFdLCBbMF0sIFswXSwgWzAsIDAsIDEsIDBdLCBbXSwgW10+ACN0cHUuZG90X2RpbWVuc2lvbl9udW1iZXJzPFsxXSwgWzBdLCBbMF0sIFsxXSwgWzAsIDAsIDEsIDFdLCBbXSwgW10+AAMFFTUXWwMFFTUXXQMFFSkXXwMFFSkXYQMFFSkXYwMFFSkXZQMFFSkXZwMFFSkXaQMFFTUXawMFFTUXbREBAREDAR0+AhkFnQWfLUoCCe4lEzImBwWhBaMdVgINBaUdXgIZBacRCxEdagINBakRAQkFqx16AhkFrR2CAhkFrx2KAg0FsQWzHZYCGQW1EQsFHaICDQW3AwMfqgITCRAAAOAPBbkdtgINBbsFvR3CAg0FvyMBCSEBAAAAAQAAAAMAAAAAAAAAHc4C0gIFwR3WAg0FwwXFHeICDQXHEwkBHe4CGQXJHYUNIwEJIQEAAAABAAAAAgAAAAAAAAAFyx0CAxkFzREBAgQdDgMZBc8F0SUFCQAAAAAF0x0iAw0F1QMJiwICjSWPJZElAwMuAzIDBdcjAQMJAQAAAB06Az4DBdkdQgMNBdsDAz9KAxELFR1SA1YDBd0dWgMNBd8dYgNmAwXhHWoDDQXjEwmQzMzMPx12A3oDBeUdfgMZBecdU4YDHYUZHY4DkgMF6R2WAwEF6wMDH54DJRcJAACA/wXtHaoDDQXvAwWXAgSZmwXxHboDDQXzBfUdxgMNBfcF+R3SAw0F+wMDH9oDJRcJAAAAAAX9HeYDDQX/AwWXBgSZmwMJiwYCjSWPJZElAwMf9gMRAQUjYXJpdGguZmFzdG1hdGg8bm9uZT4AI2FyaXRoLm92ZXJmbG93PG5vbmU+ACN2ZWN0b3Iua2luZDxtYXhpbXVtZj4AI3ZlY3Rvci5raW5kPGFkZD4AAQICAycFAgQCBAkX/QcFBQUPRwsBAgQBCQFBF/UHBQIEAgQfRycFAgQCBAEX9QUCBAIECUknAwIECScFAgQCBB8nBwUCBAIEHxf1BQIEAgQBSQcnBQIEAgQNF/UFIQIEAUkX9QcFAgQCBAlHJwcFAgQCBAknBQUCBAEnBQIEBQkFIQEBAQcHERERHSMdFRUVESUBBQsBAQEHBwcBAQEFCwEBAQcHBQEBBN4iBQERAaUHAwExCxEBqwcDU3chAQEBAQEBBwEHAREBEQERAR0BIwEdARUBFQEVAREBJQEDA3UJAwERB0NNAw0FBSEbBhEDAQMjAwMPCQMBEQcPTwMNBSUnHRQPAykJAx9NAwMtNwMJDwYhAwUDUwMDBwMDAwMDBwMDAwUGBwMFBxtXWRMFByMJVRtXWQMDLZMDCQ8GIQMFA10DAwcDAwMDAwcDAwMFBgcDBQcXYWMTBQcjCV8XYWMDAy03AwkPBiEDBQNnAwMHAwMDAwMHAwMDBQYHAwUHGWttEwUHIwlpGWttGQAPAwEFGQAPAwMLAwMDBwYLAwMDAwcGCwMDAwUVBgsDDwkJKy0vFwYRAwEDMQMDOwkDAREHQT0DDQUzNQMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JBzk7PRcGEQMBAz8bBhEDAQM3AwMPCQMBEQcPTwMNBUNFHRQPA0cJA7PqAgMDhwkDAQMDL1UDASMHLzkDAQVTVQMDBQMDAwMDBQMDAwUGBQMFBxdZWwkGBQMFA10DAwUDAwMDAwUDAwMFBgUDBQcZYWMJBgUDBQNlAwMFAwMDAwMFAwMDAwMFAwMDBQYFAxsJC2lrbQkGBQMZA28DAwUDAwMHBgUDAwNXAwMFAwMDBQYFAxsJDXN1dwkGBQMZA3kDA0WJAwUnB0UmAwMFB3F7fQMDL1UDASMHLzkDAQVBgQMDL1UDASMHLzkDAQVThSkHKzkDAQWDhzcDNgMqAwMTDwYrAxMDiSkHKzkDEwWNiwMDBQMDAwMDBQMDAwUGBQMTBxWRkwkGBQMTA5URB04DRgMDIQWXjwMDBQMDAwcGBQMDA1cFBgUDKQcTm50JBgUDKQOfAwMFAwMDAwMFAwMDBQYFAxMHEaOlCQYFAxMDpw8GQwMTA6ERB0NNAyEFqas5Bl4DAyEFma0DA3IDkwMJDwaCAwMFA7E7BooDAwUHr3+zAwOVmgMDFysHla4DAxcFtbcJBiEDKwO5DwadAwUDuz0HnRMDBQVfvS0HnxMDBQW1vy8HoRMDBQPBAwOj1gMDFysHo+oDAxcFw8UJBiEDKwPHDwYhAwUDyS0HnxMDBQVfvy8HoRMDBQPNHwdREwMFBc9nIQcrEwMFBcvRAwMHAwMDAwMHAwMDBQYHAwUHF9XXEwUHIwm/F9XXAwMHAwMDAwMHAwMDBQYHAwUHGdvdEwUHIwnTGdvdAwMFAwMDBwYFAwMDVwMDBQMDAwUGBQMbCQ/h4+UJBgUDGQPnPwYRAwUD6QMDRYkDBScHRe4DAwUHw+vtAwMFAwMDAwMFAwMDBQYFAwUHG/HzCQYFAwUD9R8HURMDBQXP9yEHKxMDBQX57wMDBwMDAwMDBwMDAwUGBwMFBxv9/xMFByMJ+xv9/wMDh/IDAwEZAA8DAQUZAA8DA3UJAwERB0NNAw0FBUkbBhEDAQNLAwMPCQMBEQcPTwMNBU1PHRQPA1EJA13RAwMFAwMDAwMFAwMDBQYFAwUHGVNVCQYFAwUDVwMDJ6YCAwkPBicDBQNbMQcnEwMFBV1ZAwMFAwMDAwMFAwMDBQYFAwUHG2FjCQYFAwUDZR8HURMDBQVnXzMGEQMZA2kDAwcDAwMDAwcDAwMDAwcDAwMFBgcDGwkdbW9xCQYHAxkDcwkGBwMbA2sTBQd7C3cdbW9xNQfKAhMDBQNZAwMFAwMDAwMFAwMDBQYFAwUHF3t9CQYFAwUDfyEHKxMDBQV5gQMDBwMDAwMDBwMDAwMDBwMDAwUGBwMnCR+Fh4kJBgcDBQOLCQYHAycDgxMFB3sLjx+Fh4kDAy03AwkPBiEDBQORAwMHAwMDAwMHAwMDBQYHAwUHF5WXEwUHIwmTF5WXAwMtNwMJDwYhAwUDmwMDBwMDAwMDBwMDAwUGBwMFBxmfoRMFByMJnRmfoQMDLTcDCQ8GIQMFA6UDAwcDAwMDAwcDAwMFBgcDBQcbqasTBQcjCacbqasZAA8DAQUZAA8NAAELEQHzBwMPDwsBAQEBAQEHAQcBAwMBCQMBAwMBCQMBDQQBBwEDCwsRAQoCBwMrRwsBAQEBAQEHAQcBAwMLAwMDBwYLAwMDAwcGCwMDAwUVBgsDDwkJCw0PFwYRAwEDEQMDOwkDAREHQT0DDQUTFQMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JBxkbHRcGEQMBAx8DAydzAwElBicDAQUBIwMDAQkDAQMDAQkDAQ0EAQclIScLEQEOAgcDK0cLAQEBAQEBBwEHAQMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JCQsNDxcGEQMBAxEDAzsJAwERB0E9Aw0FExUDAwsDAwMHBgsDAwMDBwYLAwMDBRUGCwMPCQcZGx0XBhEDAQMfAwMncwMBJQYnAwEFASMDAwEJAwEDAwEJAwENBAEHJSEnCxEBEgIHAw8PCwEBAQEBAQcBBwEDAwEJAwEDAwEJAwENBAEFAwsLEQEWAgcDJz8LAQEBAQEBBwEHAQMDCwMDAwcGCwMDAwMHBgsDAwMFFQYLAw8JCQsNDxcGEQMBAxEDAzsJAwERB0E9Aw0FExUDAwsDAwMHBgsDAwMDBwYLAwMDBRUGCwMPCQcZGx0XBhEDAQMfAwMBCQMBAwMBCQMBDQQBBSMhCxEBGgIHAw8PCwEBAQEBAQcBBwEDAwEJAwEDAwEJAwENBAEFAwsLEQEeAgcDERMLAQEBAQEBBwEHAQMDAQkDAQMDAQkDAQMDAQkDAQ0EAQULDQsRASICBwMREwsBAQEBAQEHAQcBAwMBCQMBAwMBCQMBAwMBCQMBDQQBBQsNCxEBJgIHAxETCwEBAQEBAQcBBwEDAwEJAwEDAwEJAwEDAwEJAwENBAEFCw0LEQEqAgcDDw8LAQEBAQEBBwEHAQMDAQkDAQMDAQkDAQ0EAQcBAwsLEQEuAgcDDw8LAQEBAQEBBwEHAQMDAQkDAQMDAQkDAQ0EAQcBAwsGAwEFAQDmGgICLRkRCxELEQstGSUVCQsRCw0JFQ0XMRsdCQsNIxELEQsVDRETEQsNDQcJCw0HVS0SAiUJHR1HIyEjKS0fCx0nHSVFESkJCwkJCxsZGRkZGRkZGRkZJR0VDR0lEx0XHxsXExMbFxMXLxcXGRcXFw8ZFRkZIxcjGRUlIxkfDw8NCR0RYnVpbHRpbgBzdGFibGVfbW9zYWljAHRwdQBhcml0aAB2ZWN0b3IAbW9kdWxlAGFyaXRoLmNvbnN0YW50AHZlY3Rvci5sb2FkAGFyaXRoLmluZGV4X2Nhc3QAdmVjdG9yLnNoYXBlX2Nhc3QAZnVuYy5mdW5jAGZ1bmMucmV0dXJuAHZlY3Rvci5icm9hZGNhc3QAYXJpdGguY21waQB0cHUudmVjdG9yX3N0b3JlAG1lbXJlZi5sb2FkAGFyaXRoLmV4dHNpAHNjZi55aWVsZABhcml0aC5leHR1aQBzY2YuaWYAYXJpdGgubXVsZgBhcml0aC5hZGRmAGFyaXRoLm11bGkAYXJpdGguZGl2c2kAdHB1Lm1hdG11bABhcml0aC5hZGRpAHZlY3Rvci5tdWx0aV9yZWR1Y3Rpb24AYXJpdGguc3ViZgBtYXRoLmV4cABhcml0aC5kaXZmAGFyaXRoLnRydW5jZgBtYXRoLmxvZwB0cHUuaW90YQBhcml0aC5hbmRpAGFyaXRoLnNlbGVjdABhcml0aC5tYXhpbXVtZgBhcml0aC5leHRmAGZ1bmN0aW9uX3R5cGUAc3ltX25hbWUAdHJhbnNmb3JtX2luZGljZXMAd2luZG93X2JvdW5kcwB2YWx1ZQBwcmVkaWNhdGUAcGlwZWxpbmVfbW9kZQBicm9hZGNhc3RfaW5fZGltOgB0cmFuc2Zvcm1fMAB0cmFuc2Zvcm1fMQB0cmFuc2Zvcm1fMgB0cmFuc2Zvcm1fMwB0cmFuc2Zvcm1fNAB0cmFuc2Zvcm1fNQB0cmFuc2Zvcm1fNgB0cmFuc2Zvcm1fNwB0cmFuc2Zvcm1fOAB0cmFuc2Zvcm1fOQB0cmFuc2Zvcm1fMTAAZ2V0OgBndDoAZXE6AG11bDoAYWRkAG9wZXJhbmRTZWdtZW50U2l6ZXMAc3RyaWRlcwBicm9hZGNhc3RfaW5fZGltL2Jyb2FkY2FzdF9pbl9kaW0AZGltZW5zaW9uX251bWJlcnMAdHJhbnNwb3NlX2xocwB0cmFuc3Bvc2VfbGhzX2hpbnQAdHJhbnNwb3NlX3JocwBraW5kAHJlZHVjdGlvbl9kaW1zAHN0YWJsZV9tb3NhaWMudmVyc2lvbgBkaW1lbnNpb25fc2VtYW50aWNzAGl0ZXJhdGlvbl9ib3VuZHMAc2NhbGFyX3ByZWZldGNoAHNjcmF0Y2hfb3BlcmFuZHMAc3BsYXNoX21oYV9md2Rfc2VnbWVudGVkX3Jlc2lkdWFscwB0cHUuY29yZV90eXBlAHdpbmRvd19wYXJhbXMAZ2V0AF9zcGxhc2hfYXR0ZW50aW9uAC9fX3cvbWF4dGV4dC9tYXh0ZXh0Ly52ZW52L2xpYi9weXRob24zLjEyL3NpdGUtcGFja2FnZXMvamF4L2V4cGVyaW1lbnRhbC9wYWxsYXMvb3BzL3RwdS9zcGxhc2hfYXR0ZW50aW9uL3NwbGFzaF9hdHRlbnRpb25fa2VybmVsLnB5AGNvbnZlcnRfZWxlbWVudF90eXBlOgBjb252ZXJ0X2VsZW1lbnRfdHlwZS9jb252ZXJ0X2VsZW1lbnRfdHlwZQBndABndC9ndABkaXY6AGRpdgBlcQBlcS9lcQBjb25kOgBjb25kAGdldC9nZXQAZmFzdG1hdGgAbXVsL211bABzd2FwOgBzd2FwL3N3YXAAbG9nOgBsb2cvbG9nAGFkZDoAYWRkL2FkZABicm9hZGNhc3RfaW5fZGltAHNjYW46AHNjYW4AbXVsAG92ZXJmbG93RmxhZ3MAZG90X2dlbmVyYWw6AGRvdF9nZW5lcmFsL2RvdF9nZW5lcmFsAGRpbWVuc2lvbnMAaW90YToAaW90YS9pb3RhAGdlOgBnZS9nZQBhbmQ6AGFuZC9hbmQAaml0OgBqaXQAc2VsZWN0X246AHNlbGVjdF9uL3NlbGVjdF9uAHJlZHVjZV9tYXg6AHJlZHVjZV9tYXgvcmVkdWNlX21heABtYXg6AG1heC9tYXgAc3ViOgBzdWIvc3ViAGV4cDoAZXhwL2V4cAByZWR1Y2Vfc3VtOgByZWR1Y2Vfc3VtL3JlZHVjZV9zdW0A","needs_layout_passes":true,"allow_input_fusion":[],"serialization_format":"1","output_memory_colors":[],"output_memory_space_colors":[],"input_memory_space_colors":[]},"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2214 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%splash_mha_fwd_segmented_residuals.3), index=3, frontend_attributes={kernel_metadata={
+}}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"custom_call_config":{"body":"<mosaic_body>","needs_layout_passes":true,"allow_input_fusion":[],"serialization_format":"1","output_memory_colors":[],"output_memory_space_colors":[],"input_memory_space_colors":[]},"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1674 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%splash_mha_fwd_segmented_residuals.3), index=3, frontend_attributes={kernel_metadata={
 "xprof_metadata":"{\"block_q\": 128, \"block_kv\": 128, \"block_kv_compute\": 128, \"block_q_dkv\": 128, \"block_kv_dkv\": 128, \"block_kv_dkv_compute\": 128, \"block_q_dq\": 128, \"block_kv_dq\": 128, \"use_fused_bwd_kernel\": false, \"q_layout\": 1, \"k_layout\": 1, \"v_layout\": 1}"
 }}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}
-  %fusion.523 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%get-tuple-element.2263, %all-gather.108, %get-tuple-element.2214), kind=kOutput, calls=%fused_computation.40.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2215 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.523), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %get-tuple-element.2333 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=27
-  %dynamic-slice_convert_fusion.39 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2333, %copy.255), kind=kLoop, calls=%fused_computation.11.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.112 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.39), channel_id=108, replica_groups=mesh['axis_0'=1,'axis_1'=4] {'axis_1'}, dimensions={2}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2332 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=26
-  %dynamic-slice_convert_fusion.40 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2332, %copy.255), kind=kLoop, calls=%fused_computation.12.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.113 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.40), channel_id=107, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2331 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=25
-  %dynamic-slice_convert_fusion.41 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2331, %copy.255), kind=kLoop, calls=%fused_computation.13.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.114 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.41), channel_id=106, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2216 = f32[128]{0:T(128)S(1)} get-tuple-element(%fusion.523), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %add_rsqrt_fusion.11 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.2216), kind=kLoop, calls=%fused_computation.82.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2217 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} get-tuple-element(%convert_reduce_fusion.7), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %fusion.524 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.114, %get-tuple-element.2215, %add_rsqrt_fusion.11, %get-tuple-element.2217), kind=kOutput, calls=%fused_computation.24.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.525 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.2215, %all-gather.112, %all-gather.113, %fusion.524, %add_rsqrt_fusion.11, /*index=5*/%get-tuple-element.2217), kind=kOutput, calls=%fused_computation.37.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2334 = u32[4]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=28, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.272 = u32[4]{0:T(128)} copy(%get-tuple-element.2334), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2335 = u32[4,4]{1,0:T(4,128)S(1)} get-tuple-element(%wide.param.1), index=29, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.273 = u32[4,4]{1,0:T(4,128)} copy(%get-tuple-element.2335), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2336 = u32[4]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=30, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.274 = u32[4]{0:T(128)} copy(%get-tuple-element.2336), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2337 = u32[4,4]{1,0:T(4,128)S(1)} get-tuple-element(%wide.param.1), index=31, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.275 = u32[4,4]{1,0:T(4,128)} copy(%get-tuple-element.2337), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2338 = u32[4]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=32, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.276 = u32[4]{0:T(128)} copy(%get-tuple-element.2338), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2339 = u32[4,4]{1,0:T(4,128)S(1)} get-tuple-element(%wide.param.1), index=33, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.277 = u32[4,4]{1,0:T(4,128)} copy(%get-tuple-element.2339), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2340 = u32[4]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=34, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.278 = u32[4]{0:T(128)} copy(%get-tuple-element.2340), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2341 = u32[4,4]{1,0:T(4,128)S(1)} get-tuple-element(%wide.param.1), index=35, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.279 = u32[4,4]{1,0:T(4,128)} copy(%get-tuple-element.2341), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2342 = u32[4]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=36, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.280 = u32[4]{0:T(128)} copy(%get-tuple-element.2342), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2343 = u32[4,4]{1,0:T(4,128)S(1)} get-tuple-element(%wide.param.1), index=37, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.281 = u32[4,4]{1,0:T(4,128)} copy(%get-tuple-element.2343), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2344 = u32[4]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=38, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.282 = u32[4]{0:T(128)} copy(%get-tuple-element.2344), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2345 = u32[4,4]{1,0:T(4,128)S(1)} get-tuple-element(%wide.param.1), index=39, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}
-  %copy.283 = u32[4,4]{1,0:T(4,128)} copy(%get-tuple-element.2345), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.2347 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=41
-  ROOT %tuple.250 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=5*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=10*/u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, /*index=20*/bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=25*/bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, /*index=30*/u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, /*index=35*/u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, /*index=40*/s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) tuple(%add.1069, %fusion.525, %copy.272, %copy.273, %copy.274, /*index=5*/%copy.275, %copy.276, %copy.277, %copy.278, %copy.279, /*index=10*/%copy.280, %copy.281, %copy.282, %copy.283, %bitcast_dynamic-update-slice_fusion.5, /*index=15*/%get-tuple-element.2321, %get-tuple-element.2322, %get-tuple-element.2323, %get-tuple-element.2324, %get-tuple-element.2325, /*index=20*/%get-tuple-element.2326, %get-tuple-element.2327, %get-tuple-element.2328, %get-tuple-element.2329, %get-tuple-element.2330, /*index=25*/%get-tuple-element.2331, %get-tuple-element.2332, %get-tuple-element.2333, %get-tuple-element.2334, %get-tuple-element.2335, /*index=30*/%get-tuple-element.2336, %get-tuple-element.2337, %get-tuple-element.2338, %get-tuple-element.2339, %get-tuple-element.2340, /*index=35*/%get-tuple-element.2341, %get-tuple-element.2342, %get-tuple-element.2343, %get-tuple-element.2344, %get-tuple-element.2345, /*index=40*/%get-tuple-element.2346, %get-tuple-element.2347, %get-tuple-element.2348, %get-tuple-element.2349)
+  %fusion.523 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%get-tuple-element.1699, %all-gather.106, %get-tuple-element.1674), kind=kOutput, calls=%fused_computation.40.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1675 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.523), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %get-tuple-element.1733 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=15
+  %dynamic-slice_convert_fusion.39 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1733, %copy.243), kind=kLoop, calls=%fused_computation.11.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.110 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.39), channel_id=107, replica_groups=mesh['axis_0'=1,'axis_1'=4] {'axis_1'}, dimensions={2}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1732 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=14
+  %dynamic-slice_convert_fusion.40 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1732, %copy.243), kind=kLoop, calls=%fused_computation.12.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.111 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.40), channel_id=106, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1731 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=13
+  %dynamic-slice_convert_fusion.41 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1731, %copy.243), kind=kLoop, calls=%fused_computation.13.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.112 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.41), channel_id=105, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1676 = f32[128]{0:T(128)S(1)} get-tuple-element(%fusion.523), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  %add_rsqrt_fusion.11 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.1676), kind=kLoop, calls=%fused_computation.82.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1677 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} get-tuple-element(%convert_reduce_fusion.7), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %fusion.524 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.112, %get-tuple-element.1675, %add_rsqrt_fusion.11, %get-tuple-element.1677), kind=kOutput, calls=%fused_computation.24.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.525 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1675, %all-gather.110, %all-gather.111, %fusion.524, %add_rsqrt_fusion.11, /*index=5*/%get-tuple-element.1677), kind=kOutput, calls=%fused_computation.37.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1735 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=17
+  ROOT %tuple.250 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) tuple(%add.1069, %fusion.525, %bitcast_dynamic-update-slice_fusion.5, %get-tuple-element.1721, %get-tuple-element.1722, /*index=5*/%get-tuple-element.1723, %get-tuple-element.1724, %get-tuple-element.1725, %get-tuple-element.1726, %get-tuple-element.1727, /*index=10*/%get-tuple-element.1728, %get-tuple-element.1729, %get-tuple-element.1730, %get-tuple-element.1731, %get-tuple-element.1732, /*index=15*/%get-tuple-element.1733, %get-tuple-element.1734, %get-tuple-element.1735, %get-tuple-element.1736, %get-tuple-element.1737)
 }
 
-%wide.region_6.9_spmd.clone.clone.clone (wide.param.113: (s32[], bf16[1,128,2048], u32[4], u32[4,4], u32[4], /*index=5*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=10*/u32[4], u32[4,4], u32[4], u32[4,4], bf16[4,1,128,2048], /*index=15*/bf16[4,128], bf16[4,2048], bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], /*index=20*/bf16[4,128], bf16[4,512,8,128], bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], /*index=25*/bf16[4,512,6144], bf16[4,512,6144], bf16[4,6144,512], u32[4], u32[4,4], /*index=30*/u32[4], u32[4,4], u32[4], u32[4,4], u32[4], /*index=35*/u32[4,4], u32[4], u32[4,4], u32[4], u32[4,4], /*index=40*/s32[128], s32[], s8[1,1,1], s8[1,1,1])) -> pred[] {
-  %constant.427.clone.4 = s32[]{:T(128)} constant(4)
-  %wide.param.113 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, /*index=5*/u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, /*index=10*/u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, u32[4]{0:T(128)}, u32[4,4]{1,0:T(4,128)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, /*index=20*/bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=25*/bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, /*index=30*/u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, /*index=35*/u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, u32[4]{0:T(128)S(1)}, u32[4,4]{1,0:T(4,128)S(1)}, /*index=40*/s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) parameter(0)
-  %get-tuple-element.1920 = s32[]{:T(128)} get-tuple-element(%wide.param.113), index=0
-  ROOT %lt.34 = pred[]{:T(512)} compare(%get-tuple-element.1920, %constant.427.clone.4), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/cond/lt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+%wide.region_6.9_spmd.clone.clone.clone (wide.param.113: (s32[], bf16[1,128,2048], bf16[4,1,128,2048], bf16[4,128], bf16[4,2048], /*index=5*/bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,128], bf16[4,512,8,128], /*index=10*/bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], bf16[4,512,6144], bf16[4,512,6144], /*index=15*/bf16[4,6144,512], s32[128], s32[], s8[1,1,1], s8[1,1,1])) -> pred[] {
+  %constant.411.clone.4 = s32[]{:T(128)} constant(4)
+  %wide.param.113 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) parameter(0)
+  %get-tuple-element.1476 = s32[]{:T(128)} get-tuple-element(%wide.param.113), index=0
+  ROOT %lt.34 = pred[]{:T(512)} compare(%get-tuple-element.1476, %constant.411.clone.4), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/cond/lt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
 %region_7.10 (reduce_sum.171: f32[], reduce_sum.184: f32[]) -> f32[] {
@@ -811,18 +787,18 @@ StackFrames
   %param_0.1550 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert_element_type.1283 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1550), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
   %square.243 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1283, %convert_element_type.1283), metadata={op_name="jit(train_step)/jvp()/square" stack_frame_id=0}
-  %constant.460.clone.29 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.222 = f32[128]{0:T(128)S(1)} reduce(%square.243, %constant.460.clone.29), dimensions={0,2}, to_apply=%region_7.10, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %constant.444.clone.29 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.222 = f32[128]{0:T(128)S(1)} reduce(%square.243, %constant.444.clone.29), dimensions={0,2}, to_apply=%region_7.10, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.467 (param_0.1364: f32[128]) -> f32[128] {
   %param_0.1364 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.469.clone.2 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.972 = f32[128]{0:T(128)} broadcast(%constant.469.clone.2), dimensions={}, metadata={op_name="broadcast.418"}
-  %div.784 = f32[128]{0:T(128)} multiply(%param_0.1364, %broadcast.972), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
-  %constant.470.clone.2 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.970 = f32[128]{0:T(128)} broadcast(%constant.470.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %add.940 = f32[128]{0:T(128)} add(%div.784, %broadcast.970), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %constant.452.clone.2 = f32[]{:T(128)} constant(0.00048828125)
+  %broadcast.966 = f32[128]{0:T(128)} broadcast(%constant.452.clone.2), dimensions={}, metadata={op_name="broadcast.416"}
+  %div.784 = f32[128]{0:T(128)} multiply(%param_0.1364, %broadcast.966), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
+  %constant.453.clone.2 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.964 = f32[128]{0:T(128)} broadcast(%constant.453.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %add.940 = f32[128]{0:T(128)} add(%div.784, %broadcast.964), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %bitcast.624 = f32[1,128]{1,0:T(1,128)} bitcast(%add.940), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %rsqrt.195 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.624), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
   ROOT %bitcast.614 = f32[128]{0:T(128)} bitcast(%rsqrt.195), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
@@ -863,8 +839,8 @@ StackFrames
   %param_0.1518 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(0)
   %fusion.357 = bf16[151936,2048]{1,0:T(8,128)(2,1)} fusion(%param_0.1518), kind=kLoop, calls=%bitcast_fusion.3
   %convolution.115.clone.1 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} convolution(%fusion.319.clone.1, %fusion.357), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/jvp()/dot_general" stack_frame_id=0}
-  %constant.471.clone.3 = bf16[]{:T(256)} constant(-inf)
-  %reduce.243 = bf16[128]{0:T(256)(128)(2,1)S(1)} reduce(%convolution.115.clone.1, %constant.471.clone.3), dimensions={1}, to_apply=%region_8.11, metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
+  %constant.454.clone.3 = bf16[]{:T(256)} constant(-inf)
+  %reduce.243 = bf16[128]{0:T(256)(128)(2,1)S(1)} reduce(%convolution.115.clone.1, %constant.454.clone.3), dimensions={1}, to_apply=%region_8.11, metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
   ROOT %tuple.171 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128,151936]{1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.243, %convolution.115.clone.1)
 }
 
@@ -882,8 +858,8 @@ StackFrames
   %sub.100 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1725), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %sub.71 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%bitcast.520, %sub.100), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %exp.51 = f32[1,128,151936]{2,1,0:T(8,128)} exponential(%sub.71), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
-  %constant.460.clone.28 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.199 = f32[128]{0:T(128)S(1)} reduce(%exp.51, %constant.460.clone.28), dimensions={0,2}, to_apply=%region_9.12, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %constant.444.clone.28 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.199 = f32[128]{0:T(128)S(1)} reduce(%exp.51, %constant.444.clone.28), dimensions={0,2}, to_apply=%region_9.12, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.495 (param_0.1506: f32[128], param_1.1724: bf16[128]) -> (f32[128], f32[128]) {
@@ -892,12 +868,12 @@ StackFrames
   %param_1.1724 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
   %reduce_max.18.clone.1 = f32[128]{0:T(128)} convert(%param_1.1724), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
   %add.945.clone.1 = f32[128]{0:T(128)} add(%log.23, %reduce_max.18.clone.1), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %constant.460.clone.27 = f32[]{:T(128)} constant(0)
-  %broadcast.968.clone.1 = f32[128]{0:T(128)} broadcast(%constant.460.clone.27), dimensions={}, metadata={op_name="broadcast.120"}
-  %mul.1958.clone.1 = f32[128]{0:T(128)} multiply(%add.945.clone.1, %broadcast.968.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %constant.448.clone.1.clone.1 = f32[]{:T(128)} constant(1)
-  %broadcast.965.clone.1 = f32[128]{0:T(128)} broadcast(%constant.448.clone.1.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
-  %add.934.clone.1 = f32[128]{0:T(128)S(1)} add(%mul.1958.clone.1, %broadcast.965.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
+  %constant.444.clone.27 = f32[]{:T(128)} constant(0)
+  %broadcast.962.clone.1 = f32[128]{0:T(128)} broadcast(%constant.444.clone.27), dimensions={}, metadata={op_name="broadcast.118"}
+  %mul.1958.clone.1 = f32[128]{0:T(128)} multiply(%add.945.clone.1, %broadcast.962.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %constant.432.clone.1.clone.1 = f32[]{:T(128)} constant(1)
+  %broadcast.959.clone.1 = f32[128]{0:T(128)} broadcast(%constant.432.clone.1.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
+  %add.934.clone.1 = f32[128]{0:T(128)S(1)} add(%mul.1958.clone.1, %broadcast.959.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
   ROOT %tuple.169 = (f32[128]{0:T(128)S(1)}, f32[128]{0:T(128)S(1)}) tuple(%log.23, %add.934.clone.1)
 }
 
@@ -921,10 +897,10 @@ StackFrames
   %param_1.1723 = f32[128]{0:T(128)S(1)} parameter(1)
   %sub.97 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1723), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %sub.91 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%sub.92, %sub.97), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %constant.460.clone.26 = f32[]{:T(128)} constant(0)
-  %broadcast.906 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%constant.460.clone.26), dimensions={}, metadata={op_name="broadcast.130"}
-  %mul.1808 = f32[1,128,151936]{2,1,0:T(8,128)} select(%eq.21, %sub.91, %broadcast.906), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  ROOT %reduce.200 = f32[128]{0:T(128)S(1)} reduce(%mul.1808, %constant.460.clone.26), dimensions={0,2}, to_apply=%region_54.59, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %constant.444.clone.26 = f32[]{:T(128)} constant(0)
+  %broadcast.900 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%constant.444.clone.26), dimensions={}, metadata={op_name="broadcast.128"}
+  %mul.1808 = f32[1,128,151936]{2,1,0:T(8,128)} select(%eq.21, %sub.91, %broadcast.900), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  ROOT %reduce.200 = f32[128]{0:T(128)S(1)} reduce(%mul.1808, %constant.444.clone.26), dimensions={0,2}, to_apply=%region_54.59, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %region_0.1 (reduce_sum.137: s32[], reduce_sum.138: s32[]) -> s32[] {
@@ -935,11 +911,11 @@ StackFrames
 
 %fused_computation.472 (param_0.1369: s32[1,128]) -> s32[] {
   %param_0.1369 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %constant.449.clone.8 = s32[]{:T(128)} constant(0)
-  %broadcast.983 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.449.clone.8), dimensions={}, metadata={op_name="broadcast.99"}
-  %ne.10 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1369, %broadcast.983), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
+  %constant.433.clone.8 = s32[]{:T(128)} constant(0)
+  %broadcast.977 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.8), dimensions={}, metadata={op_name="broadcast.95"}
+  %ne.10 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1369, %broadcast.977), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
   %convert_element_type.1323 = s32[1,128]{1,0:T(1,128)} convert(%ne.10), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.240 = s32[]{:T(128)} reduce(%convert_element_type.1323, %constant.449.clone.8), dimensions={0,1}, to_apply=%region_0.1, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.240 = s32[]{:T(128)} reduce(%convert_element_type.1323, %constant.433.clone.8), dimensions={0,1}, to_apply=%region_0.1, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %region_0.1.clone (reduce_sum.612: s32[], reduce_sum.613: s32[]) -> s32[] {
@@ -962,31 +938,31 @@ StackFrames
 
 %fused_computation.475 (param_0.1547: s32[1,128], param_1.1722: bf16[128], param_2.1325: f32[128], param_3.885: f32[128], param_4.523: f32[]) -> (f32[], f32[], f32[128]) {
   %param_0.1547 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %constant.449.clone.1 = s32[]{:T(128)} constant(0)
-  %broadcast.981 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.449.clone.1), dimensions={}, metadata={op_name="broadcast.99"}
-  %ne.16 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1547, %broadcast.981), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
+  %constant.433.clone.1 = s32[]{:T(128)} constant(0)
+  %broadcast.975 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.1), dimensions={}, metadata={op_name="broadcast.95"}
+  %ne.16 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1547, %broadcast.975), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
   %param_2.1325 = f32[128]{0:T(128)S(1)} parameter(2)
   %log.18 = f32[128]{0:T(128)} log(%param_2.1325), metadata={op_name="jit(train_step)/jvp()/log" stack_frame_id=0}
   %param_1.1722 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
   %reduce_max.16 = f32[128]{0:T(128)} convert(%param_1.1722), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
   %add.943 = f32[128]{0:T(128)} add(%log.18, %reduce_max.16), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %square.266 = f32[128]{0:T(128)} multiply(%add.943, %add.943), metadata={op_name="jit(train_step)/jvp()/square" stack_frame_id=0}
-  %constant.460.clone.25 = f32[]{:T(128)} constant(0)
-  %broadcast.966 = f32[128]{0:T(128)} broadcast(%constant.460.clone.25), dimensions={}, metadata={op_name="broadcast.120"}
-  %mul.1966 = f32[128]{0:T(128)} multiply(%square.266, %broadcast.966), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %constant.444.clone.25 = f32[]{:T(128)} constant(0)
+  %broadcast.960 = f32[128]{0:T(128)} broadcast(%constant.444.clone.25), dimensions={}, metadata={op_name="broadcast.118"}
+  %mul.1966 = f32[128]{0:T(128)} multiply(%square.266, %broadcast.960), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
   %bitcast.617 = f32[1,128]{1,0:T(1,128)} bitcast(%mul.1966), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %broadcast.977 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.460.clone.25), dimensions={}, metadata={op_name="broadcast.120"}
-  %mul.1952 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %bitcast.617, %broadcast.977), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %reduce.242 = f32[]{:T(128)} reduce(%mul.1952, %constant.460.clone.25), dimensions={0,1}, to_apply=%region_69.74, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %broadcast.971 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.444.clone.25), dimensions={}, metadata={op_name="broadcast.118"}
+  %mul.1952 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %bitcast.617, %broadcast.971), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %reduce.242 = f32[]{:T(128)} reduce(%mul.1952, %constant.444.clone.25), dimensions={0,1}, to_apply=%region_69.74, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
   %param_3.885 = f32[128]{0:T(128)S(1)} parameter(3)
   %neg.113.clone.1 = f32[128]{0:T(128)} negate(%param_3.885), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
   %bitcast.621.clone.1 = f32[1,128]{1,0:T(1,128)} bitcast(%neg.113.clone.1), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
   %add.933.clone.1 = f32[1,128]{1,0:T(1,128)} add(%bitcast.621.clone.1, %bitcast.617), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %mul.1950.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %add.933.clone.1, %broadcast.977), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %reduce.241.clone.1 = f32[]{:T(128)} reduce(%mul.1950.clone.1, %constant.460.clone.25), dimensions={0,1}, to_apply=%region_55.60, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %mul.1950.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %add.933.clone.1, %broadcast.971), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %reduce.241.clone.1 = f32[]{:T(128)} reduce(%mul.1950.clone.1, %constant.444.clone.25), dimensions={0,1}, to_apply=%region_55.60, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
   %param_4.523 = f32[]{:T(128)S(6)} parameter(4)
-  %broadcast_in_dim.309.clone.1 = f32[1,128]{1,0:T(1,128)} broadcast(%param_4.523), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/broadcast_in_dim" stack_frame_id=0}
-  %mul.1948.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %broadcast_in_dim.309.clone.1, %broadcast.977), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %broadcast_in_dim.283.clone.1 = f32[1,128]{1,0:T(1,128)} broadcast(%param_4.523), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/broadcast_in_dim" stack_frame_id=0}
+  %mul.1948.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %broadcast_in_dim.283.clone.1, %broadcast.971), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %bitcast.615.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%mul.1948.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   ROOT %tuple.168 = (f32[]{:T(128)}, f32[]{:T(128)}, f32[128]{0:T(128)S(1)}) tuple(%reduce.242, %reduce.241.clone.1, %bitcast.615.clone.1)
 }
@@ -1051,8 +1027,8 @@ StackFrames
   %convert.199 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1301)
   %multiply.436 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.198, %convert.199), metadata={op_name="multiply.354"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.200 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%multiply.436)
-  %constant.463.clone.1 = bf16[]{:T(256)} constant(0)
-  %reduce.224 = bf16[2048]{0:T(1024)(128)(2,1)} reduce(%convert.200, %constant.463.clone.1), dimensions={0,1}, to_apply=%region_10.13, metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}
+  %constant.446.clone.1 = bf16[]{:T(256)} constant(0)
+  %reduce.224 = bf16[2048]{0:T(1024)(128)(2,1)} reduce(%convert.200, %constant.446.clone.1), dimensions={0,1}, to_apply=%region_10.13, metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}
   ROOT %tuple.172 = (bf16[2048]{0:T(1024)(128)(2,1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.224, %bitcast.593.clone.1)
 }
 
@@ -1073,29 +1049,29 @@ StackFrames
   %dot_general.463 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.196, %convert.197), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.1289 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.463), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
   %mul.1884 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1290, %convert_element_type.1289), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %constant.460.clone.24 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.223 = f32[128]{0:T(128)S(1)} reduce(%mul.1884, %constant.460.clone.24), dimensions={0,2}, to_apply=%region_12.15, metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
+  %constant.444.clone.24 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.223 = f32[128]{0:T(128)S(1)} reduce(%mul.1884, %constant.444.clone.24), dimensions={0,2}, to_apply=%region_12.15, metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.484 (param_0.1366: f32[128], param_1.1477: f32[128]) -> f32[128] {
   %param_0.1366 = f32[128]{0:T(128)S(1)} parameter(0)
   %bitcast.631 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1366), metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
   %param_1.1477 = f32[128]{0:T(128)S(1)} parameter(1)
-  %constant.469.clone.1 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.971 = f32[128]{0:T(128)} broadcast(%constant.469.clone.1), dimensions={}, metadata={op_name="broadcast.418"}
-  %div.782 = f32[128]{0:T(128)} multiply(%param_1.1477, %broadcast.971), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
-  %constant.470.clone.1 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.969 = f32[128]{0:T(128)} broadcast(%constant.470.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %add.938 = f32[128]{0:T(128)} add(%div.782, %broadcast.969), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %constant.452.clone.1 = f32[]{:T(128)} constant(0.00048828125)
+  %broadcast.965 = f32[128]{0:T(128)} broadcast(%constant.452.clone.1), dimensions={}, metadata={op_name="broadcast.416"}
+  %div.782 = f32[128]{0:T(128)} multiply(%param_1.1477, %broadcast.965), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
+  %constant.453.clone.1 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.963 = f32[128]{0:T(128)} broadcast(%constant.453.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %add.938 = f32[128]{0:T(128)} add(%div.782, %broadcast.963), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %bitcast.630 = f32[1,128]{1,0:T(1,128)} bitcast(%add.938), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %rsqrt.201 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.630), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
   %div.780 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.201, %bitcast.630), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
-  %constant.472.clone.1 = f32[]{:T(128)} constant(-0.5)
-  %mul.1970 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.472.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %constant.455.clone.1 = f32[]{:T(128)} constant(-0.5)
+  %mul.1970 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.455.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
   %mul.1964 = f32[1,128]{1,0:T(1,128)} multiply(%div.780, %mul.1970), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
   %mul.1963 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.631, %mul.1964), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %constant.473.clone.1 = f32[]{:T(128)} constant(0.0009765625)
-  %mul.1969 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.473.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %constant.456.clone.1 = f32[]{:T(128)} constant(0.0009765625)
+  %mul.1969 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.456.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %mul.1959 = f32[1,128]{1,0:T(1,128)} multiply(%mul.1963, %mul.1969), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   ROOT %bitcast.625 = f32[128]{0:T(128)S(1)} bitcast(%mul.1959), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
 }
@@ -1123,8 +1099,8 @@ StackFrames
 %fused_computation.98.clone.1 (param_0.1731: bf16[4,512,6144], param_1.1840: s32[]) -> bf16[1,512,6144] {
   %param_0.1731 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1840 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.431.clone.87 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.192 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1731, %param_1.1840, %constant.431.clone.87, %constant.431.clone.87), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.87 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.192 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1731, %param_1.1840, %constant.415.clone.87, %constant.415.clone.87), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %convert_element_type.762.reduce_sub_computation (lhs.1: bf16[], rhs.1: bf16[]) -> bf16[] {
@@ -1142,28 +1118,28 @@ StackFrames
 %fused_computation.285.clone.1 (param_0.1701: bf16[4,2048], param_1.1822: s32[], param_2.1394: bf16[4,2048]) -> (bf16[2048], bf16[2048]) {
   %param_0.1701 = bf16[4,2048]{1,0:T(4,128)(2,1)} parameter(0)
   %param_1.1822 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.431.clone.78 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.299 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1701, %param_1.1822, %constant.431.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %constant.1121 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %reduce.263 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.299, %constant.1121), dimensions={0}, to_apply=%convert_element_type.762.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %constant.415.clone.78 = s32[]{:T(128)} constant(0)
+  %dynamic_slice.201 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1701, %param_1.1822, %constant.415.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1104 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %reduce.263 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.201, %constant.1104), dimensions={0}, to_apply=%convert_element_type.762.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %param_2.1394 = bf16[4,2048]{1,0:T(4,128)(2,1)} parameter(2)
-  %dynamic_slice.284.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1394, %param_1.1822, %constant.431.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %reduce.195.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.284.clone.3, %constant.1121), dimensions={0}, to_apply=%convert_element_type.758.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %dynamic_slice.186.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1394, %param_1.1822, %constant.415.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %reduce.195.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.186.clone.3, %constant.1104), dimensions={0}, to_apply=%convert_element_type.758.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   ROOT %tuple.216 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) tuple(%reduce.263, %reduce.195.clone.3)
 }
 
 %fused_computation.120.clone.1 (param_0.1726: bf16[4,16,128,512], param_1.1838: s32[]) -> bf16[1,16,128,512] {
   %param_0.1726 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1838 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.431.clone.86 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.191 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1726, %param_1.1838, %constant.431.clone.86, %constant.431.clone.86, %constant.431.clone.86), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.86 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.191 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1726, %param_1.1838, %constant.415.clone.86, %constant.415.clone.86, %constant.415.clone.86), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.121.clone.1 (param_0.1718: bf16[4,512,16,128], param_1.1833: s32[]) -> bf16[1,512,16,128] {
   %param_0.1718 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.1833 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.431.clone.84 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.189 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1718, %param_1.1833, %constant.431.clone.84, %constant.431.clone.84, %constant.431.clone.84), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.84 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.189 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1718, %param_1.1833, %constant.415.clone.84, %constant.415.clone.84, %constant.415.clone.84), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %region_14.16 (reduce_sum.204: f32[], reduce_sum.205: f32[]) -> f32[] {
@@ -1175,23 +1151,23 @@ StackFrames
 %fused_computation.172.clone.1 (param_0.1699: bf16[4,1,128,2048], param_1.1821: s32[]) -> f32[128] {
   %param_0.1699 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %param_1.1821 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.431.clone.77 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.184 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1699, %param_1.1821, %constant.431.clone.77, %constant.431.clone.77, %constant.431.clone.77), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.77 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.184 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1699, %param_1.1821, %constant.415.clone.77, %constant.415.clone.77, %constant.415.clone.77), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
   %bitcast.902 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.184), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
   %convert_element_type.1459 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.902), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %square.277 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1459, %convert_element_type.1459), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.432.clone.19 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.262 = f32[128]{0:T(128)S(1)} reduce(%square.277, %constant.432.clone.19), dimensions={0,2}, to_apply=%region_14.16, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  %constant.416.clone.19 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.262 = f32[128]{0:T(128)S(1)} reduce(%square.277, %constant.416.clone.19), dimensions={0,2}, to_apply=%region_14.16, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
 }
 
 %fused_computation.299.clone.1 (param_0.1700: f32[128]) -> f32[128] {
   %param_0.1700 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.433.clone.9 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.1073 = f32[128]{0:T(128)} broadcast(%constant.433.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1009 = f32[128]{0:T(128)} multiply(%param_0.1700, %broadcast.1073), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.434.clone.17 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1072 = f32[128]{0:T(128)} broadcast(%constant.434.clone.17), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %add.1045 = f32[128]{0:T(128)} add(%div.1009, %broadcast.1072), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %constant.417.clone.9 = f32[]{:T(128)} constant(0.00048828125)
+  %broadcast.1067 = f32[128]{0:T(128)} broadcast(%constant.417.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %div.1009 = f32[128]{0:T(128)} multiply(%param_0.1700, %broadcast.1067), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.418.clone.17 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.1066 = f32[128]{0:T(128)} broadcast(%constant.418.clone.17), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %add.1045 = f32[128]{0:T(128)} add(%div.1009, %broadcast.1066), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %bitcast.904 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1045), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %rsqrt.214 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.904), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
   ROOT %bitcast.903 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.214), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
@@ -1203,8 +1179,8 @@ StackFrames
   %convert.219 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.593)
   %param_2.1402 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %param_3.928 = s32[]{:T(128)S(6)} parameter(3)
-  %constant.431.clone.85 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.190 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1402, %param_3.928, %constant.431.clone.85, %constant.431.clone.85, %constant.431.clone.85), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.85 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.190 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1402, %param_3.928, %constant.415.clone.85, %constant.415.clone.85, %constant.415.clone.85), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
   %bitcast.920 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.190), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
   %convert_element_type.1469 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.920), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %param_1.1834 = f32[128]{0:T(128)S(1)} parameter(1)
@@ -1240,19 +1216,19 @@ StackFrames
   %convert_element_type.1470 = f32[128,16,128]{2,0,1:T(8,128)} convert(%convolution.69.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %bitcast.921 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1470), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %square.279 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.921, %bitcast.921), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.432.clone.21 = f32[]{:T(128)} constant(0)
-  %reduce.265 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.279, %constant.432.clone.21), dimensions={0,3}, to_apply=%region_15.17, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  %constant.416.clone.21 = f32[]{:T(128)} constant(0)
+  %reduce.265 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.279, %constant.416.clone.21), dimensions={0,3}, to_apply=%region_15.17, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
   ROOT %tuple.223 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) tuple(%reduce.265, %convolution.69.clone.3)
 }
 
 %fused_computation.279.clone.1 (param_0.1722: f32[128,16]) -> f32[128,16] {
   %param_0.1722 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
-  %constant.435.clone.13 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.1079 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.435.clone.13), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1015 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1722, %broadcast.1079), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.434.clone.19 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1078 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.434.clone.19), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %add.1048 = f32[128,16]{0,1:T(8,128)} add(%div.1015, %broadcast.1078), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %constant.419.clone.13 = f32[]{:T(128)} constant(0.0078125)
+  %broadcast.1073 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.419.clone.13), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %div.1015 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1722, %broadcast.1073), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.418.clone.19 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.1072 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.418.clone.19), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %add.1048 = f32[128,16]{0,1:T(8,128)} add(%div.1015, %broadcast.1072), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %bitcast.923 = f32[1,128,16]{1,2,0:T(8,128)} bitcast(%add.1048), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %rsqrt.216 = f32[1,128,16]{1,2,0:T(8,128)} rsqrt(%bitcast.923), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
   ROOT %bitcast.922 = f32[128,16]{0,1:T(8,128)S(1)} bitcast(%rsqrt.216), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
@@ -1261,12 +1237,12 @@ StackFrames
 %fused_computation.305.clone.1 (param_0.1706: bf16[4,128], param_1.1826: s32[], param_2.1397: bf16[4,128]) -> (bf16[128], bf16[128]) {
   %param_0.1706 = bf16[4,128]{1,0:T(4,128)(2,1)} parameter(0)
   %param_1.1826 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.431.clone.81 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.300 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1706, %param_1.1826, %constant.431.clone.81), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.909 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.300), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %constant.415.clone.81 = s32[]{:T(128)} constant(0)
+  %dynamic_slice.202 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1706, %param_1.1826, %constant.415.clone.81), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.909 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.202), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %param_2.1397 = bf16[4,128]{1,0:T(4,128)(2,1)} parameter(2)
-  %dynamic_slice.294.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1397, %param_1.1826, %constant.431.clone.81), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.470.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.294.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %dynamic_slice.196.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1397, %param_1.1826, %constant.415.clone.81), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.470.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.196.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   ROOT %tuple.217 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) tuple(%bitcast.909, %bitcast.470.clone.3)
 }
 
@@ -1297,17 +1273,17 @@ StackFrames
 }
 
 %fused_computation.314.clone.1 () -> f32[64] {
-  %constant.436.clone.3 = f32[]{:T(128)} constant(1e+06)
-  %closed_call.68 = f32[64]{0:T(128)} broadcast(%constant.436.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %constant.420.clone.3 = f32[]{:T(128)} constant(1e+06)
+  %closed_call.56 = f32[64]{0:T(128)} broadcast(%constant.420.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
   %iota.65 = s32[64]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/iota" stack_frame_id=0}
-  %constant.437.clone.3 = s32[]{:T(128)} constant(2)
-  %closed_call.67 = s32[64]{0:T(128)} broadcast(%constant.437.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %mul.2283 = s32[64]{0:T(128)} multiply(%iota.65, %closed_call.67), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %constant.421.clone.3 = s32[]{:T(128)} constant(2)
+  %closed_call.55 = s32[64]{0:T(128)} broadcast(%constant.421.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %mul.2283 = s32[64]{0:T(128)} multiply(%iota.65, %closed_call.55), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %convert_element_type.1464 = f32[64]{0:T(128)} convert(%mul.2283), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %constant.435.clone.12 = f32[]{:T(128)} constant(0.0078125)
-  %closed_call.66 = f32[64]{0:T(128)} broadcast(%constant.435.clone.12), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1011 = f32[64]{0:T(128)} multiply(%convert_element_type.1464, %closed_call.66), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  ROOT %pow.38 = f32[64]{0:T(128)S(1)} power(%closed_call.68, %div.1011), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/pow" stack_frame_id=0}
+  %constant.419.clone.12 = f32[]{:T(128)} constant(0.0078125)
+  %closed_call.54 = f32[64]{0:T(128)} broadcast(%constant.419.clone.12), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %div.1011 = f32[64]{0:T(128)} multiply(%convert_element_type.1464, %closed_call.54), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  ROOT %pow.38 = f32[64]{0:T(128)S(1)} power(%closed_call.56, %div.1011), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/pow" stack_frame_id=0}
 }
 
 %fused_computation.270.clone.1 (param_0.1712: f32[128], param_1.1830: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
@@ -1325,15 +1301,15 @@ StackFrames
 
 %fused_computation.275.clone.1 (param_0.1714: bf16[1,128,1,64]) -> (bf16[128,128], bf16[128,128]) {
   %param_0.1714 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.1123 = bf16[]{:T(256)} constant(-inf)
-  %pad.77 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1714, %constant.1123), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %constant.1106 = bf16[]{:T(256)} constant(-inf)
+  %pad.77 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1714, %constant.1106), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.274 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.77)
-  %pad.76 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1714, %constant.1123), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.76 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1714, %constant.1106), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.275 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.76)
   %maximum.57 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.274, %convert.275), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %constant.438.clone.8 = bf16[]{:T(256)} constant(0.08838)
-  %broadcast.1077 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.438.clone.8), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %convert.277 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%broadcast.1077)
+  %constant.422.clone.8 = bf16[]{:T(256)} constant(0.08838)
+  %broadcast.1071 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.8), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %convert.277 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%broadcast.1071)
   %mul.2285 = f32[1,128,1,128]{3,1,2,0:T(8,128)} multiply(%maximum.57, %convert.277), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.278 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2285)
   %bitcast.916 = bf16[128,128]{1,0:T(8,128)(2,1)} bitcast(%convert.278), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
@@ -1344,15 +1320,15 @@ StackFrames
 
 %fused_computation.274.clone.1 (param_0.1713: bf16[1,128,1,64]) -> (bf16[128,128], bf16[128,128]) {
   %param_0.1713 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.1122 = bf16[]{:T(256)} constant(-inf)
-  %pad.75 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1713, %constant.1122), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %constant.1105 = bf16[]{:T(256)} constant(-inf)
+  %pad.75 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1713, %constant.1105), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.279 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.75)
-  %pad.74 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1713, %constant.1122), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.74 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1713, %constant.1105), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.280 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.74)
   %maximum.56 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.279, %convert.280), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %constant.438.clone.7 = bf16[]{:T(256)} constant(0.08838)
-  %broadcast.1076 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.438.clone.7), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %convert.282 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%broadcast.1076)
+  %constant.422.clone.7 = bf16[]{:T(256)} constant(0.08838)
+  %broadcast.1070 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.7), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %convert.282 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%broadcast.1070)
   %mul.2284 = f32[1,128,1,128]{3,1,2,0:T(8,128)} multiply(%maximum.56, %convert.282), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.283 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2284)
   %bitcast.915 = bf16[128,128]{1,0:T(8,128)(2,1)} bitcast(%convert.283), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
@@ -1379,11 +1355,11 @@ StackFrames
   %convert.286 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2302)
   %mul.2300 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%dot_general.596, %convert.286), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_1.1837 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1125 = bf16[]{:T(256)} constant(-inf)
-  %pad.81 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1837, %constant.1125), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %constant.1108 = bf16[]{:T(256)} constant(-inf)
+  %pad.81 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1837, %constant.1108), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.287 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.81)
   %param_0.1725 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.80 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1725, %constant.1125), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.80 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1725, %constant.1108), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.288 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.80)
   %maximum.59 = f32[1,128,16,128]{3,1,2,0:T(8,128)} maximum(%convert.287, %convert.288), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_2.1405 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
@@ -1391,9 +1367,9 @@ StackFrames
   %convert.289 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2301)
   %mul.2299 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%maximum.59, %convert.289), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %add.1049 = f32[1,128,16,128]{3,1,2,0:T(8,128)} add(%mul.2300, %mul.2299), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %constant.438.clone.9 = bf16[]{:T(256)} constant(0.08838)
-  %closed_call.69 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.438.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %convert.290 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%closed_call.69)
+  %constant.422.clone.9 = bf16[]{:T(256)} constant(0.08838)
+  %closed_call.57 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %convert.290 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%closed_call.57)
   %mul.2298 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%add.1049, %convert.290), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.291 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2298)
   ROOT %bitcast.925 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.291), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
@@ -1402,8 +1378,8 @@ StackFrames
 %fused_computation.131.clone.1 (param_0.1707: bf16[4,512,8,128], param_1.1827: s32[]) -> bf16[1,512,8,128] {
   %param_0.1707 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.1827 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.431.clone.82 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.187 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1707, %param_1.1827, %constant.431.clone.82, %constant.431.clone.82, %constant.431.clone.82), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.82 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.187 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1707, %param_1.1827, %constant.415.clone.82, %constant.415.clone.82, %constant.415.clone.82), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.226.clone.clone.clone.1 (param_0.1709: bf16[2048], param_1.1828: f32[128], param_2.1398: bf16[4,1,128,2048], param_3.925: s32[]) -> bf16[128,2048,1] {
@@ -1412,8 +1388,8 @@ StackFrames
   %convert.216 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.587)
   %param_2.1398 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %param_3.925 = s32[]{:T(128)S(6)} parameter(3)
-  %constant.431.clone.83 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.188 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1398, %param_3.925, %constant.431.clone.83, %constant.431.clone.83, %constant.431.clone.83), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.83 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.188 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1398, %param_3.925, %constant.415.clone.83, %constant.415.clone.83, %constant.415.clone.83), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
   %bitcast.912 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.188), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
   %convert_element_type.1463 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.912), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %param_1.1828 = f32[128]{0:T(128)S(1)} parameter(1)
@@ -1449,19 +1425,19 @@ StackFrames
   %convert_element_type.1090.clone.3 = f32[128,8,128]{2,0,1:T(8,128)} convert(%convolution.105.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %bitcast.374.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} bitcast(%convert_element_type.1090.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %square.278 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%bitcast.374.clone.3, %bitcast.374.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.432.clone.20 = f32[]{:T(128)} constant(0)
-  %reduce.264 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.278, %constant.432.clone.20), dimensions={0,3}, to_apply=%region_16.18, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  %constant.416.clone.20 = f32[]{:T(128)} constant(0)
+  %reduce.264 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.278, %constant.416.clone.20), dimensions={0,3}, to_apply=%region_16.18, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
   ROOT %tuple.218 = (f32[128,8]{0,1:T(8,128)S(1)}, f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)}) tuple(%reduce.264, %bitcast.374.clone.3)
 }
 
 %fused_computation.288.clone.1 (param_0.1711: f32[128,8]) -> f32[128,8] {
   %param_0.1711 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
-  %constant.435.clone.11 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.1075 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.435.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1010 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1711, %broadcast.1075), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.434.clone.18 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1074 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.434.clone.18), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %add.1046 = f32[128,8]{0,1:T(8,128)} add(%div.1010, %broadcast.1074), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %constant.419.clone.11 = f32[]{:T(128)} constant(0.0078125)
+  %broadcast.1069 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.419.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %div.1010 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1711, %broadcast.1069), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.418.clone.18 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.1068 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.418.clone.18), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %add.1046 = f32[128,8]{0,1:T(8,128)} add(%div.1010, %broadcast.1068), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %bitcast.914 = f32[1,128,8]{1,2,0:T(8,128)} bitcast(%add.1046), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %rsqrt.215 = f32[1,128,8]{1,2,0:T(8,128)} rsqrt(%bitcast.914), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
   ROOT %bitcast.913 = f32[128,8]{0,1:T(8,128)S(1)} bitcast(%rsqrt.215), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
@@ -1507,11 +1483,11 @@ StackFrames
   %convert.299 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2291)
   %mul.2289 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%dot_general.590, %convert.299), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_1.1832 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1124 = bf16[]{:T(256)} constant(-inf)
-  %pad.79 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1832, %constant.1124), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %constant.1107 = bf16[]{:T(256)} constant(-inf)
+  %pad.79 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1832, %constant.1107), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.300 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.79)
   %param_0.1717 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.78 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1717, %constant.1124), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.78 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1717, %constant.1107), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
   %convert.301 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.78)
   %maximum.58 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.300, %convert.301), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %param_2.1401 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
@@ -1526,8 +1502,8 @@ StackFrames
 %fused_computation.130.clone.1 (param_0.1702: bf16[4,512,8,128], param_1.1823: s32[]) -> bf16[1,512,8,128] {
   %param_0.1702 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
   %param_1.1823 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.431.clone.79 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.185 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1702, %param_1.1823, %constant.431.clone.79, %constant.431.clone.79, %constant.431.clone.79), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.79 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.185 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1702, %param_1.1823, %constant.415.clone.79, %constant.415.clone.79, %constant.415.clone.79), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.225.clone.1 (param_0.1704: bf16[2048], param_1.1824: f32[128], param_2.1395: bf16[4,1,128,2048], param_3.923: s32[]) -> bf16[128,2048,1] {
@@ -1536,8 +1512,8 @@ StackFrames
   %convert.213 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.585)
   %param_2.1395 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %param_3.923 = s32[]{:T(128)S(6)} parameter(3)
-  %constant.431.clone.80 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.186 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1395, %param_3.923, %constant.431.clone.80, %constant.431.clone.80, %constant.431.clone.80), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.80 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.186 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1395, %param_3.923, %constant.415.clone.80, %constant.415.clone.80, %constant.415.clone.80), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
   %bitcast.907 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.186), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
   %convert_element_type.1461 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.907), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %param_1.1824 = f32[128]{0:T(128)S(1)} parameter(1)
@@ -1586,8 +1562,8 @@ StackFrames
 %fused_computation.175.clone.1 (param_0.1729: bf16[1,16,128,2048], param_1.1839: bf16[16,128,128], param_2.1406: bf16[4,1,128,2048], param_3.931: s32[]) -> (f32[128], bf16[1,128,2048]) {
   %param_2.1406 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %param_3.931 = s32[]{:T(128)S(6)} parameter(3)
-  %constant.431.clone.16.clone.3 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.113.clone.3 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1406, %param_3.931, %constant.431.clone.16.clone.3, %constant.431.clone.16.clone.3, %constant.431.clone.16.clone.3), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.16.clone.3 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.113.clone.3 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1406, %param_3.931, %constant.415.clone.16.clone.3, %constant.415.clone.16.clone.3, %constant.415.clone.16.clone.3), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
   %bitcast.430.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.113.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
   %convert.304 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.430.clone.3)
   %param_1.1839 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
@@ -1600,20 +1576,20 @@ StackFrames
   %add.818.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.304, %convert.305), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.1475 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%add.818.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %square.280 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1475, %convert_element_type.1475), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.432.clone.22 = f32[]{:T(128)} constant(0)
-  %reduce.266 = f32[128]{0:T(128)S(1)} reduce(%square.280, %constant.432.clone.22), dimensions={0,2}, to_apply=%region_17.20, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  %constant.416.clone.22 = f32[]{:T(128)} constant(0)
+  %reduce.266 = f32[128]{0:T(128)S(1)} reduce(%square.280, %constant.416.clone.22), dimensions={0,2}, to_apply=%region_17.20, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
   %convert.306 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.818.clone.3)
   ROOT %tuple.225 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.266, %convert.306)
 }
 
 %fused_computation.297.clone.1 (param_0.1730: f32[128]) -> f32[128] {
   %param_0.1730 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.433.clone.10 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.1081 = f32[128]{0:T(128)} broadcast(%constant.433.clone.10), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1016 = f32[128]{0:T(128)} multiply(%param_0.1730, %broadcast.1081), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.434.clone.20 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1080 = f32[128]{0:T(128)} broadcast(%constant.434.clone.20), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %add.1050 = f32[128]{0:T(128)} add(%div.1016, %broadcast.1080), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %constant.417.clone.10 = f32[]{:T(128)} constant(0.00048828125)
+  %broadcast.1075 = f32[128]{0:T(128)} broadcast(%constant.417.clone.10), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %div.1016 = f32[128]{0:T(128)} multiply(%param_0.1730, %broadcast.1075), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.418.clone.20 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.1074 = f32[128]{0:T(128)} broadcast(%constant.418.clone.20), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %add.1050 = f32[128]{0:T(128)} add(%div.1016, %broadcast.1074), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %bitcast.930 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1050), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %rsqrt.217 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.930), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
   ROOT %bitcast.929 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.217), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
@@ -1654,8 +1630,8 @@ StackFrames
 %fused_computation.100.clone.1 (param_0.1739: bf16[4,512,6144], param_1.1845: s32[]) -> bf16[1,512,6144] {
   %param_0.1739 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1845 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.431.clone.89 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.194 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1739, %param_1.1845, %constant.431.clone.89, %constant.431.clone.89), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.89 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.194 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1739, %param_1.1845, %constant.415.clone.89, %constant.415.clone.89), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.218.clone.1 (param_0.1741: bf16[2048], param_1.1846: f32[128], param_2.1409: bf16[1,128,2048]) -> bf16[128,2048] {
@@ -1693,8 +1669,8 @@ StackFrames
 %fused_computation.144.clone.1 (param_0.1801: bf16[1,128,6144], param_1.1888: bf16[1,128,6144]) -> bf16[128,6144] {
   %param_1.1888 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %convert.265 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1888)
-  %constant.441.clone.25 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.45 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.441.clone.25), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
+  %constant.425.clone.25 = bf16[]{:T(256)} constant(1)
+  %jit_silu_.45 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.25), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
   %convert.266 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.45)
   %neg.132 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.265), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %exp.78 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.132), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
@@ -1732,8 +1708,8 @@ StackFrames
 %fused_computation.99.clone.1 (param_0.1735: bf16[4,6144,512], param_1.1843: s32[]) -> bf16[1,6144,512] {
   %param_0.1735 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} parameter(0)
   %param_1.1843 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.431.clone.88 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.193 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1735, %param_1.1843, %constant.431.clone.88, %constant.431.clone.88), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.415.clone.88 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.193 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1735, %param_1.1843, %constant.415.clone.88, %constant.415.clone.88), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %fused_computation.90.clone.clone.clone.1 (param_0.1737: bf16[1,6144,2048]) -> bf16[6144,2048] {
@@ -1758,8 +1734,8 @@ StackFrames
 %fused_computation.147.clone.1 (param_0.1744: bf16[1,128,6144], param_1.1848: bf16[1,128,6144]) -> bf16[128,6144] {
   %param_1.1848 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %convert.228 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1848)
-  %constant.441.clone.21 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.41 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.441.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
+  %constant.425.clone.21 = bf16[]{:T(256)} constant(1)
+  %jit_silu_.41 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
   %convert.229 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.41)
   %neg.128 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.228), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %exp.74 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.128), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
@@ -1793,8 +1769,8 @@ StackFrames
   %param_2.1412 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %convert.233 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_2.1412)
   %mul.2315 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.232, %convert.233), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %constant.441.clone.22 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.42 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.441.clone.22), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
+  %constant.425.clone.22 = bf16[]{:T(256)} constant(1)
+  %jit_silu_.42 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.22), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
   %convert.235 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.42)
   %param_0.1747 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %convert.234 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1747)
@@ -1846,8 +1822,8 @@ StackFrames
   %dot_general.602 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.310, %convert.311), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.1480 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.602), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/convert_element_type" stack_frame_id=0}
   %mul.2316 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1481, %convert_element_type.1480), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %constant.432.clone.23 = f32[]{:T(128)} constant(0)
-  %reduce.267 = f32[128]{0:T(128)S(1)} reduce(%mul.2316, %constant.432.clone.23), dimensions={0,2}, to_apply=%region_18.21, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum" stack_frame_id=0}
+  %constant.416.clone.23 = f32[]{:T(128)} constant(0)
+  %reduce.267 = f32[128]{0:T(128)S(1)} reduce(%mul.2316, %constant.416.clone.23), dimensions={0,2}, to_apply=%region_18.21, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum" stack_frame_id=0}
   ROOT %tuple.226 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.267, %bitcast.359.clone.3)
 }
 
@@ -1855,21 +1831,21 @@ StackFrames
   %param_0.1749 = f32[128]{0:T(128)S(1)} parameter(0)
   %bitcast.946 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1749), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum" stack_frame_id=0}
   %param_1.1852 = f32[128]{0:T(128)S(1)} parameter(1)
-  %constant.433.clone.11 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.1083 = f32[128]{0:T(128)} broadcast(%constant.433.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1020 = f32[128]{0:T(128)} multiply(%param_1.1852, %broadcast.1083), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.434.clone.21 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1082 = f32[128]{0:T(128)} broadcast(%constant.434.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %add.1053 = f32[128]{0:T(128)} add(%div.1020, %broadcast.1082), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %constant.417.clone.11 = f32[]{:T(128)} constant(0.00048828125)
+  %broadcast.1077 = f32[128]{0:T(128)} broadcast(%constant.417.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %div.1020 = f32[128]{0:T(128)} multiply(%param_1.1852, %broadcast.1077), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.418.clone.21 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.1076 = f32[128]{0:T(128)} broadcast(%constant.418.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %add.1053 = f32[128]{0:T(128)} add(%div.1020, %broadcast.1076), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %bitcast.945 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1053), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
   %rsqrt.218 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.945), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
   %div.1019 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.218, %bitcast.945), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.442.clone.9 = f32[]{:T(128)} constant(-0.5)
-  %closed_call.70 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.442.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %mul.2319 = f32[1,128]{1,0:T(1,128)} multiply(%div.1019, %closed_call.70), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %constant.426.clone.9 = f32[]{:T(128)} constant(-0.5)
+  %closed_call.58 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.426.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
+  %mul.2319 = f32[1,128]{1,0:T(1,128)} multiply(%div.1019, %closed_call.58), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %mul.2318 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.946, %mul.2319), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %constant.443.clone.5 = f32[]{:T(128)} constant(0.0009765625)
-  %mul.2320 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.443.clone.5), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %constant.427.clone.5 = f32[]{:T(128)} constant(0.0009765625)
+  %mul.2320 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.427.clone.5), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
   %mul.2317 = f32[1,128]{1,0:T(1,128)} multiply(%mul.2318, %mul.2320), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
   ROOT %bitcast.944 = f32[128]{0:T(128)S(1)} bitcast(%mul.2317), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
 }
@@ -1892,8 +1868,8 @@ StackFrames
   %convert.313 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1482)
   %multiply.470 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.312, %convert.313), metadata={op_name="multiply.352"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.314 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%multiply.470)
-  %constant.445.clone.9 = bf16[]{:T(256)} constant(0)
-  %reduce.268 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%convert.314, %constant.445.clone.9), dimensions={0,1}, to_apply=%region_23.27, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}
+  %constant.429.clone.9 = bf16[]{:T(256)} constant(0)
+  %reduce.268 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%convert.314, %constant.429.clone.9), dimensions={0,1}, to_apply=%region_23.27, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}
   %param_3.935 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
   %convert.316 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_3.935)
   %param_5.483 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(5)
@@ -1941,8 +1917,8 @@ StackFrames
   %bitcast.949 = bf16[1,16,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%convolution.67.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/transpose" stack_frame_id=0}
   %convert.192 = f32[1,16,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.949), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/convert.1" stack_frame_id=0}
   %multiply.471 = f32[1,16,128,128]{3,2,1,0:T(8,128)} multiply(%convert.193, %convert.192), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/multiply" stack_frame_id=0}
-  %constant.432.clone.24 = f32[]{:T(128)} constant(0)
-  %dot_general.604 = f32[16,128]{1,0:T(8,128)S(1)} reduce(%multiply.471, %constant.432.clone.24), dimensions={0,3}, to_apply=%region_19.22, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general" stack_frame_id=0}
+  %constant.416.clone.24 = f32[]{:T(128)} constant(0)
+  %dot_general.604 = f32[16,128]{1,0:T(8,128)S(1)} reduce(%multiply.471, %constant.416.clone.24), dimensions={0,3}, to_apply=%region_19.22, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general" stack_frame_id=0}
   ROOT %tuple.228 = (f32[16,128]{1,0:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) tuple(%dot_general.604, %convolution.67.clone.3)
 }
 
@@ -1970,8 +1946,8 @@ StackFrames
   %bitcast.973 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1777), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
   %convert.319 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.973)
   %param_1.1871 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %broadcast.1087 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_1.1871), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.320 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.1087)
+  %broadcast.1081 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_1.1871), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.320 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.1081)
   %mul.2344 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.319, %convert.320), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %convert.321 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.2344)
   ROOT %bitcast.972 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convert.321), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
@@ -1995,6 +1971,30 @@ StackFrames
 
 %fused_computation.256.clone.1 (param_0.1779: f32[1,128,8,128], param_1.1872: f32[128,8], param_2.1428: bf16[128,128], param_3.943: bf16[8,128,128], param_4.559: bf16[1,128,8,64], param_5.486: bf16[1,128,8,64]) -> (bf16[128], bf16[1,128,8,128]) {
   %param_5.486 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
-  %constant.1098.clone.3 = bf16[]{:T(256)} constant(-inf)
-  %pad.61.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_5.486, %constant.1098.clone.3), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
+  %constant.1081.clone.3 = bf16[]{:T(256)} constant(-inf)
+  %pad.61.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_5.486, %constant.1081.clone.3), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
   %convert.324 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.61.clone.3)
+  %param_4.559 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(4)
+  %pad.60.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_4.559, %constant.1081.clone.3), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
+  %convert.325 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.60.clone.3)
+  %maximum.49.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.324, %convert.325), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_3.943 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %bitcast.683.clone.3 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_3.943), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.326 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.683.clone.3)
+  %param_2.1428 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %broadcast.979.clone.3 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_2.1428), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.327 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.979.clone.3)
+  %mul.1980.clone.3 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.326, %convert.327), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.328 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.1980.clone.3)
+  %bitcast.682.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%convert.328), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %convert.329 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%bitcast.682.clone.3)
+  %add_any.195.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%maximum.49.clone.3, %convert.329), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_0.1779 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} parameter(0)
+  %param_1.1872 = f32[128,8]{0,1:T(8,128)S(1)} parameter(1)
+  %mul.2346 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1872), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2345 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%param_0.1779, %mul.2346), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1497 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2345), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.330 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1497)
+  %multiply.475 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%add_any.195.clone.3, %convert.330), metadata={op_name="multiply.355"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.331 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%multiply.475)
+  %constant.429.clone.11 = bf16[]{:T(256)} constant(0)


### PR DESCRIPTION
# Description

This PR adds native parameter-efficient fine-tuning (PEFT), LoRA, and QLoRA training support and complete checkpoint lifecycle resume/restoration within Flax NNX training in MaxText (`train.py`, `train_sft.py`, `maxtext_utils.py`, `checkpointing.py`, `train_state_nnx.py`, `lora_utils.py`, `sharding.py`).

### Key Changes:

1. **Dynamic Parameter Filtering (`wrt`)**:
   - Standardized `nnx.Optimizer(wrt=...)` across MaxText (`train.py`, `train_sft.py`, `train_compile.py`, `generate_param_only_checkpoint.py`, `standalone_checkpointer.py`, `train_utils.py`) to target `nnx.LoRAParam` when LoRA is enabled, ensuring gradient updates affect adapter weights.

2. **Mesh Sharding & Activation Protection**:
   - Scoped `adjust_pspec_for_indivisible_shapes` in `src/maxtext/utils/sharding.py` strictly to parameter variables (`isinstance(inputs, nnx.Variable)`), preserving activation partition specs inside `shard_map` across multi-host TPU topologies.

3. **Checkpoint Lifecycle & Resume**:
   - Integrated Flax NNX checkpoint serialization and restoration in `src/maxtext/common/checkpointing.py`, supporting both Linen `'params'` wrappers and root NNX state dictionaries.
   - Updated `TrainStateNNX.split_for_checkpoint` in `train_state_nnx.py` to route `nnx.Param` and `nnx.LoRAParam` into parameter collections for complete PyTree state tracking.

4. **QWiX Quantization & Scanned Layer Execution**:
   - Added safe kernel unwrapping (`getattr(self.kernel, "value", self.kernel)`) in `src/maxtext/layers/linears.py` for QWiX quantized parameter wrappers.
   - Bypassed `nnx.split`/`nnx.merge` for QWiX layers in `src/maxtext/layers/nnx_decoders.py` and filtered `RngState` and `Intermediate` variables during layer scanning.

5. **SFT Mesh Placement & Imports**:
   - Wrapped model initialization and adapter restoration in `train_sft.py` within `with jax.set_mesh(mesh)` to ensure multi-device mesh placement.
   - Lazily imported `train_sft` in test helpers and decorated SFT test methods with `@pytest.mark.post_training`.

# Tests

- **Pre-Commit**: Passed 100% (`pyink`, `pylint`, `codespell`, `yamllint`).
- **Pipeline Parallelism**: All 6 tests in `tests/integration/pipeline_parallelism_test.py` passed (`test_full_train_circular`, `test_full_train_non_circular`, `test_subset_layers`, `test_full_train_fp8`, `test_full_train_nanoo_fp8`).
- **NNX Unit Tests**: `tests/unit/maxtext_utils_nnx_test.py` and `tests/unit/lora_utils_nnx_test.py` passed 100%.
- **E2E Integration Tests**: E2E QLoRA/LoRA tests (`test_qlora_e2e_gemma4_sft_nf4`, `test_qlora_e2e_qwen3_sft_nf4`, `test_qlora_e2e_gptoss_unscanned_nf4`) passed 100%.

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload details above.
- [x] I have made or will make corresponding changes to the doc if needed.
