### PR TITLE
Fix NNX sequential layer naming and PyTree structure

### DIFF
--- a/src/maxtext/inference/maxengine/maxengine.py
+++ b/src/maxtext/inference/maxengine/maxengine.py
@@ -29,7 +29,7 @@ import jax.numpy as jnp
 if jax.__version_info__ >= (0, 6, 3):
   from jax.experimental.layout import Layout as DLL  # type: ignore
 else:
-  from jax.experimental.layout import DeviceLocalLayout as DLL  # type: ignore
+  from jax.experimental.layout import DeviceLocalLayout as DLL  # type: ignore # pylint: disable=no-name-in-module
 
 from flax import linen as nn
 from flax import nnx
@@ -486,7 +486,10 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
           lambda x: jax.sharding.NamedSharding(self._mesh, jax.sharding.PartitionSpec(None, *x.spec)),
           self.prefill_kv_cache_shardings,
       )
-      self.prefill_kv_cache_shardings = {"decoder": {"layers": self.prefill_kv_cache_shardings["decoder"]["layers"][0]}}
+      decoder_dict = self.prefill_kv_cache_shardings["decoder"]
+      first_key = next(k for k in decoder_dict.keys() if k.endswith("layers_0"))
+      first_layer_sharding = decoder_dict[first_key]
+      self.prefill_kv_cache_shardings = {"decoder": {"layers": first_layer_sharding}}
     # scan_layers=True is already stacked on axis 0; shardings stay as-is and stack/unstack are no-ops.
     # AR-mode abstract model so axis names use CACHE_BATCH (not CACHE_BATCH_PREFILL);
     # bulk_insert / _insert_jit search for "cache_batch" in the per-leaf logical axes.
@@ -610,10 +613,17 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
       if self.config.scan_layers:
         # scan_layers already stacks the per-layer KV cache on axis 0; nothing to restack.
         return cache
-      # scan_layers=False: stack the per-layer subtrees under decoder/layers into one
+      # scan_layers=False: stack the per-layer subtrees under decoder into one
       # subtree with a leading layer axis (matching the scan_layers=True shape).
-      layers = cache["decoder"]["layers"]
-      stacked = jax.tree.map(lambda *c: jnp.stack(c), *[layers[i] for i in range(self.config.num_decoder_layers)])
+      if "dense_layers_0" in cache["decoder"] or "moe_layers_0" in cache["decoder"]:
+        first_dense = self.config.first_num_dense_layers
+        num_moe = self.config.num_decoder_layers - first_dense
+        layer_keys = [f"dense_layers_{i}" for i in range(first_dense)] + [f"moe_layers_{i}" for i in range(num_moe)]
+      else:
+        layer_keys = [f"layers_{i}" for i in range(self.config.num_decoder_layers)]
+
+      layer_cache = [cache["decoder"][key] for key in layer_keys]
+      stacked = jax.tree.map(lambda *c: jnp.stack(c), *layer_cache)
       return {"decoder": {"layers": stacked}}
 
     layer_keys = []
@@ -636,8 +646,22 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
         return cache
       # scan_layers=False: split the leading layer axis back into per-layer subtrees.
       stacked = cache["decoder"]["layers"]
-      layers = {i: jax.tree.map(lambda x, i=i: x[i], stacked) for i in range(self.config.num_decoder_layers)}
-      return {"decoder": {"layers": layers}}
+      res_cache = {"decoder": {}}
+      is_deepseek = (
+          getattr(self.model, "is_deepseek", False)
+          or (hasattr(self.model, "decoder") and getattr(self.model.decoder, "is_deepseek", False))
+          or (hasattr(self.config, "decoder_block") and str(self.config.decoder_block).lower() == "deepseek")
+      )
+      if is_deepseek:
+        first_dense = self.config.first_num_dense_layers
+        num_moe = self.config.num_decoder_layers - first_dense
+        layer_keys = [f"dense_layers_{i}" for i in range(first_dense)] + [f"moe_layers_{i}" for i in range(num_moe)]
+      else:
+        layer_keys = [f"layers_{i}" for i in range(self.config.num_decoder_layers)]
+
+      for idx, key in enumerate(layer_keys):
+        res_cache["decoder"][key] = jax.tree.map(lambda x, i=idx: x[i], stacked)
+      return res_cache
 
     flat_cache, treedef = jax.tree.flatten(cache)
     layer_cache = [jax.tree.unflatten(treedef, flat_cache_vars) for flat_cache_vars in zip(*flat_cache, strict=True)]

