### PR TITLE
Add forward_pass_compile_test script

### DIFF
--- a/tests/utils/decode_compile.py
+++ b/tests/utils/decode_compile.py
@@ -1,0 +1,138 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A command-line tool to compile and analyze MaxText inference (prefill and decode).
+
+This script performs ahead-of-time (AOT) or live compilation for inference routines:
+  1. Prefill step (`prefill_aot`): Processes prompt tokens and populates the KV cache.
+  2. Autoregressive decode step (`generate_aot`): Single-step token generation.
+  3. KV Cache & Inference Memory Analysis: Analyzes parameters, KV cache footprint,
+     and peak execution memory.
+
+Compilation Modes:
+  - Simulated Mesh (AOT): Set `compile_topology=<topology>` (e.g., `v5p-128`) on CPU/VM
+    to test sharding, compilation, KV cache allocation, and memory bounds without physical hardware.
+  - Active Hardware: Omit `compile_topology` when running directly on a TPU VM to compile for
+    attached physical TPU chips.
+
+Usage Examples:
+  [AOT Compilation on Simulated Mesh]
+    python tests/utils/decode_compile.py \
+        src/maxtext/configs/base.yml \
+        model_name=llama2-7b \
+        compile_topology=v5p-8 \
+        per_device_batch_size=1 \
+        max_prefill_predict_length=1024 \
+        max_target_length=2048
+
+  [Compilation on Active Hardware]
+    python tests/utils/decode_compile.py \
+        src/maxtext/configs/base.yml \
+        model_name=llama2-7b \
+        per_device_batch_size=1 \
+        max_prefill_predict_length=1024 \
+        max_target_length=2048
+
+Arguments:
+  Positional / Key-Value:
+    Standard MaxText configuration options (e.g., model_name, compile_topology,
+    per_device_batch_size, max_prefill_predict_length, max_target_length, etc.).
+"""
+
+import os
+from typing import Sequence
+
+from absl import app
+import jax
+import jax.numpy as jnp
+
+# Import MaxText modules
+from maxtext.configs import pyconfig
+from maxtext.inference.maxengine import maxengine
+from maxtext.trainers.pre_train import train_compile
+from maxtext.utils import max_utils
+
+
+def _validate_decode_config(config):
+  assert config.load_full_state_path == "", (
+      "Decode compilation operates on parameters, not full training state. "
+      "Ensure load_full_state_path is empty."
+  )
+
+
+def main(argv: Sequence[str]) -> None:
+  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
+  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
+
+  config = pyconfig.initialize(argv)
+  _validate_decode_config(config)
+  jax.config.update("jax_use_shardy_partitioner", config.shardy)
+
+  topology_mesh = train_compile.get_topology_mesh(config)
+  max_utils.print_system_information()
+
+  print("Initializing MaxEngine...", flush=True)
+  engine = maxengine.MaxEngine(config)
+
+  rng = jax.random.PRNGKey(1234)
+  rng, rng_prefill, rng_init_decode, rng_generate = jax.random.split(rng, 4)
+
+  # Abstract shapes for parameters and decode state (KV Cache)
+  abstract_params = engine.abstract_params
+  abstract_decode_state = jax.eval_shape(engine.init_decode_state, rng_init_decode)
+
+  # Dummy prefill inputs
+  prefill_length = config.max_prefill_predict_length
+  padded_tokens = jnp.zeros((prefill_length,), dtype=jnp.int32)
+  abstract_tokens = jax.ShapeDtypeStruct(padded_tokens.shape, padded_tokens.dtype)
+  true_length = prefill_length
+
+  compiler_options = max_utils.parse_libtpu_flags_to_dict(config.compile_xla_flags)
+
+  print("\n==================================================", flush=True)
+  print("1. Compiling Prefill Phase (Prompt Processing)...", flush=True)
+  print("==================================================", flush=True)
+  with jax.set_mesh(topology_mesh), topology_mesh:
+    prefill_lowered = jax.jit(engine.prefill_aot).lower(
+        abstract_params, abstract_tokens, true_length, rng_prefill
+    )
+    compiled_prefill = prefill_lowered.compile(compiler_options=compiler_options)
+
+  print("Prefill compilation complete!", flush=True)
+  print(f"Prefill Memory Analysis:\n{compiled_prefill.memory_analysis()}")
+
+  print("\n==================================================", flush=True)
+  print("2. Compiling Generate Phase (Single Autoregressive Step)...", flush=True)
+  print("==================================================", flush=True)
+  with jax.set_mesh(topology_mesh), topology_mesh:
+    generate_lowered = jax.jit(engine.generate_aot).lower(
+        abstract_params, abstract_decode_state, rng_generate
+    )
+    compiled_generate = generate_lowered.compile(compiler_options=compiler_options)
+
+  print("Generate compilation complete!", flush=True)
+  print(f"Generate Memory Analysis:\n{compiled_generate.memory_analysis()}")
+
+  print("\n==================================================", flush=True)
+  print("Inference Memory Summary", flush=True)
+  print("==================================================", flush=True)
+  print(f"Model Name:                 {config.model_name}")
+  print(f"Per-Device Batch Size:      {config.per_device_batch_size}")
+  print(f"Max Prefill Length:         {config.max_prefill_predict_length}")
+  print(f"Max Target (Total) Length:  {config.max_target_length}")
+  print("==================================================\n", flush=True)
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/tests/utils/forward_compile.py
+++ b/tests/utils/forward_compile.py
@@ -1,0 +1,144 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A command-line tool to compile and analyze the forward pass of a MaxText model.
+
+This script performs ahead-of-time (AOT) or live compilation of only the model's forward
+pass (and logit gathering across data-parallel groups) without running backward passes
+or optimizer step updates. It outputs JAX memory analysis upon completion.
+
+Compilation Modes:
+  - Simulated Mesh (AOT): Use `compile_topology=<topology>` (e.g., `v5p-128`) on CPU/VM
+    to test sharding, compilation, and HBM memory footprint without requiring physical TPU hardware.
+  - Active Hardware: Omit `compile_topology` when running directly on a TPU VM to compile for
+    attached physical TPU chips.
+
+Usage Examples:
+  [AOT Compilation on Simulated Mesh]
+    python tests/utils/forward_compile.py \
+        src/maxtext/configs/base.yml \
+        model_name=llama2-7b \
+        compile_topology=v5p-128 \
+        compile_topology_num_slices=1
+
+  [Compilation on Active Hardware]
+    python tests/utils/forward_compile.py \
+        src/maxtext/configs/base.yml \
+        model_name=llama2-7b
+
+Arguments:
+  Positional / Key-Value:
+    Standard MaxText configuration options (e.g., model_name, compile_topology,
+    ici_fsdp_parallelism, per_device_batch_size, etc.).
+"""
+
+import functools
+import os
+import sys
+from typing import Sequence
+
+from absl import app
+import jax
+import jax.numpy as jnp
+from flax.linen import partitioning as nn_partitioning
+
+# Import MaxText modules
+from maxtext.configs import pyconfig
+from maxtext.utils import max_utils
+from maxtext.trainers.pre_train import train_compile
+
+def forward_and_gather(model, config, state, batch, init_rng):
+    # Depending on pure_nnx or linen, state might just be the params
+    if config.pure_nnx:
+        # NNX logic mocking if needed, but the original script uses linen mostly
+        pass
+    
+    ids = batch.get('inputs')
+    decoder_positions = batch.get('inputs_position')
+    decoder_segment_ids = batch.get('inputs_segmentation')
+    encoder_images = batch.get('images')
+
+    params_dict = state.params
+    if "params" in getattr(params_dict, "keys", lambda: [])():
+        params_dict = params_dict["params"]
+
+    full_train_logits = model.apply(
+        {"params": params_dict},
+        ids,
+        decoder_positions,
+        decoder_segment_ids,
+        encoder_images,
+        enable_dropout=False,
+        rngs={"aqt": init_rng},
+    )
+
+    data_parallelism = max(config.ici_fsdp_parallelism, 1) * max(config.ici_data_parallelism, 1) * max(config.dcn_data_parallelism, 1) * max(config.dcn_fsdp_parallelism, 1)
+    if data_parallelism > 1:
+        full_train_logits = jax.experimental.multihost_utils.process_allgather(full_train_logits, tiled=True)
+    return full_train_logits
+
+
+def main(argv: Sequence[str]) -> None:
+    jax.config.update("jax_default_prng_impl", "unsafe_rbg")
+    
+    config = pyconfig.initialize(argv)
+    train_compile.validate_config(config)
+
+    topology_mesh = train_compile.get_topology_mesh(config)
+    max_utils.print_system_information()
+
+    (
+        shaped_train_args,
+        shaped_train_kwargs,
+        state_mesh_shardings,
+        logical_annotations,
+        model,
+    ) = train_compile.get_shaped_inputs(topology_mesh, config)
+
+    # shaped_train_args is usually (abstract_state, shaped_batch, shaped_rng)
+    abstract_state = shaped_train_args[0]
+    shaped_batch = shaped_train_args[1]
+    shaped_rng = shaped_train_args[2] if len(shaped_train_args) > 2 else jax.random.PRNGKey(0)
+
+    # Sharding for inputs
+    from maxtext.utils import sharding
+    data_sharding = sharding.get_input_data_sharding(config, topology_mesh)
+    
+    # We don't bother zero1 sharding updates because this is just a forward pass
+    in_shard = (state_mesh_shardings, data_sharding, None)
+    out_shard = None  # We don't strictly care about the output sharding constraint here
+
+    # Wrap function
+    func_to_compile = functools.partial(forward_and_gather, model, config)
+    
+    print("Jitting and compiling forward_and_gather...", flush=True)
+    
+    with jax.set_mesh(topology_mesh), topology_mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
+        jitted = jax.jit(
+            func_to_compile,
+            in_shardings=in_shard,
+            out_shardings=out_shard,
+            static_argnums=(),
+            donate_argnums=(),
+        )
+        lowered = jitted.lower(abstract_state, shaped_batch, shaped_rng)
+    
+    compiler_options = max_utils.parse_libtpu_flags_to_dict(config.compile_xla_flags)
+    compiled = lowered.compile(compiler_options=compiler_options)
+    
+    print("Jitting and compilation complete!", flush=True)
+    print(f"Memory analysis: {compiled.memory_analysis()}")
+
+if __name__ == "__main__":
+    app.run(main)


