### PR TITLE
Support load-balanced TPU Tokamax ring attention

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -3409,7 +3409,10 @@ class MaxTextConfig(
       if self.packing:
         raise ValueError("TPU Tokamax ring attention does not support packing yet.")
       if self.context_parallel_load_balance:
-        raise ValueError("TPU Tokamax ring attention does not support context_parallel_load_balance yet.")
+        if context_parallel_size % 2 != 0:
+          raise ValueError("TPU Tokamax ring load balancing requires an even context_parallel_size.")
+        if self.mtp_num_layers > 0:
+          raise ValueError("TPU Tokamax ring attention with context_parallel_load_balance=True does not support MTP.")
       if self.use_ragged_attention:
         raise ValueError("TPU Tokamax ring attention does not support ragged attention.")
       if self.attention_sink:

--- a/src/maxtext/kernels/attention/tokamax_ring_attention.py
+++ b/src/maxtext/kernels/attention/tokamax_ring_attention.py
@@ -25,11 +25,13 @@ from typing import Any
 
 import jax
 from jax.experimental import pallas as pl
+import numpy as np
 
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.kernels.tokamax_splash_attention import ring_attention_kernel
 from maxtext.kernels.tokamax_splash_attention import splash_attention_kernel as tokamax_splash_kernel
 from maxtext.kernels.tokamax_splash_attention import splash_attention_mask as tokamax_splash_mask
+from maxtext.utils import max_utils
 
 
 def is_context_parallel_ring_requested(config: Any) -> bool:
@@ -245,6 +247,11 @@ def build_splash_config(
   block_q_dkv = min(config.sa_block_q_dkv, q_seq_len_per_shard)
   block_kv_dkv = min(config.sa_block_kv_dkv, kv_seq_len_per_shard)
   block_kv_dkv_compute = min(config.sa_block_kv_dkv_compute, kv_seq_len_per_shard)
+  if config.context_parallel_load_balance and block_q_dkv % tokamax_splash_kernel.NUM_LANES != 0:
+    raise ValueError(
+        "TPU Tokamax ring attention with context_parallel_load_balance=True requires "
+        f"sa_block_q_dkv ({block_q_dkv}) to be a multiple of {tokamax_splash_kernel.NUM_LANES} after clamping."
+    )
   return tokamax_splash_kernel.SplashConfig(
       block_q=block_q,
       block_kv=block_kv,
@@ -270,11 +277,18 @@ def build_splash_config(
   )
 
 
-def _make_causal_mask(shape: tuple[int, int], context_parallel_size: int):
+def _make_causal_mask(shape: tuple[int, int], context_parallel_size: int, *, load_balanced: bool = False):
   """Builds a lazy causal mask for ring attention."""
   if context_parallel_size <= 1:
     raise ValueError("context_parallel_size must be > 1 for ring attention.")
-  return tokamax_splash_mask.CausalMask(shape=shape, shard_count=context_parallel_size)
+  mask = tokamax_splash_mask.CausalMask(shape=shape, shard_count=context_parallel_size)
+  if load_balanced:
+    sequence_indices = max_utils.reorder_mask_load_balancing(
+        np.arange(shape[0], dtype=np.int32), context_parallel_size, 0
+    )
+    mask.q_sequence = sequence_indices
+    mask.kv_sequence = sequence_indices
+  return mask
 
 
 def make_sharded_ring_attention_kernel(
@@ -301,6 +315,7 @@ def make_sharded_ring_attention_kernel(
   mask = _make_causal_mask(
       (query.shape[2], key.shape[2]),
       context_parallel_size,
+      load_balanced=config.context_parallel_load_balance,
   )
 
   @functools.partial(jax.jit, static_argnames=["single_head_mask"])

--- a/src/maxtext/kernels/tokamax_splash_attention/ring_attention_kernel.py
+++ b/src/maxtext/kernels/tokamax_splash_attention/ring_attention_kernel.py
@@ -604,6 +604,7 @@ class RingSplashAttentionKernel:
           if mask_info.partial_mask_blocks is not None
           else None,
           q_sequence=_resolve_spec(mask_info.q_sequence),
+          kv_sequence=jax.sharding.PartitionSpec() if mask_info.kv_sequence is not None else None,
       )
 
     return RingSplashAttentionKernel(

--- a/src/maxtext/kernels/tokamax_splash_attention/ring_attention_utils.py
+++ b/src/maxtext/kernels/tokamax_splash_attention/ring_attention_utils.py
@@ -41,12 +41,15 @@ def dynamic_slice_mask_info(mask_info: MaskInfo, kv_shard_idx: jax.Array, ring_s
       block_mask=slice_if_exists(mask_info.block_mask),
       partial_mask_blocks=mask_info.partial_mask_blocks,  # partial mask blocks are global
       q_sequence=mask_info.q_sequence,  # Q sequence stays stationary
+      kv_sequence=slice_if_exists(mask_info.kv_sequence),
   )
 
 
 def offset_q_sequence_for_kv_shard(mask_info: MaskInfo, kv_shard_idx: jax.Array, kv_seq_len: int) -> MaskInfo:
   """Converts lazy mask Q ids to the current local KV coordinate frame."""
   if mask_info.q_sequence is None:
+    return mask_info
+  if mask_info.kv_sequence is not None:
     return mask_info
 
   kv_shard_offset = jnp.asarray(kv_shard_idx, dtype=mask_info.q_sequence.dtype) * kv_seq_len

--- a/src/maxtext/kernels/tokamax_splash_attention/splash_attention_kernel.py
+++ b/src/maxtext/kernels/tokamax_splash_attention/splash_attention_kernel.py
@@ -194,6 +194,7 @@ def _apply_mask_and_soft_cap(
     mask_value: float,
     mask_ref,
     q_sequence_ref,
+    kv_sequence_ref,
     q_segment_ids_ref,
     kv_segment_ids_ref,
     *,
@@ -207,6 +208,7 @@ def _apply_mask_and_soft_cap(
 ) -> tuple[jax.Array, jax.Array | None]:
   assert mask_ref is None or q_sequence_ref is None
   assert (q_sequence_ref is None) == (mask_function is None)
+  assert kv_sequence_ref is None or mask_function is not None
 
   masks = []
   if has_partial_mask:
@@ -214,15 +216,16 @@ def _apply_mask_and_soft_cap(
       mask = mask_ref[:, k_slice] if k_in_lanes else mask_ref[k_slice, :]
       masks.append(mask)
     elif mask_function is not None:
-      # Compute the mask using the given q_sequence indices.
-      # KV indices are computed on the fly. This works because we only support Q
-      # sequence sharding. If we wanted to compute Q indices too, then we would
-      # need to keep into account the current shard along Q sequence.
+      # Compute the mask using original Q positions. K/V positions are computed
+      # on the fly unless explicit original K/V positions are provided.
 
       if k_in_lanes:
         assert q_sequence_ref.shape == (bq, NUM_LANES)
 
-        k_sequence = k_offset + jax.lax.broadcasted_iota(jnp.int32, (bq, k_slice.size), 1)
+        if kv_sequence_ref is None:
+          k_sequence = k_offset + jax.lax.broadcasted_iota(jnp.int32, (bq, k_slice.size), 1)
+        else:
+          k_sequence = jnp.broadcast_to(kv_sequence_ref[:1, k_slice], (bq, k_slice.size))
 
         repeats, rem = divmod(k_slice.size, NUM_LANES)
         assert rem == 0
@@ -230,7 +233,13 @@ def _apply_mask_and_soft_cap(
       else:
         assert q_sequence_ref.shape == (NUM_SUBLANES, bq)
 
-        k_sequence = k_offset + jax.lax.broadcasted_iota(jnp.int32, (k_slice.size, bq), 0)
+        if kv_sequence_ref is None:
+          k_sequence = k_offset + jax.lax.broadcasted_iota(jnp.int32, (k_slice.size, bq), 0)
+        else:
+          repeats, rem = divmod(bq, NUM_LANES)
+          if rem:
+            raise NotImplementedError(f"block_q must be a multiple of {NUM_LANES}")
+          k_sequence = jnp.tile(kv_sequence_ref[k_slice, :], (1, repeats))
         q_sequence = q_sequence_ref[:1, :]  # [1, bq]
         q_sequence = jnp.broadcast_to(q_sequence, (k_slice.size, bq))
 
@@ -290,6 +299,7 @@ def flash_attention_kernel(
     sinks_ref,
     mask_ref,
     q_sequence_ref,
+    kv_sequence_ref,
     max_logit_value_ref,
     # Outputs
     o_ref,
@@ -394,6 +404,7 @@ def flash_attention_kernel(
         mask_value,
         mask_ref,
         q_sequence_ref,
+        kv_sequence_ref,
         q_segment_ids_ref,
         kv_segment_ids_ref,
         attn_logits_soft_cap=attn_logits_soft_cap,
@@ -669,6 +680,13 @@ def _splash_attention_forward(
     q_sequence = None
     in_specs.append(None)
 
+  if mask_info.kv_sequence is not None:
+    kv_sequence = jax.lax.broadcast_in_dim(mask_info.kv_sequence, (NUM_SUBLANES, kv_seq_len), (1,))
+    in_specs.append(pl.BlockSpec((NUM_SUBLANES, bkv), kv_segment_ids_index_map))
+  else:
+    kv_sequence = None
+    in_specs.append(None)
+
   if max_logit_value is not None:
     # reshape to allow sublane selection for vmap-ping and shard_map-ping
     max_logit_value = jnp.broadcast_to(
@@ -819,6 +837,7 @@ def _splash_attention_forward(
         sinks,
         mask_info.partial_mask_blocks,
         q_sequence,
+        kv_sequence,
         max_logit_value,
     )
   out, logsumexp, l_linear, max_logits = all_out
@@ -996,6 +1015,7 @@ def _flash_attention_dq_kernel(
     di_ref,
     mask_ref,
     q_sequence_ref,
+    kv_sequence_ref,
     # Outputs
     dq_scratch_ref,
     dq_ref,
@@ -1049,6 +1069,7 @@ def _flash_attention_dq_kernel(
         mask_value,
         mask_ref,
         q_sequence_ref,
+        kv_sequence_ref,
         q_segment_ids_ref,
         kv_segment_ids_ref,
         attn_logits_soft_cap=attn_logits_soft_cap,
@@ -1115,6 +1136,7 @@ def _flash_attention_dkv_kernel(
     di_ref,
     mask_ref,
     q_sequence_ref,
+    kv_sequence_ref,
     # aliases
     dq_alias,
     dk_alias,
@@ -1212,6 +1234,7 @@ def _flash_attention_dkv_kernel(
         mask_value,
         mask_ref,
         q_sequence_ref,
+        kv_sequence_ref,
         q_segment_ids_ref,
         kv_segment_ids_ref,
         attn_logits_soft_cap=attn_logits_soft_cap,
@@ -1436,9 +1459,8 @@ def _splash_attention_bwd_dkv(
   mask_spec = pl.BlockSpec((None, bkv, bq), mask_index_map)
 
   q_segment_ids_index_map = unravel(lambda h, i, j: (0, i))
+  kv_segment_ids_index_map = unravel(lambda h, i, j: (j, 0))
   if segment_ids is not None:
-    kv_segment_ids_index_map = unravel(lambda h, i, j: (j, 0))
-
     q_segment_spec = pl.BlockSpec((NUM_SUBLANES, bq), q_segment_ids_index_map)
     kv_segment_spec = pl.BlockSpec((bkv, NUM_LANES), kv_segment_ids_index_map)
     q_segment_ids = jax.lax.broadcast_in_dim(segment_ids.q, (NUM_SUBLANES, q_seq_len), (1,))
@@ -1483,6 +1505,13 @@ def _splash_attention_bwd_dkv(
     q_sequence = jax.lax.broadcast_in_dim(mask_info.q_sequence, (NUM_SUBLANES, q_seq_len), (1,))
   else:
     q_sequence = None
+    in_specs.append(None)
+
+  if mask_info.kv_sequence is not None:
+    in_specs.append(pl.BlockSpec((bkv, NUM_LANES), kv_segment_ids_index_map))
+    kv_sequence = jax.lax.broadcast_in_dim(mask_info.kv_sequence, (kv_seq_len, NUM_LANES), (0,))
+  else:
+    kv_sequence = None
     in_specs.append(None)
 
   dq_reduction_steps = config.dq_reduction_steps
@@ -1581,6 +1610,7 @@ def _splash_attention_bwd_dkv(
       di,
       mask_info.partial_mask_blocks,
       q_sequence,
+      kv_sequence,
   ]
   num_args = sum(1 for x in args if x is not None)
   input_output_aliases = {}
@@ -1609,6 +1639,7 @@ def _splash_attention_bwd_dkv(
       di: jax.Array,
       partial_mask_blocks: jax.Array | None,
       q_sequence: jax.Array | None,
+      kv_sequence: jax.Array | None,
       out_shapes: list[jax.ShapeDtypeStruct],
       mask_sparsity_factor: float,
   ) -> pl.CostEstimate:
@@ -1643,6 +1674,7 @@ def _splash_attention_bwd_dkv(
         di,
         partial_mask_blocks,
         q_sequence,
+        kv_sequence,
     ]
     input_bytes = sum(map(_bytes, inputs_))
     output_bytes = sum(map(_bytes, out_shapes))
@@ -1666,6 +1698,7 @@ def _splash_attention_bwd_dkv(
       di,
       mask_info.partial_mask_blocks,
       q_sequence,
+      kv_sequence,
       out_shapes,
       dkv_mask_sparsity,
   )
@@ -1880,6 +1913,7 @@ class SplashAttentionKernel:
           if mask_info.partial_mask_blocks is not None
           else None,
           q_sequence=_resolve_spec(mask_info.q_sequence),
+          kv_sequence=(jax.sharding.PartitionSpec() if mask_info.kv_sequence is not None else None),
       )
 
     return SplashAttentionKernel(
@@ -2029,6 +2063,7 @@ def _make_dynamic_splash_attention(
       block_mask=mask_spec,
       partial_mask_blocks=mask_spec,
       q_sequence=None,
+      kv_sequence=None,
   )
   out_specs = (
       mask_info_specs,

--- a/src/maxtext/kernels/tokamax_splash_attention/splash_attention_mask.py
+++ b/src/maxtext/kernels/tokamax_splash_attention/splash_attention_mask.py
@@ -183,12 +183,15 @@ class _ComputableMask(Mask):
       to undefined softmax.
     q_sequence: Indices of Q sequence. q_sequence is reused across __getitem__
       calls which is important for compile-time performance.
+    kv_sequence: Optional indices of KV sequence. When unset, KV positions are
+      the physical column indices.
     mask_function: Function used by the SplashAttention kernel to compute the
       mask rather than loading it.
   """
 
   _shape: tuple[int, int]
   q_sequence: np.ndarray
+  kv_sequence: np.ndarray | None
   mask_function: Callable[..., Any]
 
   def __init__(
@@ -207,6 +210,7 @@ class _ComputableMask(Mask):
       )
 
     self.q_sequence = np.arange(q_seq_len, dtype=np.int32)
+    self.kv_sequence = None
 
   @property
   def shape(self) -> tuple[int, ...]:
@@ -224,7 +228,10 @@ class _ComputableMask(Mask):
     kv_slice = _fill_slice(kv_slice, self.shape[1])
 
     rows = self.q_sequence[q_slice]
-    cols = np.arange(kv_slice.start, kv_slice.stop)
+    if self.kv_sequence is None:
+      cols = np.arange(kv_slice.start, kv_slice.stop)
+    else:
+      cols = self.kv_sequence[kv_slice]
 
     return self.mask_function(rows[:, None], cols[None, :])
 
@@ -276,7 +283,12 @@ class CausalMask(_ComputableMask):
     if not isinstance(other, type(self)):
       return NotImplemented
 
-    return self.shape == other.shape and self.offset == other.offset and np.array_equal(self.q_sequence, other.q_sequence)
+    return (
+        self.shape == other.shape
+        and self.offset == other.offset
+        and np.array_equal(self.q_sequence, other.q_sequence)
+        and np.array_equal(self.kv_sequence, other.kv_sequence)
+    )
 
   def __hash__(self):
     return hash(
@@ -285,6 +297,7 @@ class CausalMask(_ComputableMask):
             self.shape,
             self.offset,
             self.q_sequence.tobytes() if self.q_sequence is not None else None,
+            self.kv_sequence.tobytes() if self.kv_sequence is not None else None,
         )
     )
 

--- a/src/maxtext/kernels/tokamax_splash_attention/splash_attention_mask_info.py
+++ b/src/maxtext/kernels/tokamax_splash_attention/splash_attention_mask_info.py
@@ -78,6 +78,9 @@ class MaskInfo(NamedTuple):
     q_sequence: A i32[q_sequence_length] NumPy array. When using causal masking,
       this contains the list of indices that correspond to q tokens. For plain
       causal this is just np.arange(q_sequence_length).
+    kv_sequence: A i32[kv_sequence_length] NumPy array. When set, this contains
+      the original-token indices that correspond to KV tokens. For plain causal
+      masks this is left unset and KV indices are derived from physical columns.
   """
 
   mask_next: np.ndarray | jax.Array | None
@@ -87,6 +90,7 @@ class MaskInfo(NamedTuple):
   num_active_blocks: np.ndarray | jax.Array | None
   partial_mask_blocks: np.ndarray | jax.Array | None
   q_sequence: np.ndarray | None
+  kv_sequence: np.ndarray | None
 
 
 def _downcast_to_small_type(array: np.ndarray) -> np.ndarray:
@@ -237,10 +241,17 @@ def _causal_state_grid(
   q_seq_len, kv_seq_len = mask.shape
   q_blocks_count = q_seq_len // q_block_size
   kv_blocks_count = kv_seq_len // kv_block_size
-  q_block_min = np.arange(q_blocks_count, dtype=np.int32) * q_block_size
-  q_block_max = q_block_min + q_block_size - 1
-  kv_block_min = np.arange(kv_blocks_count, dtype=np.int32) * kv_block_size
-  kv_block_max = kv_block_min + kv_block_size - 1
+
+  q_sequence = mask.q_sequence.reshape(q_blocks_count, q_block_size)
+  q_block_min = np.min(q_sequence, axis=1)
+  q_block_max = np.max(q_sequence, axis=1)
+
+  kv_sequence = mask.kv_sequence
+  if kv_sequence is None:
+    kv_sequence = np.arange(kv_seq_len, dtype=np.int32)
+  kv_sequence = kv_sequence.reshape(kv_blocks_count, kv_block_size)
+  kv_block_min = np.min(kv_sequence, axis=1)
+  kv_block_max = np.max(kv_sequence, axis=1)
 
   empty = q_block_max[:, None] + mask.offset < kv_block_min[None, :]
   full = q_block_min[:, None] + mask.offset >= kv_block_max[None, :]
@@ -359,6 +370,7 @@ def _process_dynamic_mask(
       num_active_blocks=num_active_blocks,
       partial_mask_blocks=mask_blocks,
       q_sequence=None,
+      kv_sequence=None,
   )
 
 
@@ -443,9 +455,10 @@ def _process_mask(
   # partial_mask_blocks are left undefined and not used in the kernel.
   if hasattr(mask, "q_sequence") and hasattr(mask, "mask_function"):
     q_sequence = mask.q_sequence
+    kv_sequence = getattr(mask, "kv_sequence", None)
     mask_function = mask.mask_function
   else:
-    q_sequence = mask_function = None
+    q_sequence = kv_sequence = mask_function = None
 
   if isinstance(mask, mask_lib.CausalMask):
     state_grid = _causal_state_grid(mask, q_block_size, kv_block_size)
@@ -462,6 +475,7 @@ def _process_mask(
               num_active_blocks=None,
               partial_mask_blocks=None,
               q_sequence=None,
+              kv_sequence=None,
           ),
           None,
       )
@@ -511,6 +525,7 @@ def _process_mask(
               num_active_blocks=None,
               partial_mask_blocks=None,
               q_sequence=None,
+              kv_sequence=None,
           ),
           None,
       )
@@ -595,6 +610,7 @@ def _process_mask(
           num_active_blocks=num_active_blocks,
           partial_mask_blocks=partial_mask_blocks if mask_function is None else None,
           q_sequence=q_sequence,
+          kv_sequence=kv_sequence,
       ),
       mask_function,
   )

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -527,8 +527,6 @@ class AttentionOp(nnx.Module):
           raise ValueError("TPU Tokamax ring attention requires use_tokamax_splash=True.")
         if self.config.use_jax_splash:
           raise ValueError("TPU Tokamax ring attention requires use_jax_splash=False.")
-        if self.config.context_parallel_load_balance:
-          raise ValueError("TPU Tokamax ring attention does not support context_parallel_load_balance yet.")
         if self.config.packing:
           raise ValueError("TPU Tokamax ring attention does not support packing yet.")
         if self.attention_type != AttentionType.GLOBAL:

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -28,6 +28,7 @@ import jax
 import jax.numpy as jnp
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask
 from jax.sharding import AxisType, Mesh
+from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
 from maxtext.common.gcloud_stub import is_decoupled
 
@@ -1140,8 +1141,12 @@ class AttentionTest(parameterized.TestCase):
         f"are not close. context_parallel_load_balance={context_parallel_load_balance}.",
     )
 
+  @parameterized.named_parameters(
+      {"testcase_name": "no_load_balance", "context_parallel_load_balance": False},
+      {"testcase_name": "load_balance", "context_parallel_load_balance": True},
+  )
   @pytest.mark.tpu_only
-  def test_tpu_flash_attention_ring_context_parallel(self):
+  def test_tpu_flash_attention_ring_context_parallel(self, context_parallel_load_balance):
     """Test equivalence between dot_product and flash attention + ring context parallelism"""
 
     cfg_cp = pyconfig.initialize(
@@ -1149,7 +1154,7 @@ class AttentionTest(parameterized.TestCase):
         **self.config_arguments,
         attention="flash",
         context_parallel_strategy="ring",
-        context_parallel_load_balance=False,
+        context_parallel_load_balance=context_parallel_load_balance,
         ici_context_parallelism=2,
         use_tokamax_splash=True,
         use_jax_splash=False,
@@ -1216,11 +1221,16 @@ class AttentionTest(parameterized.TestCase):
 
     self.assertTrue(
         jax.numpy.allclose(mha_generic_output, mha_generic_flash_cp_output, rtol=1e-02, atol=1e-02, equal_nan=False),
-        msg="Logits from generic dot product and flash attention + ring context parallelism are not close.",
+        msg="Logits from generic dot product and flash attention + ring context parallelism are not close. "
+        f"context_parallel_load_balance={context_parallel_load_balance}.",
     )
 
+  @parameterized.named_parameters(
+      {"testcase_name": "no_load_balance", "context_parallel_load_balance": False},
+      {"testcase_name": "load_balance", "context_parallel_load_balance": True},
+  )
   @pytest.mark.tpu_only
-  def test_tpu_flash_attention_ring_context_parallel_grad(self):
+  def test_tpu_flash_attention_ring_context_parallel_grad(self, context_parallel_load_balance):
     """Test gradient equivalence between dot_product and flash attention + ring context parallelism"""
 
     cfg_cp = pyconfig.initialize(
@@ -1228,7 +1238,7 @@ class AttentionTest(parameterized.TestCase):
         **self.config_arguments,
         attention="flash",
         context_parallel_strategy="ring",
-        context_parallel_load_balance=False,
+        context_parallel_load_balance=context_parallel_load_balance,
         ici_context_parallelism=2,
         use_tokamax_splash=True,
         use_jax_splash=False,
@@ -1285,11 +1295,19 @@ class AttentionTest(parameterized.TestCase):
       return jnp.mean(output.astype(jnp.float32) ** 2)
 
     def ring_loss(lnx):
+      if context_parallel_load_balance:
+        context_parallel_size = cfg_cp.ici_context_parallelism
+        lnx = max_utils.reorder_sequence(lnx, cp_size=context_parallel_size)
+        ring_decoder_segment_ids = max_utils.reorder_sequence(decoder_segment_ids, cp_size=context_parallel_size)
+        ring_decoder_positions = max_utils.reorder_sequence(decoder_positions, cp_size=context_parallel_size)
+      else:
+        ring_decoder_segment_ids = decoder_segment_ids
+        ring_decoder_positions = decoder_positions
       output, _ = attention_as_mha_flash_cp(
           lnx,
           lnx,
-          decoder_segment_ids=decoder_segment_ids,
-          inputs_positions=decoder_positions,
+          decoder_segment_ids=ring_decoder_segment_ids,
+          inputs_positions=ring_decoder_positions,
           deterministic=True,
           model_mode=MODEL_MODE_TRAIN,
       )
@@ -1303,7 +1321,8 @@ class AttentionTest(parameterized.TestCase):
 
     self.assertTrue(
         jax.numpy.allclose(generic_grad, ring_grad, rtol=1e-02, atol=1e-07, equal_nan=False),
-        msg="Input gradients from generic dot product and flash attention + ring context parallelism are not close.",
+        msg="Input gradients from generic dot product and flash attention + ring context parallelism are not close. "
+        f"context_parallel_load_balance={context_parallel_load_balance}.",
     )
 
   @pytest.mark.tpu_only

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -121,6 +121,28 @@ class ConfigTest(absltest.TestCase):
     self.assertEqual(config.attention, "flash")
     self.assertTrue(config.use_tokamax_splash)
 
+  def test_tpu_tokamax_ring_config_validation_accepts_load_balance(self):
+    argv = [
+        "",
+        _BASE_CONFIG_PATH,
+        "run_name=test",
+        "attention=flash",
+        "use_tokamax_splash=True",
+        "use_jax_splash=False",
+        "context_parallel_strategy=ring",
+        "context_parallel_load_balance=True",
+        "ici_context_parallelism=2",
+        "hardware=tpu",
+        "packing=False",
+        "dataset_type=synthetic",
+        "skip_jax_distributed_system=True",
+    ]
+    mock_devices = [unittest.mock.MagicMock(slice_index=0) for _ in range(8)]
+    with unittest.mock.patch("jax.devices", return_value=mock_devices):
+      config = pyconfig.initialize(argv)
+
+    self.assertTrue(config.context_parallel_load_balance)
+
   def test_tpu_tokamax_ring_config_validation_rejects_unsupported_configs(self):
     base_args = [
         "",
@@ -148,9 +170,21 @@ class ConfigTest(absltest.TestCase):
         (["attention_type=full"], [], "global causal"),
         (["packing=True"], ["packing=False"], "packing"),
         (
-            ["context_parallel_load_balance=True"],
+            [
+                "context_parallel_load_balance=True",
+                "ici_context_parallelism=3",
+                "max_target_length=2304",
+            ],
+            ["context_parallel_load_balance=False", "ici_context_parallelism=2"],
+            "even context_parallel_size",
+        ),
+        (
+            [
+                "context_parallel_load_balance=True",
+                "mtp_num_layers=1",
+            ],
             ["context_parallel_load_balance=False"],
-            "context_parallel_load_balance",
+            "MTP",
         ),
         (["use_ragged_attention=True"], [], "ragged attention"),
         (["attention_sink=True"], [], "attention sinks"),

--- a/tests/unit/tokamax_ring_attention_test.py
+++ b/tests/unit/tokamax_ring_attention_test.py
@@ -39,6 +39,14 @@ class TokamaxRingAttentionTest(absltest.TestCase):
 
     self.assertEqual(mask.shape, (16, 16))
     self.assertEqual(mask.q_sequence.tolist(), list(range(16)))
+    self.assertIsNone(mask.kv_sequence)
+
+  def test_make_causal_mask_sets_load_balanced_original_positions(self):
+    mask = tokamax_ring_attention._make_causal_mask((16, 16), 4, load_balanced=True)
+
+    expected_sequence = [0, 1, 14, 15, 2, 3, 12, 13, 4, 5, 10, 11, 6, 7, 8, 9]
+    self.assertEqual(mask.q_sequence.tolist(), expected_sequence)
+    self.assertEqual(mask.kv_sequence.tolist(), expected_sequence)
 
   def test_validate_ring_mesh_axis_requires_key_value_sequence_sharding(self):
     mesh = types.SimpleNamespace(shape={"context": 4})

--- a/tests/unit/tokamax_splash_attention_mask_test.py
+++ b/tests/unit/tokamax_splash_attention_mask_test.py
@@ -56,6 +56,60 @@ class TokamaxSplashAttentionMaskTest(absltest.TestCase):
     self.assertIsNone(mask_info.partial_mask_blocks)
     np.testing.assert_array_equal(mask_info.q_sequence, np.arange(8, dtype=np.int32))
 
+  def test_process_causal_mask_keeps_key_value_sequence(self):
+    mask = splash_attention_mask.CausalMask((8, 8), shard_count=2)
+    sequence = np.array([0, 1, 6, 7, 2, 3, 4, 5], dtype=np.int32)
+    mask.q_sequence = sequence
+    mask.kv_sequence = sequence
+
+    mask_info, mask_function = splash_attention_mask_info.process_mask(
+        mask,
+        block_shape=(2, 2),
+        q_seq_shards=2,
+        kv_seq_shards=2,
+        return_dynamic_grid=True,
+    )
+
+    self.assertIs(mask_function, mask.mask_function)
+    np.testing.assert_array_equal(mask_info.q_sequence, sequence)
+    np.testing.assert_array_equal(mask_info.kv_sequence, sequence)
+
+  def test_causal_mask_uses_original_query_and_key_value_positions(self):
+    mask = splash_attention_mask.CausalMask((8, 8), shard_count=2)
+    mask.q_sequence = np.array([0, 1, 6, 7, 2, 3, 4, 5], dtype=np.int32)
+    mask.kv_sequence = np.array([0, 1, 6, 7, 2, 3, 4, 5], dtype=np.int32)
+
+    got = mask[:, :]
+    expected = mask.q_sequence[:, None] >= mask.kv_sequence[None, :]
+
+    np.testing.assert_array_equal(got, expected)
+
+  def test_causal_state_grid_uses_original_key_value_positions(self):
+    mask = splash_attention_mask.CausalMask((8, 8), shard_count=2)
+    mask.q_sequence = np.array([0, 1, 6, 7, 2, 3, 4, 5], dtype=np.int32)
+    mask.kv_sequence = np.array([0, 1, 6, 7, 2, 3, 4, 5], dtype=np.int32)
+
+    got = splash_attention_mask_info._causal_state_grid(mask, q_block_size=2, kv_block_size=2)
+
+    expected = np.array(
+        [
+            [1, 0, 0, 0],
+            [2, 1, 2, 2],
+            [2, 0, 1, 0],
+            [2, 0, 2, 1],
+        ],
+        dtype=np.int32,
+    )
+    np.testing.assert_array_equal(got, expected)
+
+  def test_causal_mask_hash_includes_key_value_sequence(self):
+    left = splash_attention_mask.CausalMask((8, 8), shard_count=2)
+    right = splash_attention_mask.CausalMask((8, 8), shard_count=2)
+    left.kv_sequence = np.arange(8, dtype=np.int32)
+    right.kv_sequence = np.arange(7, -1, -1, dtype=np.int32)
+
+    self.assertNotEqual(hash(left), hash(right))
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
# Description

This PR adds load-balancing support (`context_parallel_load_balance=true`) to TPU Tokamax ring attention (`context_parallel_strategy=ring` + `use_tokamax_splash=true`), following #4266 which added the unbalanced ring.

**Why.** With causal masking and normal sequence sharding, shard 0 attends to almost nothing while the last shard attends to nearly the full sequence. At high CP, roughly half of attention compute is wasted.

**How.** Reuses MaxText current `DUAL_CHUNK_SWAP`  and makes the splash kernel mask aware of the permutation:
- A `kv_sequence` array of original token positions travels with each rotating KV chunk.
- `CausalMask`/`MaskInfo` compare original Q positions against original KV positions, so masking is exact under the permutation.


# Key Changes

- `kernels/tokamax_splash_attention/splash_attention_mask_info.py`: mask info is built from `kv_sequence`, the original token positions of the permuted KV.
- `kernels/tokamax_splash_attention/splash_attention_kernel.py`: kernels compare original Q positions against original KV positions instead of physical block indices.
- `kernels/attention/tokamax_ring_attention.py`: each ring hop passes the `kv_sequence` slice along with its KV chunk.
- `layers/attention_op.py`: removes the ring rejection of `context_parallel_load_balance`, so the existing DUAL_CHUNK_SWAP reorder now applies to ring.
- `configs/types.py`: rejects unsupported configs at startup: odd `ici_context_parallelism`, MTP with LB.

# Tests

llama3.1-8b on v5p 64 chips 

**TLDR:** load balancing gives **1.34× / 1.45× / 1.37×** end-to-end training speedup at 256K / 1M / 64K context with same loss curves.

- Tokamax ring attention + mask unit tests: all **13 passed** on TPU.
- Config validation tests (`configs_value_test -k tpu_tokamax_ring`): all **3 passed**.


# Performance Impact

Setup: llama3.1-8b, v5p-128, synthetic data, bf16, `sa_block_*=1024`, `dq_reduction_steps=3`, `remat_policy=full`, `num_vocab_tiling=16`.


Seq len | Mesh (cp×fsdp) | LB | Step time (s) | TFLOP/s/device | MFU (v5p, 459 peak) | Tokens/s/device | Speedup
-- | -- | -- | -- | -- | -- | -- | --
64K | 4×16 | off | 18.14 | 174.4 | 38.0% | 1806 | 1.00×
64K | 4×16 | on | 13.92 | 227.3 | 49.5% | 2354 | 1.30×
256K | 16×4 | off | 63.32 | 130.0 | 28.3% | 517 | 1.00×
256K | 16×4 | on | 41.24 | 199.6 | 43.5% | 795 | 1.54×
1M | 64×1 | off | 242.9 | 117.3 | 25.6% | 135 | 1.00×
1M | 64×1 | on | 150.3 | 189.6 | 41.3% | 218 | 1.62×


Memory: identical memory use.

Loss equivalence: over 100 steps at 64K near identical loss (same up to 8e-3).   

**Xprofs:**
- 256K off: [xprof](https://xprof.corp.google.com/overview_page/htn-12969162626154064340)
- 256K on: [xprof](https://xprof.corp.google.com/overview_page/htn-6255156894659535418)
- 1M off: [xprof](http://xprof.corp.google.com/trace_viewer/htn-3914347130787873298)
- 1M on: [xprof](http://xprof.corp.google.com/trace_viewer/htn-4512027334587333121)

Repro (256K uses `max_target_length=262144 ici_context_parallelism=16 ici_fsdp_parallelism=4 per_device_batch_size=0.125`):

```bash
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
  base_output_directory=$GCS dataset_type=synthetic enable_checkpointing=false \
  model_name=llama3.1-8b num_vocab_tiling=16 \
  attention=flash use_tokamax_splash=true context_parallel_strategy=ring packing=false \
  sa_block_q=1024 sa_block_kv=1024 sa_block_q_dkv=1024 sa_block_kv_dkv=1024 \
  dq_reduction_steps=3 remat_policy=full \
  max_target_length=1048576 ici_context_parallelism=64 ici_fsdp_parallelism=1 \
  per_device_batch_size=0.03125 steps=10 \
  context_parallel_load_balance=true run_name=$RUN
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.