### PR TITLE
Fix mdformat on all documentation files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,17 @@ repos:
         args: ['--number']
         additional_dependencies: [mdformat-myst, mdformat-ruff]
         files: (docs/.)
-        exclude: docs/guides/checkpointing_solutions.md|docs/guides.md|docs/run_maxtext.md
+        # Exclude all files that use complex MyST directives that mdformat breaks
+        exclude: >
+          (?x)^(
+            docs/guides/checkpointing_solutions\.md|
+            docs/guides\.md|
+            docs/run_maxtext\.md|
+            docs/guides/monitoring_and_debugging\.md|
+            docs/reference/core_concepts.md|
+            docs/reference/architecture.md|
+            docs/reference/models.md
+          )$
 
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.35.0

--- a/docs/reference/core_concepts/moe_configuration.md
+++ b/docs/reference/core_concepts/moe_configuration.md
@@ -99,7 +99,7 @@ Dropping:
 
 `mlp_bias`: If enabled, add learnable bias terms for MLP matmul. Originally implemented to support the GPT-OSS model architecture.
 
-`prefuse_moe_weights`: If enabled alongside `sparse_matmul=True`, fuses the two FFN1 grouped GEMMs (wi\_0 and wi\_1) into a single grouped GEMM call. Expert weights are stored in a concatenated `(num_experts, embed_dim, 2 * mlp_dim)` shape, so input activations are loaded from HBM once per forward pass instead of twice. Backend-agnostic (works with Megablox, JAX Ragged Dot, and Tokamax). When used with `attention=vllm_rpa`, the fused weight tensor is passed directly to the vLLM-TPU serving kernel without splitting.
+`prefuse_moe_weights`: If enabled alongside `sparse_matmul=True`, fuses the two FFN1 grouped GEMMs (wi_0 and wi_1) into a single grouped GEMM call. Expert weights are stored in a concatenated `(num_experts, embed_dim, 2 * mlp_dim)` shape, so input activations are loaded from HBM once per forward pass instead of twice. Backend-agnostic (works with Megablox, JAX Ragged Dot, and Tokamax). When used with `attention=vllm_rpa`, the fused weight tensor is passed directly to the vLLM-TPU serving kernel without splitting.
 
 `use_batch_split_schedule` (experimental): If enabled, split batch into micro-batches to hide communications that yields performance benefits.
 


### PR DESCRIPTION
# Description

This PR excludes documentation files that use complex MyST directives (such as `::::{grid}`) from the `mdformat` pre-commit hook. 

**Why this change is being made & the problem being solved:**
Currently, our scheduled code quality tests are failing. The `mdformat` tool does not recognize MyST `{grid}` components and attempts to escape their curly braces (changing `::::{grid}` to `::::\{grid}`). This corrupts the documentation syntax.

**Why this is a good solution & specific implementation:**
The best approach is to exclude these files entirely in the `.pre-commit-config.yaml`. This fixes the CI pipeline while keeping the `mdformat` check active for all other standard markdown files.

FIXES: b/535621922

# Tests

```
pre-commit run mdformat --all-files
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
