### PR TITLE
Fix NNX MTP zero-loss, qwix MTP crash, and DeepSeek scan-axis sharding corruption

### DIFF
--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -998,13 +998,9 @@ class NNXDecoder(nnx.Module):
       final_carry, scanned_state = jax.lax.scan(layer_fn_wrapped, x_in, (params, state))
       returned_kv_stacked = None
 
-      # Ensure metadata rank matches the stacked values
-      scanned_state = maxtext_utils_nnx.nnx_add_scan_axis(scanned_state, "layers", 0)
-
-      if scan_axis != 0:
-        new_params, new_rest = scanned_state.split(nnx.Param, ...)
-        new_params = maxtext_utils_nnx.nnx_sync_moveaxis(new_params, 0, scan_axis)
-        scanned_state = nnx.merge_state(new_params, new_rest)
+      # Move the scan axis to each variable's param_scan_axis and restore its name
+      # in the sharding metadata. jax.lax.scan emits it at position 0.
+      scanned_state = maxtext_utils_nnx.nnx_add_and_sync_scan_axis(scanned_state, "layers")
 
       returned_kv_stacked = None
 

--- a/src/maxtext/layers/quantizations.py
+++ b/src/maxtext/layers/quantizations.py
@@ -861,6 +861,12 @@ def maybe_quantize_model(model, config):
         dummy_tokens = jnp.ones(input_shape, dtype=jnp.int32)
         dummy_positions = jnp.ones(input_shape, dtype=jnp.int32)
         dummy_segment_ids = jnp.ones(input_shape, dtype=jnp.int32)
+        # The MTP block reads the decoder targets, so the qwix forward pass needs them.
+        # The Linen path supplies them from the is_initializing() guard in Transformer.
+        dummy_targets = {}
+        if config.mtp_num_layers > 0:
+          dummy_targets["decoder_target_tokens"] = jnp.ones(input_shape, dtype=jnp.int32)
+          dummy_targets["decoder_target_mask"] = jnp.ones(input_shape, dtype=jnp.int32)
         model = qwix.quantize_model(
             model,
             quantization_provider,
@@ -868,6 +874,7 @@ def maybe_quantize_model(model, config):
             dummy_positions,
             dummy_segment_ids,
             enable_dropout=False,
+            **dummy_targets,
         )
         # Qwix quantization runs a forward pass during tracing, which sows transient nnx.Intermediate variables
         # (e.g. max_logits from QK-Clip, MTP losses) into the model. Popping them here prevents structural mismatches

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -197,18 +197,22 @@ def loss_fn(model, config, data, dropout_rng, params, sparsity_state=None, is_tr
         decoder_target_tokens=data["targets"],
         decoder_target_mask=data["targets_segmentation"],
     )
+    # mtp_losses and mtp_acceptance subclass nnx.Intermediate, and nnx type filters match
+    # subclasses. Pop them before the generic Intermediate pop below, which would otherwise
+    # take them too and leave the MTP loss silently reading as 0.
+    mtp_losses_state, mtp_acceptance_state = None, None
+    if config.mtp_num_layers > 0:
+      mtp_losses_state = nnx.pop(model, mtp_losses)
+      mtp_acceptance_state = nnx.pop(model, mtp_acceptance)
+
     intermediates = nnx.pop(model, nnx.Intermediate)
     intermediate_outputs = intermediates.to_pure_dict()
 
-    # MTP sows mtp_losses/mtp_acceptance as custom Variable subclasses, not
-    # Intermediate, so the nnx.pop above misses them. Pop them here under their
-    # collection names so calculate_mtp_loss / calculate_mtp_acceptance_rate
-    # find them. Otherwise the MTP loss is silently zeroed. They are also
-    # excluded from the returned state below so they don't leak into
-    # out_shardings.
-    if config.mtp_num_layers > 0:
-      intermediate_outputs["mtp_losses"] = nnx.pop(model, mtp_losses).to_pure_dict()
-      intermediate_outputs["mtp_acceptance"] = nnx.pop(model, mtp_acceptance).to_pure_dict()
+    # Store them under the collection name so calculate_mtp_loss and
+    # calculate_mtp_acceptance_rate find them at the same path as the Linen collections.
+    if mtp_losses_state is not None and mtp_acceptance_state is not None:
+      intermediate_outputs["mtp_losses"] = mtp_losses_state.to_pure_dict()
+      intermediate_outputs["mtp_acceptance"] = mtp_acceptance_state.to_pure_dict()
 
     if (config.use_indexer and not config.indexer_sparse_training) and is_train:
       # In Dense Warm-up stage, we skip main model loss calculation for efficiency.

