### PR TITLE
Fix GPU Docker build by dynamically adding NVIDIA CUDA repository keyring

### DIFF
--- a/src/dependencies/dockerfiles/maxtext_gpu_dependencies.Dockerfile
+++ b/src/dependencies/dockerfiles/maxtext_gpu_dependencies.Dockerfile
@@ -27,6 +27,10 @@ RUN apt-get update && apt-get install -y google-cloud-sdk
 ENV PATH="/usr/local/google-cloud-sdk/bin:${PATH}"
 
 # Upgrade libcusprase to work with Jax
+RUN . /etc/os-release && \
+    curl -LO https://developer.download.nvidia.com/compute/cuda/repos/${ID}${VERSION_ID//./}/x86_64/cuda-keyring_1.1-1_all.deb && \
+    dpkg -i cuda-keyring_1.1-1_all.deb && \
+    rm cuda-keyring_1.1-1_all.deb
 RUN apt-get update && apt-get install -y libcusparse-13-2
 
 ARG MODE


### PR DESCRIPTION
# Description

This PR resolves the `E: Unable to locate package libcusparse-13-2` build failure in `maxtext_gpu_dependencies.Dockerfile`.

## Cause of the Issue

The base image `ghcr.io/nvidia/jax:base` (which runs Ubuntu 24.04 Noble) does not come pre-configured with the active NVIDIA CUDA repository configuration. This prevents `apt-get` from locating and downloading `libcusparse-13-2` from the NVIDIA source.

## Solution
- Added a dynamic step before the installation of `libcusparse` that reads the operating system name and version ID from `/etc/os-release`.
- Downloads and registers the correct `cuda-keyring` GPG package from the NVIDIA repository (works seamlessly for both Ubuntu 22.04 and 24.04).
- Runs `apt-get update` afterwards to successfully index and install `libcusparse-13-2`.

# Tests

Verified inside a clean `ghcr.io/nvidia/jax:base` container on a Linux environment:
1. Running `apt-get install -y libcusparse-13-2` directly fails with `E: Unable to locate package`.
2. Running with the dynamic `cuda-keyring` script successfully registers the NVIDIA repositories and installs `libcusparse-13-2` (141 MB) without issues.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
