### PR TITLE
fix(test): strict TPU tolerance for float32 in moe_test.py

### DIFF
--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -38,7 +38,10 @@ import pytest
 def assert_moe_close(actual, expected, dtype):
   """Asserts that the actual and expected MoE outputs are close."""
   assert np.isfinite(actual).all(), "Actual output contains NaNs or Infs!"
-  if dtype == jnp.bfloat16:
+
+  if jax.default_backend() == "tpu" or dtype == jnp.bfloat16:
+    # TPU float32 (which is downcasted/accumulates differently) and bfloat16
+    # both exhibit accumulation drift, especially on newer hardware like v7x.
     rtol, atol = 2e-2, 1e-2
   else:
     rtol, atol = 1e-5, 1e-6


### PR DESCRIPTION
# Description

## Overview

This PR fixes a persistent CI failure in `tests/unit/moe_test.py::RoutedMoeTest::test_dense` observed specifically on the nightly `tpu7x-tests` pipeline on the `main` branch.

## Root Cause Analysis

In a previous PR (#4518), `assert_moe_close` was introduced to standardize numerical validation. That PR successfully stabilized `bfloat16` tests by pinning expected outputs. However, it inadvertently applied a highly restrictive tolerance (`rtol=1e-5`, `atol=1e-6`) to tests configured with `dtype="float32"` (such as `test_dense`).

**1. The Compiler vs. Hardware Interaction**
While `float32` provides strict high precision on CPUs, TPU hardware optimizes `float32` matrix multiplications by defaulting to reduced precision formats (like TF32) in the MXU. 

The test previously passed on stable pipelines (which use pinned `libtpu` versions) because the older compiler's instruction schedule happened to keep the accumulation drift within `1e-5`. However, the **nightly XLA compiler** (which powers the failing job) likely introduced a new kernel fusion or altered the accumulation schedule. This bleeding-edge optimization exposed the hardware's reduced precision, pushing the max difference to `~0.0027`.

**2. Why it silently reached `main`**
The `tpu7x-tests` job is configured to skip on PR branches. Because we did not evaluate these strict `float32` assertions against the nightly XLA compiler on v7x hardware during the PR review, the regression silently made it into the `main` branch. By demanding `atol=1e-06`, the test was enforcing a level of mathematical precision that the nightly TPU compiler/hardware combination does not guarantee.

## Resolution

This PR refines `assert_moe_close` to use conditional hardware logic:
- If the test is running on a **TPU backend** (where compiler-driven downcasting and accumulation drift occur) OR explicitly uses `bfloat16`, it restores the original relaxed tolerance limits (`rtol=2e-2`, `atol=1e-2`). This safely absorbs the `~0.0027` drift observed on the nightly pipelines.
- If running on a CPU/GPU with `float32`, it preserves the strict `1e-5` bounds to continue catching logic regressions early in those environments.

This safely resolves the `test_dense` failure without blindly loosening tolerances across all hardware environments.

# Tests

Run on cicd [here](https://github.com/AI-Hypercomputer/maxtext/actions/runs/29794449832/job/88523586458?pr=4550)

## tpuv7x unit tests [TPU7X tests (tpu7x-unit) / tpu7x-unit / run](https://github.com/AI-Hypercomputer/maxtext/actions/runs/29794449832/job/88523586458?pr=4550#logs)
<img width="1400" height="899" alt="image" src="https://github.com/user-attachments/assets/64a7a3df-8498-4228-a8b7-07a74c1faec7" />

## tpu unit tests [tpu-unit tests / tpu-unit / run](https://github.com/AI-Hypercomputer/maxtext/actions/runs/29794449832/job/88523593421?pr=4550#logs)
<img width="1466" height="917" alt="image" src="https://github.com/user-attachments/assets/30e39658-e8b6-4b3f-8404-17a290cd196b" />


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
