### PR TITLE
Add eval_start_step flag and allow evaluation from step 0

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -983,6 +983,7 @@ decode_sampling_nucleus_p: -1 # set if you're doing nucleus / top-p
 decode_sampling_top_k: 0 # set if you're doing top-k
 decode_sampling_temperature: 1.
 
+eval_start_step: 0 # start eval after train step is >= eval_start_step
 eval_interval: -1  # the specific number of train step between eval_step
 eval_steps: -1  # run this number of steps for eval, recommend setting this to prevent error due to running out of evel data
 target_eval_loss: 0.  # early stop once reaching target eval_loss

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1573,6 +1573,10 @@ class TrainingLoop(BaseModel):
       description="Total number of training steps. -1 defaults to learning_rate_schedule_steps.",
   )
   log_period: int = Field(100, description="Frequency (in steps) to log metrics and flush Tensorboard.")
+  eval_start_step: int = Field(
+      0,
+      description="Start evaluation after training step is >= eval_start_step.",
+  )
   eval_interval: int = Field(
       -1,
       description="Run evaluation every N training steps. -1 disables interval-based evaluation.",

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -669,6 +669,7 @@ def training_loop_iteration(
   eval_interval = immutable_data["eval_interval"]
   eval_steps = immutable_data["eval_steps"]
   start_step = immutable_data["start_step"]
+  eval_start_step = immutable_data["eval_start_step"]
 
   # HLO dump config
   dump_hlo = immutable_data["dump_hlo"]
@@ -712,7 +713,7 @@ def training_loop_iteration(
         all_host_upload=dump_hlo_upload_all,
     )
 
-  if eval_interval > 0 and step > start_step and (step + 1) % eval_interval == 0:
+  if eval_interval > 0 and step >= start_step and step >= eval_start_step and (step + 1) % eval_interval == 0:
     assert eval_data_iterator
     # Explicitly reset the eval iterator and counters before starting the eval loop
     eval_data_iterator.reset()
@@ -863,6 +864,7 @@ def train_loop(config, recorder, state=None):
       "steps": config.steps,
       "eval_interval": config.eval_interval,
       "eval_steps": config.eval_steps,
+      "eval_start_step": config.eval_start_step,
       "save_checkpoint_on_completion": config.save_checkpoint_on_completion,
       "start_step": start_step,
       "dump_hlo": config.dump_hlo,

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -317,6 +317,21 @@ class PyconfigTest(unittest.TestCase):
     self.assertEqual(config.local_sa_v_layout, "SEQ_MINOR")
     self.assertFalse(config.local_use_splash_scheduler)
 
+  def test_eval_start_step_config(self):
+    """Verifies that eval_start_step defaults to 0 and can be overridden via pyconfig."""
+    config_default = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+    )
+    self.assertEqual(config_default.eval_start_step, 0)
+
+    config_override = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+        eval_start_step=50,
+    )
+    self.assertEqual(config_override.eval_start_step, 50)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
# Description

This PR adds full support for the `eval_start_step` configuration flag in MaxText to delay or control when interval-based evaluations trigger during pre-training, and updates the evaluation step check from `step > start_step` to `step >= start_step`.

### Why is this change being made

1. **Support for `eval_start_step`:** The need of the delay is coming from the new validation [requirement of MLPerf](https://github.com/mlcommons/training/pull/891)

> The validation starts after N(GBS) = GBS*FLOOR(42+24576/GBS) samples - this gives us 2-3 spare evaluations before we hit the RCP min, and ~4 before we hit the RCP avg. 


2. **Support evaluation on step 0 / `start_step` (`step >= start_step`):** The evaluation condition previously checked `step > start_step`, strictly preventing evaluations from firing on the very first step (`step == start_step`), such as when `start_step = 0` and `eval_interval = 1`. Updating this to `step >= start_step` allows evaluation to fire on step 0 or the starting step when configured.





FIXES: b/535641549

# Tests

* When setting `eval_start_step=10`, the log shows the eval started at step 10: https://fusion2.corp.google.com/invocations/f6ea1094-7d28-4c76-be75-f0bbaeb9ac5d/log

* The eval now can start from step 0: https://fusion2.corp.google.com/invocations/7cb76b6f-e36e-4ba7-ab17-aa90a9e1c6e6/log

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
