### PR TITLE
Support ragged_sort_use_single_sparsecore flag to restrict token sorting to 1 SparseCore

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -846,6 +846,10 @@ class MoEGeneral(BaseModel):
       False,
       description="Whether to use ragged kernel for sorting, improve performance when EP is enabled.",
   )
+  ragged_sort_use_single_sparsecore: bool = Field(
+      False,
+      description="Whether to run ragged sort kernels on 1 SparseCore instead of all SparseCores.",
+  )
   use_gather_mosaic_kernel: bool = Field(
       False,
       description="Whether to use a custom mosaic kernel for token gather ops.",

--- a/src/maxtext/kernels/ragged/ragged_gather.py
+++ b/src/maxtext/kernels/ragged/ragged_gather.py
@@ -275,6 +275,8 @@ def get_cost_estimate(
       auto-computing.  -1 (default) means auto-compute.
     bytes_accessed_override: If > 0, use this value as bytes_accessed instead
       of auto-computing.  -1 (default) means auto-compute.
+    use_single_sparsecore: Static bool flag. When True, launch the kernel
+      on 1 SparseCore instead of all SparseCores.
 
   Returns:
     A ``pl.CostEstimate`` suitable for XLA scheduling.
@@ -343,7 +345,14 @@ def calculate_col_size(hidden_size: int) -> int:
 
 
 @functools.partial(
-    jax.jit, static_argnames=("has_weights", "enforce_fallback", "flops_override", "bytes_accessed_override")
+    jax.jit,
+    static_argnames=(
+        "has_weights",
+        "enforce_fallback",
+        "flops_override",
+        "bytes_accessed_override",
+        "use_single_sparsecore",
+    ),
 )
 def ragged_gather(
     x: jax.Array,
@@ -355,6 +364,7 @@ def ragged_gather(
     enforce_fallback: bool = False,
     flops_override: int = -1,
     bytes_accessed_override: int = -1,
+    use_single_sparsecore: bool = False,
 ) -> jax.Array:
   """Perform gather on indices within dynamic array start and end.
 
@@ -375,6 +385,8 @@ def ragged_gather(
       auto-computing.  -1 (default) means auto-compute.
     bytes_accessed_override: If > 0, use this value as bytes_accessed instead
       of auto-computing.  -1 (default) means auto-compute.
+    use_single_sparsecore: Static bool flag. When True, launch the kernel
+      on 1 SparseCore instead of all SparseCores.
 
   Returns:
     Gathered output of shape ``(indices_size, hidden_size)``.
@@ -410,7 +422,8 @@ def ragged_gather(
   out_size = indices.size
 
   num_simd_lanes = sc_info.num_lanes
-  num_cores = sc_info.num_cores * sc_info.num_subcores
+  num_sc_cores = 1 if use_single_sparsecore else sc_info.num_cores
+  num_cores = num_sc_cores * sc_info.num_subcores
   block_size = num_simd_lanes * num_cores
   col_size = calculate_col_size(hidden_size)
 
@@ -427,7 +440,7 @@ def ragged_gather(
   aligned_hidden_size = pl.cdiv(hidden_size, col_size) * col_size
 
   vector_mesh = plsc.VectorSubcoreMesh(
-      num_cores=sc_info.num_cores,
+      num_cores=num_sc_cores,
       num_subcores=sc_info.num_subcores,
       core_axis_name="core",
       subcore_axis_name="subcore",

--- a/src/maxtext/kernels/ragged/ragged_gather_reduce.py
+++ b/src/maxtext/kernels/ragged/ragged_gather_reduce.py
@@ -410,7 +410,14 @@ def _preprocess(
 
 
 @functools.partial(
-    jax.jit, static_argnames=("reduce_group_size", "enforce_fallback", "flops_override", "bytes_accessed_override")
+    jax.jit,
+    static_argnames=(
+        "reduce_group_size",
+        "enforce_fallback",
+        "flops_override",
+        "bytes_accessed_override",
+        "use_single_sparsecore",
+    ),
 )
 def ragged_gather_reduce(
     x: jax.Array,
@@ -421,6 +428,7 @@ def ragged_gather_reduce(
     enforce_fallback: bool = False,
     flops_override: int = -1,
     bytes_accessed_override: int = -1,
+    use_single_sparsecore: bool = False,
 ) -> jax.Array:
   """Gathers `x` according to `indices`, applies weights and masks, and reduces.
 
@@ -474,7 +482,8 @@ def ragged_gather_reduce(
   hidden_size = x.shape[-1]
   input_size = indices.size
   num_simd_lanes = sc_info.num_lanes
-  num_cores = sc_info.num_cores * sc_info.num_subcores
+  num_sc_cores = 1 if use_single_sparsecore else sc_info.num_cores
+  num_cores = num_sc_cores * sc_info.num_subcores
 
   # This kernel partitions the output's columns into `num_column_partitions`
   # and partition the output's rows into `num_row_partitions` and run each
@@ -528,7 +537,7 @@ def ragged_gather_reduce(
   )
 
   vector_mesh = plsc.VectorSubcoreMesh(
-      num_cores=sc_info.num_cores,
+      num_cores=num_sc_cores,
       num_subcores=sc_info.num_subcores,
       core_axis_name="core",
       subcore_axis_name="subcore",

--- a/src/maxtext/kernels/ragged/ragged_gather_reduce_v2.py
+++ b/src/maxtext/kernels/ragged/ragged_gather_reduce_v2.py
@@ -625,7 +625,14 @@ def main_kernel(
 
 
 @functools.partial(
-    jax.jit, static_argnames=("reduce_group_size", "enforce_fallback", "flops_override", "bytes_accessed_override")
+    jax.jit,
+    static_argnames=(
+        "reduce_group_size",
+        "enforce_fallback",
+        "flops_override",
+        "bytes_accessed_override",
+        "use_single_sparsecore",
+    ),
 )
 def ragged_gather_reduce(
     x: jax.Array,
@@ -636,6 +643,7 @@ def ragged_gather_reduce(
     enforce_fallback: bool = False,
     flops_override: int = -1,
     bytes_accessed_override: int = -1,
+    use_single_sparsecore: bool = False,
 ) -> jax.Array:
   """Gathers ``x`` by ``indices``, weights and masks, then reduces by group.
 
@@ -673,7 +681,8 @@ def ragged_gather_reduce(
   input_size = indices.size
   num_simd_lanes = sc_info.num_lanes
   num_lanes = pltpu.get_tpu_info().num_lanes
-  num_cores = sc_info.num_cores * sc_info.num_subcores
+  num_sc_cores = 1 if use_single_sparsecore else sc_info.num_cores
+  num_cores = num_sc_cores * sc_info.num_subcores
 
   num_column_partitions = _calculate_num_column_partitions(hidden_size, input_size, num_cores, num_lanes, num_simd_lanes)
   num_row_partitions = num_cores // num_column_partitions
@@ -711,7 +720,7 @@ def ragged_gather_reduce(
 
   # Step 4: Launch the SparseCore kernel.
   vector_mesh = plsc.VectorSubcoreMesh(
-      num_cores=sc_info.num_cores,
+      num_cores=num_sc_cores,
       num_subcores=sc_info.num_subcores,
       core_axis_name="core",
       subcore_axis_name="subcore",

--- a/src/maxtext/kernels/ragged/ragged_sort.py
+++ b/src/maxtext/kernels/ragged/ragged_sort.py
@@ -34,6 +34,7 @@ def ring_ragged_sort(
     gather_reduce_flops_override=-1,
     gather_bytes_accessed_override=-1,
     gather_reduce_bytes_accessed_override=-1,
+    use_single_sparsecore=False,
 ):
   """Ragged-gather variant for AG-RS Expert Parallelism token routing.
 
@@ -111,6 +112,7 @@ def ring_ragged_sort(
           enforce_fallback=enforce_gather_fallback,
           flops_override=gather_flops_override,
           bytes_accessed_override=gather_bytes_accessed_override,
+          use_single_sparsecore=use_single_sparsecore,
       )
     else:
       local_buffer_size = buffer_size
@@ -134,6 +136,7 @@ def ring_ragged_sort(
           enforce_fallback=enforce_gather_fallback,
           flops_override=gather_flops_override,
           bytes_accessed_override=gather_bytes_accessed_override,
+          use_single_sparsecore=use_single_sparsecore,
       )
 
     out = (x, group_sizes_local, topk_argsort_revert_indices)
@@ -188,6 +191,7 @@ def ring_ragged_sort(
           enforce_fallback=enforce_gather_reduce_fallback,
           flops_override=gather_reduce_flops_override,
           bytes_accessed_override=gather_reduce_bytes_accessed_override,
+          use_single_sparsecore=use_single_sparsecore,
       )
     else:
       # Buffering: g_x has size `local_buffer_size` (packed).
@@ -213,6 +217,7 @@ def ring_ragged_sort(
           enforce_fallback=enforce_gather_reduce_fallback,
           flops_override=gather_reduce_flops_override,
           bytes_accessed_override=gather_reduce_bytes_accessed_override,
+          use_single_sparsecore=use_single_sparsecore,
       )
     return grad_hidden_states, None
 
@@ -235,6 +240,7 @@ def ring_ragged_unsort(
     gather_reduce_flops_override=-1,
     gather_bytes_accessed_override=-1,
     gather_reduce_bytes_accessed_override=-1,
+    use_single_sparsecore=False,
 ):
   """Dual of :func:`ring_ragged_sort`.
 
@@ -266,14 +272,27 @@ def ring_ragged_unsort(
   """
 
   @jax.custom_vjp
-  def _ring_ragged_unsort(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices, topk_weights_flat):
+  def _ring_ragged_unsort(
+      sorted_tokens_local,
+      group_sizes_local,
+      topk_argsort_revert_indices,
+      topk_weights_flat,
+  ):
     """Unsort and scatter activations."""
     return _ring_ragged_unsort_fwd(
-        sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices, topk_weights_flat
+        sorted_tokens_local,
+        group_sizes_local,
+        topk_argsort_revert_indices,
+        topk_weights_flat,
     )[0]
 
   @jax.named_scope("ragged-unsort-fwd")
-  def _ring_ragged_unsort_fwd(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices, topk_weights_flat):
+  def _ring_ragged_unsort_fwd(
+      sorted_tokens_local,
+      group_sizes_local,
+      topk_argsort_revert_indices,
+      topk_weights_flat,
+  ):
     """Executes unsorting sending tokens back."""
     group_offsets = jnp.cumulative_sum(group_sizes_local, include_initial=True)
 
@@ -309,6 +328,7 @@ def ring_ragged_unsort(
           enforce_fallback=enforce_gather_reduce_fallback,
           flops_override=gather_reduce_flops_override,
           bytes_accessed_override=gather_reduce_bytes_accessed_override,
+          use_single_sparsecore=use_single_sparsecore,
       )
     else:
       # Shift indices so they map to the packed local buffer [0, local_num_tokens).
@@ -327,6 +347,7 @@ def ring_ragged_unsort(
           enforce_fallback=enforce_gather_reduce_fallback,
           flops_override=gather_reduce_flops_override,
           bytes_accessed_override=gather_reduce_bytes_accessed_override,
+          use_single_sparsecore=use_single_sparsecore,
       )
 
     res = (
@@ -385,6 +406,7 @@ def ring_ragged_unsort(
           enforce_fallback=enforce_gather_fallback,
           flops_override=gather_flops_override,
           bytes_accessed_override=gather_bytes_accessed_override,
+          use_single_sparsecore=use_single_sparsecore,
       )
       # Mask out gradients that correspond to elements outside the valid shard
       # output range.
@@ -408,6 +430,7 @@ def ring_ragged_unsort(
           enforce_fallback=enforce_gather_fallback,
           flops_override=gather_flops_override,
           bytes_accessed_override=gather_bytes_accessed_override,
+          use_single_sparsecore=use_single_sparsecore,
       )
       # Mask out gradients for elements beyond the valid limit of the local buffer.
       limit = jnp.minimum(shard_output_end - shard_output_start, buffer_size)
@@ -420,10 +443,22 @@ def ring_ragged_unsort(
   # Build the flat weights array from the routing weights.
   topk_weights_flat = topk_weights.astype(jnp.float32)
 
-  return _ring_ragged_unsort(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices, topk_weights_flat)
+  return _ring_ragged_unsort(
+      sorted_tokens_local,
+      group_sizes_local,
+      topk_argsort_revert_indices,
+      topk_weights_flat,
+  )
 
 
-def a2a_ragged_sort(inputs, sort_indices, valid_end, enforce_gather_fallback=False, enforce_gather_reduce_fallback=False):
+def a2a_ragged_sort(
+    inputs,
+    sort_indices,
+    valid_end,
+    enforce_gather_fallback=False,
+    enforce_gather_reduce_fallback=False,
+    use_single_sparsecore=False,
+):
   """Ragged-gather variant for ``local_permute``.
 
   Unlike :func:`ring_ragged_sort`, the rows valid for this shard live in
@@ -463,7 +498,13 @@ def a2a_ragged_sort(inputs, sort_indices, valid_end, enforce_gather_fallback=Fal
   def _a2a_ragged_sort_fwd(inputs, sort_indices, valid_end):
     start = jnp.int32(0)
     end = valid_end.astype(jnp.int32) if hasattr(valid_end, "astype") else jnp.int32(valid_end)
-    out = ragged_gather(inputs, sort_indices, start[None], end[None])
+    out = ragged_gather(
+        inputs,
+        sort_indices,
+        start[None],
+        end[None],
+        use_single_sparsecore=use_single_sparsecore,
+    )
     n = sort_indices.shape[0]
     valid_mask = jnp.arange(n) < end
     out = jnp.where(valid_mask[:, None], out, 0.0)
@@ -487,6 +528,7 @@ def a2a_ragged_sort(inputs, sort_indices, valid_end, enforce_gather_fallback=Fal
         valid_rows_mask=valid_rows_mask[idx_inv],
         reduce_group_size=1,
         enforce_fallback=enforce_gather_reduce_fallback,
+        use_single_sparsecore=use_single_sparsecore,
     )
     # custom_vjp must return one gradient per primal arg; valid_end is integer
     # and non-differentiable, so we return None for it.
@@ -497,7 +539,12 @@ def a2a_ragged_sort(inputs, sort_indices, valid_end, enforce_gather_fallback=Fal
 
 
 def a2a_ragged_unsort(
-    sorted_tokens, revert_indices, valid_end, enforce_gather_fallback=False, enforce_gather_reduce_fallback=False
+    sorted_tokens,
+    revert_indices,
+    valid_end,
+    enforce_gather_fallback=False,
+    enforce_gather_reduce_fallback=False,
+    use_single_sparsecore=False,
 ):
   """Dual of :func:`a2a_ragged_sort`.
 
@@ -540,6 +587,7 @@ def a2a_ragged_unsort(
         valid_rows_mask=valid_rows_mask,
         reduce_group_size=1,
         enforce_fallback=enforce_gather_reduce_fallback,
+        use_single_sparsecore=use_single_sparsecore,
     )
     res = (revert_indices, end, sorted_tokens.shape, start)
     return out, res
@@ -551,7 +599,13 @@ def a2a_ragged_unsort(
     # Because revert_indices is a permutation, build the inverse and use
     # ragged_gather to pull the per-row gradients to the right positions.
     idx_inv = jnp.argsort(revert_indices)
-    grad_sorted = ragged_gather(g_out, idx_inv, start[None], end[None])
+    grad_sorted = ragged_gather(
+        g_out,
+        idx_inv,
+        start[None],
+        end[None],
+        use_single_sparsecore=use_single_sparsecore,
+    )
     num_rows = sorted_tokens_shape[0]
     pos = jnp.arange(num_rows)
     valid = pos < end

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -917,6 +917,7 @@ class RoutedMoE(nnx.Module):
           gather_reduce_flops_override=self.config.ragged_gather_reduce_cost_estimate_flops,
           gather_bytes_accessed_override=self.config.ragged_gather_cost_estimate_bytes_accessed,
           gather_reduce_bytes_accessed_override=self.config.ragged_gather_reduce_cost_estimate_bytes_accessed,
+          use_single_sparsecore=self.config.ragged_sort_use_single_sparsecore,
       )
     else:
       flatten_selected_experts = jnp.ravel(selected_experts)
@@ -1005,6 +1006,7 @@ class RoutedMoE(nnx.Module):
           gather_reduce_flops_override=self.config.ragged_gather_reduce_cost_estimate_flops,
           gather_bytes_accessed_override=self.config.ragged_gather_cost_estimate_bytes_accessed,
           gather_reduce_bytes_accessed_override=self.config.ragged_gather_reduce_cost_estimate_bytes_accessed,
+          use_single_sparsecore=self.config.ragged_sort_use_single_sparsecore,
       )
     else:
       unsort_intermediate = _sort_activations(
@@ -1069,6 +1071,7 @@ class RoutedMoE(nnx.Module):
       use_custom_sort_vjp=True,
       use_ragged_sort=False,
       ragged_buffer_factor=-1.0,
+      use_single_sparsecore=False,
   ):
     """Permutes tokens locally within an expert shard.
 
@@ -1152,7 +1155,12 @@ class RoutedMoE(nnx.Module):
       # the worst-case ragged buffer. Restricting the gather to that prefix
       # makes both forward and backward proportional to the routed token count.
       valid_end = jnp.sum(local_group_size).astype(jnp.int32)
-      sorted_inputs = a2a_ragged_sort(inputs, sorted_indices, valid_end)
+      sorted_inputs = a2a_ragged_sort(
+          inputs,
+          sorted_indices,
+          valid_end,
+          use_single_sparsecore=use_single_sparsecore,
+      )
     else:
       sorted_inputs = _sort_activations(inputs, sorted_indices, use_custom_sort_vjp)
     sorted_experts_ids = expert_indices[sorted_indices]
@@ -1762,6 +1770,7 @@ class RoutedMoE(nnx.Module):
               use_custom_sort_vjp=self.config.use_custom_sort_vjp,
               use_ragged_sort=self.config.use_ragged_sort,
               ragged_buffer_factor=self.config.ragged_buffer_factor,
+              use_single_sparsecore=self.config.ragged_sort_use_single_sparsecore,
           )
         else:
           x, local_sorted_indices, group_sizes, selected_experts = RoutedMoE.local_permute(
@@ -1774,6 +1783,7 @@ class RoutedMoE(nnx.Module):
               use_custom_sort_vjp=self.config.use_custom_sort_vjp,
               use_ragged_sort=self.config.use_ragged_sort,
               ragged_buffer_factor=self.config.ragged_buffer_factor,
+              use_single_sparsecore=self.config.ragged_sort_use_single_sparsecore,
           )
 
       return (
@@ -1959,6 +1969,7 @@ class RoutedMoE(nnx.Module):
               intermediate_output,
               jnp.argsort(route_metadata.local_sorted_indices),  # pylint: disable=undefined-variable
               valid_end,
+              use_single_sparsecore=self.config.ragged_sort_use_single_sparsecore,
           )
         else:
           local_output = _sort_activations(

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -753,6 +753,7 @@ class RoutedMoeTest(unittest.TestCase):
       ragged_buffer_factor: float = -1.0,
       ragged_gather_fallback: bool = False,
       ragged_gather_reduce_fallback: bool = False,
+      ragged_sort_use_single_sparsecore: bool = False,
   ):
     """Loss and gradient correctness for the use_ragged_sort flag.
 
@@ -786,6 +787,7 @@ class RoutedMoeTest(unittest.TestCase):
           ragged_buffer_factor=effective_buffer_factor,
           ragged_gather_fallback=ragged_gather_fallback,
           ragged_gather_reduce_fallback=ragged_gather_reduce_fallback,
+          ragged_sort_use_single_sparsecore=ragged_sort_use_single_sparsecore,
       )
 
     def _build_model(cfg, mesh):
@@ -896,6 +898,14 @@ class RoutedMoeTest(unittest.TestCase):
     self._run_ragged_sort_loss_and_grad(
         use_ring_of_experts=False, ragged_gather_fallback=True, ragged_gather_reduce_fallback=True
     )
+
+  @pytest.mark.tpu_only
+  def test_ragged_sort_single_sparsecore_ring_of_experts(self):
+    self._run_ragged_sort_loss_and_grad(use_ring_of_experts=True, ragged_sort_use_single_sparsecore=True)
+
+  @pytest.mark.tpu_only
+  def test_ragged_sort_single_sparsecore_no_ring_of_experts(self):
+    self._run_ragged_sort_loss_and_grad(use_ring_of_experts=False, ragged_sort_use_single_sparsecore=True)
 
   @pytest.mark.tpu_only
   def test_moe_fsdp_two_stage_parallelism_tpu_only(self):


### PR DESCRIPTION
### Motivation
If token sorting runs on both SparseCores, it can interfere with FSDP all-gather scheduling and prevent overlap (e.g. custom Qwen model).
We add `ragged_sort_use_single_sparsecore` to restrict token sorting kernels to 1 SparseCore core.

### Performance Impact & XProf Benchmark
- **`sc_ragged_gather` (Forward)**: 51.5 µs → 97.6 µs (~1.89x)
- **`sc_ragged_gather_reduce` (Backward)**: 583.4 µs → 1,045.6 µs (~1.79x)

### XProf Traces
- **Baseline (2 SparseCores)**: https://xprof.corp.google.com/?session_id=shuwenf-12635063694751230364
- **Single SparseCore (`ragged_sort_use_single_sparsecore=True`)**: https://xprof.corp.google.com/?session_id=shuwenf-7290787811420351875

bug: b/525027581

# Checklist
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
