### PR TITLE
Fix Gemma3-4b E2E script

### DIFF
--- a/tests/end_to_end/tpu/gemma3/4b/test_gemma3_lora.sh
+++ b/tests/end_to_end/tpu/gemma3/4b/test_gemma3_lora.sh
@@ -17,7 +17,8 @@
 
 set -ex
 
-run_id=${1:-$(date +%Y-%m-%d-%H-%M)}
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+use_pathways=${2:-false}
 MODEL_NAME='gemma3-4b'
 
 # Non-Googlers please remember to point `BASE_OUTPUT_DIRECTORY` to the GCS paths where you have the scanned and unscanned checkpoints stored
@@ -25,37 +26,34 @@ BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
 UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned/${run_id}/0/items
 SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned/${run_id}/0/items
 
-# Step 1: Install torch
-python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
-
-# Step 2: Run inference on the original checkpoint converted from Hugging Face
+# Step 1: Run inference on the original checkpoint converted from Hugging Face
 python3 -m maxtext.inference.vllm_decode \
     model_name=${MODEL_NAME} \
     load_parameters_path=${UNSCANNED_CKPT_PATH} \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
-    hbm_utilization_vllm=0.6 \
+    hbm_utilization_vllm=0.5 \
     prompt="Suggest some famous landmarks in London." \
     use_chat_template=True \
-    scan_layers=false
+    scan_layers=false \
+    enable_single_controller=${use_pathways}
 
-# Step 3: Run LoRA on the converted checkpoint
+# Step 2: Run LoRA on the converted checkpoint
 python3 -m maxtext.trainers.post_train.sft.train_sft \
     base_output_directory=${BASE_OUTPUT_DIRECTORY}/lora \
     load_parameters_path=${SCANNED_CKPT_PATH} \
     per_device_batch_size=1 run_name=${run_id} \
-    steps=5 scan_layers=true \
+    steps=5 \
+    scan_layers=true \
     model_name=${MODEL_NAME} \
     learning_rate=3e-6 \
     lora.enable_lora=True \
     lora.lora_rank=16 \
     lora.lora_alpha=32.0 \
-    enable_nnx=True \
-    pure_nnx_decoder=True \
-    enable_single_controller=True \
-    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False
+    enable_single_controller=${use_pathways} \
+    checkpoint_storage_use_zarr3=False \
+    checkpoint_storage_use_ocdbt=False
 
-
-# Step 4: Run inference on the checkpoint generated from the previous run
+# Step 3: Run inference on the checkpoint generated from the previous run
 python3 -m maxtext.inference.vllm_decode \
     --use_tunix=True \
     model_name=${MODEL_NAME} \
@@ -68,16 +66,5 @@ python3 -m maxtext.inference.vllm_decode \
     hbm_utilization_vllm=0.6 \
     prompt="Suggest some famous landmarks in London." \
     use_chat_template=True \
-    enable_nnx=True \
-    pure_nnx_decoder=True \
-    scan_layers=true
-
-# Step 5: Convert the checkpoint from MaxText format to Hugging Face format
-python3 -m maxtext.checkpoint_conversion.to_huggingface \
-    model_name=${MODEL_NAME} \
-    load_parameters_path=${SCANNED_CKPT_PATH} \
-    lora.lora_restore_path=${BASE_OUTPUT_DIRECTORY}/lora/${run_id}/checkpoints/5/model_params \
-    base_output_directory=${BASE_OUTPUT_DIRECTORY}/to_huggingface/unscanned/${run_id} \
     scan_layers=true \
-    enable_nnx=True \
-    pure_nnx_decoder=True
+    enable_single_controller=${use_pathways}

--- a/tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh
+++ b/tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh
@@ -18,11 +18,13 @@
 set -ex
 
 run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+use_pathways=${2:-false}
 MODEL_NAME='gemma3-4b'
 
 # Non-Googlers please remember to point `BASE_OUTPUT_DIRECTORY` to the GCS paths where you have the scanned and unscanned checkpoints stored
 BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
 UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned/${run_id}/0/items
+MULTIMODAL_SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned_multimodal/${run_id}/0/items
 SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned/${run_id}/0/items
 
 # Step 1: Install google-jetstream
