### PR TITLE
Separate TPU and GPU nightly docker image build workflows

### DIFF
--- a/.github/workflows/gpu_nightly_images_pipeline.yml
+++ b/.github/workflows/gpu_nightly_images_pipeline.yml
@@ -1,0 +1,84 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow builds and pushes GPU MaxText images.
+# It runs automatically daily at 12am UTC, or manually via Workflow Dispatch.
+
+name: Build GPU Nightly Docker Images
+
+on:
+  schedule:
+    # Run the job daily at 12AM UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      image_suffix:
+        description: 'An image suffix can be provided to add to the image name'
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  build_maxtext_package:
+    name: Build MaxText Package
+    uses: ./.github/workflows/build_package.yml
+    with:
+      device_type: tpu
+      device_name: v4-8
+      cloud_runner: linux-x86-n2-16-buildkit
+
+  build_and_push_docker_images:
+    name: Build ${{ matrix.name }} Docker Image
+    needs: build_maxtext_package
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "GPU Pre-Training Stable"
+            build_mode: stable
+            workflow: pre-training
+            image_name: maxtext_gpu_jax_stable
+          - name: "GPU Pre-Training Nightly"
+            build_mode: nightly
+            workflow: pre-training
+            image_name: maxtext_gpu_jax_nightly
+    uses: ./.github/workflows/build_and_push_docker_image.yml
+    with:
+      image_name: ${{ inputs.image_suffix != '' && format('{0}_{1}', matrix.image_name, inputs.image_suffix) || matrix.image_name }}
+      device: gpu
+      build_mode: ${{ matrix.build_mode }}
+      workflow: ${{ matrix.workflow }}
+      dockerfile: maxtext_gpu_dependencies.Dockerfile
+      maxtext_sha: ${{ needs.build_maxtext_package.outputs.maxtext_sha }}
+      include_test_assets: true
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  notify_failure:
+    name: Notify failed build
+    needs: [build_and_push_docker_images]
+    if: ${{ failure() && inputs.image_suffix == '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue on failure
+        uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          title-template: "MaxText Docker Image Build Failure"
+          label-name: "docker-image-build-failure"

--- a/.github/workflows/tpu_nightly_images_pipeline.yml
+++ b/.github/workflows/tpu_nightly_images_pipeline.yml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This workflow builds and pushes MaxText images for both TPU and GPU devices.
+# This workflow builds and pushes TPU MaxText images.
 # It runs automatically daily at 12am UTC, or manually via Workflow Dispatch.
 
-name: Build Nightly Docker Images
+name: Build TPU Nightly Docker Images
 
 on:
   schedule:
@@ -23,15 +23,6 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
-      target_device:
-        description: 'Specify target device (all, tpu, or gpu)'
-        required: true
-        type: choice
-        default: 'all'
-        options:
-          - all
-          - tpu
-          - gpu
       image_suffix:
         description: 'An image suffix can be provided to add to the image name'
         required: false
@@ -50,7 +41,7 @@ jobs:
       device_name: v4-8
       cloud_runner: linux-x86-n2-16-buildkit
 
-  build_and_push_tpu_docker_images:
+  build_and_push_docker_images:
     name: Build ${{ matrix.name }} Docker Image
     needs: build_maxtext_package
     strategy:
@@ -58,96 +49,56 @@ jobs:
       matrix:
         include:
           - name: "TPU Pre-Training Stable"
-            device: tpu
             build_mode: stable
             workflow: pre-training
             image_name: maxtext_jax_stable
-            dockerfile: maxtext_tpu_dependencies.Dockerfile
           - name: "TPU Pre-Training Nightly"
-            device: tpu
             build_mode: nightly
             workflow: pre-training
             image_name: maxtext_jax_nightly
-            dockerfile: maxtext_tpu_dependencies.Dockerfile
           - name: "TPU Post-Training Nightly"
-            device: tpu
             build_mode: nightly
             workflow: post-training
             image_name: maxtext_post_training_nightly
-            dockerfile: maxtext_tpu_dependencies.Dockerfile
     uses: ./.github/workflows/build_and_push_docker_image.yml
     with:
       image_name: ${{ inputs.image_suffix != '' && format('{0}_{1}', matrix.image_name, inputs.image_suffix) || matrix.image_name }}
-      device: ${{ matrix.device }}
+      device: tpu
       build_mode: ${{ matrix.build_mode }}
       workflow: ${{ matrix.workflow }}
-      dockerfile: ${{ matrix.dockerfile }}
+      dockerfile: maxtext_tpu_dependencies.Dockerfile
       maxtext_sha: ${{ needs.build_maxtext_package.outputs.maxtext_sha }}
       include_test_assets: true
       run_tests: false
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
-  build_and_push_gpu_docker_images:
-    name: Build ${{ matrix.name }} Docker Image
-    needs: build_maxtext_package
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: "GPU Pre-Training Stable"
-            device: gpu
-            build_mode: stable
-            workflow: pre-training
-            image_name: maxtext_gpu_jax_stable
-            dockerfile: maxtext_gpu_dependencies.Dockerfile
-          - name: "GPU Pre-Training Nightly"
-            device: gpu
-            build_mode: nightly
-            workflow: pre-training
-            image_name: maxtext_gpu_jax_nightly
-            dockerfile: maxtext_gpu_dependencies.Dockerfile
-    uses: ./.github/workflows/build_and_push_docker_image.yml
-    with:
-      image_name: ${{ inputs.image_suffix != '' && format('{0}_{1}', matrix.image_name, inputs.image_suffix) || matrix.image_name }}
-      device: ${{ matrix.device }}
-      build_mode: ${{ matrix.build_mode }}
-      workflow: ${{ matrix.workflow }}
-      dockerfile: ${{ matrix.dockerfile }}
-      maxtext_sha: ${{ needs.build_maxtext_package.outputs.maxtext_sha }}
-      include_test_assets: true
-    secrets:
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-
-  run_tpu_ci_tests:
-    name: Run TPU ${{ matrix.name }} CI Tests
-    needs: build_and_push_tpu_docker_images
+  run_ci_tests:
+    name: Run ${{ matrix.name }} CI Tests
+    needs: build_and_push_docker_images
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: "Pre-Training Stable"
             image_name: maxtext_jax_stable
-            device: tpu
             workflow: pre-training
           - name: "Pre-Training Nightly"
             image_name: maxtext_jax_nightly
-            device: tpu
             workflow: pre-training
           - name: "Post-Training Nightly"
             image_name: maxtext_post_training_nightly
-            device: tpu
             workflow: post-training
     uses: ./.github/workflows/run_ci_tests.yml
     with:
       image_name: ${{ inputs.image_suffix != '' && format('{0}_{1}', matrix.image_name, inputs.image_suffix) || matrix.image_name }}
       image_tag: ${{ github.run_id }}
-      device: ${{ matrix.device }}
+      device: tpu
       workflow: ${{ matrix.workflow }}
 
   run_e2e_tests:
     name: Run E2E tests
-    needs: build_and_push_tpu_docker_images
+    needs: build_and_push_docker_images
     if: github.event_name == 'schedule'
     uses: ./.github/workflows/run_e2e_tests.yml
     with:
@@ -158,7 +109,7 @@ jobs:
 
   notify_failure:
     name: Notify failed build
-    needs: [build_and_push_tpu_docker_images, build_and_push_gpu_docker_images, run_tpu_ci_tests, run_e2e_tests]
+    needs: [build_and_push_docker_images, run_ci_tests, run_e2e_tests]
     if: ${{ failure() && inputs.image_suffix == '' }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# Description

This PR separates the nightly Docker image build workflows for TPU and GPU into their own dedicated workflows. 

Separating the TPU and GPU builds into distinct workflows provides isolation. Failures in the GPU build will no longer affect the TPU build, and vice versa, making it easier to pinpoint issues.

# Tests

These are new workflows, which can only be triggered once merged into main.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