--- a/src/maxtext/layers/learn_to_init_layer.py
+++ b/src/maxtext/layers/learn_to_init_layer.py
@@ -388,14 +388,7 @@ def apply_lti_model_update(student_model, student_config):
   if student_config.attn_module_name is None:
     return
 
-  if getattr(student_config, "scan_layers", True):
-    layer_modules = [student_model.decoder.layers]
-  else:
-    layer_modules = []
-    # Collect all possible layer names (e.g. layers_0, dense_layers_0, moe_layers_0)
-    for name, module in vars(student_model.decoder).items():
-      if name.startswith(LTI_LAYER_PATH_PREFIXES):
-        layer_modules.append(module)
+  layer_modules = student_model.decoder.get_layers()
 
   for layer_module in layer_modules:
     attn_state_dict = layer_module.get(student_config.attn_module_name)

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -502,13 +502,13 @@ class NNXDecoder(nnx.Module):
     else:
       self.num_dense_layers = config.first_num_dense_layers
       for i in range(self.num_dense_layers):
-        self._create_and_register_named_layer(dense_cls, rngs, "dense_layers", i)
+        self._create_and_register_layer(dense_cls, rngs, "dense_layers", i)
       self.num_moe_outside_pipeline = (
           config.num_decoder_layers - config.first_num_dense_layers
       ) - config.pipeline_parallel_layers
       if self.num_moe_outside_pipeline > 0:
         for i in range(self.num_moe_outside_pipeline):
-          self._create_and_register_named_layer(moe_cls, rngs, "moe_layers_outside_pipeline", i)
+          self._create_and_register_layer(moe_cls, rngs, "moe_layers_outside_pipeline", i)
 
   def _init_pipeline_generic(self, decoder_block_classes, rngs):
     """Initializes generic decoder layers outside pipeline."""
@@ -526,7 +526,7 @@ class NNXDecoder(nnx.Module):
       else:
         self.num_layers_outside_pipeline = remaining_layers
         for i in range(self.num_layers_outside_pipeline):
-          self._create_and_register_named_layer(base_cls, rngs, "layers_outside_pipeline", i)
+          self._create_and_register_layer(base_cls, rngs, "layers_outside_pipeline", i)
 
   def _init_scanned_layers(self, decoder_block_classes, rngs, mesh):
     """Initializes decoder layers with scanning (non-pipeline)."""
@@ -693,12 +693,9 @@ class NNXDecoder(nnx.Module):
           rngs=rngs,
           **layer_kwargs,
       )
-    else:
-      self.layers = nnx.List([])
 
   def _init_sequential_layers(self, decoder_block_classes, rngs):
     """Initializes decoder layers sequentially (no scanning)."""
-    self.layers = nnx.List([])
 
     if self.is_deepseek:
       self._init_sequential_deepseek(decoder_block_classes, rngs)
@@ -710,9 +707,9 @@ class NNXDecoder(nnx.Module):
     config = self.config
     dense_cls, moe_cls = decoder_block_classes
     for i in range(config.first_num_dense_layers):
-      self._create_and_register_layer(dense_cls, rngs, "dense_layer", i)
+      self._create_and_register_layer(dense_cls, rngs, "dense_layers", i)
     for i in range(config.num_decoder_layers - config.first_num_dense_layers):
-      self._create_and_register_layer(moe_cls, rngs, "moe_layer", i)
+      self._create_and_register_layer(moe_cls, rngs, "moe_layers", i)
 
   def _init_sequential_generic(self, decoder_block_classes, rngs):
     """Initializes sequential generic decoder layers with per-architecture layer_kwargs."""