@@ -31,35 +33,43 @@ python3 -m pip install google-jetstream@https://github.com/AI-Hypercomputer/JetS
 # Step 2: Run inference on the original checkpoint converted from Hugging Face
 python3 -m maxtext.inference.decode \
     model_name=${MODEL_NAME} \
-    load_parameters_path=${UNSCANNED_CKPT_PATH} \
+    load_parameters_path=${MULTIMODAL_SCANNED_CKPT_PATH} \
     per_device_batch_size=1 \
     run_name=${run_id} \
     max_prefill_predict_length=272 \
     max_target_length=300 \
     steps=1 \
     async_checkpointing=false \
-    scan_layers=false \
+    scan_layers=true \
     use_multimodal=True \
     tokenizer_type=huggingface \
     prompt=\'Describe\ image\ \<start_of_image\>\' \
     image_path=\'tests/assets/test_image.jpg\' \
-    attention=\'dot_product\' skip_jax_distributed_system=True
+    attention=\'dot_product\' \
+    skip_jax_distributed_system=True
 
 # Step 3: Run SFT on the MaxText checkpoint on ChartQA dataset
 python -m maxtext.trainers.post_train.sft.train_sft_native "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/post_train/sft-vision-chartqa.yml \
     run_name=${run_id} \
     model_name=${MODEL_NAME} \
     per_device_batch_size=1 \
-    max_prefill_predict_length=1024 max_target_length=2048 \
+    max_prefill_predict_length=1024 \
+    max_target_length=2048 \
     steps=5 \
-    scan_layers=false async_checkpointing=False \
-    attention=dot_product \
+    scan_layers=true \
+    async_checkpointing=False \
+    attention=\'dot_product\' \
     dataset_type=hf hf_path=parquet \
     hf_train_files=gs://aireenmei-multipod/dataset/hf/chartqa/train-* \
     base_output_directory=${BASE_OUTPUT_DIRECTORY}/multimodal/sft \
-    load_parameters_path=${UNSCANNED_CKPT_PATH} \
-    dtype=bfloat16 weight_dtype=bfloat16 sharding_tolerance=0.05 \
-    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False
+    load_parameters_path=${MULTIMODAL_SCANNED_CKPT_PATH} \
+    dtype=bfloat16 \
+    weight_dtype=bfloat16 \
+    sharding_tolerance=0.05 \
+    checkpoint_storage_use_zarr3=False \
+    checkpoint_storage_use_ocdbt=False \
+    enable_single_controller=${use_pathways} \
+    grain_worker_count=0
 
 # Step 4: Run inference on the checkpoint generated from the previous run
 python3 -m maxtext.inference.decode \
@@ -71,10 +81,9 @@ python3 -m maxtext.inference.decode \
     max_target_length=300 \
     steps=1 \
     async_checkpointing=false \
-    scan_layers=false \
+    scan_layers=true \
     use_multimodal=true \
     tokenizer_type=huggingface \
     prompt=\'Describe\ image\ \<start_of_image\>\' \
     image_path=\'tests/assets/test_image.jpg\' \
-    attention=\'dot_product\'
-
+    attention=\'dot_product\' skip_jax_distributed_system=True

--- a/tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_hf.sh
+++ b/tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_hf.sh
@@ -22,10 +22,30 @@ else
     scan_status="unscanned"
 fi
 
-python3 -m maxtext.checkpoint_conversion.to_huggingface \
-    model_name=${MODEL_NAME} \
-    tokenizer_type="huggingface" \
-    load_parameters_path=${CKPT_PATH} \
-    base_output_directory=${BASE_OUTPUT_DIRECTORY}/to_huggingface/${scan_status}/${run_id} \
-    use_multimodal=${USE_MULTIMODAL} \
-    scan_layers=$SCAN_LAYERS
+if [[ "${CKPT_PATH,,}" == *lora* ]]; then
+    
+    LORA_RESTORE_PATH="${CKPT_PATH}"
+
+    BASE_MODEL_CKPT="${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned/${run_id}/0/items"
+
+    python3 -m maxtext.checkpoint_conversion.to_huggingface \
+        model_name=${MODEL_NAME} \
+        tokenizer_type="huggingface" \
+        load_parameters_path=${BASE_MODEL_CKPT} \
+        lora.lora_restore_path=${LORA_RESTORE_PATH} \
+        base_output_directory=${BASE_OUTPUT_DIRECTORY}/to_huggingface/${scan_status}/${run_id} \
+        use_multimodal=${USE_MULTIMODAL} \
+        scan_layers=${SCAN_LAYERS} \
+        enable_nnx=True \
+        pure_nnx_decoder=True
+
+else
+    python3 -m maxtext.checkpoint_conversion.to_huggingface \
+        model_name=${MODEL_NAME} \
+        tokenizer_type="huggingface" \
+        load_parameters_path=${CKPT_PATH} \
+        base_output_directory=${BASE_OUTPUT_DIRECTORY}/to_huggingface/${scan_status}/${run_id} \
+        use_multimodal=${USE_MULTIMODAL} \
+        scan_layers=${SCAN_LAYERS}
+
+fi

