### PR TITLE
Pass github_event_name to Airflow DAG trigger

### DIFF
--- a/.github/workflows/nightly_images_pipeline.yml
+++ b/.github/workflows/nightly_images_pipeline.yml
@@ -148,6 +148,7 @@ jobs:
   run_e2e_tests:
     name: Run E2E tests
     needs: build_and_push_tpu_docker_images
+    if: github.event_name == 'schedule'
     uses: ./.github/workflows/run_e2e_tests.yml
     with:
       mode: ${{ inputs.image_suffix != '' && format('{0}_{1}', 'nightly', inputs.image_suffix) || 'nightly' }}


### PR DESCRIPTION
# Description

Restrict E2E tests to scheduled runs in the nightly pipeline.

This PR adds an `if: github.event_name == 'schedule'` condition to the `run_e2e_tests` job in `nightly_images_pipeline.yml`. This prevents manual workflow runs (`workflow_dispatch`) of the nightly build from triggering the Airflow E2E tests DAG, while still allowing the scheduled nightly runs to trigger them.

This is a cleaner way to restrict the trigger at the source, ensuring we don't waste Airflow resources on manual runs and don't break other pipelines (like the release pipeline) that also trigger these tests.

Related changes in `ml-auto-solutions-3`: https://github.com/CIeNET-International/ml-auto-solutions-3/pull/301

# Tests

Verified by checking the workflow file structure.

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