--- a/src/maxtext/utils/maxtext_utils_nnx.py
+++ b/src/maxtext/utils/maxtext_utils_nnx.py
@@ -218,33 +218,6 @@ def nnx_update_sharding_meta(variable, transform_fn):
   return variable
 
 
-def nnx_sync_moveaxis(tree, from_axis, to_axis):
-  """Moves an axis in both values and sharding metadata of nnx.Variables."""
-  if from_axis == to_axis:
-    return tree
-
-  def _op(x):
-    is_var = isinstance(x, nnx.Variable)
-    val = x.get_value() if is_var else x
-    if not hasattr(val, "shape"):
-      return x
-
-    new_val = jnp.moveaxis(val, from_axis, to_axis)
-    if not is_var:
-      return new_val
-
-    def move_fn(l):
-      while len(l) < val.ndim:
-        l.append(None)
-      if len(l) > max(from_axis, to_axis):
-        l.insert(to_axis, l.pop(from_axis))
-      return l
-
-    return nnx_update_sharding_meta(x.replace(value=new_val), move_fn)
-
-  return jax.tree.map(_op, tree, is_leaf=lambda x: isinstance(x, nnx.Variable) or hasattr(x, "shape"))
-
-
 def nnx_remove_scan_axis(tree, name="layers"):
   """Removes the given scan axis from the PartitionSpec."""
 
@@ -252,11 +225,25 @@ def nnx_remove_scan_axis(tree, name="layers"):
     if not isinstance(x, nnx.Variable):
       return x
 
+    # Scanned stacks record their own axis name, such as "dense_layers" or "moe_layers",
+    # so prefer it over the caller's default. Otherwise the name never matches and the
+    # check below strips a real logical axis instead of the scan axis.
+    axis_name = x.get_metadata().get(nnx.PARTITION_NAME, name)
+
     def remove_fn(l):
-      if name in l:
-        l.remove(name)
-      while len(l) > x.get_value().ndim:
-        l.pop(0)
+      removed = axis_name in l
+      if removed:
+        l.remove(axis_name)
+      if len(l) > x.get_value().ndim:
+        if removed:
+          raise ValueError(
+              f"Sharding names {l} still exceed value rank {x.get_value().ndim} after removing scan axis "
+              f"{axis_name!r}; the partition metadata is inconsistent."
+          )
+        raise ValueError(
+            f"Scan axis {axis_name!r} not found in sharding names {l} for a rank-{x.get_value().ndim} value; "
+            "the partition metadata is inconsistent."
+        )
       return l
 
     return nnx_update_sharding_meta(x, remove_fn)
@@ -264,18 +251,31 @@ def nnx_remove_scan_axis(tree, name="layers"):
   return jax.tree.map(_op, tree, is_leaf=lambda x: isinstance(x, nnx.Variable))
 
 
-def nnx_add_scan_axis(tree, name="layers", pos=0):
-  """Adds the given scan axis to the PartitionSpec at the specified position."""
+def nnx_add_and_sync_scan_axis(tree, name="layers", pos=0):
+  """Restores the scan axis on each variable's value and sharding metadata.
+
+  jax.lax.scan stacks its outputs with the scan axis at position 0. For each
+  variable this moves that axis to the variable's own param_scan_axis (falling
+  back to pos when the metadata is absent) and inserts the matching axis name at
+  the same position, so the value and its sharding metadata stay aligned.
+  """
 
   def _op(x):
     if not isinstance(x, nnx.Variable):
       return x
 