--- a/tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh
+++ b/tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh
@@ -37,22 +37,42 @@ python3 -m maxtext.checkpoint_conversion.to_maxtext \
     base_output_directory=${BASE_OUTPUT_DIRECTORY}/unscanned/${run_id} \
     use_multimodal=${USE_MULTIMODAL} \
     scan_layers=false \
-    hardware=cpu skip_jax_distributed_system=True \
-    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    hardware=cpu \
+    skip_jax_distributed_system=True \
+    checkpoint_storage_use_zarr3=False \
+    checkpoint_storage_use_ocdbt=False \
     --lazy_load_tensors=False \
     --eager_load_method='transformers'
 
 UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/unscanned/${run_id}/0/items
 echo "Unscanned checkpoint path: ${UNSCANNED_CKPT_PATH}"
 
-# Step 2.b: Convert to scanned checkpoint (for training)
+# Step 2.b: Convert to scanned multimodal checkpoint (for multimodal training)
+python3 -m maxtext.checkpoint_conversion.to_maxtext \
+    model_name=${MODEL_NAME} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/scanned_multimodal/${run_id} \
+    use_multimodal=true \
+    scan_layers=true \
+    hardware=cpu \
+    skip_jax_distributed_system=True \
+    checkpoint_storage_use_zarr3=False \
+    checkpoint_storage_use_ocdbt=False \
+    --lazy_load_tensors=False \
+    --eager_load_method='transformers'
+
+MULTIMODAL_SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/scanned_multimodal/${run_id}/0/items
+echo "Multimodal Scanned checkpoint path: ${MULTIMODAL_SCANNED_CKPT_PATH}"
+
+# Step 2.c: Convert to scanned checkpoint (for training)
 python3 -m maxtext.checkpoint_conversion.to_maxtext \
     model_name=${MODEL_NAME} \
     base_output_directory=${BASE_OUTPUT_DIRECTORY}/scanned/${run_id} \
     use_multimodal=${USE_MULTIMODAL} \
     scan_layers=true \
-    hardware=cpu skip_jax_distributed_system=True \
-    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    hardware=cpu \
+    skip_jax_distributed_system=True \
+    checkpoint_storage_use_zarr3=False \
+    checkpoint_storage_use_ocdbt=False \
     --lazy_load_tensors=False \
     --eager_load_method='transformers'
 
@@ -71,5 +91,6 @@ if [ "${USE_MULTIMODAL}" = "false" ]; then
         --hf_model_path=${HF_GOLDEN_MODEL} \
         --max_kl_div=0.03 \
         --run_hf_model=true \
-        hardware=cpu skip_jax_distributed_system=True
+        hardware=cpu \
+        skip_jax_distributed_system=True
 fi


### PR DESCRIPTION
# Description

This PR fixes downstream execution failures in the Gemma3-4B multimodal SFT and LoRA end-to-end (E2E) post-training script.

[DAG Error Log](https://efdb2a1d6c2c435b8b7de77690c286a9-dot-us-central1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_post_training/grid?search=maxtext_e2e_tpu_post_training&task_id=gemma3-4b.multimodal_sft-gemma3-4b.train-multimodal_sft-gemma3-4b.run_model.wait_for_workload_completion&tab=logs&dag_run_id=manual__2026-07-16T02%3A48%3A34.068226%2B00%3A00)

# Tests (Testing on v6e-8 TPU VM)

Multimodal SFT:

```bash
export RUN_ID=$(date +%Y-%m-%d-%H-%M)
bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh $RUN_ID
bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh $RUN_ID
```
LoRA:
```bash
export RUN_ID=$(date +%Y-%m-%d-%H-%M)
bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh $RUN_ID
bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_lora.sh $RUN_ID
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