@@ -753,7 +750,6 @@ class NNXDecoder(nnx.Module):
     ``_create_and_register_layer``.
     """
     cfg = self.config
-    self.layers = nnx.List([])
     # Only register the PLE submodule when it exists (mirrors the optional position_embedder
     # pattern); assigning None first would make nnx treat the attribute as static.
     if cfg.hidden_size_per_layer_input > 0 and cfg.vocab_size_per_layer_input > 0:
@@ -771,7 +767,6 @@ class NNXDecoder(nnx.Module):
           rngs=rngs,
       )
       setattr(self, f"layers_{lyr}", layer)
-      self.layers.append(layer)
 
   def _get_pipeline_stage_module(self, decoder_blocks, rngs):
     """Retrieves the wrapper module formatted for single pipeline stage execution."""
@@ -801,14 +796,7 @@ class NNXDecoder(nnx.Module):
     )
 
   def _create_and_register_layer(self, layer_cls, rngs, base_name, i, **layer_kwargs):
-    attr_name = f"{base_name}_{i}"
-    layer = self._create_single_layer(layer_cls, rngs, **layer_kwargs)
-    setattr(self, attr_name, layer)
-    self.layers.append(layer)
-
-  def _create_and_register_named_layer(self, layer_cls, rngs, base_name, i, **layer_kwargs):
-    """Creates a layer registered ONLY via named attribute. Used by pipeline-outside paths
-    to avoid double-registration when self.layers list is also tracked elsewhere."""
+    """Creates a layer registered ONLY via named attribute."""
     attr_name = f"{base_name}_{i}"
     layer = self._create_single_layer(layer_cls, rngs, **layer_kwargs)
     setattr(self, attr_name, layer)
@@ -1408,6 +1396,11 @@ class NNXDecoder(nnx.Module):
     decoder_input_tokens = kwargs.get("decoder_input_tokens")
     layer_kwargs = kwargs.get("layer_kwargs", {})
 
+    # Create a copy of layer_kwargs and pop decoder_input_tokens if it exists
+    # to avoid passing it twice (once explicitly and once via **layer_kwargs).
+    layer_kwargs = dict(layer_kwargs)
+    layer_kwargs.pop("decoder_input_tokens", None)
+
     out = layer(y, *args, decoder_input_tokens=decoder_input_tokens, **layer_kwargs)
     if isinstance(out, tuple):
       y = out[0]
@@ -1544,6 +1537,9 @@ class NNXDecoder(nnx.Module):
 
     if attention_metadata is not None:
       layer_kwargs["attention_metadata"] = attention_metadata
+
+    if cfg.engram_layers and decoder_input_tokens is not None:
+      layer_kwargs["decoder_input_tokens"] = decoder_input_tokens
 
     if getattr(cfg, "using_pipeline_parallelism", False):
       logical_partition_spec = (
@@ -1780,23 +1776,41 @@ class NNXDecoder(nnx.Module):
             )
       else:
         prevent_cse = maxtext_utils.should_prevent_cse_in_remat(cfg)
+        dynamic_graph_init = bool(getattr(self, "disable_quant_stats_update", False))
 
-        # Hoisted function to preserve XLA cache ID
-        def pure_layer_fn(graphdef, state_in, y_in, kv_in):
-
+        def pure_layer_fn(graphdef_in, state_in, y_in, kv_in):
           if cfg.parameter_memory_host_offload:
             state_in = jax.tree.map(
                 lambda x: jax.device_put(x, max_utils.device_space()),
                 state_in,
             )
-
-          merged_layer = nnx.merge(graphdef, state_in)
+          merged_layer = nnx.merge(graphdef_in, state_in)
           out_y, out_kv = merged_layer(y_in, *layer_args, kv_cache=kv_in, **layer_kwargs)
-          return out_y, out_kv, nnx.state(merged_layer)
+          state_out = nnx.state(merged_layer)
+
+          if dynamic_graph_init:
+            new_graphdef, _, _ = nnx.split(merged_layer, nnx.Param, ...)
+            return out_y, out_kv, state_out, new_graphdef
+          else:
+            return out_y, out_kv, state_out, graphdef_in
 
         checkpointed_fn = jax.checkpoint(pure_layer_fn, policy=policy, prevent_cse=prevent_cse)
 
-        for lyr, layer in enumerate(self.layers):
+        for lyr in range(cfg.num_decoder_layers):
+          if self.is_deepseek:
+            if lyr < cfg.first_num_dense_layers:
+              layer = getattr(self, f"dense_layers_{lyr}", None)
+            else:
+              moe_idx = lyr - cfg.first_num_dense_layers
+              layer = getattr(self, f"moe_layers_{moe_idx}", None)
+          else:
+            layer = getattr(self, f"layers_{lyr}", None)
+            if layer is None and hasattr(self, "layers") and self.layers:
+              layer = self.layers[lyr]
+
+          if layer is None:
+            raise AttributeError(f"Could not locate decoder layer at index {lyr} in {self.__class__.__name__}")
+
           graphdef, state = nnx.split(layer)
           if kv_caches is not None:
             if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
@@ -1812,12 +1826,23 @@ class NNXDecoder(nnx.Module):
           else:
             kv_cache = None
 
-          input_tokens = decoder_input_tokens if cfg.engram_layers else None
-          if input_tokens is not None:
-            layer_kwargs["decoder_input_tokens"] = input_tokens
+          if cfg.remat_policy != "none":
+            y, kv_cache, new_state, new_graphdef = checkpointed_fn(graphdef, state, y, kv_cache)
+          else:
+            y, kv_cache, new_state, new_graphdef = pure_layer_fn(graphdef, state, y, kv_cache)
 
-          y, kv_cache, new_state = checkpointed_fn(graphdef, state, y, kv_cache)
-          nnx.update(layer, new_state)
+          if dynamic_graph_init:
+            new_layer = nnx.merge(new_graphdef, new_state)
+            if self.is_deepseek:
+              if lyr < cfg.first_num_dense_layers:
+                setattr(self, f"dense_layers_{lyr}", new_layer)
+              else:
+                moe_idx = lyr - cfg.first_num_dense_layers
+                setattr(self, f"moe_layers_{moe_idx}", new_layer)
+            else:
+              setattr(self, f"layers_{lyr}", new_layer)
+          else:
+            nnx.update(layer, new_state)
 
           if kv_caches is not None and kv_cache is not None:
             if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
@@ -2024,7 +2049,7 @@ class NNXDecoder(nnx.Module):
     cache_index_of = gemma4_small.kv_cache_slot_map(layer_types, num_kv_shared)
 
     for lyr in range(cfg.num_decoder_layers):
-      layer = self.layers[lyr]
+      layer = getattr(self, f"layers_{lyr}")
       donor_idx = gemma4_small.kv_donor_layer_idx(lyr, layer_types, num_kv_shared)
       is_donor = gemma4_small.is_kv_donor_layer(lyr, layer_types, num_kv_shared)
 
@@ -2068,6 +2093,63 @@ class NNXDecoder(nnx.Module):
         kv_caches[cache_idx] = kv_cache
 
     return y, kv_caches
+
+  def get_layers(self) -> list[nnx.Module]:
+    """Returns all decoder layer modules/blocks in their forward-pass execution order."""
+    layers = []
+    seen = set()
+
+    def _add(module):
+      if module is not None and id(module) not in seen:
+        seen.add(id(module))
+        layers.append(module)
+
+    def _append_unscanned(prefix):
+      i = 0
+      while hasattr(self, f"{prefix}_{i}"):
+        _add(getattr(self, f"{prefix}_{i}"))
+        i += 1
+
+    def _append_scanned(name):
+      if hasattr(self, name):
+        val = getattr(self, name)
+        if name == "layers_remainder" and getattr(val, "num_of_layers", 0) == 0:
+          return
+        if isinstance(val, (nnx.Module, list)):
+          _add(val)
+
+    if self.is_deepseek:
+      _append_scanned("dense_layers")
+      _append_unscanned("dense_layers")
+
+      _append_scanned("moe_layers")
+      _append_unscanned("moe_layers")
+
+      _append_scanned("moe_layers_outside_pipeline")
+      _append_unscanned("moe_layers_outside_pipeline")
+
+      if hasattr(self, "pipeline_module"):
+        _add(getattr(self.pipeline_module, "layers", None))
+    else:
+      if hasattr(self, "pipeline_module"):
+        _add(getattr(self.pipeline_module, "layers", None))
+
+      _append_scanned("scanned_blocks")  # Gemma 4
+      _append_scanned("layers")
+      _append_unscanned("layers")
+
+      _append_scanned("layers_remainder")  # Gemma 3/4
+
+      _append_scanned("layers_outside_pipeline")
+      _append_unscanned("layers_outside_pipeline")
+
+    # Fallback for dynamic/chunked layer attributes (e.g. Engram dense_layers_0_3)
+    if not layers:
+      for k, m in vars(self).items():
+        if k.startswith(("dense_layers", "moe_layers", "layers", "scanned_blocks")) and isinstance(m, (nnx.Module, list)):
+          _add(m)
+
+    return layers
 
 
 def decoder_as_linen(

--- a/src/maxtext/layers/nnx_wrappers.py
+++ b/src/maxtext/layers/nnx_wrappers.py
@@ -312,6 +312,57 @@ class ToNNX(Module):
 
     return out
 
+  def get_layers(self) -> list[Any]:
+    """Returns all decoder layer modules in execution order."""
+    layers = []
+    seen = set()
+
+    def _add(module):
+      if module is not None and id(module) not in seen:
+        seen.add(id(module))
+        layers.append(module)
+
+    def _append_unscanned(prefix):
+      i = 0
+      while hasattr(self, f"{prefix}_{i}"):
+        _add(getattr(self, f"{prefix}_{i}"))
+        i += 1
+
+    def _append_scanned(name):
+      if hasattr(self, name):
+        val = getattr(self, name)
+        if name == "layers_remainder" and getattr(val, "num_of_layers", 0) == 0:
+          return
+        _add(val)
+
+    _append_scanned("dense_layers")
+    _append_unscanned("dense_layers")
+
+    _append_scanned("moe_layers")
+    _append_unscanned("moe_layers")
+
+    _append_scanned("moe_layers_outside_pipeline")
+    _append_unscanned("moe_layers_outside_pipeline")
+
+    if hasattr(self, "pipeline_module"):
+      _add(getattr(self.pipeline_module, "layers", None))
+
+    _append_scanned("scanned_blocks")  # Gemma 4
+    _append_scanned("layers")
+    _append_unscanned("layers")
+
+    _append_scanned("layers_remainder")  # Gemma 3/4
+
+    _append_scanned("layers_outside_pipeline")
+    _append_unscanned("layers_outside_pipeline")
+
+    if not layers:
+      for k, m in vars(self).items():
+        if k.startswith(("dense_layers", "moe_layers", "layers", "scanned_blocks")):
+          _add(m)
+
+    return layers
+
 
 def linen_rngs_dict(linen_module: linen.Module, add_default: bool = False):
   """Given a module, split out one of its every active RNG key collections."""

--- a/src/maxtext/utils/lora_utils.py
+++ b/src/maxtext/utils/lora_utils.py
@@ -433,10 +433,10 @@ def _get_lora_module_path(mt_config: pyconfig.HyperParameters) -> str:
 
   raw_path = lora_configs.get(matched_key, "decoder/layers/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))")
 
-  # This regex makes the layer index optional, matching both scanned and unscanned layer paths
-  # (e.g. 'layers/0/mlp/...' vs 'layers/mlp/...').
-  optional_layer_index = "(?:[0-9]+/)?"
-  final_path = str(raw_path).replace("layers/", f"layers/{optional_layer_index}")
+  # This regex makes the layer index optional, matching scanned, unscanned named (layers_0),
+  # and unscanned index (layers/0) layer paths.
+  layer_pattern = r"layers(?:_[0-9]+|/[0-9]+)?/"
+  final_path = str(raw_path).replace("layers/", layer_pattern)
 
   max_logging.log(f"Using lora_module_path: {final_path}")
   return final_path
@@ -485,7 +485,8 @@ def is_lora_enabled(model: nnx.Module) -> bool:
 def _verify_lora_parameters(lora_model: nnx.Module, mt_config: pyconfig.HyperParameters) -> None:
   """Validates that LoRA is active or that target modules were matched."""
 
-  if is_lora_enabled(lora_model):
+  enabled = is_lora_enabled(lora_model)
+  if enabled:
     wrapped_modules = set()
     for path, value in nnx.iter_graph(lora_model):
       if isinstance(value, nnx.LoRAParam):
@@ -579,6 +580,7 @@ def apply_lora_to_model(
     mt_config: pyconfig.HyperParameters,
 ) -> nnx.Module:
   """Optionally applies LoRA/QLoRA to a MaxText model using Qwix."""
+  # pylint: disable=protected-access
   # Skip Qwix LoRA if MaxText LoRA adapters are loaded
   if mt_config.lora_input_adapters_path:
     max_logging.log("MaxText LoRA adapters loaded, skipping Qwix LoRA application")

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -1496,10 +1496,15 @@ def get_intermediate_value(model, nested_key, default=None, clear=False):
   intermediate_value = default
   match nested_key:
     case "out_projection_activations":
-      if nested_key in model.decoder.layers["self_attention"]:
-        intermediate_value = model.decoder.layers["self_attention"][nested_key].get_value()[-1]
-        if clear:
-          del model.decoder.layers["self_attention"][nested_key]
+      layers = model.decoder.get_layers()
+      last_layer = layers[-1]
+      if hasattr(last_layer, "self_attention"):
+        attn = last_layer.self_attention
+        if hasattr(attn, nested_key):
+          var = getattr(attn, nested_key)
+          intermediate_value = var.get_value()[-1]
+          if clear:
+            delattr(attn, nested_key)
     case _:
       # Default case to handle any unknown nested keys
       raise ValueError(f"Incorrect nested_key: {nested_key}")

--- a/tests/integration/maxengine_test.py
+++ b/tests/integration/maxengine_test.py
@@ -74,8 +74,8 @@ class MaxEngineTest(unittest.TestCase):
     cfg = self._init_nnx_pyconfig(stack_prefill_result_cache=True, scan_layers=False)
     engine = maxengine.MaxEngine(cfg, jax.devices())
     num_layers = engine.config.num_decoder_layers
-    # scan_layers=False keeps the per-layer subtrees under decoder/layers, keyed by layer index.
-    cache = {"decoder": {"layers": {i: {"a": jnp.ones((1, 10)), "b": jnp.ones((1, 9))} for i in range(num_layers)}}}
+    # scan_layers=False keeps the per-layer subtrees under decoder, keyed by layers_i.
+    cache = {"decoder": {f"layers_{i}": {"a": jnp.ones((1, 10)), "b": jnp.ones((1, 9))} for i in range(num_layers)}}
 
     expected_stacked = {
         "decoder": {

--- a/tests/post_training/unit/lora_utils_test.py
+++ b/tests/post_training/unit/lora_utils_test.py
@@ -88,7 +88,7 @@ class LoraUtilsTest(unittest.TestCase):
     path = lora_utils._get_lora_module_path(mock_config)
     self.assertEqual(
         path,
-        "decoder/layers/(?:[0-9]+/)?.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))",
+        "decoder/layers(?:_[0-9]+|/[0-9]+)?/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))",
     )
 
     mock_config.model_name = "gemma4-9b"
@@ -106,7 +106,7 @@ class LoraUtilsTest(unittest.TestCase):
     # Fallback to default
     self.assertEqual(
         path,
-        "decoder/layers/(?:[0-9]+/)?.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))",
+        "decoder/layers(?:_[0-9]+|/[0-9]+)?/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))",
     )
 
     mock_config.lora.lora_module_path = "custom/path"
@@ -243,6 +243,15 @@ class LoraUtilsTest(unittest.TestCase):
 
     # Verify it IS now LoRA enabled
     self.assertTrue(lora_utils.is_lora_enabled(lora_model))
+
+    # Verify quantization if weight_qtype is set
+    flat_state_paths = [".".join(str(p) for p in path) for path, _ in state.flat_state()]
+    if weight_qtype is not None:
+      self.assertTrue(any("qvalue" in path for path in flat_state_paths), "Expected quantized weights (qvalue) in state")
+    else:
+      self.assertFalse(
+          any("qvalue" in path for path in flat_state_paths), "Did not expect quantized weights (qvalue) in state"
+      )
 
     # Test fit for PeftTrainer
     trainer_cfg = peft_trainer.TrainingConfig(eval_every_n_steps=10)

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -107,21 +107,33 @@ class TestIntermediateValueRetrieval(unittest.TestCase):
     # 2. Create the Decoder Mock
     self.mock_decoder = MagicMock(name="Decoder")
     self.mock_model.decoder = self.mock_decoder
-    self.mock_layers = {}
-    self.mock_model.decoder.layers = self.mock_layers
-    self.self_attention = {}
-    self.mock_layers["self_attention"] = self.self_attention
+    self.mock_layer = MagicMock(name="Layer")
+    self.mock_decoder.get_layers.return_value = [self.mock_layer]
+    self.self_attention = MagicMock(name="Attention", spec=[])
+    self.mock_layer.self_attention = self.self_attention
 
   def test_valid_intermediate_key(self):
     expected_sowed_data = [0.1, 0.5, 0.9]
     mock_sowed_variable = Mock(name="out_projection_activations")
     mock_sowed_variable.get_value.return_value = (expected_sowed_data,)
 
-    self.mock_decoder.layers["self_attention"]["out_projection_activations"] = mock_sowed_variable
+    self.self_attention.out_projection_activations = mock_sowed_variable
 
     result = maxtext_utils.get_intermediate_value(self.mock_model, "out_projection_activations")
 
     self.assertEqual(result, expected_sowed_data)
+
+  def test_clear_intermediate_key(self):
+    expected_sowed_data = [0.1, 0.5, 0.9]
+    mock_sowed_variable = Mock(name="out_projection_activations")
+    mock_sowed_variable.get_value.return_value = (expected_sowed_data,)
+
+    self.self_attention.out_projection_activations = mock_sowed_variable
+
+    result = maxtext_utils.get_intermediate_value(self.mock_model, "out_projection_activations", clear=True)
+
+    self.assertEqual(result, expected_sowed_data)
+    self.assertFalse(hasattr(self.self_attention, "out_projection_activations"))
 
   def test_returns_default_if_sow_did_not_happen(self):
     """