+    axis_name = x.get_metadata().get(nnx.PARTITION_NAME, name)
+    target = x.get_metadata().get("param_scan_axis", pos)
+
+    val = x.get_value()
+    if target != 0 and hasattr(val, "ndim") and val.ndim > target:
+      x = x.replace(value=jnp.moveaxis(val, 0, target))
+
     def add_fn(l):
-      if name not in l:
+      if axis_name not in l:
         while len(l) < x.get_value().ndim - 1:
           l.append(None)
-        l.insert(pos, name)
+        l.insert(target, axis_name)
       else:
         while len(l) < x.get_value().ndim:
           l.append(None)

--- a/tests/unit/maxtext_utils_nnx_test.py
+++ b/tests/unit/maxtext_utils_nnx_test.py
@@ -203,5 +203,68 @@ class TestMaxTextUtilsNNX(unittest.TestCase):
     self.assertEqual(broadcast_state["raw_array"].shape, (10,))
 
 
+def _make_scanned_param(shape, out_sharding, partition_name):
+  """Build an nnx.Param mirroring a scanned decoder variable.
+
+  DeepSeek stacks name their scan axis via nnx.PARTITION_NAME ("dense_layers" or
+  "moe_layers"), so the variable carries that name in its metadata rather than
+  the caller literal "layers". Eager sharding is disabled because the sliced
+  value rank is intentionally one less than the metadata length.
+  """
+  with nnx.use_eager_sharding(False):
+    return nnx.Param(jnp.zeros(shape), out_sharding=out_sharding, **{nnx.PARTITION_NAME: partition_name})
+
+
+class TestScanAxisMetadata(unittest.TestCase):
+  """Lock in per-variable scan-axis resolution for DeepSeek-style stacks."""
+
+  def test_nnx_remove_scan_axis_preserves_real_leading_axis(self):
+    """nnx_remove_scan_axis must drop the stack's own scan axis, not "embed"."""
+    # Metadata carries the real fsdp axis "embed" plus the scan axis
+    # "dense_layers"; the sliced value is rank-2, one less than the 3 names.
+    param = _make_scanned_param((4, 8), ("embed", "dense_layers", "mlp"), "dense_layers")
+    state = nnx.State({"kernel": param})
+
+    result = maxtext_utils_nnx.nnx_remove_scan_axis(state, "layers")
+
+    out_sharding = result["kernel"].get_metadata().get("out_sharding")
+    # The scan axis is gone and the real leading logical axis survives. The
+    # unfixed fallback pops index 0 and strips "embed" to ("dense_layers", "mlp").
+    self.assertEqual(tuple(out_sharding), ("embed", "mlp"))
+
+  def test_nnx_remove_scan_axis_moe_layers(self):
+    """The same resolution holds for the "moe_layers" stack axis name."""
+    param = _make_scanned_param((4, 8), ("embed", "moe_layers", "mlp"), "moe_layers")
+    state = nnx.State({"kernel": param})
+
+    result = maxtext_utils_nnx.nnx_remove_scan_axis(state, "layers")
+
+    out_sharding = result["kernel"].get_metadata().get("out_sharding")
+    self.assertEqual(tuple(out_sharding), ("embed", "mlp"))
+
+  def test_nnx_remove_scan_axis_raises_on_inconsistent_metadata(self):
+    """A rank mismatch with no matching scan axis is an error, not a silent pop."""
+    # No name in the metadata matches the resolved scan axis, and the metadata
+    # is one longer than the value rank; the fixed code raises instead of
+    # blindly popping a real axis.
+    param = _make_scanned_param((4, 8), ("embed", "mlp", "vocab"), "dense_layers")
+    state = nnx.State({"kernel": param})
+
+    with self.assertRaises(ValueError):
+      maxtext_utils_nnx.nnx_remove_scan_axis(state, "layers")
+
+  def test_nnx_add_and_sync_scan_axis_uses_partition_name(self):
+    """nnx_add_and_sync_scan_axis must insert the stack's own axis name, not "layers"."""
+    # Stacked value is rank-3; metadata holds the two sliced logical axes.
+    param = _make_scanned_param((2, 4, 8), ("embed", "mlp"), "dense_layers")
+    state = nnx.State({"kernel": param})
+
+    result = maxtext_utils_nnx.nnx_add_and_sync_scan_axis(state, "layers", 0)
+
+    out_sharding = result["kernel"].get_metadata().get("out_sharding")
+    # The unfixed code inserts the literal "layers" here.
+    self.assertEqual(tuple(out_sharding), ("dense_layers", "embed", "mlp"))
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/tests/unit/multi_token_prediction_test.py
+++ b/tests/unit/multi_token_prediction_test.py
@@ -23,9 +23,11 @@ from flax import nnx
 from maxtext.configs import pyconfig
 from maxtext.layers import multi_token_prediction  # The class under test
 from maxtext.layers import embeddings