### PR DESCRIPTION
# Description

This PR introduces a standalone script to compile the forward pass logit checker offline in MaxText, enabling mathematical verification of HBM limits without incurring actual array data overhead on remote TPUs.

**Features additions:**

* **Offline CPU Compilation Script:** Added `tests/utils/forward_compile.py` to allow users to mock the parameter tree structure exactly as expected by the golden checker.
* **HBM Profiling Validation:** Incorporates XLA static compilation `lower().compile()` on the model application footprint, which yields explicit `CompiledMemoryStats` including exact byte allocations for code size, temporaries, and IO arguments, making OOM triaging infinitely easier for large parameter meshes.

# Tests

* Verified functionality directly on high-RAM CPU VMs simulating a `v6e-256` TPU mesh using `deepseek4-284b` parameterized layers to prove that the `.lower().compile()` safely projects temporary size execution vectors matching hardware capacity exactly.

**Command Executed:**
```bash
python3 tests/utils/forward_compile.py src/maxtext/configs/base.yml \
  base_output_directory=gs://snehalv-data/forward_compile_test \
  run_name=ds4-parity scan_layers=False attention=dot_product \
  per_device_batch_size=1 model_name=deepseek4-284b max_target_length=1024 \
  ici_fsdp_parallelism=1 ici_expert_parallelism=-1 weight_dtype=bfloat16 \
  dtype=bfloat16 activations_in_float32=false matmul_precision=highest \
  float32_logits=false float32_qk_product=false override_model_config=True \
  indexer_topk=4 enable_nnx=false pure_nnx=false pure_nnx_decoder=false \
  compile_topology=v6e-256 compile_topology_num_slices=1
```

**Output:**
```text
Jitting and compiling forward_and_gather...
/home/snehalv_google_com/maxtext/tests/utils/forward_compile.py:82: DeprecationWarning: `with mesh:` context manager has been deprecated. Please use `with jax.set_mesh(mesh):` instead.
  with jax.set_mesh(topology_mesh), topology_mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
Jitting and compilation complete!
Memory analysis: CompiledMemoryStats(generated_code_size_in_bytes=1627936768, argument_size_in_bytes=5260023808, output_size_in_bytes=529530880, alias_size_in_bytes=0, temp_size_in_bytes=4745168512, host_generated_code_size_in_bytes=0, host_argument_size_in_bytes=0, host_output_size_in_bytes=0, host_alias_size_in_bytes=0, host_temp_size_in_bytes=0)
```

# Checklist

* [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
* [x] I have necessary comments in my code, particularly in hard-to-understand areas.
* [x] I have run end-to-end tests and provided workload links above if applicable.
* [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in our documentation.
