### PR TITLE
Fix 'Promote Docker Image' workflow to only promote when nightly build succeeds

### DIFF
--- a/.github/workflows/promote_docker_image.yml
+++ b/.github/workflows/promote_docker_image.yml
@@ -25,6 +25,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   handle_result:
@@ -32,13 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Report DAG result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STATE: ${{ github.event.client_payload.state }}
+          DAG_ID: ${{ github.event.client_payload.dag_id }}
+          DAG_RUN_ID: ${{ github.event.client_payload.dag_run_id }}
+          SHA: ${{ github.event.client_payload.sha }}
+          GITHUB_RUN_ID: ${{ github.event.client_payload.github_run_id }}
         run: |
-          STATE="${{ github.event.client_payload.state }}"
-          DAG_ID="${{ github.event.client_payload.dag_id }}"
-          DAG_RUN_ID="${{ github.event.client_payload.dag_run_id }}"
-          SHA="${{ github.event.client_payload.sha }}"
-          GITHUB_RUN_ID="${{ github.event.client_payload.github_run_id }}"
-
           echo "================================"
           echo "Github Run ID: ${GITHUB_RUN_ID}"
           echo "DAG ID:        ${DAG_ID}"
@@ -52,6 +54,14 @@ jobs:
             failed|upstream_failed) echo "E2E tests FAILED."; exit 1 ;;
             *) echo "DAG ended with unexpected state: ${STATE}"; exit 1 ;;
           esac
+
+          if [ -n "$GITHUB_RUN_ID" ]; then
+            echo "Checking nightly build status for run: $GITHUB_RUN_ID"
+            gh run watch "$GITHUB_RUN_ID" --exit-status --interval 60 --repo "$GITHUB_REPOSITORY"
+          else
+            echo "Error: No Github Run ID provided. Cannot verify nightly build status."
+            exit 1
+          fi
 
   tag_docker_image:
     name: Promote ${{ matrix.image_name }} Docker Image
@@ -71,9 +81,10 @@ jobs:
         run: gcloud auth configure-docker us-docker.pkg.dev,gcr.io -q
       - name: Add tags to Docker image
         shell: bash
+        env:
+          GITHUB_RUN_ID: ${{ github.event.client_payload.github_run_id }}
         run: |
           SOURCE_IMAGE="gcr.io/${{ vars.PROJECT_NAME }}/${{ matrix.image_name }}"
-          GITHUB_RUN_ID="${{ github.event.client_payload.github_run_id }}"
 
           # Add the traceability tag to confirm it passed validation suite
           gcloud container images add-tag "${SOURCE_IMAGE}:${GITHUB_RUN_ID}" \


### PR DESCRIPTION
# Description

This PR fixes the "Promote Docker Image" workflow to ensure the `latest` tag is only applied to built images when both the E2E Airflow DAG tests and the nightly build (including CI tests) succeed.

Historically, the workflow was triggered by a callback from the completed Airflow DAG and proceeded to add the `latest` tag solely based on the success state of that DAG. If CI tests (like TPU tests) in the nightly pipeline failed, the promotion could still occur.

To fix this:
1. Added `actions: read` permission to the `Promote MaxText Docker Image` workflow.
2. In the `handle_result` job, we use `gh run watch` to monitor the nightly build workflow run (`github.event.client_payload.github_run_id`).
3. If the nightly build run failed, or does not complete successfully, we terminate the promotion job early, preventing incorrect tagging.

# Tests

Verified the `gh run watch` command behavior locally on various workflow run IDs:
- Successfully completed runs returned immediately with exit code 0.
- Failed runs exited immediately with exit code 1.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