+from maxtext.layers import quantizations
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.common.common_types import Config
 from maxtext.layers.nnx_decoders import NNXDecoderLayer
+from maxtext.trainers.pre_train import train as pre_train
 from maxtext.utils import max_logging
 from maxtext.utils import maxtext_utils
 
@@ -120,6 +122,24 @@ class MultiTokenPredictionLayerTest(unittest.TestCase):
     max_logging.log(f"  Output shape: {output_hidden_state.shape}")
 
 
+class _MockDecoderForMTP:
+  """A mock decoder that simulates the behavior needed by MTPBlock."""
+
+  def __init__(self, config: Config):
+    self.config = config
+    self.model_mode = MODEL_MODE_TRAIN
+
+  def _apply_embedding(self, _shared_embedding, input_ids, _position_ids, _deterministic, model_mode):
+    """Returns a zero tensor with the correct embedding shape."""
+    batch_size, seq_len = input_ids.shape
+    return jnp.zeros((batch_size, seq_len, self.config.base_emb_dim), dtype=self.config.dtype)
+
+  def apply_output_head(self, _shared_embedding, hidden_state, _deterministic, model_mode):
+    """Returns a zero tensor with the correct logit shape."""
+    batch_size, seq_len, _ = hidden_state.shape
+    return jnp.zeros((batch_size, seq_len, self.config.vocab_size), dtype=self.config.dtype)
+
+
 # A lightweight wrapper model for robustly testing the MTPBlock.
 class MTPBlockTestModel(nnx.Module):
   """A lightweight wrapper model for testing the MTPBlock."""
@@ -137,25 +157,7 @@ class MTPBlockTestModel(nnx.Module):
         rngs=self.rngs,
     )
 