--- a/tests/unit/nnx_decoders_test.py
+++ b/tests/unit/nnx_decoders_test.py
@@ -999,7 +999,7 @@ class TestGemma4SmallNNXDecoder(unittest.TestCase):
     )
 
     # Mock each layer's compute_shared_kv
-    for layer in decoder.layers:
+    for layer in decoder.get_layers():
       layer.compute_shared_kv = MagicMock(return_value=(jnp.zeros((1, 16, 128)), jnp.zeros((1, 16, 128))))
 
     # Inputs

--- a/tests/unit/nnx_wrappers_test.py
+++ b/tests/unit/nnx_wrappers_test.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ToNNX wrappers and layer retrieval."""
+
+import unittest
+from unittest import mock
+import jax
+from flax import linen as nn
+from flax import nnx
+from maxtext.layers import nnx_wrappers
+from maxtext.common.common_types import Config
+
+
+class DummyLayer(nn.Module):
+  """Dummy Linen layer for testing."""
+
+  @nn.compact
+  def __call__(self, x):
+    return nn.Dense(features=10)(x)
+
+
+class DummyDecoderScanned(nn.Module):
+  """Dummy scanned decoder for testing."""
+
+  config: Config
+
+  def setup(self):
+    self.layers = DummyLayer()
+
+  def __call__(self, x):
+    return self.layers(x)
+
+
+class DummyDecoderUnscanned(nn.Module):
+  """Dummy unscanned decoder for testing."""
+
+  config: Config
+
+  def setup(self):
+    self.layers_0 = DummyLayer()
+    self.layers_1 = DummyLayer()
+
+  def __call__(self, x):
+    x = self.layers_0(x)
+    x = self.layers_1(x)
+    return x
+
+
+class ToNNXGetLayersTest(unittest.TestCase):
+  """Tests for ToNNX.get_layers()."""
+
+  def test_get_layers_scanned(self):
+    cfg = mock.Mock()
+    cfg.scan_layers = True
+    cfg.num_decoder_layers = 2
+
+    decoder = DummyDecoderScanned(config=cfg)
+    x = jax.numpy.ones((1, 10))
+
+    # Initialize ToNNX
+    model = nnx_wrappers.ToNNX(decoder, rngs=nnx.Rngs(0)).lazy_init(x)
+
+    self.assertTrue(hasattr(model, "layers"))
+    layers = model.get_layers()
+    self.assertEqual(len(layers), 1)
+    self.assertIsInstance(layers[0], (nnx.Module, dict))
+    self.assertEqual(layers[0], model.layers)
+
+  def test_get_layers_unscanned(self):
+    cfg = mock.Mock()
+    cfg.scan_layers = False
+    cfg.num_decoder_layers = 2
+
+    decoder = DummyDecoderUnscanned(config=cfg)
+    x = jax.numpy.ones((1, 10))
+
+    # Initialize ToNNX
+    model = nnx_wrappers.ToNNX(decoder, rngs=nnx.Rngs(0)).lazy_init(x)
+
+    self.assertTrue(hasattr(model, "layers_0"))
+    self.assertTrue(hasattr(model, "layers_1"))
+    layers = model.get_layers()
+    self.assertEqual(len(layers), 2)
+    self.assertIsInstance(layers[0], (nnx.Module, dict))
+    self.assertIsInstance(layers[1], (nnx.Module, dict))
+    self.assertEqual(layers[0], model.layers_0)
+    self.assertEqual(layers[1], model.layers_1)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

This is for checkpoint loading

Fix the Errors:
1. DeepSeek Unscanned Checkpoint Mismatch:

When restoring unscanned DeepSeek checkpoints, loading failed with: 
```
ValueError: Checkpoint structure mismatch: 374 of 377 model parameter paths were not found... 
Example missing paths: decoder.dense_layer_0...
```

Cause: `_init_sequential_deepseek` registered layers as singular `dense_layer` and `moe_layer`, producing PyTree paths like `decoder.dense_layer_0`. However, Linen checkpoints and MaxText converter scripts format layer keys as plural (`decoder.dense_layers_0`, `decoder.moe_layers_0`).

2. Generic Unscanned Model Checkpoint Mismatch (GPT-OSS, Llama4, etc.):

When restoring unscanned generic models, loading failed with: 
```
ValueError: Checkpoint structure mismatch: 456 of 459 model parameter paths were not found
... 
Example missing paths: decoder.layers.0
...
```

Cause: `_init_sequential_generic` used `_create_and_register_layer` which appended to `self.layers` initialized as `nnx.List([])`. In Flax NNX, tracking submodules in an `nnx.List` container forces state PyTree extraction to use list-index paths (`decoder.layers.0`) instead of named attribute paths (`decoder.layers_0`), breaking compatibility with on-disk Linen checkpoints.


FIXES: b/532719643
FIXES: b/532731449
FIXES: b/532916578

# Test
1. llama4-17b-16e
```
python3 -m tests.utils.forward_pass_logit_checker \
    src/maxtext/configs/base.yml \
    tokenizer_path=meta-llama/Llama-4-Scout-17B-16E \
    load_parameters_path=gs://ml-auto-solutions/output/jax_models_and_performance/maxtext/chained_tests_llama4_nightly-2026-07-06-01-30-12/unscanned/0/items \
    model_name=llama4-17b-16e \
   ...
```
Logs: [b/532916578](https://paste.googleplex.com/4617524799995904)


2. gpt-oss-20b
```
python3 -m tests.utils.forward_pass_logit_checker \
    src/maxtext/configs/base.yml \
    model_name=gpt-oss-20b \
    load_parameters_path=gs://ml-auto-solutions/output/unowned/maxtext_stable_gpt-oss-20b-v5p-8-2026-07-06-04-15-19/unscanned/0/items \
   ...
```
Logs: [b/532731449](https://paste.googleplex.com/6433213902880768)

5. deepseek2-16b
```
python3 -m maxtext.inference.decode src/maxtext/configs/base.yml \
  run_name=decode \
  model_name=deepseek2-16b \
  tokenizer_type=huggingface \
  tokenizer_path=deepseek-ai/DeepSeek-V2-Lite \
  load_parameters_path=gs://ml-auto-solutions/output/unowned/maxtext_nightly_deepseek2-16b-v5p-8-2026-07-01-07-56-03/unscanned/0/items \
```
Logs: [b/532719643](https://paste.googleplex.com/5267510688612352)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).