-    class MockDecoderForMTP:
-      """A mock decoder that simulates the behavior needed by MTPBlock."""
-
-      def __init__(self, config: Config):
-        self.config = config
-        self.model_mode = MODEL_MODE_TRAIN
-
-      def _apply_embedding(self, _shared_embedding, input_ids, _position_ids, _deterministic, model_mode):
-        """Returns a zero tensor with the correct embedding shape."""
-        batch_size, seq_len = input_ids.shape
-        embed_dim = self.config.base_emb_dim
-        return jnp.zeros((batch_size, seq_len, embed_dim), dtype=self.config.dtype)
-
-      def apply_output_head(self, _shared_embedding, hidden_state, _deterministic, model_mode):
-        """Returns a zero tensor with the correct logit shape."""
-        batch_size, seq_len, _ = hidden_state.shape
-        return jnp.zeros((batch_size, seq_len, self.config.vocab_size), dtype=self.config.dtype)
-
-    self.decoder = MockDecoderForMTP(config=self.config)
+    self.decoder = _MockDecoderForMTP(config=self.config)
 
     self.mtp_block = multi_token_prediction.MultiTokenPredictionBlock(
         config=self.config,
@@ -381,6 +383,219 @@ class TestRollAndMask(unittest.TestCase):
     # This should result in no change to the tensor.
     rolled_by_0 = multi_token_prediction.roll_and_mask(input_tensor, shift=0)
     self.assertTrue(jnp.array_equal(rolled_by_0, input_tensor), "A shift of 0 should be a no-op.")
+
+
+class _MTPLossFnTestModel(nnx.Module):
+  """Tiny NNX model exposing the interface loss_fn's NNX branch drives.
+
+  Wraps the real MultiTokenPredictionBlock so the production loss_fn pop
+  sequence and calculate_mtp_loss run against real mtp_losses variables. The
+  decoder body and output head are mocked; only the MTP sow and pop path
+  matters for the regression under test.
+  """
+
+  def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs):
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
+    self._shared_embedding = embeddings.Embed(
+        num_embeddings=config.vocab_size,
+        num_features=config.base_emb_dim,
+        config=config,
+        mesh=mesh,
+        rngs=rngs,
+    )
+
+    self.decoder = _MockDecoderForMTP(config)
+    self.mtp_block = multi_token_prediction.MultiTokenPredictionBlock(
+        config=config,
+        mesh=mesh,
+        transformer_layer_module=NNXDecoderLayer,
+        decoder=self.decoder,
+        rngs=rngs,
+    )
+
+  def __call__(
+      self,
+      decoder_input_tokens,
+      decoder_positions,
+      decoder_segment_ids=None,
+      encoder_images=None,
+      encoder_image_masks=None,
+      enable_dropout=False,
+      decoder_target_tokens=None,
+      decoder_target_mask=None,
+  ):
+    del encoder_images, encoder_image_masks, enable_dropout
+    main_hidden_state = self._shared_embedding(decoder_input_tokens)
+    self.mtp_block(
+        self._shared_embedding,
+        main_hidden_state,
+        decoder_input_tokens,
+        decoder_target_tokens,
+        decoder_target_mask,
+        position_ids=decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        model_mode=MODEL_MODE_TRAIN,
+        deterministic=True,
+    )
+    return jnp.zeros(
+        (decoder_input_tokens.shape[0], decoder_input_tokens.shape[1], self.config.vocab_size),
+        dtype=self.config.dtype,
+    )
+
+
+class MTPLossFnZeroRegressionTest(unittest.TestCase):
+  """Regression test: the NNX loss_fn must not silently zero the MTP loss.
+
+  mtp_losses and mtp_acceptance subclass nnx.Intermediate, and nnx type filters
+  match subclasses. If the generic nnx.pop(model, nnx.Intermediate) in loss_fn
+  runs before the mtp-specific pops it consumes them, and calculate_mtp_loss
+  falls back to its 0.0 default. This drives the real production loss_fn on a
+  tiny NNX model that wraps the real MultiTokenPredictionBlock and asserts the
+  reported MTP loss is non-zero.
+  """
+
+  def setUp(self):
+    super().setUp()
+    num_devices = jax.device_count()
+    self.cfg = pyconfig.initialize(
+        [None, get_test_config_path()],
+        run_name="mtp_lossfn_zero_regression_test",
+        skip_jax_distributed_system=True,
+        mtp_num_layers=2,
+        attention="dot_product",
+        enable_dropout=False,
+        base_emb_dim=16,
+        base_mlp_dim=32,
+        base_num_query_heads=4,
+        base_num_kv_heads=4,
+        head_dim=8,
+        max_target_length=8,
+        per_device_batch_size=1,
+        vocab_size=128,
+    )
+    self.rng = jax.random.PRNGKey(43)
+    self.rngs = nnx.Rngs(params=self.rng, dropout=self.rng)
+    devices_array = maxtext_utils.create_device_mesh(self.cfg)
+    self.mesh = Mesh(devices_array, self.cfg.mesh_axes)
+
+    self.batch_size, self.seq_len = num_devices, 8
+    key = jax.random.PRNGKey(7)
+    self.data = {
+        "inputs": jax.random.randint(key, (self.batch_size, self.seq_len), 0, self.cfg.vocab_size),
+        "inputs_position": jnp.arange(self.seq_len, dtype=jnp.int32).reshape(1, -1).repeat(self.batch_size, axis=0),
+        "inputs_segmentation": jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32),
+        "targets": jax.random.randint(key, (self.batch_size, self.seq_len), 0, self.cfg.vocab_size),
+        "targets_segmentation": jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32),
+    }
+    self.model = _MTPLossFnTestModel(config=self.cfg, mesh=self.mesh, rngs=self.rngs)
+
+  def test_mtp_loss_is_nonzero_through_real_loss_fn(self):
+    """Assert the real NNX loss_fn reports a positive MTP loss (not silently zeroed)."""
+    _, aux = pre_train.loss_fn(self.model, self.cfg, self.data, None, None, is_train=True)
+    self.assertGreater(float(aux["mtp_loss"]), 0.0)
+
+
+class _TransformerWithMTP(nnx.Module):
+  """Smallest NNX model that reads decoder targets through a real MTP block.
+
+  The call signature matches what quantizations.maybe_quantize_model passes into
+  qwix.quantize_model. decoder_target_tokens and decoder_target_mask default to
+  None, mirroring the pure-NNX forward where nothing supplies them unless
+  maybe_quantize_model does.
+  """
+
+  def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs):
+    self.config = config
+    self.mesh = mesh
+    self._shared_embedding = embeddings.Embed(
+        num_embeddings=config.vocab_size,
+        num_features=config.base_emb_dim,
+        config=config,
+        mesh=mesh,
+        rngs=rngs,
+    )
+    self.decoder = _MockDecoderForMTP(config)
+    self.mtp_block = multi_token_prediction.MultiTokenPredictionBlock(
+        config=config,
+        mesh=mesh,
+        transformer_layer_module=NNXDecoderLayer,
+        decoder=self.decoder,
+        rngs=rngs,
+    )
+
+  def __call__(
+      self,
+      decoder_input_tokens,
+      decoder_positions,
+      decoder_segment_ids=None,
+      enable_dropout=False,
+      decoder_target_tokens=None,
+      decoder_target_mask=None,
+  ):
+    del enable_dropout
+    main_hidden_state = self._shared_embedding(decoder_input_tokens)
+    self.mtp_block(
+        self._shared_embedding,
+        main_hidden_state,
+        decoder_input_tokens,
+        decoder_target_tokens,
+        decoder_target_mask,
+        position_ids=decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        model_mode=MODEL_MODE_TRAIN,
+        deterministic=True,
+    )
+    return self.decoder.apply_output_head(self._shared_embedding, main_hidden_state, True, MODEL_MODE_TRAIN)
+
+
+class MaybeQuantizeModelMTPTest(unittest.TestCase):
+  """Qwix must forward dummy decoder targets so the MTP block's roll does not see None."""
+
+  def _build(self, mtp_num_layers):
+    """Builds a tiny pure-NNX model with qwix int8 quantization configured."""
+    cfg = pyconfig.initialize(
+        [None, get_test_config_path()],
+        run_name="maybe_quantize_model_mtp_test",
+        skip_jax_distributed_system=True,
+        per_device_batch_size=1,
+        mtp_num_layers=mtp_num_layers,
+        base_emb_dim=16,
+        base_mlp_dim=32,
+        base_num_query_heads=4,
+        base_num_kv_heads=4,
+        head_dim=8,
+        max_target_length=16,
+        vocab_size=32,
+        pure_nnx=True,
+        pure_nnx_decoder=True,
+        use_qwix_quantization=True,
+        quantization="int8",
+        enable_dropout=False,
+    )
+    mesh = Mesh(maxtext_utils.create_device_mesh(cfg), cfg.mesh_axes)
+    model = _TransformerWithMTP(cfg, mesh, rngs=nnx.Rngs(params=0, dropout=0, aqt=0))
+    return cfg, mesh, model
+
+  def test_quantize_with_mtp_supplies_decoder_targets(self):
+    """With MTP enabled, quantizing the model runs the qwix forward pass without error.
+
+    Before the fix, maybe_quantize_model called qwix.quantize_model without the
+    decoder targets, so the MTP block rolled a None target and jnp.roll raised a
+    TypeError during tracing.
+    """
+    cfg, mesh, model = self._build(mtp_num_layers=1)
+    with mesh:
+      quantized = quantizations.maybe_quantize_model(model, cfg)
+    self.assertIsNotNone(quantized)
+
+  def test_quantize_without_mtp_still_works(self):
+    """The mtp_num_layers=0 path (no dummy targets needed) must remain unaffected."""
+    cfg, mesh, model = self._build(mtp_num_layers=0)
+    with mesh:
+      quantized = quantizations.maybe_quantize_model(model, cfg)
+    self.assertIsNotNone(quantized)
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_maxtext_utils_nnx.py
+++ b/tests/utils/test_maxtext_utils_nnx.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Tests for NNX utilities. """
+"""Tests for NNX utilities."""
 
 import unittest
 from flax import nnx
@@ -23,30 +23,6 @@ from maxtext.utils import maxtext_utils_nnx  # pylint: disable=no-name-in-module
 
 class TestMaxtextUtilsNnx(unittest.TestCase):
   """Tests for maxtext_utils_nnx."""
-
-  def test_nnx_sync_moveaxis(self):
-    val = jnp.zeros((10, 20, 30))
-    sharding = P("layers", "embed", None)
-
-    var = nnx.Param(val)
-    var.set_metadata(out_sharding=sharding)
-
-    moved_var = maxtext_utils_nnx.nnx_sync_moveaxis(var, 0, 2)
-
-    self.assertEqual(moved_var.get_value().shape, (20, 30, 10))
-    self.assertEqual(moved_var.get_metadata().get("out_sharding"), P("embed", None, "layers"))
-
-  def test_nnx_sync_moveaxis_missing_trailing(self):
-    val = jnp.zeros((10, 20, 30))
-    sharding = P("layers", "embed")  # missing trailing None
-
-    var = nnx.Param(val)
-    var.set_metadata(out_sharding=sharding)
-
-    moved_var = maxtext_utils_nnx.nnx_sync_moveaxis(var, 0, 2)
-
-    self.assertEqual(moved_var.get_value().shape, (20, 30, 10))
-    self.assertEqual(moved_var.get_metadata().get("out_sharding"), P("embed", None, "layers"))
 
   def test_nnx_remove_scan_axis(self):
     val = jnp.zeros((10, 20))
@@ -63,7 +39,7 @@ class TestMaxtextUtilsNnx(unittest.TestCase):
     self.assertEqual(fixed_var.get_value().ndim, 1)
     self.assertEqual(fixed_var.get_metadata().get("out_sharding"), P("embed"))
 
-  def test_nnx_add_scan_axis(self):
+  def test_nnx_add_and_sync_scan_axis(self):
     val = jnp.zeros((20,))
     sharding = P("embed")
     var = nnx.Param(val)
@@ -73,12 +49,12 @@ class TestMaxtextUtilsNnx(unittest.TestCase):
     stacked_val = jnp.stack([val] * 10, axis=0)
     var_with_stacked_val = var.replace(value=stacked_val)
 
-    fixed_var = maxtext_utils_nnx.nnx_add_scan_axis(var_with_stacked_val, "layers", 0)
+    fixed_var = maxtext_utils_nnx.nnx_add_and_sync_scan_axis(var_with_stacked_val, "layers", 0)
 
     self.assertEqual(fixed_var.get_value().ndim, 2)
     self.assertEqual(fixed_var.get_metadata().get("out_sharding"), P("layers", "embed"))
 
-  def test_nnx_add_scan_axis_missing_trailing(self):
+  def test_nnx_add_and_sync_scan_axis_missing_trailing(self):
     val = jnp.zeros((20, 30))
     sharding = P("embed")  # missing trailing None for 2D
     var = nnx.Param(val)
@@ -88,7 +64,7 @@ class TestMaxtextUtilsNnx(unittest.TestCase):
     stacked_val = jnp.stack([val] * 10, axis=0)
     var_with_stacked_val = var.replace(value=stacked_val)
 
-    fixed_var = maxtext_utils_nnx.nnx_add_scan_axis(var_with_stacked_val, "layers", 0)
+    fixed_var = maxtext_utils_nnx.nnx_add_and_sync_scan_axis(var_with_stacked_val, "layers", 0)
 
     self.assertEqual(fixed_var.get_value().ndim, 3)
     self.assertEqual(fixed_var.get_metadata().get("out_sharding"), P("layers", "embed", None))


### PR DESCRIPTION

Fixes three bugs in the NNX path surfaced by running DeepSeek-V3 with multi-token prediction. They are independent; the third is not an MTP bug at all and was hiding behind the second.

## 1. `mtp_loss` is silently 0 under NNX (b/535659954)

`mtp_losses` / `mtp_acceptance` subclass `nnx.Intermediate`, and NNX type filters match by `isinstance`. So the generic `nnx.pop(model, nnx.Intermediate)` in `loss_fn` consumed them before the dedicated pop ran, which then returned `{}`; `calculate_mtp_loss` fell through to its `return 0.0` default. No error, just a wrong number.

The comment claiming these variables are "not Intermediate, so the nnx.pop above misses them" was the false premise behind the bug.

Fix: pop the specific subclasses before the generic `nnx.Intermediate` pop. Linen is unaffected — it keys mutable collections by literal name.

## 2. `TypeError: roll requires ndarray ... got NoneType` with qwix (b/535662227)

NNX modules are stateful, so `qwix.quantize_model` must run a real forward pass. MaxText passed only tokens/positions/segment_ids, so the MTP block received `target_ids=None` and `jnp.roll` raised. Linen never hits this because `quantize_linen_model` rejects model inputs and never traces a forward.

Fix: supply dummy targets at that call site, gated on `mtp_num_layers > 0`, restoring the semantics of the `is_initializing()` guard that the NNX port left commented out in `models.py`.

## 3. DeepSeek params silently replicated under NNX (pre-existing)

Surfaced once (2) was fixed: `AssertionError: Unsharded parameter percentage (2.60%) exceeds tolerance (2.00%)`.

`_create_scanned_layers` records each stack's axis name in `nnx.PARTITION_NAME` — `dense_layers` / `moe_layers` for DeepSeek — but `_apply_layers_sequentially` hardcoded the literal `"layers"` when round-tripping the scan axis. The name never matched, so the fallback `while len(l) > ndim: l.pop(0)` deleted the real leading logical axis and `nnx_add_scan_axis` inserted a bogus `'layers'`:

```
decoder/dense_layers/mlp/wi_0/kernel
  before: ('embed', 'dense_layers', 'mlp')
  after : ('dense_layers', 'layers', 'mlp')   <- after ONE forward pass
```

`'embed'` is the only carrier of `fsdp`, so the params became `P(None, ...)`.

This is neither an MTP bug nor a qwix bug: it reproduces at `mtp_num_layers=0` and with qwix entirely absent (29 of 32 params corrupted by a single plain forward). It normally stays invisible because `get_abstract_state_nnx` snapshots shardings before the first train step, so the damage lands on a discarded traced copy. qwix makes it fatal only because it quantizes from inside model construction, i.e. inside the traced snapshot. Standard models pass `metadata_axis_name="layers"`, matching the literal — only DeepSeek-style multi-stack models are exposed.

Fix: resolve the axis name per-variable from `nnx.PARTITION_NAME` rather than a caller literal, and raise instead of blindly stripping an axis when the metadata is inconsistent. Flax's own `nnx.spmd.remove_axis` raises on this same mismatch; this reimplementation corrupted silently.

`sharding_tolerance` is untouched — the params are genuinely sharded again.

FIXES: b/535662227
FIXES: b/535659954


## Test
```
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
  base_output_directory=/home/wanglance_google_com/tmp/out run_name=nnx_mtp \
  model_name=deepseek3-tiny per_device_batch_size=1 max_target_length=128 steps=20 \
  dataset_type=synthetic enable_checkpointing=false sparse_matmul=false \
  mtp_num_layers=1 mtp_loss_scaling_factor=0.1
```
+ `enable_nnx=false pure_nnx_decoder=false pure_nnx=false` for Linen, + `use_qwix_quantization=true quantization=fp8_full` for qwix.

- [nnx_mtp](https://paste.googleplex.com/4724701682335744)
- [nnx_mtp_qwix](https://paste.googleplex.com/6535000483823616)
- [linen_mtp](https://paste.googleplex.com/6555822703378432)
- [linen_mtp_qwix](https://paste.googleplex.com/4700876357894144)


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
