### PR TITLE
Adding improved profiles for qwen3 models

### DIFF
--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -180,6 +180,7 @@ def naive_jax_chunk_gated_delta_rule(
   return core_attn_out, final_state if output_final_state else None
 
 
+@functools.partial(jax.named_call, name="jax_chunked_delta_rule")
 def jax_chunk_gated_delta_rule(
     query: Array,
     key: Array,
@@ -565,6 +566,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         rngs=rngs,
     )
 
+  @functools.partial(jax.named_call, name="qwen3_next_gated_delta_net")
   def __call__(
       self,
       hidden_states: Array,
@@ -1029,6 +1031,7 @@ class Qwen3NextFullAttention(nnx.Module):
         rngs=rngs,
     )
 
+  @functools.partial(jax.named_call, name="qwen3_next_full_attention")
   def __call__(
       self,
       inputs: jnp.ndarray,
@@ -1435,6 +1438,7 @@ class AttentionWithNorm(nnx.Module):
         rngs=rngs,
     )
 
+  @functools.partial(jax.named_call, name="apply_attention_with_norm")
   def apply_attention_with_norm(
       self,
       inputs: jnp.ndarray,
@@ -1449,25 +1453,28 @@ class AttentionWithNorm(nnx.Module):
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     # Pre attention norm
-    lnx = self.pre_self_attention_layer_norm(inputs)
-    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+    with jax.named_scope("pre_self_attention"):
+      lnx = self.pre_self_attention_layer_norm(inputs)
+      lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
     # Self attention
-    attention_lnx, kv_cache = self.self_attention(
-        lnx,
-        lnx,
-        decoder_positions,
-        decoder_segment_ids=decoder_segment_ids,
-        deterministic=deterministic,
-        model_mode=model_mode,
-        kv_cache=kv_cache,
-        attention_metadata=attention_metadata,
-    )
+    with jax.named_scope("self_attention"):
+      attention_lnx, kv_cache = self.self_attention(
+          lnx,
+          lnx,
+          decoder_positions,
+          decoder_segment_ids=decoder_segment_ids,
+          deterministic=deterministic,
+          model_mode=model_mode,
+          kv_cache=kv_cache,
+          attention_metadata=attention_metadata,
+      )
     attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
     # Residual connection after attention
     intermediate_inputs = inputs + attention_lnx
     # Post attention norm
-    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    with jax.named_scope("post_self_attention_layer"):
+      hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
+      hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
     return hidden_states, intermediate_inputs, kv_cache
 
 
@@ -1500,6 +1507,7 @@ class Qwen3DecoderLayer(AttentionWithNorm):
         rngs=rngs,
     )
 
+  @functools.partial(jax.named_call, name="qwen3_decoder_layer")
   def __call__(
       self,
       inputs: jnp.ndarray,
@@ -1515,18 +1523,19 @@ class Qwen3DecoderLayer(AttentionWithNorm):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):
       inputs = inputs[0]
-    hidden_states, intermediate_inputs, kv_cache = self.apply_attention_with_norm(
-        inputs,
-        decoder_segment_ids,
-        decoder_positions,
-        deterministic,
-        model_mode,
-        kv_cache=kv_cache,
-        attention_metadata=attention_metadata,
-    )
-
-    mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+    with jax.named_scope("apply_attention_with_norm"):
+      hidden_states, intermediate_inputs, kv_cache = self.apply_attention_with_norm(
+          inputs,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          kv_cache=kv_cache,
+          attention_metadata=attention_metadata,
+      )
+    with jax.named_scope("apply_mlp"):
+      mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
+      mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
 
     layer_output = intermediate_inputs + mlp_lnx
     layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
@@ -1563,6 +1572,7 @@ class Qwen3MoeDecoderLayer(AttentionWithNorm):
         rngs=rngs,
     )
 
+  @functools.partial(jax.named_call, name="qwen3_moe_decoder_layer")
   def __call__(
       self,
       inputs: jnp.ndarray,
@@ -1596,8 +1606,9 @@ class Qwen3MoeDecoderLayer(AttentionWithNorm):
         attention_metadata=attention_metadata,
     )
 
-    mlp_lnx, load_balance_loss, _ = self.moe_block(hidden_states)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+    with jax.named_scope("moe_block"):
+      mlp_lnx, load_balance_loss, _ = self.moe_block(hidden_states)
+      mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
     if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
       self.moe_lb_loss = nnx.Intermediate(load_balance_loss)
 

--- a/tests/utils/reference_hlo_qwen3_1.7b.txt
+++ b/tests/utils/reference_hlo_qwen3_1.7b.txt
@@ -9,26 +9,26 @@ FileLocations
 StackFrames
 
 
-%fused_computation.478 (param_0.1336: s32[1,128]) -> s32[1,1,128] {
-  %param_0.1336 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
+%fused_computation.484 (param_0.1358: s32[1,128]) -> s32[1,1,128] {
+  %param_0.1358 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
   %constant.433.clone.9 = s32[]{:T(128)} constant(0)
   %broadcast.976 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.9), dimensions={}, metadata={op_name="broadcast.95"}
-  %lt.32 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1336, %broadcast.976), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
+  %lt.32 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1358, %broadcast.976), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
   %constant.445.clone.1 = s32[]{:T(128)} constant(151936)
-  %add.941 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.445.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %add.930 = s32[1,128]{1,0:T(1,128)} add(%param_0.1336, %add.941), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %select_n.180 = s32[1,128]{1,0:T(1,128)} select(%lt.32, %add.930, %param_0.1336), metadata={op_name="jit(train_step)/jvp()/select_n" stack_frame_id=0}
-  ROOT %bitcast.616 = s32[1,1,128]{2,1,0:T(1,128)S(1)} bitcast(%select_n.180)
+  %add.946 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.445.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %add.935 = s32[1,128]{1,0:T(1,128)} add(%param_0.1358, %add.946), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %select_n.180 = s32[1,128]{1,0:T(1,128)} select(%lt.32, %add.935, %param_0.1358), metadata={op_name="jit(train_step)/jvp()/select_n" stack_frame_id=0}
+  ROOT %bitcast.628 = s32[1,1,128]{2,1,0:T(1,128)S(1)} bitcast(%select_n.180)
 }
 
-%fused_computation.448 (param_0.1269: s32[512]) -> s32[1024] {
-  %constant.1038 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.946 = s32[1024]{0:T(1024)} broadcast(%constant.1038), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %param_0.1269 = s32[512]{0:T(512)S(1)} parameter(0)
-  %constant.1039 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %pad.57 = s32[1024]{0:T(1024)} pad(%param_0.1269, %constant.1039), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %constant.1037 = s32[] constant(151935), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.945 = s32[1024]{0:T(1024)} broadcast(%constant.1037), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+%fused_computation.454 (param_0.1291: s32[512]) -> s32[1024] {
+  %constant.1044 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.946 = s32[1024]{0:T(1024)} broadcast(%constant.1044), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %param_0.1291 = s32[512]{0:T(512)S(1)} parameter(0)
+  %constant.1045 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %pad.57 = s32[1024]{0:T(1024)} pad(%param_0.1291, %constant.1045), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.1043 = s32[] constant(151935), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.945 = s32[1024]{0:T(1024)} broadcast(%constant.1043), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   ROOT %clamp.3 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.946, %pad.57, %broadcast.945), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
@@ -44,163 +44,163 @@ StackFrames
   ROOT %reshape.780 = bf16[512,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.441), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
-%fused_computation.494 (param_0.1517: f32[128,4]) -> bf16[4,128] {
-  %param_0.1517 = f32[128,4]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.757 = f32[4,128]{1,0:T(4,128)} bitcast(%param_0.1517), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.178 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.757)
+%fused_computation.500 (param_0.1539: f32[128,4]) -> bf16[4,128] {
+  %param_0.1539 = f32[128,4]{0,1:T(4,128)S(1)} parameter(0)
+  %bitcast.769 = f32[4,128]{1,0:T(4,128)} bitcast(%param_0.1539), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.178 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.769)
 }
 
-%fused_computation.491 (param_0.1515: f32[2048,4]) -> bf16[4,2048] {
-  %param_0.1515 = f32[2048,4]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.755 = f32[4,2048]{1,0:T(4,128)} bitcast(%param_0.1515), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.172 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.755)
+%fused_computation.497 (param_0.1537: f32[2048,4]) -> bf16[4,2048] {
+  %param_0.1537 = f32[2048,4]{0,1:T(4,128)S(1)} parameter(0)
+  %bitcast.767 = f32[4,2048]{1,0:T(4,128)} bitcast(%param_0.1537), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.172 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.767)
 }
 
-%fused_computation.486 (param_0.1352: s32[1,128]) -> (f32[1,128,1,1], f32[128]) {
-  %param_0.1352 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %convert_element_type.1325 = f32[1,128]{1,0:T(1,128)} convert(%param_0.1352), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  %bitcast.626 = f32[1,128,1,1]{1,3,2,0:T(1,128)} bitcast(%convert_element_type.1325), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %bitcast.627.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%convert_element_type.1325), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.170 = (f32[1,128,1,1]{1,3,2,0:T(1,128)}, f32[128]{0:T(128)S(1)}) tuple(%bitcast.626, %bitcast.627.clone.1)
+%fused_computation.492 (param_0.1374: s32[1,128]) -> (f32[1,128,1,1], f32[128]) {
+  %param_0.1374 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
+  %convert_element_type.1325 = f32[1,128]{1,0:T(1,128)} convert(%param_0.1374), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %bitcast.638 = f32[1,128,1,1]{1,3,2,0:T(1,128)} bitcast(%convert_element_type.1325), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %bitcast.639.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%convert_element_type.1325), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.169 = (f32[1,128,1,1]{1,3,2,0:T(1,128)}, f32[128]{0:T(128)S(1)}) tuple(%bitcast.638, %bitcast.639.clone.1)
 }
 
-%fused_computation.485 () -> f32[64] {
+%fused_computation.491 () -> f32[64] {
   %constant.449.clone.1 = f32[]{:T(128)} constant(1e+06)
   %broadcast.969 = f32[64]{0:T(128)} broadcast(%constant.449.clone.1), dimensions={}, metadata={op_name="broadcast.407"}
-  %iota.56 = s32[64]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/iota" stack_frame_id=0}
+  %iota.56 = s32[64]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/iota" stack_frame_id=0}
   %constant.450.clone.1 = s32[]{:T(128)} constant(2)
   %broadcast.968 = s32[64]{0:T(128)} broadcast(%constant.450.clone.1), dimensions={}, metadata={op_name="broadcast.408"}
-  %mul.1960 = s32[64]{0:T(128)} multiply(%iota.56, %broadcast.968), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %convert_element_type.1324 = f32[64]{0:T(128)} convert(%mul.1960), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
+  %mul.1969 = s32[64]{0:T(128)} multiply(%iota.56, %broadcast.968), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1324 = f32[64]{0:T(128)} convert(%mul.1969), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
   %constant.451.clone.1 = f32[]{:T(128)} constant(0.0078125)
   %broadcast.967 = f32[64]{0:T(128)} broadcast(%constant.451.clone.1), dimensions={}, metadata={op_name="broadcast.409"}
-  %div.778 = f32[64]{0:T(128)} multiply(%convert_element_type.1324, %broadcast.967), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  ROOT %pow.36 = f32[64]{0:T(128)S(1)} power(%broadcast.969, %div.778), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
+  %div.783 = f32[64]{0:T(128)} multiply(%convert_element_type.1324, %broadcast.967), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
+  ROOT %pow.36 = f32[64]{0:T(128)S(1)} power(%broadcast.969, %div.783), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/pow" stack_frame_id=0}
 }
 
-%fused_computation.421 (param_0.1238: f32[128], param_1.1308: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
-  %param_0.1238 = f32[128]{0:T(128)S(1)} parameter(0)
-  %div.732 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_0.1238), dimensions={1}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %param_1.1308 = f32[64]{0:T(128)S(1)} parameter(1)
-  %div.738 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_1.1308), dimensions={3}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.729 = f32[1,128,1,64]{3,1,2,0:T(8,128)} divide(%div.732, %div.738), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %sin.38 = f32[1,128,1,64]{3,1,2,0:T(8,128)} sine(%div.729), metadata={op_name="jit(train_step)/sin" stack_frame_id=0}
-  %convert_element_type.1310 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%sin.38), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  %cos.41.clone.1 = f32[1,128,1,64]{3,1,2,0:T(8,128)} cosine(%div.729), metadata={op_name="jit(train_step)/cos" stack_frame_id=0}
-  %convert_element_type.1309.clone.1 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%cos.41.clone.1), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.167 = (bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert_element_type.1310, %convert_element_type.1309.clone.1)
+%fused_computation.427 (param_0.1260: f32[128], param_1.1321: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
+  %param_0.1260 = f32[128]{0:T(128)S(1)} parameter(0)
+  %div.737 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_0.1260), dimensions={1}, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
+  %param_1.1321 = f32[64]{0:T(128)S(1)} parameter(1)
+  %div.743 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_1.1321), dimensions={3}, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
+  %div.734 = f32[1,128,1,64]{3,1,2,0:T(8,128)} divide(%div.737, %div.743), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
+  %sin.38 = f32[1,128,1,64]{3,1,2,0:T(8,128)} sine(%div.734), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/sin" stack_frame_id=0}
+  %convert_element_type.1310 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%sin.38), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %cos.41.clone.1 = f32[1,128,1,64]{3,1,2,0:T(8,128)} cosine(%div.734), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/cos" stack_frame_id=0}
+  %convert_element_type.1309.clone.1 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%cos.41.clone.1), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.166 = (bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert_element_type.1310, %convert_element_type.1309.clone.1)
 }
 
-%fused_computation.424 (param_0.1209: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
-  %param_0.1209 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+%fused_computation.430 (param_0.1231: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
+  %param_0.1231 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
   %constant.454.clone.2 = bf16[]{:T(256)} constant(-inf)
-  %pad.54 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1209, %constant.454.clone.2), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %pad.54 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1231, %constant.454.clone.2), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.201 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.54)
-  %pad.53 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1209, %constant.454.clone.2), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %pad.53 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1231, %constant.454.clone.2), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.202 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.53)
-  %maximum.46 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.201, %convert.202), metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %maximum.46 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.201, %convert.202), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   ROOT %convert.203 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%maximum.46)
 }
 
-%fused_computation.425 (param_0.1211: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
-  %param_0.1211 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+%fused_computation.431 (param_0.1233: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
+  %param_0.1233 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
   %constant.454.clone.1 = bf16[]{:T(256)} constant(-inf)
-  %pad.56 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1211, %constant.454.clone.1), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %pad.56 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1233, %constant.454.clone.1), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.204 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.56)
-  %pad.55 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1211, %constant.454.clone.1), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %pad.55 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1233, %constant.454.clone.1), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.205 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.55)
-  %maximum.47 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.204, %convert.205), metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %maximum.47 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.204, %convert.205), metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   ROOT %convert.206 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%maximum.47)
 }
 
-%fused_computation.493 (param_0.1516: f32[128,4]) -> bf16[4,128] {
-  %param_0.1516 = f32[128,4]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.756 = f32[4,128]{1,0:T(4,128)} bitcast(%param_0.1516), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.176 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.756)
+%fused_computation.499 (param_0.1538: f32[128,4]) -> bf16[4,128] {
+  %param_0.1538 = f32[128,4]{0,1:T(4,128)S(1)} parameter(0)
+  %bitcast.768 = f32[4,128]{1,0:T(4,128)} bitcast(%param_0.1538), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.176 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.768)
 }
 
-%fused_computation.387 (param_0.1098: f32[512,4,8,128]) -> bf16[4,512,8,128] {
-  %param_0.1098 = f32[512,4,8,128]{3,2,1,0:T(8,128)S(1)} parameter(0)
-  %copy.213 = bf16[512,4,8,128]{3,0,2,1:T(8,128)(2,1)} copy(%param_0.1098), sharding={devices=[4,1,1,1]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'self_attention\'][\'value\'][\'kernel\'].value"}
-  ROOT %bitcast.568 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%copy.213), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+%fused_computation.393 (param_0.1120: f32[512,4,8,128]) -> bf16[4,512,8,128] {
+  %param_0.1120 = f32[512,4,8,128]{3,2,1,0:T(8,128)S(1)} parameter(0)
+  %copy.213 = bf16[512,4,8,128]{3,0,2,1:T(8,128)(2,1)} copy(%param_0.1120), sharding={devices=[4,1,1,1]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'self_attention\'][\'value\'][\'kernel\'].value"}
+  ROOT %bitcast.580 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%copy.213), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
-%fused_computation.370 (param_0.1066: f32[16,4,128,512]) -> bf16[4,16,128,512] {
-  %param_0.1066 = f32[16,4,128,512]{3,2,1,0:T(8,128)S(1)} parameter(0)
-  %copy.212 = bf16[16,4,128,512]{3,2,0,1:T(8,128)(2,1)} copy(%param_0.1066), sharding={devices=[1,1,1,4]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'self_attention\'][\'out\'][\'kernel\'].value"}
-  ROOT %bitcast.559 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} bitcast(%copy.212), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+%fused_computation.376 (param_0.1088: f32[16,4,128,512]) -> bf16[4,16,128,512] {
+  %param_0.1088 = f32[16,4,128,512]{3,2,1,0:T(8,128)S(1)} parameter(0)
+  %copy.212 = bf16[16,4,128,512]{3,2,0,1:T(8,128)(2,1)} copy(%param_0.1088), sharding={devices=[1,1,1,4]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'self_attention\'][\'out\'][\'kernel\'].value"}
+  ROOT %bitcast.571 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} bitcast(%copy.212), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
-%fused_computation.492 (param_0.1514: f32[2048,4]) -> bf16[4,2048] {
-  %param_0.1514 = f32[2048,4]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.754 = f32[4,2048]{1,0:T(4,128)} bitcast(%param_0.1514), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.174 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.754)
+%fused_computation.498 (param_0.1536: f32[2048,4]) -> bf16[4,2048] {
+  %param_0.1536 = f32[2048,4]{0,1:T(4,128)S(1)} parameter(0)
+  %bitcast.766 = f32[4,2048]{1,0:T(4,128)} bitcast(%param_0.1536), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.174 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.766)
 }
 
-%fused_computation.347 (param_0.1017: f32[512,4,6144]) -> bf16[4,512,6144] {
-  %param_0.1017 = f32[512,4,6144]{2,1,0:T(4,128)} parameter(0)
-  %copy.211 = bf16[512,4,6144]{2,0,1:T(8,128)(2,1)} copy(%param_0.1017), sharding={devices=[4,1,1]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'mlp\'][\'wi_0\'][\'kernel\'].value"}
-  ROOT %bitcast.547 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} bitcast(%copy.211), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+%fused_computation.353 (param_0.1039: f32[512,4,6144]) -> bf16[4,512,6144] {
+  %param_0.1039 = f32[512,4,6144]{2,1,0:T(4,128)S(1)} parameter(0)
+  %copy.211 = bf16[512,4,6144]{2,0,1:T(8,128)(2,1)} copy(%param_0.1039), sharding={devices=[4,1,1]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'mlp\'][\'wi_0\'][\'kernel\'].value"}
+  ROOT %bitcast.559 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} bitcast(%copy.211), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
-%fused_computation.346 (param_0.1015: f32[512,4,6144]) -> bf16[4,512,6144] {
-  %param_0.1015 = f32[512,4,6144]{2,1,0:T(4,128)} parameter(0)
-  %copy.210 = bf16[512,4,6144]{2,0,1:T(8,128)(2,1)} copy(%param_0.1015), sharding={devices=[4,1,1]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'mlp\'][\'wi_1\'][\'kernel\'].value"}
-  ROOT %bitcast.546 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} bitcast(%copy.210), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+%fused_computation.352 (param_0.1037: f32[512,4,6144]) -> bf16[4,512,6144] {
+  %param_0.1037 = f32[512,4,6144]{2,1,0:T(4,128)} parameter(0)
+  %copy.210 = bf16[512,4,6144]{2,0,1:T(8,128)(2,1)} copy(%param_0.1037), sharding={devices=[4,1,1]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'mlp\'][\'wi_1\'][\'kernel\'].value"}
+  ROOT %bitcast.558 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} bitcast(%copy.210), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
-%fused_computation.345 (param_0.1013: f32[6144,4,512]) -> bf16[4,6144,512] {
-  %param_0.1013 = f32[6144,4,512]{2,1,0:T(4,128)S(1)} parameter(0)
-  %copy.209 = bf16[6144,4,512]{2,0,1:T(8,128)(2,1)} copy(%param_0.1013), sharding={devices=[1,1,4]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'mlp\'][\'wo\'][\'kernel\'].value"}
-  ROOT %bitcast.545 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} bitcast(%copy.209), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+%fused_computation.351 (param_0.1035: f32[6144,4,512]) -> bf16[4,6144,512] {
+  %param_0.1035 = f32[6144,4,512]{2,1,0:T(4,128)S(1)} parameter(0)
+  %copy.209 = bf16[6144,4,512]{2,0,1:T(8,128)(2,1)} copy(%param_0.1035), sharding={devices=[1,1,4]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'layers\'][\'mlp\'][\'wo\'][\'kernel\'].value"}
+  ROOT %bitcast.557 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} bitcast(%copy.209), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
-%fused_computation.60.clone.1 (param_0.1806: bf16[4,1,128,2048], param_1.1890: s32[], param_2.1442: bf16[1,128,2048]) -> bf16[4,1,128,2048] {
-  %param_0.1806 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_2.1442 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %bitcast.1011 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.1442), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/broadcast_in_dim" stack_frame_id=0}
-  %param_1.1890 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.66.clone.1 (param_0.1828: bf16[4,1,128,2048], param_1.1903: s32[], param_2.1451: bf16[1,128,2048]) -> bf16[4,1,128,2048] {
+  %param_0.1828 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_2.1451 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %bitcast.1023 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.1451), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/broadcast_in_dim" stack_frame_id=0}
+  %param_1.1903 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.35 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-update-slice.32 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.1806, %bitcast.1011, %param_1.1890, %constant.404.clone.35, %constant.404.clone.35, /*index=5*/%constant.404.clone.35), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-update-slice.32 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.1828, %bitcast.1023, %param_1.1903, %constant.404.clone.35, %constant.404.clone.35, /*index=5*/%constant.404.clone.35), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.22.clone.1 (param_0.1831: bf16[4,16,128,512], param_1.1906: s32[]) -> bf16[1,16,128,512] {
-  %param_0.1831 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1906 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.22.clone.1 (param_0.1853: bf16[4,16,128,512], param_1.1919: s32[]) -> bf16[1,16,128,512] {
+  %param_0.1853 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1919 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.41 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.210 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1831, %param_1.1906, %constant.404.clone.41, %constant.404.clone.41, %constant.404.clone.41), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.208 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1853, %param_1.1919, %constant.404.clone.41, %constant.404.clone.41, %constant.404.clone.41), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.23.clone.1 (param_0.1823: bf16[4,512,16,128], param_1.1901: s32[]) -> bf16[1,512,16,128] {
-  %param_0.1823 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %param_1.1901 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.23.clone.1 (param_0.1845: bf16[4,512,16,128], param_1.1914: s32[]) -> bf16[1,512,16,128] {
+  %param_0.1845 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %param_1.1914 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.40 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.209 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1823, %param_1.1901, %constant.404.clone.40, %constant.404.clone.40, %constant.404.clone.40), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.207 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1845, %param_1.1914, %constant.404.clone.40, %constant.404.clone.40, %constant.404.clone.40), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %region_2.3 (reduce_sum.143: f32[], reduce_sum.144: f32[]) -> f32[] {
-  %reduce_sum.143 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum"}
-  %reduce_sum.144 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum"}
-  ROOT %reduce_sum.145 = f32[]{:T(128)} add(%reduce_sum.143, %reduce_sum.144), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce_sum.143 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/reduce_sum"}
+  %reduce_sum.144 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/reduce_sum"}
+  ROOT %reduce_sum.145 = f32[]{:T(128)} add(%reduce_sum.143, %reduce_sum.144), metadata={op_name="qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.38.clone.1 (param_0.1808: bf16[1,128,2048]) -> f32[128] {
-  %param_0.1808 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1516 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1808), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %square.281 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1516, %convert_element_type.1516), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
+%fused_computation.43.clone.1 (param_0.1830: bf16[1,128,2048]) -> f32[128] {
+  %param_0.1830 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1516 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1830), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
+  %square.281 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1516, %convert_element_type.1516), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/square" stack_frame_id=0}
   %constant.405.clone.13 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.276 = f32[128]{0:T(128)S(1)} reduce(%square.281, %constant.405.clone.13), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.276 = f32[128]{0:T(128)S(1)} reduce(%square.281, %constant.405.clone.13), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.83.clone.1 (param_0.1809: f32[128]) -> f32[128] {
-  %param_0.1809 = f32[128]{0:T(128)S(1)} parameter(0)
+%fused_computation.89.clone.1 (param_0.1831: f32[128]) -> f32[128] {
+  %param_0.1831 = f32[128]{0:T(128)S(1)} parameter(0)
   %constant.406.clone.9 = f32[]{:T(128)} constant(0.00048828125)
   %broadcast.1087 = f32[128]{0:T(128)} broadcast(%constant.406.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.1030 = f32[128]{0:T(128)} multiply(%param_0.1809, %broadcast.1087), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %div.1035 = f32[128]{0:T(128)} multiply(%param_0.1831, %broadcast.1087), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/div" stack_frame_id=0}
   %constant.407.clone.13 = f32[]{:T(128)} constant(1e-06)
   %broadcast.1086 = f32[128]{0:T(128)} broadcast(%constant.407.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.1061 = f32[128]{0:T(128)} add(%div.1030, %broadcast.1086), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
-  ROOT %rsqrt.222 = f32[128]{0:T(128)S(1)} rsqrt(%add.1061), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
+  %add.1066 = f32[128]{0:T(128)} add(%div.1035, %broadcast.1086), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/add" stack_frame_id=0}
+  ROOT %rsqrt.222 = f32[128]{0:T(128)S(1)} rsqrt(%add.1066), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/rsqrt" stack_frame_id=0}
 }
 
 %convert_element_type.932.reduce_sub_computation (lhs.3: bf16[], rhs.3: bf16[]) -> bf16[] {
@@ -215,566 +215,566 @@ StackFrames
   ROOT %add.794 = bf16[] add(%lhs.2, %rhs.2), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.73.clone.1 (param_0.1807: bf16[4,2048], param_1.1891: s32[], param_2.1443: bf16[4,2048]) -> (bf16[2048], bf16[2048]) {
-  %param_0.1807 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} parameter(0)
-  %param_1.1891 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.79.clone.1 (param_0.1829: bf16[4,2048], param_1.1904: s32[], param_2.1452: bf16[4,2048]) -> (bf16[2048], bf16[2048]) {
+  %param_0.1829 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} parameter(0)
+  %param_1.1904 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.36 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.203 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1807, %param_1.1891, %constant.404.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %constant.1117 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %reduce.275 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.203, %constant.1117), dimensions={0}, to_apply=%convert_element_type.932.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %param_2.1443 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} parameter(2)
-  %dynamic_slice.174.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1443, %param_1.1891, %constant.404.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %reduce.181.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.174.clone.3, %constant.1117), dimensions={0}, to_apply=%convert_element_type.920.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.240 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) tuple(%reduce.275, %reduce.181.clone.3)
+  %dynamic_slice.203 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1829, %param_1.1904, %constant.404.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1123 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
+  %reduce.275 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.203, %constant.1123), dimensions={0}, to_apply=%convert_element_type.932.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %param_2.1452 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} parameter(2)
+  %dynamic_slice.174.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1452, %param_1.1904, %constant.404.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %reduce.181.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.174.clone.3, %constant.1123), dimensions={0}, to_apply=%convert_element_type.920.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.237 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) tuple(%reduce.275, %reduce.181.clone.3)
 }
 
-%fused_computation.53.clone.2.clone.clone.clone.1 (param_0.1825: bf16[1,128,2048], param_1.1902: f32[128], param_2.1451: bf16[2048]) -> bf16[128,2048,1] {
-  %param_2.1451 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.636 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1451), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.59.clone.2.clone.clone.clone.1 (param_0.1847: bf16[1,128,2048], param_1.1915: f32[128], param_2.1460: bf16[2048]) -> bf16[128,2048,1] {
+  %param_2.1460 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.636 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1460), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.374 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.636)
-  %param_0.1825 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1524 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1825), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %param_1.1902 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2392 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1902), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %mul.2391 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1524, %mul.2392), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert_element_type.1523 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2391), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %param_0.1847 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1524 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1847), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
+  %param_1.1915 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2401 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1915), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %mul.2400 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1524, %mul.2401), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1523 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2400), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
   %convert.375 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1523)
-  %dot_general.635 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.374, %convert.375), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %dot_general.635 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.374, %convert.375), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.376 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.635)
-  ROOT %bitcast.1020 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.376)
+  ROOT %bitcast.1032 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.376)
 }
 
-%fused_computation.17.clone.clone.clone.1 (param_0.1824: bf16[1,2048,16,128]) -> bf16[2048,16,128] {
-  %param_0.1824 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1019 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1824), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+%fused_computation.17.clone.clone.clone.1 (param_0.1846: bf16[1,2048,16,128]) -> bf16[2048,16,128] {
+  %param_0.1846 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1031 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1846), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
 }
 
 %region_3.4 (reduce_sum.146: f32[], reduce_sum.150: f32[]) -> f32[] {
-  %reduce_sum.146 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum"}
-  %reduce_sum.150 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum"}
-  ROOT %reduce_sum.151 = f32[]{:T(128)} add(%reduce_sum.146, %reduce_sum.150), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce_sum.146 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum"}
+  %reduce_sum.150 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum"}
+  ROOT %reduce_sum.151 = f32[]{:T(128)} add(%reduce_sum.146, %reduce_sum.150), metadata={op_name="qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.44.clone.1 (param_0.1826: bf16[1,2048,16,128], param_1.1903: bf16[1,128,2048], param_2.1452: f32[128], param_3.954: bf16[2048]) -> (f32[128,16], bf16[128,16,128]) {
-  %param_1.1903 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.1452 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.954 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
-  %fusion.91.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1903, %param_2.1452, %param_3.954), kind=kLoop, calls=%fused_computation.53.clone.2.clone.clone.clone.1
-  %param_0.1826 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.22.clone.3 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1826), kind=kLoop, calls=%fused_computation.17.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convolution.34.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} convolution(%fusion.91.clone.3, %fusion.22.clone.3), window={size=16 pad=15_15 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convert_element_type.1525 = f32[128,16,128]{2,0,1:T(8,128)} convert(%convolution.34.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %bitcast.1021 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1525), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %square.283 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.1021, %bitcast.1021), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
+%fused_computation.49.clone.1 (param_0.1848: bf16[1,2048,16,128], param_1.1916: bf16[1,128,2048], param_2.1461: f32[128], param_3.961: bf16[2048]) -> (f32[128,16], bf16[128,16,128]) {
+  %param_1.1916 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.1461 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.961 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
+  %fusion.101.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1916, %param_2.1461, %param_3.961), kind=kLoop, calls=%fused_computation.59.clone.2.clone.clone.clone.1
+  %param_0.1848 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.22.clone.3 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1848), kind=kLoop, calls=%fused_computation.17.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convolution.34.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} convolution(%fusion.101.clone.3, %fusion.22.clone.3), window={size=16 pad=15_15 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convert_element_type.1525 = f32[128,16,128]{2,0,1:T(8,128)} convert(%convolution.34.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %bitcast.1033 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1525), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %square.283 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.1033, %bitcast.1033), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/square" stack_frame_id=0}
   %constant.405.clone.15 = f32[]{:T(128)} constant(0)
-  %reduce.278 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.283, %constant.405.clone.15), dimensions={0,3}, to_apply=%region_3.4, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.244 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) tuple(%reduce.278, %convolution.34.clone.3)
+  %reduce.278 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.283, %constant.405.clone.15), dimensions={0,3}, to_apply=%region_3.4, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.241 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) tuple(%reduce.278, %convolution.34.clone.3)
 }
 
-%fused_computation.72.clone.1 (param_0.1827: f32[128,16]) -> f32[128,16] {
-  %param_0.1827 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
+%fused_computation.78.clone.1 (param_0.1849: f32[128,16]) -> f32[128,16] {
+  %param_0.1849 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
   %constant.408.clone.10 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.1091 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.408.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %div.1032 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1827, %broadcast.1091), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %broadcast.1091 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.408.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
+  %div.1037 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1849, %broadcast.1091), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
   %constant.407.clone.15 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1090 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.407.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
-  %add.1064 = f32[128,16]{0,1:T(8,128)} add(%div.1032, %broadcast.1090), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
-  ROOT %rsqrt.224 = f32[128,16]{0,1:T(8,128)S(1)} rsqrt(%add.1064), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
+  %broadcast.1090 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.407.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}
+  %add.1069 = f32[128,16]{0,1:T(8,128)} add(%div.1037, %broadcast.1090), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}
+  ROOT %rsqrt.224 = f32[128,16]{0,1:T(8,128)S(1)} rsqrt(%add.1069), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.79.clone.1 (param_0.1814: bf16[4,128], param_1.1895: s32[], param_2.1446: bf16[4,128]) -> (bf16[128], bf16[128]) {
-  %param_0.1814 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(0)
-  %param_1.1895 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.85.clone.1 (param_0.1836: bf16[4,128], param_1.1908: s32[], param_2.1455: bf16[4,128]) -> (bf16[128], bf16[128]) {
+  %param_0.1836 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(0)
+  %param_1.1908 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.38 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.204 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1814, %param_1.1895, %constant.404.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.1015 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.204), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %param_2.1446 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(2)
-  %dynamic_slice.184.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1446, %param_1.1895, %constant.404.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.278.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.184.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.241 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) tuple(%bitcast.1015, %bitcast.278.clone.3)
+  %dynamic_slice.204 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1836, %param_1.1908, %constant.404.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.1027 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.204), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %param_2.1455 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(2)
+  %dynamic_slice.184.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1455, %param_1.1908, %constant.404.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.290.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.184.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.238 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) tuple(%bitcast.1027, %bitcast.290.clone.3)
 }
 
-%fused_computation.49.clone.2 (param_0.1828: bf16[128,16,128], param_1.1904: f32[128,16], param_2.1453: bf16[128]) -> bf16[1,128,16,128] {
-  %param_2.1453 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
-  %dot_general.638 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1453), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.55.clone.2 (param_0.1850: bf16[128,16,128], param_1.1917: f32[128,16], param_2.1462: bf16[128]) -> bf16[1,128,16,128] {
+  %param_2.1462 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
+  %dot_general.638 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1462), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.387 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.638)
-  %param_0.1828 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1527 = f32[128,16,128]{2,0,1:T(8,128)} convert(%param_0.1828), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %bitcast.1022 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1527), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %param_1.1904 = f32[128,16]{0,1:T(8,128)S(1)} parameter(1)
-  %mul.2394 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1904), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %mul.2393 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.1022, %mul.2394), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert_element_type.1526 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2393), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %param_0.1850 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1527 = f32[128,16,128]{2,0,1:T(8,128)} convert(%param_0.1850), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %bitcast.1034 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1527), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %param_1.1917 = f32[128,16]{0,1:T(8,128)S(1)} parameter(1)
+  %mul.2403 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1917), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %mul.2402 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.1034, %mul.2403), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1526 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2402), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
   %convert.388 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1526)
-  %dot_general.637 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.387, %convert.388), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %dot_general.637 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.387, %convert.388), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   ROOT %convert.389 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.637)
 }
 
-%fused_computation.54.clone.1 (param_0.1829: bf16[1,128,16,128]) -> (bf16[1,128,16,64], bf16[1,128,16,64]) {
-  %param_0.1829 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.82 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1829), slice={[0:1], [0:128], [0:16], [64:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/split" stack_frame_id=0}
+%fused_computation.60.clone.1 (param_0.1851: bf16[1,128,16,128]) -> (bf16[1,128,16,64], bf16[1,128,16,64]) {
+  %param_0.1851 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.82 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1851), slice={[0:1], [0:128], [0:16], [64:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/split" stack_frame_id=0}
   %convert.390 = f32[1,128,16,64]{3,1,2,0:T(8,128)} convert(%slice.82)
-  %neg.134 = f32[1,128,16,64]{3,1,2,0:T(8,128)} negate(%convert.390), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.391 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.134)
-  %slice.83 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1829), slice={[0:1], [0:128], [0:16], [0:64]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/split" stack_frame_id=0}
-  ROOT %tuple.245 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.391, %slice.83)
+  %neg.139 = f32[1,128,16,64]{3,1,2,0:T(8,128)} negate(%convert.390), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.391 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.139)
+  %slice.83 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1851), slice={[0:1], [0:128], [0:16], [0:64]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/split" stack_frame_id=0}
+  ROOT %tuple.242 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.391, %slice.83)
 }
 
-%fused_computation.58.clone.1 (param_0.1830: bf16[1,128,16,64], param_1.1905: bf16[1,128,16,64], param_2.1454: bf16[128,128], param_3.955: bf16[128,128], param_4.567: f32[128,16], param_5.491: bf16[128,16,128], param_6.344: bf16[128]) -> bf16[16,128,128] {
+%fused_computation.64.clone.1 (param_0.1852: bf16[1,128,16,64], param_1.1918: bf16[1,128,16,64], param_2.1463: bf16[128,128], param_3.962: bf16[128,128], param_4.572: f32[128,16], param_5.495: bf16[128,16,128], param_6.344: bf16[128]) -> bf16[16,128,128] {
   %param_6.344 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
-  %dot_general.640 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.344), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}
+  %dot_general.640 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.344), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.392 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.640)
-  %param_5.491 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} parameter(5)
-  %convert_element_type.1529 = f32[128,16,128]{2,0,1:T(8,128)} convert(%param_5.491), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %bitcast.1024 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1529), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %param_4.567 = f32[128,16]{0,1:T(8,128)S(1)} parameter(4)
-  %mul.2402 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_4.567), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %mul.2401 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.1024, %mul.2402), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert_element_type.1528 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2401), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %param_5.495 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} parameter(5)
+  %convert_element_type.1529 = f32[128,16,128]{2,0,1:T(8,128)} convert(%param_5.495), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %bitcast.1036 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1529), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %param_4.572 = f32[128,16]{0,1:T(8,128)S(1)} parameter(4)
+  %mul.2411 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_4.572), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %mul.2410 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.1036, %mul.2411), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1528 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2410), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
   %convert.393 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1528)
-  %dot_general.639 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.392, %convert.393), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_3.955 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %mul.2399 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.955), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert.394 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2399)
-  %mul.2397 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%dot_general.639, %convert.394), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_1.1905 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1119 = bf16[]{:T(256)} constant(-inf)
-  %pad.85 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1905, %constant.1119), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %dot_general.639 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.392, %convert.393), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_3.962 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %mul.2408 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.962), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert.394 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2408)
+  %mul.2406 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%dot_general.639, %convert.394), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_1.1918 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1125 = bf16[]{:T(256)} constant(-inf)
+  %pad.85 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1918, %constant.1125), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.395 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.85)
-  %param_0.1830 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.84 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1830, %constant.1119), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %param_0.1852 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.84 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1852, %constant.1125), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.396 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.84)
-  %maximum.61 = f32[1,128,16,128]{3,1,2,0:T(8,128)} maximum(%convert.395, %convert.396), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_2.1454 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %mul.2398 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1454), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert.397 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2398)
-  %mul.2396 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%maximum.61, %convert.397), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %add.1065 = f32[1,128,16,128]{3,1,2,0:T(8,128)} add(%mul.2397, %mul.2396), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %maximum.61 = f32[1,128,16,128]{3,1,2,0:T(8,128)} maximum(%convert.395, %convert.396), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_2.1463 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %mul.2407 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1463), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert.397 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2407)
+  %mul.2405 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%maximum.61, %convert.397), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %add.1070 = f32[1,128,16,128]{3,1,2,0:T(8,128)} add(%mul.2406, %mul.2405), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %constant.409.clone.7 = bf16[]{:T(256)} constant(0.08838)
-  %mul.2400 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.409.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert.398 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2400)
-  %mul.2395 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%add.1065, %convert.398), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.399 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2395)
-  ROOT %bitcast.1023 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.399), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %mul.2409 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.409.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert.398 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2409)
+  %mul.2404 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%add.1070, %convert.398), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.399 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2404)
+  ROOT %bitcast.1035 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.399), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.29.clone.1 (param_0.1815: bf16[4,512,8,128], param_1.1896: s32[]) -> bf16[1,512,8,128] {
-  %param_0.1815 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1896 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.29.clone.1 (param_0.1837: bf16[4,512,8,128], param_1.1909: s32[]) -> bf16[1,512,8,128] {
+  %param_0.1837 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1909 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.39 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.208 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1815, %param_1.1896, %constant.404.clone.39, %constant.404.clone.39, %constant.404.clone.39), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.206 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1837, %param_1.1909, %constant.404.clone.39, %constant.404.clone.39, %constant.404.clone.39), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.53.clone.1.clone.clone.clone.1 (param_0.1817: bf16[1,128,2048], param_1.1897: f32[128], param_2.1447: bf16[2048]) -> bf16[128,2048,1] {
-  %param_2.1447 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.630 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1447), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.59.clone.1.clone.clone.clone.1 (param_0.1839: bf16[1,128,2048], param_1.1910: f32[128], param_2.1456: bf16[2048]) -> bf16[128,2048,1] {
+  %param_2.1456 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.630 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1456), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.371 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.630)
-  %param_0.1817 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1520 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1817), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %param_1.1897 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2382 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1897), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %mul.2381 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1520, %mul.2382), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert_element_type.1519 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2381), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %param_0.1839 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1520 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1839), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
+  %param_1.1910 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2391 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1910), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %mul.2390 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1520, %mul.2391), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1519 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2390), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
   %convert.372 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1519)
-  %dot_general.629 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.371, %convert.372), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %dot_general.629 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.371, %convert.372), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.373 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.629)
-  ROOT %bitcast.1017 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.373)
+  ROOT %bitcast.1029 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.373)
 }
 
-%fused_computation.21.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1816: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
-  %param_0.1816 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1016 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1816), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+%fused_computation.21.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1838: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
+  %param_0.1838 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1028 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1838), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
 }
 
 %region_4.5 (reduce_sum.152: f32[], reduce_sum.153: f32[]) -> f32[] {
-  %reduce_sum.152 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum"}
-  %reduce_sum.153 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum"}
-  ROOT %reduce_sum.157 = f32[]{:T(128)} add(%reduce_sum.152, %reduce_sum.153), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce_sum.152 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum"}
+  %reduce_sum.153 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum"}
+  ROOT %reduce_sum.157 = f32[]{:T(128)} add(%reduce_sum.152, %reduce_sum.153), metadata={op_name="qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.64.clone.1 (param_0.1818: bf16[1,2048,8,128], param_1.1898: bf16[1,128,2048], param_2.1448: f32[128], param_3.952: bf16[2048]) -> (f32[128,8], f32[1,128,8,128]) {
-  %param_1.1898 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.1448 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.952 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
-  %fusion.90.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1898, %param_2.1448, %param_3.952), kind=kLoop, calls=%fused_computation.53.clone.1.clone.clone.clone.1
-  %param_0.1818 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.64.clone.3 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1818), kind=kLoop, calls=%fused_computation.21.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convolution.58.clone.3 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.90.clone.3, %fusion.64.clone.3), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convert_element_type.971.clone.3 = f32[128,8,128]{2,0,1:T(8,128)} convert(%convolution.58.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %bitcast.256.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} bitcast(%convert_element_type.971.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %square.282 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%bitcast.256.clone.3, %bitcast.256.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
+%fused_computation.70.clone.1 (param_0.1840: bf16[1,2048,8,128], param_1.1911: bf16[1,128,2048], param_2.1457: f32[128], param_3.959: bf16[2048]) -> (f32[128,8], f32[1,128,8,128]) {
+  %param_1.1911 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.1457 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.959 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
+  %fusion.100.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1911, %param_2.1457, %param_3.959), kind=kLoop, calls=%fused_computation.59.clone.1.clone.clone.clone.1
+  %param_0.1840 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.74.clone.3 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1840), kind=kLoop, calls=%fused_computation.21.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convolution.62.clone.3 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.100.clone.3, %fusion.74.clone.3), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convert_element_type.971.clone.3 = f32[128,8,128]{2,0,1:T(8,128)} convert(%convolution.62.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %bitcast.268.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} bitcast(%convert_element_type.971.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %square.282 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%bitcast.268.clone.3, %bitcast.268.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/square" stack_frame_id=0}
   %constant.405.clone.14 = f32[]{:T(128)} constant(0)
-  %reduce.277 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.282, %constant.405.clone.14), dimensions={0,3}, to_apply=%region_4.5, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.242 = (f32[128,8]{0,1:T(8,128)S(1)}, f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)}) tuple(%reduce.277, %bitcast.256.clone.3)
+  %reduce.277 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.282, %constant.405.clone.14), dimensions={0,3}, to_apply=%region_4.5, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.239 = (f32[128,8]{0,1:T(8,128)S(1)}, f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)}) tuple(%reduce.277, %bitcast.268.clone.3)
 }
 
-%fused_computation.75.clone.1 (param_0.1819: f32[128,8]) -> f32[128,8] {
-  %param_0.1819 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
+%fused_computation.81.clone.1 (param_0.1841: f32[128,8]) -> f32[128,8] {
+  %param_0.1841 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
   %constant.408.clone.9 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.1089 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.408.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
-  %div.1031 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1819, %broadcast.1089), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %broadcast.1089 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.408.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
+  %div.1036 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1841, %broadcast.1089), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
   %constant.407.clone.14 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1088 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.407.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
-  %add.1062 = f32[128,8]{0,1:T(8,128)} add(%div.1031, %broadcast.1088), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
-  ROOT %rsqrt.223 = f32[128,8]{0,1:T(8,128)S(1)} rsqrt(%add.1062), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
+  %broadcast.1088 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.407.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}
+  %add.1067 = f32[128,8]{0,1:T(8,128)} add(%div.1036, %broadcast.1088), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}
+  ROOT %rsqrt.223 = f32[128,8]{0,1:T(8,128)S(1)} rsqrt(%add.1067), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.65.clone.2 (param_0.1820: f32[1,128,8,128], param_1.1899: f32[128,8], param_2.1449: bf16[128]) -> bf16[1,128,8,128] {
-  %param_2.1449 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
-  %dot_general.632 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1449), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.71.clone.2 (param_0.1842: f32[1,128,8,128], param_1.1912: f32[128,8], param_2.1458: bf16[128]) -> bf16[1,128,8,128] {
+  %param_2.1458 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
+  %dot_general.632 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1458), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.400 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.632)
-  %param_0.1820 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} parameter(0)
-  %param_1.1899 = f32[128,8]{0,1:T(8,128)S(1)} parameter(1)
-  %mul.2384 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1899), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %mul.2383 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%param_0.1820, %mul.2384), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert_element_type.1521 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2383), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %param_0.1842 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} parameter(0)
+  %param_1.1912 = f32[128,8]{0,1:T(8,128)S(1)} parameter(1)
+  %mul.2393 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1912), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %mul.2392 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%param_0.1842, %mul.2393), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1521 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2392), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
   %convert.401 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1521)
-  %dot_general.631 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.400, %convert.401), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %dot_general.631 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.400, %convert.401), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   ROOT %convert.402 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.631)
 }
 
-%fused_computation.66.clone.1 (param_0.1821: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
-  %param_0.1821 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.80 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1821), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/split" stack_frame_id=0}
+%fused_computation.72.clone.1 (param_0.1843: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
+  %param_0.1843 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.80 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1843), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/split" stack_frame_id=0}
   %convert.403 = f32[1,128,8,64]{3,1,2,0:T(8,128)} convert(%slice.80)
-  %neg.133 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.403), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.404 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.133)
-  %slice.81 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1821), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/split" stack_frame_id=0}
-  ROOT %tuple.243 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.404, %slice.81)
+  %neg.138 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.403), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.404 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.138)
+  %slice.81 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1843), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/split" stack_frame_id=0}
+  ROOT %tuple.240 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.404, %slice.81)
 }
 
-%fused_computation.69.clone.1 (param_0.1822: bf16[1,128,8,64], param_1.1900: bf16[1,128,8,64], param_2.1450: bf16[128,128], param_3.953: bf16[128,128], param_4.566: f32[1,128,8,128], param_5.490: f32[128,8], param_6.343: bf16[128]) -> bf16[8,128,128] {
+%fused_computation.75.clone.1 (param_0.1844: bf16[1,128,8,64], param_1.1913: bf16[1,128,8,64], param_2.1459: bf16[128,128], param_3.960: bf16[128,128], param_4.571: f32[1,128,8,128], param_5.494: f32[128,8], param_6.343: bf16[128]) -> bf16[8,128,128] {
   %param_6.343 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
-  %dot_general.634 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.343), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}
+  %dot_general.634 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.343), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.405 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.634)
-  %param_4.566 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} parameter(4)
-  %param_5.490 = f32[128,8]{0,1:T(8,128)S(1)} parameter(5)
-  %mul.2390 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_5.490), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %mul.2389 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%param_4.566, %mul.2390), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert_element_type.1522 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2389), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %param_4.571 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} parameter(4)
+  %param_5.494 = f32[128,8]{0,1:T(8,128)S(1)} parameter(5)
+  %mul.2399 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_5.494), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %mul.2398 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%param_4.571, %mul.2399), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1522 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2398), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
   %convert.406 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1522)
-  %dot_general.633 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.405, %convert.406), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_3.953 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %mul.2388 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.953), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert.407 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2388)
-  %mul.2386 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%dot_general.633, %convert.407), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_1.1900 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1118 = bf16[]{:T(256)} constant(-inf)
-  %pad.83 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1900, %constant.1118), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %dot_general.633 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.405, %convert.406), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_3.960 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %mul.2397 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.960), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert.407 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2397)
+  %mul.2395 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%dot_general.633, %convert.407), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_1.1913 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1124 = bf16[]{:T(256)} constant(-inf)
+  %pad.83 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1913, %constant.1124), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.408 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.83)
-  %param_0.1822 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.82 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1822, %constant.1118), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}
+  %param_0.1844 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.82 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1844, %constant.1124), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.409 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.82)
-  %maximum.60 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.408, %convert.409), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_2.1450 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %mul.2387 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1450), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert.410 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2387)
-  %mul.2385 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%maximum.60, %convert.410), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %add.1063 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.2386, %mul.2385), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.411 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.1063)
-  ROOT %bitcast.1018 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.411), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %maximum.60 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.408, %convert.409), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_2.1459 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %mul.2396 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1459), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert.410 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2396)
+  %mul.2394 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%maximum.60, %convert.410), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %add.1068 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.2395, %mul.2394), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.411 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.1068)
+  ROOT %bitcast.1030 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.411), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.28.clone.1 (param_0.1810: bf16[4,512,8,128], param_1.1892: s32[]) -> bf16[1,512,8,128] {
-  %param_0.1810 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1892 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.28.clone.1 (param_0.1832: bf16[4,512,8,128], param_1.1905: s32[]) -> bf16[1,512,8,128] {
+  %param_0.1832 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1905 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.37 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.207 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1810, %param_1.1892, %constant.404.clone.37, %constant.404.clone.37, %constant.404.clone.37), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.205 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1832, %param_1.1905, %constant.404.clone.37, %constant.404.clone.37, %constant.404.clone.37), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.53.clone.clone.1 (param_0.1812: bf16[1,128,2048], param_1.1893: f32[128], param_2.1444: bf16[2048]) -> bf16[128,2048,1] {
-  %param_2.1444 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.628 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1444), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.59.clone.clone.1 (param_0.1834: bf16[1,128,2048], param_1.1906: f32[128], param_2.1453: bf16[2048]) -> bf16[128,2048,1] {
+  %param_2.1453 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.628 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1453), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.368 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.628)
-  %param_0.1812 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1518 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1812), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %param_1.1893 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2380 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1893), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %mul.2379 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1518, %mul.2380), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert_element_type.1517 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2379), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %param_0.1834 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1518 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1834), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
+  %param_1.1906 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2389 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1906), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %mul.2388 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1518, %mul.2389), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1517 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2388), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
   %convert.369 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1517)
-  %dot_general.627 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.368, %convert.369), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %dot_general.627 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.368, %convert.369), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.370 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.627)
-  ROOT %bitcast.1013 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.370)
+  ROOT %bitcast.1025 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.370)
 }
 
-%fused_computation.19.clone.clone.clone.1 (param_0.1811: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
-  %param_0.1811 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1012 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1811), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+%fused_computation.19.clone.clone.clone.1 (param_0.1833: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
+  %param_0.1833 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1024 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1833), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.48.clone.1 (param_0.1813: bf16[1,2048,8,128], param_1.1894: bf16[1,128,2048], param_2.1445: f32[128], param_3.951: bf16[2048]) -> bf16[8,128,128] {
-  %param_1.1894 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.1445 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.951 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
-  %fusion.509 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1894, %param_2.1445, %param_3.951), kind=kLoop, calls=%fused_computation.53.clone.clone.1
-  %param_0.1813 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.508 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1813), kind=kLoop, calls=%fused_computation.19.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convolution.148 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.509, %fusion.508), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  ROOT %bitcast.1014 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.148), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+%fused_computation.54.clone.1 (param_0.1835: bf16[1,2048,8,128], param_1.1907: bf16[1,128,2048], param_2.1454: f32[128], param_3.958: bf16[2048]) -> bf16[8,128,128] {
+  %param_1.1907 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.1454 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.958 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
+  %fusion.520 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1907, %param_2.1454, %param_3.958), kind=kLoop, calls=%fused_computation.59.clone.clone.1
+  %param_0.1835 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.519 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1835), kind=kLoop, calls=%fused_computation.19.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convolution.152 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.520, %fusion.519), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  ROOT %bitcast.1026 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.152), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.59.clone.clone.clone.1 (param_0.1833: bf16[16,128,128]) -> bf16[128,16,128] {
-  %param_0.1833 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1026 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1833)
+%fused_computation.65.clone.clone.clone.1 (param_0.1855: bf16[16,128,128]) -> bf16[128,16,128] {
+  %param_0.1855 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1038 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1855)
 }
 
-%fused_computation.15.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1832: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
-  %param_0.1832 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1025 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1832), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+%fused_computation.15.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1854: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
+  %param_0.1854 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1037 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1854), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
 }
 
 %region_5.7 (reduce_sum.158: f32[], reduce_sum.159: f32[]) -> f32[] {
-  %reduce_sum.158 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum"}
-  %reduce_sum.159 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum"}
-  ROOT %reduce_sum.160 = f32[]{:T(128)} add(%reduce_sum.158, %reduce_sum.159), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce_sum.158 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum"}
+  %reduce_sum.159 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum"}
+  ROOT %reduce_sum.160 = f32[]{:T(128)} add(%reduce_sum.158, %reduce_sum.159), metadata={op_name="qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.40.clone.1 (param_0.1834: bf16[1,128,2048], param_1.1907: bf16[1,16,128,2048], param_2.1455: bf16[16,128,128]) -> (f32[128], bf16[1,128,2048]) {
-  %param_0.1834 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.412 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1834)
-  %param_2.1455 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.79.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} fusion(%param_2.1455), kind=kLoop, calls=%fused_computation.59.clone.clone.clone.1
-  %param_1.1907 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.47.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_1.1907), kind=kLoop, calls=%fused_computation.15.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convolution.50.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.79.clone.3, %fusion.47.clone.3), window={size=16}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %bitcast.236.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.50.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convert.413 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.236.clone.3)
-  %add.797.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.412, %convert.413), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.1530 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%add.797.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %square.284 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1530, %convert_element_type.1530), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/square" stack_frame_id=0}
+%fused_computation.45.clone.1 (param_0.1856: bf16[1,128,2048], param_1.1920: bf16[1,16,128,2048], param_2.1464: bf16[16,128,128]) -> (f32[128], bf16[1,128,2048]) {
+  %param_0.1856 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.412 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1856)
+  %param_2.1464 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.89.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} fusion(%param_2.1464), kind=kLoop, calls=%fused_computation.65.clone.clone.clone.1
+  %param_1.1920 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.56.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_1.1920), kind=kLoop, calls=%fused_computation.15.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convolution.54.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.89.clone.3, %fusion.56.clone.3), window={size=16}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %bitcast.248.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.54.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convert.413 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.248.clone.3)
+  %add.802.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.412, %convert.413), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.1530 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%add.802.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %square.284 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1530, %convert_element_type.1530), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/square" stack_frame_id=0}
   %constant.405.clone.16 = f32[]{:T(128)} constant(0)
-  %reduce.279 = f32[128]{0:T(128)S(1)} reduce(%square.284, %constant.405.clone.16), dimensions={0,2}, to_apply=%region_5.7, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %convert.414 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.797.clone.3)
-  ROOT %tuple.246 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.279, %convert.414)
+  %reduce.279 = f32[128]{0:T(128)S(1)} reduce(%square.284, %constant.405.clone.16), dimensions={0,2}, to_apply=%region_5.7, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum" stack_frame_id=0}
+  %convert.414 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.802.clone.3)
+  ROOT %tuple.243 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.279, %convert.414)
 }
 
-%fused_computation.11.clone.1 (param_0.1841: bf16[4,6144,512], param_1.1912: s32[]) -> bf16[1,6144,512] {
-  %param_0.1841 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1912 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.11.clone.1 (param_0.1863: bf16[4,6144,512], param_1.1925: s32[]) -> bf16[1,6144,512] {
+  %param_0.1863 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1925 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.44 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.213 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1841, %param_1.1912, %constant.404.clone.44, %constant.404.clone.44), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.211 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1863, %param_1.1925, %constant.404.clone.44, %constant.404.clone.44), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.12.clone.1 (param_0.1840: bf16[4,512,6144], param_1.1911: s32[]) -> bf16[1,512,6144] {
-  %param_0.1840 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1911 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.12.clone.1 (param_0.1862: bf16[4,512,6144], param_1.1924: s32[]) -> bf16[1,512,6144] {
+  %param_0.1862 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1924 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.43 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.212 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1840, %param_1.1911, %constant.404.clone.43, %constant.404.clone.43), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.210 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1862, %param_1.1924, %constant.404.clone.43, %constant.404.clone.43), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.13.clone.1 (param_0.1836: bf16[4,512,6144], param_1.1908: s32[]) -> bf16[1,512,6144] {
-  %param_0.1836 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1908 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.13.clone.1 (param_0.1858: bf16[4,512,6144], param_1.1921: s32[]) -> bf16[1,512,6144] {
+  %param_0.1858 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1921 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.42 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.211 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1836, %param_1.1908, %constant.404.clone.42, %constant.404.clone.42), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.209 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1858, %param_1.1921, %constant.404.clone.42, %constant.404.clone.42), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.82.clone.1 (param_0.1835: f32[128]) -> f32[128] {
-  %param_0.1835 = f32[128]{0:T(128)S(1)} parameter(0)
+%fused_computation.88.clone.1 (param_0.1857: f32[128]) -> f32[128] {
+  %param_0.1857 = f32[128]{0:T(128)S(1)} parameter(0)
   %constant.406.clone.10 = f32[]{:T(128)} constant(0.00048828125)
   %broadcast.1093 = f32[128]{0:T(128)} broadcast(%constant.406.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %div.1033 = f32[128]{0:T(128)} multiply(%param_0.1835, %broadcast.1093), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/div" stack_frame_id=0}
+  %div.1038 = f32[128]{0:T(128)} multiply(%param_0.1857, %broadcast.1093), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/div" stack_frame_id=0}
   %constant.407.clone.16 = f32[]{:T(128)} constant(1e-06)
   %broadcast.1092 = f32[128]{0:T(128)} broadcast(%constant.407.clone.16), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call" stack_frame_id=0}
-  %add.1066 = f32[128]{0:T(128)} add(%div.1033, %broadcast.1092), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}
-  ROOT %rsqrt.225 = f32[128]{0:T(128)S(1)} rsqrt(%add.1066), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}
+  %add.1071 = f32[128]{0:T(128)} add(%div.1038, %broadcast.1092), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/add" stack_frame_id=0}
+  ROOT %rsqrt.225 = f32[128]{0:T(128)S(1)} rsqrt(%add.1071), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.51.clone.1.clone.1 (param_0.1838: bf16[1,128,2048], param_1.1909: f32[128], param_2.1456: bf16[2048]) -> bf16[128,2048] {
-  %param_2.1456 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.642 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1456), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.57.clone.1.clone.1 (param_0.1860: bf16[1,128,2048], param_1.1922: f32[128], param_2.1465: bf16[2048]) -> bf16[128,2048] {
+  %param_2.1465 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.642 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1465), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.377 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.642)
-  %param_0.1838 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1532 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1838), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %param_1.1909 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2404 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1909), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %mul.2403 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1532, %mul.2404), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert_element_type.1531 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2403), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %param_0.1860 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1532 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1860), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %param_1.1922 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2413 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1922), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %mul.2412 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1532, %mul.2413), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %convert_element_type.1531 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2412), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
   %convert.378 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1531)
-  %dot_general.641 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.377, %convert.378), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %dot_general.641 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.377, %convert.378), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.379 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.641)
-  ROOT %bitcast.1028 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.379)
+  ROOT %bitcast.1040 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.379)
 }
 
-%fused_computation.10.clone.clone.clone.1 (param_0.1837: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1837 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1027 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1837), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+%fused_computation.10.clone.clone.clone.1 (param_0.1859: bf16[1,2048,6144]) -> bf16[2048,6144] {
+  %param_0.1859 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1039 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1859), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.24.clone.1 (param_0.1839: bf16[1,2048,6144], param_1.1910: bf16[1,128,2048], param_2.1457: f32[128], param_3.956: bf16[2048]) -> bf16[1,128,6144] {
-  %param_1.1910 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.1457 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.956 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
-  %fusion.511 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1910, %param_2.1457, %param_3.956), kind=kLoop, calls=%fused_computation.51.clone.1.clone.1
-  %param_0.1839 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.510 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1839), kind=kLoop, calls=%fused_computation.10.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convolution.149 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.511, %fusion.510), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  ROOT %bitcast.1029 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.149), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+%fused_computation.24.clone.1 (param_0.1861: bf16[1,2048,6144], param_1.1923: bf16[1,128,2048], param_2.1466: f32[128], param_3.963: bf16[2048]) -> bf16[1,128,6144] {
+  %param_1.1923 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.1466 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.963 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
+  %fusion.522 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1923, %param_2.1466, %param_3.963), kind=kLoop, calls=%fused_computation.57.clone.1.clone.1
+  %param_0.1861 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.521 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1861), kind=kLoop, calls=%fused_computation.10.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %convolution.153 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.522, %fusion.521), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  ROOT %bitcast.1041 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.153), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.51.clone.clone.clone.1 (param_0.1844: bf16[1,128,2048], param_1.1913: f32[128], param_2.1458: bf16[2048]) -> bf16[128,2048] {
-  %param_2.1458 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.644 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1458), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.57.clone.clone.clone.1 (param_0.1866: bf16[1,128,2048], param_1.1926: f32[128], param_2.1467: bf16[2048]) -> bf16[128,2048] {
+  %param_2.1467 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.644 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1467), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.380 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.644)
-  %param_0.1844 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1534 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1844), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %param_1.1913 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2406 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1913), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %mul.2405 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1534, %mul.2406), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}
-  %convert_element_type.1533 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2405), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
+  %param_0.1866 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1534 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1866), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %param_1.1926 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2415 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1926), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %mul.2414 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1534, %mul.2415), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %convert_element_type.1533 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2414), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
   %convert.381 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1533)
-  %dot_general.643 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.380, %convert.381), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %dot_general.643 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.380, %convert.381), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.382 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.643)
-  ROOT %bitcast.1032 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.382)
+  ROOT %bitcast.1044 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.382)
 }
 
-%fused_computation.8.clone.clone.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1843: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1843 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.1031 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1843), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+%fused_computation.8.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1865: bf16[1,2048,6144]) -> bf16[2048,6144] {
+  %param_0.1865 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1043 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1865), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.27.clone.clone.clone.1 (param_0.1845: bf16[1,2048,6144], param_1.1914: bf16[1,128,6144], param_2.1459: bf16[1,128,2048], param_3.957: f32[128], param_4.568: bf16[2048]) -> bf16[128,6144] {
-  %param_1.1914 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.383 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1914)
+%fused_computation.27.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1867: bf16[1,2048,6144], param_1.1927: bf16[1,128,6144], param_2.1468: bf16[1,128,2048], param_3.964: f32[128], param_4.573: bf16[2048]) -> bf16[128,6144] {
+  %param_1.1927 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.383 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1927)
   %constant.410.clone.10 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.46 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.410.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)" stack_frame_id=0}
-  %convert.384 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.46)
-  %neg.135 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.383), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %exp.79 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.135), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %add.1067 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.79, %convert.384), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %div.1034 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.384, %add.1067), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2408 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.383, %div.1034), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %param_2.1459 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.957 = f32[128]{0:T(128)S(1)} parameter(3)
-  %param_4.568 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(4)
-  %fusion.513 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_2.1459, %param_3.957, %param_4.568), kind=kLoop, calls=%fused_computation.51.clone.clone.clone.1
-  %param_0.1845 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %fusion.512 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1845), kind=kLoop, calls=%fused_computation.8.clone.clone.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convolution.150 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.513, %fusion.512), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %bitcast.1034 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.150), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convert.385 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%bitcast.1034)
-  %mul.2407 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2408, %convert.385), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.386 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2407)
-  ROOT %bitcast.1033 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.386)
+  %jit_silu_.47 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.410.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/jit(silu)" stack_frame_id=0}
+  %convert.384 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.47)
+  %neg.140 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.383), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %exp.84 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.140), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %add.1072 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.84, %convert.384), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %div.1039 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.384, %add.1072), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2417 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.383, %div.1039), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %param_2.1468 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.964 = f32[128]{0:T(128)S(1)} parameter(3)
+  %param_4.573 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(4)
+  %fusion.524 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_2.1468, %param_3.964, %param_4.573), kind=kLoop, calls=%fused_computation.57.clone.clone.clone.1
+  %param_0.1867 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.523 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1867), kind=kLoop, calls=%fused_computation.8.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %convolution.154 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.524, %fusion.523), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %bitcast.1046 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.154), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %convert.385 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%bitcast.1046)
+  %mul.2416 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2417, %convert.385), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.386 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2416)
+  ROOT %bitcast.1045 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.386)
 }
 
-%fused_computation.6.clone.clone.clone.clone.clone.1 (param_0.1842: bf16[1,6144,2048]) -> bf16[6144,2048] {
-  %param_0.1842 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1030 = bf16[6144,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1842), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
+%fused_computation.6.clone.clone.clone.clone.clone.1 (param_0.1864: bf16[1,6144,2048]) -> bf16[6144,2048] {
+  %param_0.1864 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1042 = bf16[6144,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1864), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.37.clone.1 (param_0.1846: bf16[1,128,2048], param_1.1915: bf16[1,6144,2048], param_2.1460: bf16[1,2048,6144], param_3.958: bf16[1,128,6144], param_4.569: f32[128], param_5.492: bf16[2048]) -> bf16[1,128,2048] {
-  %param_0.1846 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.415 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1846)
-  %param_2.1460 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} parameter(2)
-  %param_3.958 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %param_4.569 = f32[128]{0:T(128)S(1)} parameter(4)
-  %param_5.492 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(5)
-  %fusion.36.clone.3 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_2.1460, %param_3.958, %param_0.1846, %param_4.569, %param_5.492), kind=kOutput, calls=%fused_computation.27.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %param_1.1915 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.514 = bf16[6144,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1915), kind=kLoop, calls=%fused_computation.6.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convolution.151 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.36.clone.3, %fusion.514), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %bitcast.1035 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.151), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}
-  %convert.416 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.1035)
-  %add.1068 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.415, %convert.416), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  ROOT %convert.417 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.1068)
+%fused_computation.42.clone.1 (param_0.1868: bf16[1,128,2048], param_1.1928: bf16[1,6144,2048], param_2.1469: bf16[1,2048,6144], param_3.965: bf16[1,128,6144], param_4.574: f32[128], param_5.496: bf16[2048]) -> bf16[1,128,2048] {
+  %param_0.1868 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.415 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1868)
+  %param_2.1469 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.965 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_4.574 = f32[128]{0:T(128)S(1)} parameter(4)
+  %param_5.496 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(5)
+  %fusion.36.clone.7 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_2.1469, %param_3.965, %param_0.1868, %param_4.574, %param_5.496), kind=kOutput, calls=%fused_computation.27.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %param_1.1928 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.525 = bf16[6144,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1928), kind=kLoop, calls=%fused_computation.6.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %convolution.155 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.36.clone.7, %fusion.525), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %bitcast.1047 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.155), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %convert.416 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.1047)
+  %add.1073 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.415, %convert.416), metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  ROOT %convert.417 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.1073)
 }
 
 %wide.region_1.8_spmd.sunk.clone.clone.clone.sunk (wide.param.1: (s32[], bf16[1,128,2048], bf16[4,1,128,2048], bf16[4,128], bf16[4,2048], /*index=5*/bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,128], bf16[4,512,8,128], /*index=10*/bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], bf16[4,512,6144], bf16[4,512,6144], /*index=15*/bf16[4,6144,512], s32[128], s32[], s8[1,1,1], s8[1,1,1])) -> (s32[], bf16[1,128,2048], bf16[4,1,128,2048], bf16[4,128], bf16[4,2048], /*index=5*/bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,128], bf16[4,512,8,128], /*index=10*/bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], bf16[4,512,6144], bf16[4,512,6144], /*index=15*/bf16[4,6144,512], s32[128], s32[], s8[1,1,1], s8[1,1,1]) {
   %constant.460.clone..sunk.1 = s32[]{:T(128)} constant(1)
   %wide.param.1 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) parameter(0)
-  %get-tuple-element.1698 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=0
-  %copy.243 = s32[]{:T(128)S(6)} copy(%get-tuple-element.1698), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add.1069 = s32[]{:T(128)} add(%copy.243, %constant.460.clone..sunk.1), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1700 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=2
-  %get-tuple-element.1699 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=1
-  %bitcast_dynamic-update-slice_fusion.5 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} fusion(%get-tuple-element.1700, %copy.243, %get-tuple-element.1699), kind=kLoop, calls=%fused_computation.60.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
-  %get-tuple-element.1729 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=11
-  %dynamic-slice_convert_fusion.35 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1729, %copy.243), kind=kLoop, calls=%fused_computation.22.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.106 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.35), channel_id=104, replica_groups=mesh['axis_0'=1,'axis_1'=1,'axis_2'=4] {'axis_2'}, dimensions={3}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1736 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=18, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
-  %get-tuple-element.1737 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=19, metadata={op_name="jit(train_step)/sharding_constraint" stack_frame_id=0}
-  %get-tuple-element.1723 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=5
-  %dynamic-slice_convert_fusion.36 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1723, %copy.243), kind=kLoop, calls=%fused_computation.23.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.107 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.36), channel_id=101, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.515 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.1699), kind=kLoop, calls=%fused_computation.38.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add_rsqrt_fusion.8 = f32[128]{0:T(128)S(1)} fusion(%fusion.515), kind=kLoop, calls=%fused_computation.83.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1730 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=12
-  %get-tuple-element.1722 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=4
-  %convert_reduce_fusion.7 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) fusion(%get-tuple-element.1730, %copy.243, %get-tuple-element.1722), kind=kLoop, calls=%fused_computation.73.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1663 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} get-tuple-element(%convert_reduce_fusion.7), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %fusion.516 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) fusion(%all-gather.107, %get-tuple-element.1699, %add_rsqrt_fusion.8, %get-tuple-element.1663), kind=kOutput, calls=%fused_computation.44.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1664 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.516), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %get-tuple-element.1665 = f32[128,16]{0,1:T(8,128)S(1)} get-tuple-element(%fusion.516), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %add_rsqrt_fusion.9 = f32[128,16]{0,1:T(8,128)S(1)} fusion(%get-tuple-element.1665), kind=kLoop, calls=%fused_computation.72.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1721 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=3
-  %get-tuple-element.1726 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=8
-  %fusion.517 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) fusion(%get-tuple-element.1721, %copy.243, %get-tuple-element.1726), kind=kLoop, calls=%fused_computation.79.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1666 = bf16[128]{0:T(256)(128)(2,1)S(1)} get-tuple-element(%fusion.517), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %fusion.518 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1664, %add_rsqrt_fusion.9, %get-tuple-element.1666), kind=kLoop, calls=%fused_computation.49.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice_negate_fusion.12 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.518), kind=kLoop, calls=%fused_computation.54.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1667 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %get-tuple-element.1668 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %get-tuple-element.1725 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=7
-  %get-tuple-element.1724 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=6
-  %bitcast.1070 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1725)
-  %bitcast.1068 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1724)
-  %fusion.519 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1667, %get-tuple-element.1668, %bitcast.1070, %bitcast.1068, %add_rsqrt_fusion.9, /*index=5*/%get-tuple-element.1664, %get-tuple-element.1666), kind=kLoop, calls=%fused_computation.58.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1727 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=9
-  %dynamic-slice_convert_fusion.37 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1727, %copy.243), kind=kLoop, calls=%fused_computation.29.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.108 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.37), channel_id=102, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %multiply_reduce_fusion.48 = (f32[128,8]{0,1:T(8,128)S(1)}, f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)}) fusion(%all-gather.108, %get-tuple-element.1699, %add_rsqrt_fusion.8, %get-tuple-element.1663), kind=kOutput, calls=%fused_computation.64.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1669 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} get-tuple-element(%multiply_reduce_fusion.48), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %get-tuple-element.1670 = f32[128,8]{0,1:T(8,128)S(1)} get-tuple-element(%multiply_reduce_fusion.48), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %add_rsqrt_fusion.10 = f32[128,8]{0,1:T(8,128)S(1)} fusion(%get-tuple-element.1670), kind=kLoop, calls=%fused_computation.75.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1671 = bf16[128]{0:T(256)(128)(2,1)S(1)} get-tuple-element(%fusion.517), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %fusion.520 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1669, %add_rsqrt_fusion.10, %get-tuple-element.1671), kind=kLoop, calls=%fused_computation.65.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice_negate_fusion.13 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.520), kind=kLoop, calls=%fused_computation.66.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1672 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %get-tuple-element.1673 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/neg" stack_frame_id=0}
-  %bitcast.1071 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1725)
-  %bitcast.1069 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1724)
-  %fusion.521 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1672, %get-tuple-element.1673, %bitcast.1071, %bitcast.1069, %get-tuple-element.1669, /*index=5*/%add_rsqrt_fusion.10, %get-tuple-element.1671), kind=kLoop, calls=%fused_computation.69.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1728 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=10
-  %dynamic-slice_convert_fusion.38 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1728, %copy.243), kind=kLoop, calls=%fused_computation.28.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.109 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.38), channel_id=103, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.522 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.109, %get-tuple-element.1699, %add_rsqrt_fusion.8, %get-tuple-element.1663), kind=kOutput, calls=%fused_computation.48.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1734 = s32[128]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=16
-  %squeeze.274 = s32[128,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.1734), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8"]},"aliasing_operands":{"lists":[]}}
-  %squeeze.275 = s32[8,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.1734), dimensions={1}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["128"]},"aliasing_operands":{"lists":[]}}
-  %iota.68 = s32[128,128]{1,0:T(8,128)S(1)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %splash_mha_fwd_segmented_residuals.3 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[16,128,128]{2,1,0:T(8,128)}) custom-call(%get-tuple-element.1736, %get-tuple-element.1737, %fusion.519, %fusion.521, %fusion.522, /*index=5*/%squeeze.274, %squeeze.275, %iota.68), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[16,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
+  %get-tuple-element.1686 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=0
+  %copy.243 = s32[]{:T(128)S(6)} copy(%get-tuple-element.1686), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add.1074 = s32[]{:T(128)} add(%copy.243, %constant.460.clone..sunk.1), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1688 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=2
+  %get-tuple-element.1687 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=1
+  %bitcast_dynamic-update-slice_fusion.5 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} fusion(%get-tuple-element.1688, %copy.243, %get-tuple-element.1687), kind=kLoop, calls=%fused_computation.66.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
+  %get-tuple-element.1717 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=11
+  %dynamic-slice_convert_fusion.35 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1717, %copy.243), kind=kLoop, calls=%fused_computation.22.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.106 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.35), channel_id=104, replica_groups=mesh['axis_0'=1,'axis_1'=1,'axis_2'=4] {'axis_2'}, dimensions={3}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1724 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=18, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/sharding_constraint" stack_frame_id=0}
+  %get-tuple-element.1725 = s8[1,1,1]{2,1,0:T(4,128)(4,1)} get-tuple-element(%wide.param.1), index=19, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/sharding_constraint" stack_frame_id=0}
+  %get-tuple-element.1711 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=5
+  %dynamic-slice_convert_fusion.36 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1711, %copy.243), kind=kLoop, calls=%fused_computation.23.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.107 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.36), channel_id=101, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.526 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.1687), kind=kLoop, calls=%fused_computation.43.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add_rsqrt_fusion.8 = f32[128]{0:T(128)S(1)} fusion(%fusion.526), kind=kLoop, calls=%fused_computation.89.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1718 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=12
+  %get-tuple-element.1710 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=4
+  %convert_reduce_fusion.7 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) fusion(%get-tuple-element.1718, %copy.243, %get-tuple-element.1710), kind=kLoop, calls=%fused_computation.79.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1651 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} get-tuple-element(%convert_reduce_fusion.7), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %fusion.527 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) fusion(%all-gather.107, %get-tuple-element.1687, %add_rsqrt_fusion.8, %get-tuple-element.1651), kind=kOutput, calls=%fused_computation.49.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1652 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.527), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}
+  %get-tuple-element.1653 = f32[128,16]{0,1:T(8,128)S(1)} get-tuple-element(%fusion.527), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}
+  %add_rsqrt_fusion.9 = f32[128,16]{0,1:T(8,128)S(1)} fusion(%get-tuple-element.1653), kind=kLoop, calls=%fused_computation.78.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1709 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=3
+  %get-tuple-element.1714 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=8
+  %fusion.528 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) fusion(%get-tuple-element.1709, %copy.243, %get-tuple-element.1714), kind=kLoop, calls=%fused_computation.85.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1654 = bf16[128]{0:T(256)(128)(2,1)S(1)} get-tuple-element(%fusion.528), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %fusion.529 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1652, %add_rsqrt_fusion.9, %get-tuple-element.1654), kind=kLoop, calls=%fused_computation.55.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %slice_negate_fusion.12 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.529), kind=kLoop, calls=%fused_computation.60.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1655 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/neg" stack_frame_id=0}
+  %get-tuple-element.1656 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.12), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/neg" stack_frame_id=0}
+  %get-tuple-element.1713 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=7
+  %get-tuple-element.1712 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%wide.param.1), index=6
+  %bitcast.1093 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1713)
+  %bitcast.1091 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1712)
+  %fusion.530 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1655, %get-tuple-element.1656, %bitcast.1093, %bitcast.1091, %add_rsqrt_fusion.9, /*index=5*/%get-tuple-element.1652, %get-tuple-element.1654), kind=kLoop, calls=%fused_computation.64.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1715 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=9
+  %dynamic-slice_convert_fusion.37 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1715, %copy.243), kind=kLoop, calls=%fused_computation.29.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.108 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.37), channel_id=102, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %multiply_reduce_fusion.48 = (f32[128,8]{0,1:T(8,128)S(1)}, f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)}) fusion(%all-gather.108, %get-tuple-element.1687, %add_rsqrt_fusion.8, %get-tuple-element.1651), kind=kOutput, calls=%fused_computation.70.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1657 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} get-tuple-element(%multiply_reduce_fusion.48), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}
+  %get-tuple-element.1658 = f32[128,8]{0,1:T(8,128)S(1)} get-tuple-element(%multiply_reduce_fusion.48), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}
+  %add_rsqrt_fusion.10 = f32[128,8]{0,1:T(8,128)S(1)} fusion(%get-tuple-element.1658), kind=kLoop, calls=%fused_computation.81.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1659 = bf16[128]{0:T(256)(128)(2,1)S(1)} get-tuple-element(%fusion.528), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %fusion.531 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1657, %add_rsqrt_fusion.10, %get-tuple-element.1659), kind=kLoop, calls=%fused_computation.71.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %slice_negate_fusion.13 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.531), kind=kLoop, calls=%fused_computation.72.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1660 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/neg" stack_frame_id=0}
+  %get-tuple-element.1661 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} get-tuple-element(%slice_negate_fusion.13), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/neg" stack_frame_id=0}
+  %bitcast.1094 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1713)
+  %bitcast.1092 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%get-tuple-element.1712)
+  %fusion.532 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1660, %get-tuple-element.1661, %bitcast.1094, %bitcast.1092, %get-tuple-element.1657, /*index=5*/%add_rsqrt_fusion.10, %get-tuple-element.1659), kind=kLoop, calls=%fused_computation.75.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1716 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=10
+  %dynamic-slice_convert_fusion.38 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1716, %copy.243), kind=kLoop, calls=%fused_computation.28.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.109 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.38), channel_id=103, replica_groups=mesh['axis_0'=4,'axis_1'=1,'axis_2'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.533 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.109, %get-tuple-element.1687, %add_rsqrt_fusion.8, %get-tuple-element.1651), kind=kOutput, calls=%fused_computation.54.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1722 = s32[128]{0:T(128)S(1)} get-tuple-element(%wide.param.1), index=16
+  %squeeze.274 = s32[128,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.1722), dimensions={0}, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8"]},"aliasing_operands":{"lists":[]}}
+  %squeeze.275 = s32[8,128]{1,0:T(8,128)S(1)} broadcast(%get-tuple-element.1722), dimensions={1}, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["128"]},"aliasing_operands":{"lists":[]}}
+  %iota.68 = s32[128,128]{1,0:T(8,128)S(1)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %splash_mha_fwd_segmented_residuals.3 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[16,128,128]{2,1,0:T(8,128)}) custom-call(%get-tuple-element.1724, %get-tuple-element.1725, %fusion.530, %fusion.532, %fusion.533, /*index=5*/%squeeze.274, %squeeze.275, %iota.68), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[16,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
 "xprof_metadata":"{\"block_q\": 128, \"block_kv\": 128, \"block_kv_compute\": 128, \"block_q_dkv\": 128, \"block_kv_dkv\": 128, \"block_kv_dkv_compute\": 128, \"block_q_dq\": 128, \"block_kv_dq\": 128, \"use_fused_bwd_kernel\": false, \"q_layout\": 1, \"k_layout\": 1, \"v_layout\": 1}"
-}}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"custom_call_config":{"body":"<mosaic_body>","needs_layout_passes":true,"allow_input_fusion":[],"serialization_format":"1","output_memory_colors":[],"output_memory_space_colors":[],"input_memory_space_colors":[]},"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1674 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%splash_mha_fwd_segmented_residuals.3), index=3, frontend_attributes={kernel_metadata={
+}}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"custom_call_config":{"body":"<mosaic_body>","needs_layout_passes":true,"allow_input_fusion":[],"serialization_format":"1","output_memory_colors":[],"output_memory_space_colors":[],"input_memory_space_colors":[]},"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1662 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%splash_mha_fwd_segmented_residuals.3), index=3, frontend_attributes={kernel_metadata={
 "xprof_metadata":"{\"block_q\": 128, \"block_kv\": 128, \"block_kv_compute\": 128, \"block_q_dkv\": 128, \"block_kv_dkv\": 128, \"block_kv_dkv_compute\": 128, \"block_q_dq\": 128, \"block_kv_dq\": 128, \"use_fused_bwd_kernel\": false, \"q_layout\": 1, \"k_layout\": 1, \"v_layout\": 1}"
-}}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}
-  %fusion.523 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%get-tuple-element.1699, %all-gather.106, %get-tuple-element.1674), kind=kOutput, calls=%fused_computation.40.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1675 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.523), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %get-tuple-element.1733 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=15
-  %dynamic-slice_convert_fusion.39 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1733, %copy.243), kind=kLoop, calls=%fused_computation.11.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.110 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.39), channel_id=107, replica_groups=mesh['axis_0'=1,'axis_1'=4] {'axis_1'}, dimensions={2}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1732 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=14
-  %dynamic-slice_convert_fusion.40 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1732, %copy.243), kind=kLoop, calls=%fused_computation.12.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.111 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.40), channel_id=106, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1731 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=13
-  %dynamic-slice_convert_fusion.41 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1731, %copy.243), kind=kLoop, calls=%fused_computation.13.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.112 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.41), channel_id=105, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1676 = f32[128]{0:T(128)S(1)} get-tuple-element(%fusion.523), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/reduce_sum" stack_frame_id=0}
-  %add_rsqrt_fusion.11 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.1676), kind=kLoop, calls=%fused_computation.82.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1677 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} get-tuple-element(%convert_reduce_fusion.7), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/convert_element_type" stack_frame_id=0}
-  %fusion.524 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.112, %get-tuple-element.1675, %add_rsqrt_fusion.11, %get-tuple-element.1677), kind=kOutput, calls=%fused_computation.24.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.525 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1675, %all-gather.110, %all-gather.111, %fusion.524, %add_rsqrt_fusion.11, /*index=5*/%get-tuple-element.1677), kind=kOutput, calls=%fused_computation.37.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %get-tuple-element.1735 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=17
-  ROOT %tuple.250 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) tuple(%add.1069, %fusion.525, %bitcast_dynamic-update-slice_fusion.5, %get-tuple-element.1721, %get-tuple-element.1722, /*index=5*/%get-tuple-element.1723, %get-tuple-element.1724, %get-tuple-element.1725, %get-tuple-element.1726, %get-tuple-element.1727, /*index=10*/%get-tuple-element.1728, %get-tuple-element.1729, %get-tuple-element.1730, %get-tuple-element.1731, %get-tuple-element.1732, /*index=15*/%get-tuple-element.1733, %get-tuple-element.1734, %get-tuple-element.1735, %get-tuple-element.1736, %get-tuple-element.1737)
+}}, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}
+  %fusion.534 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%get-tuple-element.1687, %all-gather.106, %get-tuple-element.1662), kind=kOutput, calls=%fused_computation.45.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1663 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} get-tuple-element(%fusion.534), index=1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum" stack_frame_id=0}
+  %get-tuple-element.1721 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=15
+  %dynamic-slice_convert_fusion.39 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1721, %copy.243), kind=kLoop, calls=%fused_computation.11.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.110 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.39), channel_id=107, replica_groups=mesh['axis_0'=1,'axis_1'=4] {'axis_1'}, dimensions={2}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1720 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=14
+  %dynamic-slice_convert_fusion.40 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1720, %copy.243), kind=kLoop, calls=%fused_computation.12.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.111 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.40), channel_id=106, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1719 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} get-tuple-element(%wide.param.1), index=13
+  %dynamic-slice_convert_fusion.41 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1719, %copy.243), kind=kLoop, calls=%fused_computation.13.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.112 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.41), channel_id=105, replica_groups=mesh['axis_0'=4,'axis_1'=1] {'axis_0'}, dimensions={1}, use_global_device_ids=true, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1664 = f32[128]{0:T(128)S(1)} get-tuple-element(%fusion.534), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum" stack_frame_id=0}
+  %add_rsqrt_fusion.11 = f32[128]{0:T(128)S(1)} fusion(%get-tuple-element.1664), kind=kLoop, calls=%fused_computation.88.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1665 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} get-tuple-element(%convert_reduce_fusion.7), index=0, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %fusion.535 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.112, %get-tuple-element.1663, %add_rsqrt_fusion.11, %get-tuple-element.1665), kind=kOutput, calls=%fused_computation.24.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.536 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} fusion(%get-tuple-element.1663, %all-gather.110, %all-gather.111, %fusion.535, %add_rsqrt_fusion.11, /*index=5*/%get-tuple-element.1665), kind=kOutput, calls=%fused_computation.42.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/closed_call/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1723 = s32[]{:T(128)} get-tuple-element(%wide.param.1), index=17
+  ROOT %tuple.247 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) tuple(%add.1074, %fusion.536, %bitcast_dynamic-update-slice_fusion.5, %get-tuple-element.1709, %get-tuple-element.1710, /*index=5*/%get-tuple-element.1711, %get-tuple-element.1712, %get-tuple-element.1713, %get-tuple-element.1714, %get-tuple-element.1715, /*index=10*/%get-tuple-element.1716, %get-tuple-element.1717, %get-tuple-element.1718, %get-tuple-element.1719, %get-tuple-element.1720, /*index=15*/%get-tuple-element.1721, %get-tuple-element.1722, %get-tuple-element.1723, %get-tuple-element.1724, %get-tuple-element.1725)
 }
 
 %wide.region_6.9_spmd.clone.clone.clone (wide.param.113: (s32[], bf16[1,128,2048], bf16[4,1,128,2048], bf16[4,128], bf16[4,2048], /*index=5*/bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,128], bf16[4,512,8,128], /*index=10*/bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], bf16[4,512,6144], bf16[4,512,6144], /*index=15*/bf16[4,6144,512], s32[128], s32[], s8[1,1,1], s8[1,1,1])) -> pred[] {
   %constant.411.clone.4 = s32[]{:T(128)} constant(4)
   %wide.param.113 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) parameter(0)
-  %get-tuple-element.1476 = s32[]{:T(128)} get-tuple-element(%wide.param.113), index=0
-  ROOT %lt.34 = pred[]{:T(512)} compare(%get-tuple-element.1476, %constant.411.clone.4), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/cond/lt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %get-tuple-element.1468 = s32[]{:T(128)} get-tuple-element(%wide.param.113), index=0
+  ROOT %lt.34 = pred[]{:T(512)} compare(%get-tuple-element.1468, %constant.411.clone.4), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/cond/lt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
 %region_7.10 (reduce_sum.171: f32[], reduce_sum.184: f32[]) -> f32[] {
@@ -783,46 +783,46 @@ StackFrames
   ROOT %reduce_sum.185 = f32[]{:T(128)} add(%reduce_sum.171, %reduce_sum.184), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.406 (param_0.1550: bf16[1,128,2048]) -> f32[128] {
-  %param_0.1550 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1283 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1550), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+%fused_computation.412 (param_0.1572: bf16[1,128,2048]) -> f32[128] {
+  %param_0.1572 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1283 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1572), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
   %square.243 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1283, %convert_element_type.1283), metadata={op_name="jit(train_step)/jvp()/square" stack_frame_id=0}
   %constant.444.clone.29 = f32[]{:T(128)} constant(0)
   ROOT %reduce.222 = f32[128]{0:T(128)S(1)} reduce(%square.243, %constant.444.clone.29), dimensions={0,2}, to_apply=%region_7.10, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.467 (param_0.1364: f32[128]) -> f32[128] {
-  %param_0.1364 = f32[128]{0:T(128)S(1)} parameter(0)
+%fused_computation.473 (param_0.1386: f32[128]) -> f32[128] {
+  %param_0.1386 = f32[128]{0:T(128)S(1)} parameter(0)
   %constant.452.clone.2 = f32[]{:T(128)} constant(0.00048828125)
   %broadcast.966 = f32[128]{0:T(128)} broadcast(%constant.452.clone.2), dimensions={}, metadata={op_name="broadcast.416"}
-  %div.784 = f32[128]{0:T(128)} multiply(%param_0.1364, %broadcast.966), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
+  %div.789 = f32[128]{0:T(128)} multiply(%param_0.1386, %broadcast.966), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
   %constant.453.clone.2 = f32[]{:T(128)} constant(1e-06)
   %broadcast.964 = f32[128]{0:T(128)} broadcast(%constant.453.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %add.940 = f32[128]{0:T(128)} add(%div.784, %broadcast.964), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %bitcast.624 = f32[1,128]{1,0:T(1,128)} bitcast(%add.940), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %rsqrt.195 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.624), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.614 = f32[128]{0:T(128)} bitcast(%rsqrt.195), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
+  %add.945 = f32[128]{0:T(128)} add(%div.789, %broadcast.964), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %bitcast.636 = f32[1,128]{1,0:T(1,128)} bitcast(%add.945), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %rsqrt.195 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.636), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.626 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.195), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.412.clone.clone (param_0.1510: bf16[2048], param_1.1694: f32[128], param_2.1284: bf16[1,128,2048]) -> bf16[128,2048] {
-  %param_0.1510 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.506 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1510), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
+%fused_computation.418.clone.clone (param_0.1532: bf16[2048], param_1.1707: f32[128], param_2.1293: bf16[1,128,2048]) -> bf16[128,2048] {
+  %param_0.1532 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.506 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1532), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
   %convert.210 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.506)
-  %param_2.1284 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(2)
-  %convert_element_type.1364 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1284), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_1.1694 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2124 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1694), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %mul.2123 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1364, %mul.2124), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %convert_element_type.1363 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2123), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_2.1293 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %convert_element_type.1364 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1293), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_1.1707 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2133 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1707), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %mul.2132 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1364, %mul.2133), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %convert_element_type.1363 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2132), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
   %convert.211 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1363)
   %dot_general.505 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.210, %convert.211), metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.212 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.505)
-  ROOT %bitcast.749 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.212)
+  ROOT %bitcast.761 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.212)
 }
 
 %bitcast_fusion.3 (bitcast_input.3: bf16[151936,2048]) -> bf16[151936,2048] {
   %bitcast_input.3 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.761 = bf16[151936,2048]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.3)
+  ROOT %bitcast.773 = bf16[151936,2048]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.3)
 }
 
 %region_8.11 (reduce_max.6: bf16[], reduce_max.8: bf16[]) -> bf16[] {
@@ -831,17 +831,17 @@ StackFrames
   ROOT %reduce_max.9 = bf16[]{:T(256)} maximum(%reduce_max.6, %reduce_max.8), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.496 (param_0.1518: bf16[151936,2048], param_1.1699: bf16[2048], param_2.1301: f32[128], param_3.867: bf16[1,128,2048]) -> (bf16[128], bf16[128,151936]) {
-  %param_1.1699 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_2.1301 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.867 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(3)
-  %fusion.319.clone.1 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1699, %param_2.1301, %param_3.867), kind=kLoop, calls=%fused_computation.412.clone.clone
-  %param_0.1518 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(0)
-  %fusion.357 = bf16[151936,2048]{1,0:T(8,128)(2,1)} fusion(%param_0.1518), kind=kLoop, calls=%bitcast_fusion.3
-  %convolution.115.clone.1 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} convolution(%fusion.319.clone.1, %fusion.357), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/jvp()/dot_general" stack_frame_id=0}
+%fused_computation.502 (param_0.1540: bf16[151936,2048], param_1.1712: bf16[2048], param_2.1310: f32[128], param_3.874: bf16[1,128,2048]) -> (bf16[128], bf16[128,151936]) {
+  %param_1.1712 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_2.1310 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.874 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %fusion.329.clone.1 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1712, %param_2.1310, %param_3.874), kind=kLoop, calls=%fused_computation.418.clone.clone
+  %param_0.1540 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(0)
+  %fusion.366 = bf16[151936,2048]{1,0:T(8,128)(2,1)} fusion(%param_0.1540), kind=kLoop, calls=%bitcast_fusion.3
+  %convolution.119.clone.1 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} convolution(%fusion.329.clone.1, %fusion.366), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/jvp()/dot_general" stack_frame_id=0}
   %constant.454.clone.3 = bf16[]{:T(256)} constant(-inf)
-  %reduce.243 = bf16[128]{0:T(256)(128)(2,1)S(1)} reduce(%convolution.115.clone.1, %constant.454.clone.3), dimensions={1}, to_apply=%region_8.11, metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
-  ROOT %tuple.171 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128,151936]{1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.243, %convolution.115.clone.1)
+  %reduce.243 = bf16[128]{0:T(256)(128)(2,1)S(1)} reduce(%convolution.119.clone.1, %constant.454.clone.3), dimensions={1}, to_apply=%region_8.11, metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
+  ROOT %tuple.170 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128,151936]{1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.243, %convolution.119.clone.1)
 }
 
 %region_9.12 (reduce_sum.186: f32[], reduce_sum.190: f32[]) -> f32[] {
@@ -850,31 +850,31 @@ StackFrames
   ROOT %reduce_sum.191 = f32[]{:T(128)} add(%reduce_sum.186, %reduce_sum.190), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.328 (param_0.1549: bf16[128,151936], param_1.1725: bf16[128]) -> f32[128] {
-  %param_0.1549 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1250 = f32[128,151936]{1,0:T(8,128)} convert(%param_0.1549), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %bitcast.520 = f32[1,128,151936]{2,1,0:T(8,128)} bitcast(%convert_element_type.1250), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_1.1725 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
-  %sub.100 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1725), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.71 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%bitcast.520, %sub.100), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %exp.51 = f32[1,128,151936]{2,1,0:T(8,128)} exponential(%sub.71), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
+%fused_computation.334 (param_0.1571: bf16[128,151936], param_1.1738: bf16[128]) -> f32[128] {
+  %param_0.1571 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1250 = f32[128,151936]{1,0:T(8,128)} convert(%param_0.1571), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %bitcast.532 = f32[1,128,151936]{2,1,0:T(8,128)} bitcast(%convert_element_type.1250), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_1.1738 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
+  %sub.100 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1738), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.71 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%bitcast.532, %sub.100), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %exp.56 = f32[1,128,151936]{2,1,0:T(8,128)} exponential(%sub.71), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
   %constant.444.clone.28 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.199 = f32[128]{0:T(128)S(1)} reduce(%exp.51, %constant.444.clone.28), dimensions={0,2}, to_apply=%region_9.12, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.199 = f32[128]{0:T(128)S(1)} reduce(%exp.56, %constant.444.clone.28), dimensions={0,2}, to_apply=%region_9.12, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.495 (param_0.1506: f32[128], param_1.1724: bf16[128]) -> (f32[128], f32[128]) {
-  %param_0.1506 = f32[128]{0:T(128)S(1)} parameter(0)
-  %log.23 = f32[128]{0:T(128)S(1)} log(%param_0.1506), metadata={op_name="jit(train_step)/jvp()/log" stack_frame_id=0}
-  %param_1.1724 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
-  %reduce_max.18.clone.1 = f32[128]{0:T(128)} convert(%param_1.1724), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
-  %add.945.clone.1 = f32[128]{0:T(128)} add(%log.23, %reduce_max.18.clone.1), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+%fused_computation.501 (param_0.1528: f32[128], param_1.1737: bf16[128]) -> (f32[128], f32[128]) {
+  %param_0.1528 = f32[128]{0:T(128)S(1)} parameter(0)
+  %log.23 = f32[128]{0:T(128)S(1)} log(%param_0.1528), metadata={op_name="jit(train_step)/jvp()/log" stack_frame_id=0}
+  %param_1.1737 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
+  %reduce_max.18.clone.1 = f32[128]{0:T(128)} convert(%param_1.1737), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
+  %add.950.clone.1 = f32[128]{0:T(128)} add(%log.23, %reduce_max.18.clone.1), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %constant.444.clone.27 = f32[]{:T(128)} constant(0)
   %broadcast.962.clone.1 = f32[128]{0:T(128)} broadcast(%constant.444.clone.27), dimensions={}, metadata={op_name="broadcast.118"}
-  %mul.1958.clone.1 = f32[128]{0:T(128)} multiply(%add.945.clone.1, %broadcast.962.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %mul.1967.clone.1 = f32[128]{0:T(128)} multiply(%add.950.clone.1, %broadcast.962.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %constant.432.clone.1.clone.1 = f32[]{:T(128)} constant(1)
   %broadcast.959.clone.1 = f32[128]{0:T(128)} broadcast(%constant.432.clone.1.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
-  %add.934.clone.1 = f32[128]{0:T(128)S(1)} add(%mul.1958.clone.1, %broadcast.959.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
-  ROOT %tuple.169 = (f32[128]{0:T(128)S(1)}, f32[128]{0:T(128)S(1)}) tuple(%log.23, %add.934.clone.1)
+  %add.939.clone.1 = f32[128]{0:T(128)S(1)} add(%mul.1967.clone.1, %broadcast.959.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
+  ROOT %tuple.168 = (f32[128]{0:T(128)S(1)}, f32[128]{0:T(128)S(1)}) tuple(%log.23, %add.939.clone.1)
 }
 
 %region_54.59 (reduce_sum.389: f32[], reduce_sum.393: f32[]) -> f32[] {
@@ -883,24 +883,24 @@ StackFrames
   ROOT %reduce_sum.394 = f32[]{:T(128)} add(%reduce_sum.389, %reduce_sum.393), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.334 (param_0.1548: bf16[128,151936], param_1.1723: f32[128], param_2.1326: bf16[128], param_3.886: s32[128]) -> f32[128] {
-  %param_3.886 = s32[128]{0:T(128)S(1)} parameter(3)
-  %eq.26 = s32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_3.886), dimensions={1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
+%fused_computation.340 (param_0.1570: bf16[128,151936], param_1.1736: f32[128], param_2.1335: bf16[128], param_3.893: s32[128]) -> f32[128] {
+  %param_3.893 = s32[128]{0:T(128)S(1)} parameter(3)
+  %eq.26 = s32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_3.893), dimensions={1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %iota.51 = s32[1,128,151936]{2,1,0:T(8,128)} iota(), iota_dimension=2, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %eq.21 = pred[1,128,151936]{2,1,0:T(8,128)(4,1)} compare(%eq.26, %iota.51), direction=EQ, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
-  %param_0.1548 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1263 = f32[128,151936]{1,0:T(8,128)} convert(%param_0.1548), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %bitcast.532 = f32[1,128,151936]{2,1,0:T(8,128)} bitcast(%convert_element_type.1263), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_2.1326 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
-  %sub.99 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_2.1326), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.92 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%bitcast.532, %sub.99), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %param_1.1723 = f32[128]{0:T(128)S(1)} parameter(1)
-  %sub.97 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1723), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %param_0.1570 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1263 = f32[128,151936]{1,0:T(8,128)} convert(%param_0.1570), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %bitcast.544 = f32[1,128,151936]{2,1,0:T(8,128)} bitcast(%convert_element_type.1263), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_2.1335 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
+  %sub.99 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_2.1335), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.92 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%bitcast.544, %sub.99), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %param_1.1736 = f32[128]{0:T(128)S(1)} parameter(1)
+  %sub.97 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1736), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %sub.91 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%sub.92, %sub.97), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %constant.444.clone.26 = f32[]{:T(128)} constant(0)
   %broadcast.900 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%constant.444.clone.26), dimensions={}, metadata={op_name="broadcast.128"}
-  %mul.1808 = f32[1,128,151936]{2,1,0:T(8,128)} select(%eq.21, %sub.91, %broadcast.900), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  ROOT %reduce.200 = f32[128]{0:T(128)S(1)} reduce(%mul.1808, %constant.444.clone.26), dimensions={0,2}, to_apply=%region_54.59, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %mul.1817 = f32[1,128,151936]{2,1,0:T(8,128)} select(%eq.21, %sub.91, %broadcast.900), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  ROOT %reduce.200 = f32[128]{0:T(128)S(1)} reduce(%mul.1817, %constant.444.clone.26), dimensions={0,2}, to_apply=%region_54.59, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %region_0.1 (reduce_sum.137: s32[], reduce_sum.138: s32[]) -> s32[] {
@@ -909,11 +909,11 @@ StackFrames
   ROOT %reduce_sum.139 = s32[]{:T(128)} add(%reduce_sum.137, %reduce_sum.138), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.472 (param_0.1369: s32[1,128]) -> s32[] {
-  %param_0.1369 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
+%fused_computation.478 (param_0.1391: s32[1,128]) -> s32[] {
+  %param_0.1391 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
   %constant.433.clone.8 = s32[]{:T(128)} constant(0)
   %broadcast.977 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.8), dimensions={}, metadata={op_name="broadcast.95"}
-  %ne.10 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1369, %broadcast.977), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
+  %ne.10 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1391, %broadcast.977), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
   %convert_element_type.1323 = s32[1,128]{1,0:T(1,128)} convert(%ne.10), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
   ROOT %reduce.240 = s32[]{:T(128)} reduce(%convert_element_type.1323, %constant.433.clone.8), dimensions={0,1}, to_apply=%region_0.1, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
@@ -936,67 +936,67 @@ StackFrames
   ROOT %reduce_sum.400 = f32[]{:T(128)} add(%reduce_sum.395, %reduce_sum.396), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.475 (param_0.1547: s32[1,128], param_1.1722: bf16[128], param_2.1325: f32[128], param_3.885: f32[128], param_4.523: f32[]) -> (f32[], f32[], f32[128]) {
-  %param_0.1547 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
+%fused_computation.481 (param_0.1569: s32[1,128], param_1.1735: bf16[128], param_2.1334: f32[128], param_3.892: f32[128], param_4.528: f32[]) -> (f32[], f32[], f32[128]) {
+  %param_0.1569 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
   %constant.433.clone.1 = s32[]{:T(128)} constant(0)
   %broadcast.975 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.1), dimensions={}, metadata={op_name="broadcast.95"}
-  %ne.16 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1547, %broadcast.975), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
-  %param_2.1325 = f32[128]{0:T(128)S(1)} parameter(2)
-  %log.18 = f32[128]{0:T(128)} log(%param_2.1325), metadata={op_name="jit(train_step)/jvp()/log" stack_frame_id=0}
-  %param_1.1722 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
-  %reduce_max.16 = f32[128]{0:T(128)} convert(%param_1.1722), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
-  %add.943 = f32[128]{0:T(128)} add(%log.18, %reduce_max.16), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %square.266 = f32[128]{0:T(128)} multiply(%add.943, %add.943), metadata={op_name="jit(train_step)/jvp()/square" stack_frame_id=0}
+  %ne.16 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1569, %broadcast.975), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
+  %param_2.1334 = f32[128]{0:T(128)S(1)} parameter(2)
+  %log.18 = f32[128]{0:T(128)} log(%param_2.1334), metadata={op_name="jit(train_step)/jvp()/log" stack_frame_id=0}
+  %param_1.1735 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
+  %reduce_max.16 = f32[128]{0:T(128)} convert(%param_1.1735), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
+  %add.948 = f32[128]{0:T(128)} add(%log.18, %reduce_max.16), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %square.266 = f32[128]{0:T(128)} multiply(%add.948, %add.948), metadata={op_name="jit(train_step)/jvp()/square" stack_frame_id=0}
   %constant.444.clone.25 = f32[]{:T(128)} constant(0)
   %broadcast.960 = f32[128]{0:T(128)} broadcast(%constant.444.clone.25), dimensions={}, metadata={op_name="broadcast.118"}
-  %mul.1966 = f32[128]{0:T(128)} multiply(%square.266, %broadcast.960), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %bitcast.617 = f32[1,128]{1,0:T(1,128)} bitcast(%mul.1966), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %mul.1975 = f32[128]{0:T(128)} multiply(%square.266, %broadcast.960), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %bitcast.629 = f32[1,128]{1,0:T(1,128)} bitcast(%mul.1975), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
   %broadcast.971 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.444.clone.25), dimensions={}, metadata={op_name="broadcast.118"}
-  %mul.1952 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %bitcast.617, %broadcast.971), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %reduce.242 = f32[]{:T(128)} reduce(%mul.1952, %constant.444.clone.25), dimensions={0,1}, to_apply=%region_69.74, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
-  %param_3.885 = f32[128]{0:T(128)S(1)} parameter(3)
-  %neg.113.clone.1 = f32[128]{0:T(128)} negate(%param_3.885), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
-  %bitcast.621.clone.1 = f32[1,128]{1,0:T(1,128)} bitcast(%neg.113.clone.1), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
-  %add.933.clone.1 = f32[1,128]{1,0:T(1,128)} add(%bitcast.621.clone.1, %bitcast.617), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %mul.1950.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %add.933.clone.1, %broadcast.971), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %reduce.241.clone.1 = f32[]{:T(128)} reduce(%mul.1950.clone.1, %constant.444.clone.25), dimensions={0,1}, to_apply=%region_55.60, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
-  %param_4.523 = f32[]{:T(128)S(6)} parameter(4)
-  %broadcast_in_dim.283.clone.1 = f32[1,128]{1,0:T(1,128)} broadcast(%param_4.523), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/broadcast_in_dim" stack_frame_id=0}
-  %mul.1948.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %broadcast_in_dim.283.clone.1, %broadcast.971), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %bitcast.615.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%mul.1948.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  ROOT %tuple.168 = (f32[]{:T(128)}, f32[]{:T(128)}, f32[128]{0:T(128)S(1)}) tuple(%reduce.242, %reduce.241.clone.1, %bitcast.615.clone.1)
+  %mul.1961 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %bitcast.629, %broadcast.971), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %reduce.242 = f32[]{:T(128)} reduce(%mul.1961, %constant.444.clone.25), dimensions={0,1}, to_apply=%region_69.74, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %param_3.892 = f32[128]{0:T(128)S(1)} parameter(3)
+  %neg.118.clone.1 = f32[128]{0:T(128)} negate(%param_3.892), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
+  %bitcast.633.clone.1 = f32[1,128]{1,0:T(1,128)} bitcast(%neg.118.clone.1), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
+  %add.938.clone.1 = f32[1,128]{1,0:T(1,128)} add(%bitcast.633.clone.1, %bitcast.629), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %mul.1959.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %add.938.clone.1, %broadcast.971), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %reduce.241.clone.1 = f32[]{:T(128)} reduce(%mul.1959.clone.1, %constant.444.clone.25), dimensions={0,1}, to_apply=%region_55.60, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %param_4.528 = f32[]{:T(128)S(6)} parameter(4)
+  %broadcast_in_dim.283.clone.1 = f32[1,128]{1,0:T(1,128)} broadcast(%param_4.528), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/broadcast_in_dim" stack_frame_id=0}
+  %mul.1957.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %broadcast_in_dim.283.clone.1, %broadcast.971), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %bitcast.627.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%mul.1957.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  ROOT %tuple.167 = (f32[]{:T(128)}, f32[]{:T(128)}, f32[128]{0:T(128)S(1)}) tuple(%reduce.242, %reduce.241.clone.1, %bitcast.627.clone.1)
 }
 
-%fused_computation.363.clone.1.clone.clone (param_0.1513: bf16[128,151936], param_1.1698: f32[128], param_2.1289: f32[128], param_3.865: bf16[128], param_4.500: s32[128], param_5.434: f32[128]) -> bf16[128,151936] {
-  %param_5.434 = f32[128]{0:T(128)S(1)} parameter(5)
-  %mul.2132 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_5.434), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %param_1.1698 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2131 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1698), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %param_0.1513 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1370 = f32[128,151936]{1,0:T(8,128)} convert(%param_0.1513), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %bitcast.753 = f32[1,128,151936]{2,1,0:T(8,128)} bitcast(%convert_element_type.1370), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_3.865 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(3)
-  %sub.114 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_3.865), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.113 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%bitcast.753, %sub.114), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %exp.67 = f32[1,128,151936]{2,1,0:T(8,128)} exponential(%sub.113), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
-  %mul.2130 = f32[1,128,151936]{2,1,0:T(8,128)} multiply(%mul.2131, %exp.67), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %param_2.1289 = f32[128]{0:T(128)S(1)} parameter(2)
-  %div.982 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_2.1289), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
-  %div.981 = f32[1,128,151936]{2,1,0:T(8,128)} divide(%mul.2130, %div.982), metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
-  %param_4.500 = s32[128]{0:T(128)S(1)} parameter(4)
-  %eq.35 = s32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_4.500), dimensions={1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
+%fused_computation.369.clone.1.clone.clone (param_0.1535: bf16[128,151936], param_1.1711: f32[128], param_2.1298: f32[128], param_3.872: bf16[128], param_4.505: s32[128], param_5.438: f32[128]) -> bf16[128,151936] {
+  %param_5.438 = f32[128]{0:T(128)S(1)} parameter(5)
+  %mul.2141 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_5.438), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %param_1.1711 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2140 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1711), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %param_0.1535 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1370 = f32[128,151936]{1,0:T(8,128)} convert(%param_0.1535), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %bitcast.765 = f32[1,128,151936]{2,1,0:T(8,128)} bitcast(%convert_element_type.1370), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_3.872 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(3)
+  %sub.114 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_3.872), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.113 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%bitcast.765, %sub.114), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %exp.72 = f32[1,128,151936]{2,1,0:T(8,128)} exponential(%sub.113), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
+  %mul.2139 = f32[1,128,151936]{2,1,0:T(8,128)} multiply(%mul.2140, %exp.72), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %param_2.1298 = f32[128]{0:T(128)S(1)} parameter(2)
+  %div.987 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_2.1298), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
+  %div.986 = f32[1,128,151936]{2,1,0:T(8,128)} divide(%mul.2139, %div.987), metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
+  %param_4.505 = s32[128]{0:T(128)S(1)} parameter(4)
+  %eq.35 = s32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_4.505), dimensions={1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %iota.60 = s32[1,128,151936]{2,1,0:T(8,128)} iota(), iota_dimension=2, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %eq.34 = pred[1,128,151936]{2,1,0:T(8,128)(4,1)} compare(%eq.35, %iota.60), direction=EQ, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %convert_element_type.1369 = f32[1,128,151936]{2,1,0:T(8,128)} convert(%eq.34), metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/convert_element_type" stack_frame_id=0}
-  %sub.112 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%div.981, %convert_element_type.1369), metadata={op_name="jit(train_step)/transpose(jvp())/sub" stack_frame_id=0}
-  %mul.2129 = f32[1,128,151936]{2,1,0:T(8,128)} multiply(%mul.2132, %sub.112), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %convert_element_type.1368 = bf16[1,128,151936]{2,1,0:T(8,128)(2,1)} convert(%mul.2129), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
-  ROOT %bitcast.752 = bf16[128,151936]{1,0:T(8,128)(2,1)} bitcast(%convert_element_type.1368)
+  %sub.112 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%div.986, %convert_element_type.1369), metadata={op_name="jit(train_step)/transpose(jvp())/sub" stack_frame_id=0}
+  %mul.2138 = f32[1,128,151936]{2,1,0:T(8,128)} multiply(%mul.2141, %sub.112), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %convert_element_type.1368 = bf16[1,128,151936]{2,1,0:T(8,128)(2,1)} convert(%mul.2138), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
+  ROOT %bitcast.764 = bf16[128,151936]{1,0:T(8,128)(2,1)} bitcast(%convert_element_type.1368)
 }
 
 %bitcast_fusion.2 (bitcast_input.2: bf16[151936,2048]) -> bf16[151936,2048] {
   %bitcast_input.2 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.760 = bf16[151936,2048]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.2)
+  ROOT %bitcast.772 = bf16[151936,2048]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.2)
 }
 
 %region_10.13 (dot_general.204: bf16[], dot_general.205: bf16[]) -> bf16[] {
@@ -1005,31 +1005,31 @@ StackFrames
   ROOT %add.416 = bf16[]{:T(256)} add(%dot_general.204, %dot_general.205), metadata={op_name="add.79"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.413 (param_0.1512: f32[128], param_1.1697: bf16[1,128,2048], param_2.1290: bf16[151936,2048], param_3.866: bf16[128,151936], param_4.501: f32[128], param_5.435: f32[128], param_6.299: bf16[128], param_7.189: s32[128], param_8.111: f32[128]) -> (bf16[2048], bf16[1,128,2048]) {
-  %param_3.866 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %param_4.501 = f32[128]{0:T(128)S(1)} parameter(4)
-  %param_5.435 = f32[128]{0:T(128)S(1)} parameter(5)
+%fused_computation.419 (param_0.1534: f32[128], param_1.1710: bf16[1,128,2048], param_2.1299: bf16[151936,2048], param_3.873: bf16[128,151936], param_4.506: f32[128], param_5.439: f32[128], param_6.299: bf16[128], param_7.189: s32[128], param_8.111: f32[128]) -> (bf16[2048], bf16[1,128,2048]) {
+  %param_3.873 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_4.506 = f32[128]{0:T(128)S(1)} parameter(4)
+  %param_5.439 = f32[128]{0:T(128)S(1)} parameter(5)
   %param_6.299 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
   %param_7.189 = s32[128]{0:T(128)S(1)} parameter(7)
   %param_8.111 = f32[128]{0:T(128)S(1)} parameter(8)
-  %fusion.341.clone.1 = bf16[128,151936]{1,0:T(8,128)(2,1)} fusion(%param_3.866, %param_4.501, %param_5.435, %param_6.299, %param_7.189, /*index=5*/%param_8.111), kind=kLoop, calls=%fused_computation.363.clone.1.clone.clone
-  %param_2.1290 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(2)
-  %fusion.356 = bf16[151936,2048]{1,0:T(8,128)(2,1)} fusion(%param_2.1290), kind=kLoop, calls=%bitcast_fusion.2
-  %convolution.113.clone.1 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.341.clone.1, %fusion.356), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/dot_general" stack_frame_id=0}
-  %bitcast.593.clone.1 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.113.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/dot_general" stack_frame_id=0}
-  %convert.198 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.593.clone.1)
-  %param_1.1697 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert_element_type.1302 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_1.1697), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_0.1512 = f32[128]{0:T(128)S(1)} parameter(0)
-  %mul.1899 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_0.1512), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %mul.1898 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1302, %mul.1899), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %convert_element_type.1301 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.1898), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %fusion.351.clone.1 = bf16[128,151936]{1,0:T(8,128)(2,1)} fusion(%param_3.873, %param_4.506, %param_5.439, %param_6.299, %param_7.189, /*index=5*/%param_8.111), kind=kLoop, calls=%fused_computation.369.clone.1.clone.clone
+  %param_2.1299 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(2)
+  %fusion.365 = bf16[151936,2048]{1,0:T(8,128)(2,1)} fusion(%param_2.1299), kind=kLoop, calls=%bitcast_fusion.2
+  %convolution.117.clone.1 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.351.clone.1, %fusion.365), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/dot_general" stack_frame_id=0}
+  %bitcast.605.clone.1 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.117.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/dot_general" stack_frame_id=0}
+  %convert.198 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.605.clone.1)
+  %param_1.1710 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert_element_type.1302 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_1.1710), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_0.1534 = f32[128]{0:T(128)S(1)} parameter(0)
+  %mul.1908 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_0.1534), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %mul.1907 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1302, %mul.1908), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %convert_element_type.1301 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.1907), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
   %convert.199 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1301)
   %multiply.436 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.198, %convert.199), metadata={op_name="multiply.354"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.200 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%multiply.436)
   %constant.446.clone.1 = bf16[]{:T(256)} constant(0)
   %reduce.224 = bf16[2048]{0:T(1024)(128)(2,1)} reduce(%convert.200, %constant.446.clone.1), dimensions={0,1}, to_apply=%region_10.13, metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}
-  ROOT %tuple.172 = (bf16[2048]{0:T(1024)(128)(2,1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.224, %bitcast.593.clone.1)
+  ROOT %tuple.171 = (bf16[2048]{0:T(1024)(128)(2,1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.224, %bitcast.605.clone.1)
 }
 
 %region_12.15 (reduce_sum.198: f32[], reduce_sum.199: f32[]) -> f32[] {
@@ -1038,69 +1038,69 @@ StackFrames
   ROOT %reduce_sum.200 = f32[]{:T(128)} add(%reduce_sum.198, %reduce_sum.199), metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.408 (param_0.1546: bf16[1,128,2048], param_1.1721: bf16[1,128,2048], param_2.1324: bf16[2048]) -> f32[128] {
-  %param_0.1546 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1290 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1546), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_1.1721 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.196 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_1.1721)
-  %param_2.1324 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.477 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1324), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
+%fused_computation.414 (param_0.1568: bf16[1,128,2048], param_1.1734: bf16[1,128,2048], param_2.1333: bf16[2048]) -> f32[128] {
+  %param_0.1568 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1290 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1568), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_1.1734 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.196 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_1.1734)
+  %param_2.1333 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.477 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1333), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
   %convert.197 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.477)
   %dot_general.463 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.196, %convert.197), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.1289 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.463), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
-  %mul.1884 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1290, %convert_element_type.1289), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %mul.1893 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1290, %convert_element_type.1289), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %constant.444.clone.24 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.223 = f32[128]{0:T(128)S(1)} reduce(%mul.1884, %constant.444.clone.24), dimensions={0,2}, to_apply=%region_12.15, metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.223 = f32[128]{0:T(128)S(1)} reduce(%mul.1893, %constant.444.clone.24), dimensions={0,2}, to_apply=%region_12.15, metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.484 (param_0.1366: f32[128], param_1.1477: f32[128]) -> f32[128] {
-  %param_0.1366 = f32[128]{0:T(128)S(1)} parameter(0)
-  %bitcast.631 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1366), metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
-  %param_1.1477 = f32[128]{0:T(128)S(1)} parameter(1)
+%fused_computation.490 (param_0.1388: f32[128], param_1.1490: f32[128]) -> f32[128] {
+  %param_0.1388 = f32[128]{0:T(128)S(1)} parameter(0)
+  %bitcast.643 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1388), metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
+  %param_1.1490 = f32[128]{0:T(128)S(1)} parameter(1)
   %constant.452.clone.1 = f32[]{:T(128)} constant(0.00048828125)
   %broadcast.965 = f32[128]{0:T(128)} broadcast(%constant.452.clone.1), dimensions={}, metadata={op_name="broadcast.416"}
-  %div.782 = f32[128]{0:T(128)} multiply(%param_1.1477, %broadcast.965), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
+  %div.787 = f32[128]{0:T(128)} multiply(%param_1.1490, %broadcast.965), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
   %constant.453.clone.1 = f32[]{:T(128)} constant(1e-06)
   %broadcast.963 = f32[128]{0:T(128)} broadcast(%constant.453.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %add.938 = f32[128]{0:T(128)} add(%div.782, %broadcast.963), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %bitcast.630 = f32[1,128]{1,0:T(1,128)} bitcast(%add.938), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %rsqrt.201 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.630), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
-  %div.780 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.201, %bitcast.630), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
+  %add.943 = f32[128]{0:T(128)} add(%div.787, %broadcast.963), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %bitcast.642 = f32[1,128]{1,0:T(1,128)} bitcast(%add.943), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %rsqrt.201 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.642), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
+  %div.785 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.201, %bitcast.642), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
   %constant.455.clone.1 = f32[]{:T(128)} constant(-0.5)
-  %mul.1970 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.455.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %mul.1964 = f32[1,128]{1,0:T(1,128)} multiply(%div.780, %mul.1970), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %mul.1963 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.631, %mul.1964), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %mul.1979 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.455.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %mul.1973 = f32[1,128]{1,0:T(1,128)} multiply(%div.785, %mul.1979), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %mul.1972 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.643, %mul.1973), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %constant.456.clone.1 = f32[]{:T(128)} constant(0.0009765625)
-  %mul.1969 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.456.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %mul.1959 = f32[1,128]{1,0:T(1,128)} multiply(%mul.1963, %mul.1969), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  ROOT %bitcast.625 = f32[128]{0:T(128)S(1)} bitcast(%mul.1959), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %mul.1978 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.456.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %mul.1968 = f32[1,128]{1,0:T(1,128)} multiply(%mul.1972, %mul.1978), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  ROOT %bitcast.637 = f32[128]{0:T(128)S(1)} bitcast(%mul.1968), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
 }
 
-%fused_computation.405 (param_0.1174: bf16[1,128,2048], param_1.1238: f32[128], param_2.804: f32[128], param_3.435: bf16[1,128,2048], param_4.244: bf16[2048]) -> bf16[1,128,2048] {
-  %param_3.435 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %convert.194 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_3.435)
-  %param_4.244 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(4)
-  %dot_general.478 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_4.244), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
+%fused_computation.411 (param_0.1196: bf16[1,128,2048], param_1.1251: f32[128], param_2.813: f32[128], param_3.442: bf16[1,128,2048], param_4.249: bf16[2048]) -> bf16[1,128,2048] {
+  %param_3.442 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %convert.194 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_3.442)
+  %param_4.249 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(4)
+  %dot_general.478 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_4.249), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
   %convert.195 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.478)
   %dot_general.464 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.194, %convert.195), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert_element_type.1281 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.464), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
-  %param_2.804 = f32[128]{0:T(128)S(1)} parameter(2)
-  %mul.1888 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_2.804), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %mul.1880 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1281, %mul.1888), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %param_0.1174 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1292 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1174), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_1.1238 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.1887 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1238), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %mul.1886 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1292, %mul.1887), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %add_any.193 = f32[1,128,2048]{2,1,0:T(8,128)} add(%mul.1880, %mul.1886), metadata={op_name="jit(train_step)/transpose(jvp())/add_any" stack_frame_id=0}
-  ROOT %convert_element_type.1279 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%add_any.193), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
+  %param_2.813 = f32[128]{0:T(128)S(1)} parameter(2)
+  %mul.1897 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_2.813), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %mul.1889 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1281, %mul.1897), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %param_0.1196 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1292 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1196), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_1.1251 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.1896 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1251), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %mul.1895 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1292, %mul.1896), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %add_any.193 = f32[1,128,2048]{2,1,0:T(8,128)} add(%mul.1889, %mul.1895), metadata={op_name="jit(train_step)/transpose(jvp())/add_any" stack_frame_id=0}
+  ROOT %convert_element_type.1279 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add_any.193), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.98.clone.1 (param_0.1731: bf16[4,512,6144], param_1.1840: s32[]) -> bf16[1,512,6144] {
-  %param_0.1731 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1840 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.104.clone.1 (param_0.1753: bf16[4,512,6144], param_1.1853: s32[]) -> bf16[1,512,6144] {
+  %param_0.1753 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1853 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.87 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.192 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1731, %param_1.1840, %constant.415.clone.87, %constant.415.clone.87), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.190 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1753, %param_1.1853, %constant.415.clone.87, %constant.415.clone.87), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %convert_element_type.762.reduce_sub_computation (lhs.1: bf16[], rhs.1: bf16[]) -> bf16[] {
@@ -1115,788 +1115,788 @@ StackFrames
   ROOT %add.792 = bf16[] add(%lhs, %rhs), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.285.clone.1 (param_0.1701: bf16[4,2048], param_1.1822: s32[], param_2.1394: bf16[4,2048]) -> (bf16[2048], bf16[2048]) {
-  %param_0.1701 = bf16[4,2048]{1,0:T(4,128)(2,1)} parameter(0)
-  %param_1.1822 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.291.clone.1 (param_0.1723: bf16[4,2048], param_1.1835: s32[], param_2.1403: bf16[4,2048]) -> (bf16[2048], bf16[2048]) {
+  %param_0.1723 = bf16[4,2048]{1,0:T(4,128)(2,1)} parameter(0)
+  %param_1.1835 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.78 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.201 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1701, %param_1.1822, %constant.415.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %constant.1104 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %reduce.263 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.201, %constant.1104), dimensions={0}, to_apply=%convert_element_type.762.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_2.1394 = bf16[4,2048]{1,0:T(4,128)(2,1)} parameter(2)
-  %dynamic_slice.186.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1394, %param_1.1822, %constant.415.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %reduce.195.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.186.clone.3, %constant.1104), dimensions={0}, to_apply=%convert_element_type.758.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.216 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) tuple(%reduce.263, %reduce.195.clone.3)
+  %dynamic_slice.201 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1723, %param_1.1835, %constant.415.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1108 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %reduce.263 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.201, %constant.1108), dimensions={0}, to_apply=%convert_element_type.762.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
+  %param_2.1403 = bf16[4,2048]{1,0:T(4,128)(2,1)} parameter(2)
+  %dynamic_slice.186.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1403, %param_1.1835, %constant.415.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %reduce.195.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.186.clone.3, %constant.1108), dimensions={0}, to_apply=%convert_element_type.758.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.214 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) tuple(%reduce.263, %reduce.195.clone.3)
 }
 
-%fused_computation.120.clone.1 (param_0.1726: bf16[4,16,128,512], param_1.1838: s32[]) -> bf16[1,16,128,512] {
-  %param_0.1726 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1838 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.126.clone.1 (param_0.1748: bf16[4,16,128,512], param_1.1851: s32[]) -> bf16[1,16,128,512] {
+  %param_0.1748 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1851 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.86 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.191 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1726, %param_1.1838, %constant.415.clone.86, %constant.415.clone.86, %constant.415.clone.86), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.189 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1748, %param_1.1851, %constant.415.clone.86, %constant.415.clone.86, %constant.415.clone.86), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.121.clone.1 (param_0.1718: bf16[4,512,16,128], param_1.1833: s32[]) -> bf16[1,512,16,128] {
-  %param_0.1718 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1833 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.127.clone.1 (param_0.1740: bf16[4,512,16,128], param_1.1846: s32[]) -> bf16[1,512,16,128] {
+  %param_0.1740 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1846 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.84 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.189 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1718, %param_1.1833, %constant.415.clone.84, %constant.415.clone.84, %constant.415.clone.84), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.187 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1740, %param_1.1846, %constant.415.clone.84, %constant.415.clone.84, %constant.415.clone.84), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %region_14.16 (reduce_sum.204: f32[], reduce_sum.205: f32[]) -> f32[] {
-  %reduce_sum.204 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum"}
-  %reduce_sum.205 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum"}
-  ROOT %reduce_sum.206 = f32[]{:T(128)} add(%reduce_sum.204, %reduce_sum.205), metadata={op_name="checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce_sum.204 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/reduce_sum"}
+  %reduce_sum.205 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/reduce_sum"}
+  ROOT %reduce_sum.206 = f32[]{:T(128)} add(%reduce_sum.204, %reduce_sum.205), metadata={op_name="checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.172.clone.1 (param_0.1699: bf16[4,1,128,2048], param_1.1821: s32[]) -> f32[128] {
-  %param_0.1699 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %param_1.1821 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.178.clone.1 (param_0.1721: bf16[4,1,128,2048], param_1.1834: s32[]) -> f32[128] {
+  %param_0.1721 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %param_1.1834 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.77 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.184 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1699, %param_1.1821, %constant.415.clone.77, %constant.415.clone.77, %constant.415.clone.77), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.902 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.184), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1459 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.902), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %square.277 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1459, %convert_element_type.1459), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
+  %dynamic-slice.182 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1721, %param_1.1834, %constant.415.clone.77, %constant.415.clone.77, %constant.415.clone.77), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.914 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.182), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1459 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.914), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
+  %square.277 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1459, %convert_element_type.1459), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/square" stack_frame_id=0}
   %constant.416.clone.19 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.262 = f32[128]{0:T(128)S(1)} reduce(%square.277, %constant.416.clone.19), dimensions={0,2}, to_apply=%region_14.16, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.262 = f32[128]{0:T(128)S(1)} reduce(%square.277, %constant.416.clone.19), dimensions={0,2}, to_apply=%region_14.16, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.299.clone.1 (param_0.1700: f32[128]) -> f32[128] {
-  %param_0.1700 = f32[128]{0:T(128)S(1)} parameter(0)
+%fused_computation.305.clone.1 (param_0.1722: f32[128]) -> f32[128] {
+  %param_0.1722 = f32[128]{0:T(128)S(1)} parameter(0)
   %constant.417.clone.9 = f32[]{:T(128)} constant(0.00048828125)
   %broadcast.1067 = f32[128]{0:T(128)} broadcast(%constant.417.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1009 = f32[128]{0:T(128)} multiply(%param_0.1700, %broadcast.1067), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %div.1014 = f32[128]{0:T(128)} multiply(%param_0.1722, %broadcast.1067), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/div" stack_frame_id=0}
   %constant.418.clone.17 = f32[]{:T(128)} constant(1e-06)
   %broadcast.1066 = f32[128]{0:T(128)} broadcast(%constant.418.clone.17), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %add.1045 = f32[128]{0:T(128)} add(%div.1009, %broadcast.1066), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.904 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1045), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.214 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.904), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.903 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.214), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %add.1050 = f32[128]{0:T(128)} add(%div.1014, %broadcast.1066), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/add" stack_frame_id=0}
+  %bitcast.916 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1050), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/add" stack_frame_id=0}
+  %rsqrt.214 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.916), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.915 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.214), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.227.clone.clone.clone.1 (param_0.1720: bf16[2048], param_1.1834: f32[128], param_2.1402: bf16[4,1,128,2048], param_3.928: s32[]) -> bf16[128,2048,1] {
-  %param_0.1720 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.593 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1720), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.233.clone.clone.clone.1 (param_0.1742: bf16[2048], param_1.1847: f32[128], param_2.1411: bf16[4,1,128,2048], param_3.935: s32[]) -> bf16[128,2048,1] {
+  %param_0.1742 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.593 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1742), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.219 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.593)
-  %param_2.1402 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.928 = s32[]{:T(128)S(6)} parameter(3)
+  %param_2.1411 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.935 = s32[]{:T(128)S(6)} parameter(3)
   %constant.415.clone.85 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.190 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1402, %param_3.928, %constant.415.clone.85, %constant.415.clone.85, %constant.415.clone.85), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.920 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.190), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1469 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.920), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1834 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2295 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1834), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2294 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1469, %mul.2295), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1468 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2294), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %dynamic-slice.188 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1411, %param_3.935, %constant.415.clone.85, %constant.415.clone.85, %constant.415.clone.85), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.932 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.188), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1469 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.932), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
+  %param_1.1847 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2304 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1847), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %mul.2303 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1469, %mul.2304), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1468 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2303), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
   %convert.220 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1468)
-  %dot_general.592 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.219, %convert.220), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %dot_general.592 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.219, %convert.220), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.221 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.592)
-  ROOT %bitcast.919 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.221)
+  ROOT %bitcast.931 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.221)
 }
 
-%fused_computation.108.clone.clone.clone.1 (param_0.1719: bf16[1,2048,16,128]) -> bf16[2048,16,128] {
-  %param_0.1719 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.918 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1719), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+%fused_computation.114.clone.clone.clone.1 (param_0.1741: bf16[1,2048,16,128]) -> bf16[2048,16,128] {
+  %param_0.1741 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.930 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1741), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
 }
 
 %region_15.17 (reduce_sum.207: f32[], reduce_sum.211: f32[]) -> f32[] {
-  %reduce_sum.207 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum"}
-  %reduce_sum.211 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum"}
-  ROOT %reduce_sum.212 = f32[]{:T(128)} add(%reduce_sum.207, %reduce_sum.211), metadata={op_name="checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce_sum.207 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum"}
+  %reduce_sum.211 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum"}
+  ROOT %reduce_sum.212 = f32[]{:T(128)} add(%reduce_sum.207, %reduce_sum.211), metadata={op_name="checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.181.clone.1 (param_0.1721: bf16[1,2048,16,128], param_1.1835: bf16[2048], param_2.1403: f32[128], param_3.929: bf16[4,1,128,2048], param_4.550: s32[]) -> (f32[128,16], bf16[128,16,128]) {
-  %param_1.1835 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_2.1403 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.929 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %param_4.550 = s32[]{:T(128)S(6)} parameter(4)
-  %fusion.228.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1835, %param_2.1403, %param_3.929, %param_4.550), kind=kLoop, calls=%fused_computation.227.clone.clone.clone.1
-  %param_0.1721 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.114.clone.3 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1721), kind=kLoop, calls=%fused_computation.108.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convolution.69.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} convolution(%fusion.228.clone.3, %fusion.114.clone.3), window={size=16 pad=15_15 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convert_element_type.1470 = f32[128,16,128]{2,0,1:T(8,128)} convert(%convolution.69.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %bitcast.921 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1470), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %square.279 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.921, %bitcast.921), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
+%fused_computation.187.clone.1 (param_0.1743: bf16[1,2048,16,128], param_1.1848: bf16[2048], param_2.1412: f32[128], param_3.936: bf16[4,1,128,2048], param_4.555: s32[]) -> (f32[128,16], bf16[128,16,128]) {
+  %param_1.1848 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_2.1412 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.936 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_4.555 = s32[]{:T(128)S(6)} parameter(4)
+  %fusion.238.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1848, %param_2.1412, %param_3.936, %param_4.555), kind=kLoop, calls=%fused_computation.233.clone.clone.clone.1
+  %param_0.1743 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.124.clone.3 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1743), kind=kLoop, calls=%fused_computation.114.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convolution.73.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} convolution(%fusion.238.clone.3, %fusion.124.clone.3), window={size=16 pad=15_15 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convert_element_type.1470 = f32[128,16,128]{2,0,1:T(8,128)} convert(%convolution.73.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %bitcast.933 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1470), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %square.279 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.933, %bitcast.933), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/square" stack_frame_id=0}
   %constant.416.clone.21 = f32[]{:T(128)} constant(0)
-  %reduce.265 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.279, %constant.416.clone.21), dimensions={0,3}, to_apply=%region_15.17, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.223 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) tuple(%reduce.265, %convolution.69.clone.3)
+  %reduce.265 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.279, %constant.416.clone.21), dimensions={0,3}, to_apply=%region_15.17, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.221 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) tuple(%reduce.265, %convolution.73.clone.3)
 }
 
-%fused_computation.279.clone.1 (param_0.1722: f32[128,16]) -> f32[128,16] {
-  %param_0.1722 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
+%fused_computation.285.clone.1 (param_0.1744: f32[128,16]) -> f32[128,16] {
+  %param_0.1744 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
   %constant.419.clone.13 = f32[]{:T(128)} constant(0.0078125)
   %broadcast.1073 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.419.clone.13), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1015 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1722, %broadcast.1073), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %div.1020 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1744, %broadcast.1073), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
   %constant.418.clone.19 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1072 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.418.clone.19), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %add.1048 = f32[128,16]{0,1:T(8,128)} add(%div.1015, %broadcast.1072), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.923 = f32[1,128,16]{1,2,0:T(8,128)} bitcast(%add.1048), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.216 = f32[1,128,16]{1,2,0:T(8,128)} rsqrt(%bitcast.923), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.922 = f32[128,16]{0,1:T(8,128)S(1)} bitcast(%rsqrt.216), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %broadcast.1072 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.418.clone.19), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}
+  %add.1053 = f32[128,16]{0,1:T(8,128)} add(%div.1020, %broadcast.1072), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}
+  %bitcast.935 = f32[1,128,16]{1,2,0:T(8,128)} bitcast(%add.1053), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}
+  %rsqrt.216 = f32[1,128,16]{1,2,0:T(8,128)} rsqrt(%bitcast.935), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.934 = f32[128,16]{0,1:T(8,128)S(1)} bitcast(%rsqrt.216), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.305.clone.1 (param_0.1706: bf16[4,128], param_1.1826: s32[], param_2.1397: bf16[4,128]) -> (bf16[128], bf16[128]) {
-  %param_0.1706 = bf16[4,128]{1,0:T(4,128)(2,1)} parameter(0)
-  %param_1.1826 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.311.clone.1 (param_0.1728: bf16[4,128], param_1.1839: s32[], param_2.1406: bf16[4,128]) -> (bf16[128], bf16[128]) {
+  %param_0.1728 = bf16[4,128]{1,0:T(4,128)(2,1)} parameter(0)
+  %param_1.1839 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.81 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.202 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1706, %param_1.1826, %constant.415.clone.81), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.909 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.202), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_2.1397 = bf16[4,128]{1,0:T(4,128)(2,1)} parameter(2)
-  %dynamic_slice.196.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1397, %param_1.1826, %constant.415.clone.81), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.470.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.196.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.217 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) tuple(%bitcast.909, %bitcast.470.clone.3)
+  %dynamic_slice.202 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1728, %param_1.1839, %constant.415.clone.81), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.921 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.202), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %param_2.1406 = bf16[4,128]{1,0:T(4,128)(2,1)} parameter(2)
+  %dynamic_slice.196.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1406, %param_1.1839, %constant.415.clone.81), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.482.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.196.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.215 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) tuple(%bitcast.921, %bitcast.482.clone.3)
 }
 
-%fused_computation.237.clone.2 (param_0.1723: f32[128,16], param_1.1836: bf16[128,16,128], param_2.1404: bf16[128]) -> bf16[1,128,16,128] {
-  %param_2.1404 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
-  %dot_general.595 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1404), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.243.clone.2 (param_0.1745: f32[128,16], param_1.1849: bf16[128,16,128], param_2.1413: bf16[128]) -> bf16[1,128,16,128] {
+  %param_2.1413 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
+  %dot_general.595 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1413), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.269 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.595)
-  %param_1.1836 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} parameter(1)
-  %convert_element_type.1472 = f32[128,16,128]{2,0,1:T(8,128)} convert(%param_1.1836), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %bitcast.924 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1472), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_0.1723 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
-  %mul.2297 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_0.1723), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2296 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.924, %mul.2297), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1471 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2296), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1849 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} parameter(1)
+  %convert_element_type.1472 = f32[128,16,128]{2,0,1:T(8,128)} convert(%param_1.1849), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %bitcast.936 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1472), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %param_0.1745 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
+  %mul.2306 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_0.1745), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %mul.2305 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.936, %mul.2306), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1471 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2305), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
   %convert.270 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1471)
-  %dot_general.594 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.269, %convert.270), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %dot_general.594 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.269, %convert.270), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   ROOT %convert.271 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.594)
 }
 
-%fused_computation.198.clone.1 (param_0.1724: bf16[1,128,16,128]) -> (bf16[1,128,16,64], bf16[1,128,16,64]) {
-  %param_0.1724 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.75 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1724), slice={[0:1], [0:128], [0:16], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/split" stack_frame_id=0}
+%fused_computation.204.clone.1 (param_0.1746: bf16[1,128,16,128]) -> (bf16[1,128,16,64], bf16[1,128,16,64]) {
+  %param_0.1746 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.75 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1746), slice={[0:1], [0:128], [0:16], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/split" stack_frame_id=0}
   %convert.272 = f32[1,128,16,64]{3,1,2,0:T(8,128)} convert(%slice.75)
-  %neg.127 = f32[1,128,16,64]{3,1,2,0:T(8,128)} negate(%convert.272), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.273 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.127)
-  %slice.76 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1724), slice={[0:1], [0:128], [0:16], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/split" stack_frame_id=0}
-  ROOT %tuple.224 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.273, %slice.76)
+  %neg.132 = f32[1,128,16,64]{3,1,2,0:T(8,128)} negate(%convert.272), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.273 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.132)
+  %slice.76 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1746), slice={[0:1], [0:128], [0:16], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/split" stack_frame_id=0}
+  ROOT %tuple.222 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.273, %slice.76)
 }
 
-%fused_computation.314.clone.1 () -> f32[64] {
+%fused_computation.320.clone.1 () -> f32[64] {
   %constant.420.clone.3 = f32[]{:T(128)} constant(1e+06)
   %closed_call.56 = f32[64]{0:T(128)} broadcast(%constant.420.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %iota.65 = s32[64]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/iota" stack_frame_id=0}
+  %iota.65 = s32[64]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/iota" stack_frame_id=0}
   %constant.421.clone.3 = s32[]{:T(128)} constant(2)
   %closed_call.55 = s32[64]{0:T(128)} broadcast(%constant.421.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %mul.2283 = s32[64]{0:T(128)} multiply(%iota.65, %closed_call.55), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1464 = f32[64]{0:T(128)} convert(%mul.2283), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %mul.2292 = s32[64]{0:T(128)} multiply(%iota.65, %closed_call.55), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1464 = f32[64]{0:T(128)} convert(%mul.2292), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
   %constant.419.clone.12 = f32[]{:T(128)} constant(0.0078125)
   %closed_call.54 = f32[64]{0:T(128)} broadcast(%constant.419.clone.12), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1011 = f32[64]{0:T(128)} multiply(%convert_element_type.1464, %closed_call.54), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  ROOT %pow.38 = f32[64]{0:T(128)S(1)} power(%closed_call.56, %div.1011), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/pow" stack_frame_id=0}
+  %div.1016 = f32[64]{0:T(128)} multiply(%convert_element_type.1464, %closed_call.54), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
+  ROOT %pow.38 = f32[64]{0:T(128)S(1)} power(%closed_call.56, %div.1016), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/pow" stack_frame_id=0}
 }
 
-%fused_computation.270.clone.1 (param_0.1712: f32[128], param_1.1830: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
-  %param_0.1712 = f32[128]{0:T(128)S(1)} parameter(0)
-  %div.1013 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_0.1712), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %param_1.1830 = f32[64]{0:T(128)S(1)} parameter(1)
-  %div.1014 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_1.1830), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %div.1012 = f32[1,128,1,64]{3,1,2,0:T(8,128)} divide(%div.1013, %div.1014), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %cos.43 = f32[1,128,1,64]{3,1,2,0:T(8,128)} cosine(%div.1012), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/cos" stack_frame_id=0}
-  %convert_element_type.1465 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%cos.43), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %sin.35.clone.3 = f32[1,128,1,64]{3,1,2,0:T(8,128)} sine(%div.1012), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/sin" stack_frame_id=0}
-  %convert_element_type.1140.clone.3 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%sin.35.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.219 = (bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert_element_type.1465, %convert_element_type.1140.clone.3)
+%fused_computation.276.clone.1 (param_0.1734: f32[128], param_1.1843: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
+  %param_0.1734 = f32[128]{0:T(128)S(1)} parameter(0)
+  %div.1018 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_0.1734), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
+  %param_1.1843 = f32[64]{0:T(128)S(1)} parameter(1)
+  %div.1019 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_1.1843), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
+  %div.1017 = f32[1,128,1,64]{3,1,2,0:T(8,128)} divide(%div.1018, %div.1019), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
+  %cos.43 = f32[1,128,1,64]{3,1,2,0:T(8,128)} cosine(%div.1017), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/cos" stack_frame_id=0}
+  %convert_element_type.1465 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%cos.43), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %sin.35.clone.3 = f32[1,128,1,64]{3,1,2,0:T(8,128)} sine(%div.1017), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/sin" stack_frame_id=0}
+  %convert_element_type.1140.clone.3 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%sin.35.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.217 = (bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert_element_type.1465, %convert_element_type.1140.clone.3)
 }
 
-%fused_computation.275.clone.1 (param_0.1714: bf16[1,128,1,64]) -> (bf16[128,128], bf16[128,128]) {
-  %param_0.1714 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.1106 = bf16[]{:T(256)} constant(-inf)
-  %pad.77 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1714, %constant.1106), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+%fused_computation.281.clone.1 (param_0.1736: bf16[1,128,1,64]) -> (bf16[128,128], bf16[128,128]) {
+  %param_0.1736 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %constant.1110 = bf16[]{:T(256)} constant(-inf)
+  %pad.77 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1736, %constant.1110), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.274 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.77)
-  %pad.76 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1714, %constant.1106), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.76 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1736, %constant.1110), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.275 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.76)
-  %maximum.57 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.274, %convert.275), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %maximum.57 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.274, %convert.275), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %constant.422.clone.8 = bf16[]{:T(256)} constant(0.08838)
-  %broadcast.1071 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.8), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %broadcast.1071 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.8), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
   %convert.277 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%broadcast.1071)
-  %mul.2285 = f32[1,128,1,128]{3,1,2,0:T(8,128)} multiply(%maximum.57, %convert.277), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.278 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2285)
-  %bitcast.916 = bf16[128,128]{1,0:T(8,128)(2,1)} bitcast(%convert.278), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %mul.2294 = f32[1,128,1,128]{3,1,2,0:T(8,128)} multiply(%maximum.57, %convert.277), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.278 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2294)
+  %bitcast.928 = bf16[128,128]{1,0:T(8,128)(2,1)} bitcast(%convert.278), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
   %convert.276 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.57)
-  %bitcast.455.clone.3 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.276), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  ROOT %tuple.221 = (bf16[128,128]{1,0:T(8,128)(2,1)}, bf16[128,128]{1,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.916, %bitcast.455.clone.3)
+  %bitcast.467.clone.3 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.276), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  ROOT %tuple.219 = (bf16[128,128]{1,0:T(8,128)(2,1)}, bf16[128,128]{1,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.928, %bitcast.467.clone.3)
 }
 
-%fused_computation.274.clone.1 (param_0.1713: bf16[1,128,1,64]) -> (bf16[128,128], bf16[128,128]) {
-  %param_0.1713 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.1105 = bf16[]{:T(256)} constant(-inf)
-  %pad.75 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1713, %constant.1105), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+%fused_computation.280.clone.1 (param_0.1735: bf16[1,128,1,64]) -> (bf16[128,128], bf16[128,128]) {
+  %param_0.1735 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %constant.1109 = bf16[]{:T(256)} constant(-inf)
+  %pad.75 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1735, %constant.1109), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.279 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.75)
-  %pad.74 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1713, %constant.1105), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %pad.74 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1735, %constant.1109), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.280 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.74)
-  %maximum.56 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.279, %convert.280), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %maximum.56 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.279, %convert.280), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %constant.422.clone.7 = bf16[]{:T(256)} constant(0.08838)
-  %broadcast.1070 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.7), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %broadcast.1070 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.7), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
   %convert.282 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%broadcast.1070)
-  %mul.2284 = f32[1,128,1,128]{3,1,2,0:T(8,128)} multiply(%maximum.56, %convert.282), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.283 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2284)
-  %bitcast.915 = bf16[128,128]{1,0:T(8,128)(2,1)} bitcast(%convert.283), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %mul.2293 = f32[1,128,1,128]{3,1,2,0:T(8,128)} multiply(%maximum.56, %convert.282), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.283 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2293)
+  %bitcast.927 = bf16[128,128]{1,0:T(8,128)(2,1)} bitcast(%convert.283), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
   %convert.281 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.56)
-  %bitcast.456.clone.3 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.281), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  ROOT %tuple.220 = (bf16[128,128]{1,0:T(8,128)(2,1)}, bf16[128,128]{1,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.915, %bitcast.456.clone.3)
+  %bitcast.468.clone.3 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.281), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  ROOT %tuple.218 = (bf16[128,128]{1,0:T(8,128)(2,1)}, bf16[128,128]{1,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.927, %bitcast.468.clone.3)
 }
 
-%fused_computation.202.clone.1 (param_0.1725: bf16[1,128,16,64], param_1.1837: bf16[1,128,16,64], param_2.1405: bf16[128,128], param_3.930: bf16[128,128], param_4.551: f32[128,16], param_5.481: bf16[128,16,128], param_6.338: bf16[128]) -> bf16[16,128,128] {
+%fused_computation.208.clone.1 (param_0.1747: bf16[1,128,16,64], param_1.1850: bf16[1,128,16,64], param_2.1414: bf16[128,128], param_3.937: bf16[128,128], param_4.556: f32[128,16], param_5.485: bf16[128,16,128], param_6.338: bf16[128]) -> bf16[16,128,128] {
   %param_6.338 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
-  %dot_general.597 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.338), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %dot_general.597 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.338), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.284 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.597)
-  %param_5.481 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} parameter(5)
-  %convert_element_type.1474 = f32[128,16,128]{2,0,1:T(8,128)} convert(%param_5.481), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %bitcast.926 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1474), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_4.551 = f32[128,16]{0,1:T(8,128)S(1)} parameter(4)
-  %mul.2304 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_4.551), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2303 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.926, %mul.2304), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1473 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2303), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_5.485 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} parameter(5)
+  %convert_element_type.1474 = f32[128,16,128]{2,0,1:T(8,128)} convert(%param_5.485), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %bitcast.938 = f32[1,128,16,128]{3,1,2,0:T(8,128)} bitcast(%convert_element_type.1474), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %param_4.556 = f32[128,16]{0,1:T(8,128)S(1)} parameter(4)
+  %mul.2313 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_4.556), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %mul.2312 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%bitcast.938, %mul.2313), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1473 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2312), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
   %convert.285 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1473)
-  %dot_general.596 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.284, %convert.285), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_3.930 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %mul.2302 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.930), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.286 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2302)
-  %mul.2300 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%dot_general.596, %convert.286), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_1.1837 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1108 = bf16[]{:T(256)} constant(-inf)
-  %pad.81 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1837, %constant.1108), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %dot_general.596 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.284, %convert.285), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_3.937 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %mul.2311 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.937), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert.286 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2311)
+  %mul.2309 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%dot_general.596, %convert.286), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_1.1850 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1112 = bf16[]{:T(256)} constant(-inf)
+  %pad.81 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1850, %constant.1112), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.287 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.81)
-  %param_0.1725 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.80 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1725, %constant.1108), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %param_0.1747 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.80 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1747, %constant.1112), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.288 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.80)
-  %maximum.59 = f32[1,128,16,128]{3,1,2,0:T(8,128)} maximum(%convert.287, %convert.288), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_2.1405 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %mul.2301 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1405), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.289 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2301)
-  %mul.2299 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%maximum.59, %convert.289), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %add.1049 = f32[1,128,16,128]{3,1,2,0:T(8,128)} add(%mul.2300, %mul.2299), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %maximum.59 = f32[1,128,16,128]{3,1,2,0:T(8,128)} maximum(%convert.287, %convert.288), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_2.1414 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %mul.2310 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1414), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert.289 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2310)
+  %mul.2308 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%maximum.59, %convert.289), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %add.1054 = f32[1,128,16,128]{3,1,2,0:T(8,128)} add(%mul.2309, %mul.2308), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %constant.422.clone.9 = bf16[]{:T(256)} constant(0.08838)
   %closed_call.57 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
   %convert.290 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%closed_call.57)
-  %mul.2298 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%add.1049, %convert.290), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.291 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2298)
-  ROOT %bitcast.925 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.291), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %mul.2307 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%add.1054, %convert.290), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.291 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2307)
+  ROOT %bitcast.937 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.291), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.131.clone.1 (param_0.1707: bf16[4,512,8,128], param_1.1827: s32[]) -> bf16[1,512,8,128] {
-  %param_0.1707 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1827 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.137.clone.1 (param_0.1729: bf16[4,512,8,128], param_1.1840: s32[]) -> bf16[1,512,8,128] {
+  %param_0.1729 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1840 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.82 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.187 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1707, %param_1.1827, %constant.415.clone.82, %constant.415.clone.82, %constant.415.clone.82), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.185 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1729, %param_1.1840, %constant.415.clone.82, %constant.415.clone.82, %constant.415.clone.82), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.226.clone.clone.clone.1 (param_0.1709: bf16[2048], param_1.1828: f32[128], param_2.1398: bf16[4,1,128,2048], param_3.925: s32[]) -> bf16[128,2048,1] {
-  %param_0.1709 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.587 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1709), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.232.clone.clone.clone.1 (param_0.1731: bf16[2048], param_1.1841: f32[128], param_2.1407: bf16[4,1,128,2048], param_3.932: s32[]) -> bf16[128,2048,1] {
+  %param_0.1731 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.587 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1731), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.216 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.587)
-  %param_2.1398 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.925 = s32[]{:T(128)S(6)} parameter(3)
+  %param_2.1407 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.932 = s32[]{:T(128)S(6)} parameter(3)
   %constant.415.clone.83 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.188 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1398, %param_3.925, %constant.415.clone.83, %constant.415.clone.83, %constant.415.clone.83), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.912 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.188), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1463 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.912), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1828 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2282 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1828), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2281 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1463, %mul.2282), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1462 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2281), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %dynamic-slice.186 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1407, %param_3.932, %constant.415.clone.83, %constant.415.clone.83, %constant.415.clone.83), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.924 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.186), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1463 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.924), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
+  %param_1.1841 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2291 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1841), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %mul.2290 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1463, %mul.2291), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1462 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2290), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
   %convert.217 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1462)
-  %dot_general.586 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.216, %convert.217), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %dot_general.586 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.216, %convert.217), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.218 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.586)
-  ROOT %bitcast.911 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.218)
+  ROOT %bitcast.923 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.218)
 }
 
-%fused_computation.118.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1708: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
-  %param_0.1708 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.910 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1708), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+%fused_computation.124.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1730: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
+  %param_0.1730 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.922 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1730), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
 }
 
 %region_16.18 (reduce_sum.213: f32[], reduce_sum.214: f32[]) -> f32[] {
-  %reduce_sum.213 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum"}
-  %reduce_sum.214 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum"}
-  ROOT %reduce_sum.218 = f32[]{:T(128)} add(%reduce_sum.213, %reduce_sum.214), metadata={op_name="checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce_sum.213 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum"}
+  %reduce_sum.214 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum"}
+  ROOT %reduce_sum.218 = f32[]{:T(128)} add(%reduce_sum.213, %reduce_sum.214), metadata={op_name="checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.232.clone.1 (param_0.1710: bf16[1,2048,8,128], param_1.1829: bf16[2048], param_2.1399: f32[128], param_3.926: bf16[4,1,128,2048], param_4.548: s32[]) -> (f32[128,8], f32[1,128,8,128]) {
-  %param_1.1829 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_2.1399 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.926 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %param_4.548 = s32[]{:T(128)S(6)} parameter(4)
-  %fusion.227.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1829, %param_2.1399, %param_3.926, %param_4.548), kind=kLoop, calls=%fused_computation.226.clone.clone.clone.1
-  %param_0.1710 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.194.clone.3 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1710), kind=kLoop, calls=%fused_computation.118.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convolution.105.clone.3 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.227.clone.3, %fusion.194.clone.3), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convert_element_type.1090.clone.3 = f32[128,8,128]{2,0,1:T(8,128)} convert(%convolution.105.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %bitcast.374.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} bitcast(%convert_element_type.1090.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %square.278 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%bitcast.374.clone.3, %bitcast.374.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
+%fused_computation.238.clone.1 (param_0.1732: bf16[1,2048,8,128], param_1.1842: bf16[2048], param_2.1408: f32[128], param_3.933: bf16[4,1,128,2048], param_4.553: s32[]) -> (f32[128,8], f32[1,128,8,128]) {
+  %param_1.1842 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_2.1408 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.933 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_4.553 = s32[]{:T(128)S(6)} parameter(4)
+  %fusion.237.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1842, %param_2.1408, %param_3.933, %param_4.553), kind=kLoop, calls=%fused_computation.232.clone.clone.clone.1
+  %param_0.1732 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.204.clone.3 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1732), kind=kLoop, calls=%fused_computation.124.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convolution.109.clone.3 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.237.clone.3, %fusion.204.clone.3), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convert_element_type.1090.clone.3 = f32[128,8,128]{2,0,1:T(8,128)} convert(%convolution.109.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %bitcast.386.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} bitcast(%convert_element_type.1090.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %square.278 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%bitcast.386.clone.3, %bitcast.386.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/square" stack_frame_id=0}
   %constant.416.clone.20 = f32[]{:T(128)} constant(0)
-  %reduce.264 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.278, %constant.416.clone.20), dimensions={0,3}, to_apply=%region_16.18, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.218 = (f32[128,8]{0,1:T(8,128)S(1)}, f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)}) tuple(%reduce.264, %bitcast.374.clone.3)
+  %reduce.264 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.278, %constant.416.clone.20), dimensions={0,3}, to_apply=%region_16.18, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.216 = (f32[128,8]{0,1:T(8,128)S(1)}, f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)}) tuple(%reduce.264, %bitcast.386.clone.3)
 }
 
-%fused_computation.288.clone.1 (param_0.1711: f32[128,8]) -> f32[128,8] {
-  %param_0.1711 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
+%fused_computation.294.clone.1 (param_0.1733: f32[128,8]) -> f32[128,8] {
+  %param_0.1733 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
   %constant.419.clone.11 = f32[]{:T(128)} constant(0.0078125)
   %broadcast.1069 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.419.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1010 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1711, %broadcast.1069), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %div.1015 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1733, %broadcast.1069), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/div" stack_frame_id=0}
   %constant.418.clone.18 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1068 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.418.clone.18), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %add.1046 = f32[128,8]{0,1:T(8,128)} add(%div.1010, %broadcast.1068), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.914 = f32[1,128,8]{1,2,0:T(8,128)} bitcast(%add.1046), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.215 = f32[1,128,8]{1,2,0:T(8,128)} rsqrt(%bitcast.914), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.913 = f32[128,8]{0,1:T(8,128)S(1)} bitcast(%rsqrt.215), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %broadcast.1068 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.418.clone.18), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}
+  %add.1051 = f32[128,8]{0,1:T(8,128)} add(%div.1015, %broadcast.1068), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}
+  %bitcast.926 = f32[1,128,8]{1,2,0:T(8,128)} bitcast(%add.1051), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}
+  %rsqrt.215 = f32[1,128,8]{1,2,0:T(8,128)} rsqrt(%bitcast.926), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.925 = f32[128,8]{0,1:T(8,128)S(1)} bitcast(%rsqrt.215), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.267.clone.2 (param_0.1715: bf16[128], param_1.1831: f32[1,128,8,128], param_2.1400: f32[128,8]) -> bf16[1,128,8,128] {
-  %param_0.1715 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(0)
-  %dot_general.589 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_0.1715), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.273.clone.2 (param_0.1737: bf16[128], param_1.1844: f32[1,128,8,128], param_2.1409: f32[128,8]) -> bf16[1,128,8,128] {
+  %param_0.1737 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(0)
+  %dot_general.589 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_0.1737), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.292 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.589)
-  %param_1.1831 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} parameter(1)
-  %param_2.1400 = f32[128,8]{0,1:T(8,128)S(1)} parameter(2)
-  %mul.2287 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_2.1400), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2286 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%param_1.1831, %mul.2287), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1466 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2286), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1844 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} parameter(1)
+  %param_2.1409 = f32[128,8]{0,1:T(8,128)S(1)} parameter(2)
+  %mul.2296 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_2.1409), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %mul.2295 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%param_1.1844, %mul.2296), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1466 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2295), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
   %convert.293 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1466)
-  %dot_general.588 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.292, %convert.293), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %dot_general.588 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.292, %convert.293), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   ROOT %convert.294 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.588)
 }
 
-%fused_computation.246.clone.1 (param_0.1716: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
-  %param_0.1716 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.73 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1716), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/split" stack_frame_id=0}
+%fused_computation.252.clone.1 (param_0.1738: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
+  %param_0.1738 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.73 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1738), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/split" stack_frame_id=0}
   %convert.295 = f32[1,128,8,64]{3,1,2,0:T(8,128)} convert(%slice.73)
-  %neg.126 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.295), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.296 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.126)
-  %slice.74 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1716), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/split" stack_frame_id=0}
-  ROOT %tuple.222 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.296, %slice.74)
+  %neg.131 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.295), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.296 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.131)
+  %slice.74 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1738), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/split" stack_frame_id=0}
+  ROOT %tuple.220 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.296, %slice.74)
 }
 
-%fused_computation.249.clone.1 (param_0.1717: bf16[1,128,8,64], param_1.1832: bf16[1,128,8,64], param_2.1401: bf16[128,128], param_3.927: bf16[128,128], param_4.549: f32[1,128,8,128], param_5.480: f32[128,8], param_6.337: bf16[128]) -> bf16[8,128,128] {
+%fused_computation.255.clone.1 (param_0.1739: bf16[1,128,8,64], param_1.1845: bf16[1,128,8,64], param_2.1410: bf16[128,128], param_3.934: bf16[128,128], param_4.554: f32[1,128,8,128], param_5.484: f32[128,8], param_6.337: bf16[128]) -> bf16[8,128,128] {
   %param_6.337 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
-  %dot_general.591 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.337), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %dot_general.591 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.337), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.297 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.591)
-  %param_4.549 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} parameter(4)
-  %param_5.480 = f32[128,8]{0,1:T(8,128)S(1)} parameter(5)
-  %mul.2293 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_5.480), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2292 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%param_4.549, %mul.2293), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1467 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2292), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_4.554 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} parameter(4)
+  %param_5.484 = f32[128,8]{0,1:T(8,128)S(1)} parameter(5)
+  %mul.2302 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_5.484), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %mul.2301 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%param_4.554, %mul.2302), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1467 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2301), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
   %convert.298 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1467)
-  %dot_general.590 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.297, %convert.298), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_3.927 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %mul.2291 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.927), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.299 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2291)
-  %mul.2289 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%dot_general.590, %convert.299), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_1.1832 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1107 = bf16[]{:T(256)} constant(-inf)
-  %pad.79 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1832, %constant.1107), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %dot_general.590 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.297, %convert.298), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_3.934 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %mul.2300 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.934), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert.299 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2300)
+  %mul.2298 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%dot_general.590, %convert.299), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_1.1845 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1111 = bf16[]{:T(256)} constant(-inf)
+  %pad.79 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1845, %constant.1111), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.300 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.79)
-  %param_0.1717 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.78 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1717, %constant.1107), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %param_0.1739 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.78 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1739, %constant.1111), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.301 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.78)
-  %maximum.58 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.300, %convert.301), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_2.1401 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %mul.2290 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1401), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.302 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2290)
-  %mul.2288 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%maximum.58, %convert.302), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %add.1047 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.2289, %mul.2288), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.303 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.1047)
-  ROOT %bitcast.917 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.303), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %maximum.58 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.300, %convert.301), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_2.1410 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %mul.2299 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1410), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert.302 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2299)
+  %mul.2297 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%maximum.58, %convert.302), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %add.1052 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.2298, %mul.2297), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.303 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.1052)
+  ROOT %bitcast.929 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.303), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.130.clone.1 (param_0.1702: bf16[4,512,8,128], param_1.1823: s32[]) -> bf16[1,512,8,128] {
-  %param_0.1702 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1823 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.136.clone.1 (param_0.1724: bf16[4,512,8,128], param_1.1836: s32[]) -> bf16[1,512,8,128] {
+  %param_0.1724 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1836 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.79 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.185 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1702, %param_1.1823, %constant.415.clone.79, %constant.415.clone.79, %constant.415.clone.79), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.183 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1724, %param_1.1836, %constant.415.clone.79, %constant.415.clone.79, %constant.415.clone.79), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.225.clone.1 (param_0.1704: bf16[2048], param_1.1824: f32[128], param_2.1395: bf16[4,1,128,2048], param_3.923: s32[]) -> bf16[128,2048,1] {
-  %param_0.1704 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.585 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1704), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.231.clone.1 (param_0.1726: bf16[2048], param_1.1837: f32[128], param_2.1404: bf16[4,1,128,2048], param_3.930: s32[]) -> bf16[128,2048,1] {
+  %param_0.1726 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.585 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1726), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.213 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.585)
-  %param_2.1395 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.923 = s32[]{:T(128)S(6)} parameter(3)
+  %param_2.1404 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.930 = s32[]{:T(128)S(6)} parameter(3)
   %constant.415.clone.80 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.186 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1395, %param_3.923, %constant.415.clone.80, %constant.415.clone.80, %constant.415.clone.80), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.907 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.186), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1461 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.907), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1824 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2280 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1824), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2279 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1461, %mul.2280), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1460 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2279), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %dynamic-slice.184 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1404, %param_3.930, %constant.415.clone.80, %constant.415.clone.80, %constant.415.clone.80), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.919 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.184), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1461 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.919), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
+  %param_1.1837 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2289 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1837), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %mul.2288 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1461, %mul.2289), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1460 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2288), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/convert_element_type" stack_frame_id=0}
   %convert.214 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1460)
-  %dot_general.584 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.213, %convert.214), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %dot_general.584 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.213, %convert.214), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/pre_self_attention/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.215 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.584)
-  ROOT %bitcast.906 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.215)
+  ROOT %bitcast.918 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.215)
 }
 
-%fused_computation.116.clone.clone.clone.1 (param_0.1703: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
-  %param_0.1703 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.905 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1703), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+%fused_computation.122.clone.clone.clone.1 (param_0.1725: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
+  %param_0.1725 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.917 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1725), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.190.clone.1 (param_0.1705: bf16[1,2048,8,128], param_1.1825: bf16[2048], param_2.1396: f32[128], param_3.924: bf16[4,1,128,2048], param_4.547: s32[]) -> bf16[8,128,128] {
-  %param_1.1825 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_2.1396 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.924 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %param_4.547 = s32[]{:T(128)S(6)} parameter(4)
-  %fusion.443 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1825, %param_2.1396, %param_3.924, %param_4.547), kind=kLoop, calls=%fused_computation.225.clone.1
-  %param_0.1705 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.442 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1705), kind=kLoop, calls=%fused_computation.116.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convolution.134 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.443, %fusion.442), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.908 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.134), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+%fused_computation.196.clone.1 (param_0.1727: bf16[1,2048,8,128], param_1.1838: bf16[2048], param_2.1405: f32[128], param_3.931: bf16[4,1,128,2048], param_4.552: s32[]) -> bf16[8,128,128] {
+  %param_1.1838 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_2.1405 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.931 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_4.552 = s32[]{:T(128)S(6)} parameter(4)
+  %fusion.453 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1838, %param_2.1405, %param_3.931, %param_4.552), kind=kLoop, calls=%fused_computation.231.clone.1
+  %param_0.1727 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.452 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1727), kind=kLoop, calls=%fused_computation.122.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convolution.138 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.453, %fusion.452), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  ROOT %bitcast.920 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.138), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.206.clone.clone.clone.1 (param_0.1728: bf16[16,128,128]) -> bf16[128,16,128] {
-  %param_0.1728 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.928 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1728)
+%fused_computation.212.clone.clone.clone.1 (param_0.1750: bf16[16,128,128]) -> bf16[128,16,128] {
+  %param_0.1750 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.940 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1750)
 }
 
-%fused_computation.106.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1727: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
-  %param_0.1727 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.927 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1727), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+%fused_computation.112.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1749: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
+  %param_0.1749 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.939 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1749), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
 }
 
 %region_17.20 (reduce_sum.219: f32[], reduce_sum.220: f32[]) -> f32[] {
-  %reduce_sum.219 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum"}
-  %reduce_sum.220 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum"}
-  ROOT %reduce_sum.221 = f32[]{:T(128)} add(%reduce_sum.219, %reduce_sum.220), metadata={op_name="checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce_sum.219 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum"}
+  %reduce_sum.220 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum"}
+  ROOT %reduce_sum.221 = f32[]{:T(128)} add(%reduce_sum.219, %reduce_sum.220), metadata={op_name="checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.175.clone.1 (param_0.1729: bf16[1,16,128,2048], param_1.1839: bf16[16,128,128], param_2.1406: bf16[4,1,128,2048], param_3.931: s32[]) -> (f32[128], bf16[1,128,2048]) {
-  %param_2.1406 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.931 = s32[]{:T(128)S(6)} parameter(3)
+%fused_computation.181.clone.1 (param_0.1751: bf16[1,16,128,2048], param_1.1852: bf16[16,128,128], param_2.1415: bf16[4,1,128,2048], param_3.938: s32[]) -> (f32[128], bf16[1,128,2048]) {
+  %param_2.1415 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.938 = s32[]{:T(128)S(6)} parameter(3)
   %constant.415.clone.16.clone.3 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.113.clone.3 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1406, %param_3.931, %constant.415.clone.16.clone.3, %constant.415.clone.16.clone.3, %constant.415.clone.16.clone.3), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.430.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.113.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert.304 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.430.clone.3)
-  %param_1.1839 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.209.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} fusion(%param_1.1839), kind=kLoop, calls=%fused_computation.206.clone.clone.clone.1
-  %param_0.1729 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.162.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_0.1729), kind=kLoop, calls=%fused_computation.106.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convolution.95.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.209.clone.3, %fusion.162.clone.3), window={size=16}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %bitcast.351.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.95.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convert.305 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.351.clone.3)
-  %add.818.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.304, %convert.305), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.1475 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%add.818.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %square.280 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1475, %convert_element_type.1475), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/square" stack_frame_id=0}
+  %dynamic-slice.113.clone.3 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1415, %param_3.938, %constant.415.clone.16.clone.3, %constant.415.clone.16.clone.3, %constant.415.clone.16.clone.3), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.442.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.113.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert.304 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.442.clone.3)
+  %param_1.1852 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.219.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} fusion(%param_1.1852), kind=kLoop, calls=%fused_computation.212.clone.clone.clone.1
+  %param_0.1751 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.172.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_0.1751), kind=kLoop, calls=%fused_computation.112.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convolution.99.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.219.clone.3, %fusion.172.clone.3), window={size=16}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %bitcast.363.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.99.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convert.305 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.363.clone.3)
+  %add.823.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.304, %convert.305), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.1475 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%add.823.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %square.280 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1475, %convert_element_type.1475), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/square" stack_frame_id=0}
   %constant.416.clone.22 = f32[]{:T(128)} constant(0)
-  %reduce.266 = f32[128]{0:T(128)S(1)} reduce(%square.280, %constant.416.clone.22), dimensions={0,2}, to_apply=%region_17.20, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
-  %convert.306 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.818.clone.3)
-  ROOT %tuple.225 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.266, %convert.306)
+  %reduce.266 = f32[128]{0:T(128)S(1)} reduce(%square.280, %constant.416.clone.22), dimensions={0,2}, to_apply=%region_17.20, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum" stack_frame_id=0}
+  %convert.306 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.823.clone.3)
+  ROOT %tuple.223 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.266, %convert.306)
 }
 
-%fused_computation.297.clone.1 (param_0.1730: f32[128]) -> f32[128] {
-  %param_0.1730 = f32[128]{0:T(128)S(1)} parameter(0)
+%fused_computation.303.clone.1 (param_0.1752: f32[128]) -> f32[128] {
+  %param_0.1752 = f32[128]{0:T(128)S(1)} parameter(0)
   %constant.417.clone.10 = f32[]{:T(128)} constant(0.00048828125)
   %broadcast.1075 = f32[128]{0:T(128)} broadcast(%constant.417.clone.10), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1016 = f32[128]{0:T(128)} multiply(%param_0.1730, %broadcast.1075), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %div.1021 = f32[128]{0:T(128)} multiply(%param_0.1752, %broadcast.1075), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/div" stack_frame_id=0}
   %constant.418.clone.20 = f32[]{:T(128)} constant(1e-06)
   %broadcast.1074 = f32[128]{0:T(128)} broadcast(%constant.418.clone.20), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %add.1050 = f32[128]{0:T(128)} add(%div.1016, %broadcast.1074), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.930 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1050), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.217 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.930), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.929 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.217), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %add.1055 = f32[128]{0:T(128)} add(%div.1021, %broadcast.1074), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/add" stack_frame_id=0}
+  %bitcast.942 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1055), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/add" stack_frame_id=0}
+  %rsqrt.217 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.942), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.941 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.217), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.217.clone.1 (param_0.1733: bf16[2048], param_1.1841: f32[128], param_2.1407: bf16[1,128,2048]) -> bf16[128,2048] {
-  %param_0.1733 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.599 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1733), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.223.clone.1 (param_0.1755: bf16[2048], param_1.1854: f32[128], param_2.1416: bf16[1,128,2048]) -> bf16[128,2048] {
+  %param_0.1755 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.599 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1755), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.222 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.599)
-  %param_2.1407 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %convert_element_type.1477 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1407), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1841 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2306 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1841), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2305 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1477, %mul.2306), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1476 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2305), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_2.1416 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %convert_element_type.1477 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1416), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %param_1.1854 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2315 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1854), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %mul.2314 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1477, %mul.2315), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %convert_element_type.1476 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2314), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
   %convert.223 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1476)
-  %dot_general.598 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.222, %convert.223), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %dot_general.598 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.222, %convert.223), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.224 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.598)
-  ROOT %bitcast.932 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.224)
+  ROOT %bitcast.944 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.224)
 }
 
-%fused_computation.86.clone.clone.clone.1 (param_0.1732: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1732 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.931 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1732), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.92.clone.clone.clone.1 (param_0.1754: bf16[1,2048,6144]) -> bf16[2048,6144] {
+  %param_0.1754 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.943 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1754), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.124.clone.1 (param_0.1734: bf16[1,2048,6144], param_1.1842: bf16[2048], param_2.1408: bf16[1,128,2048], param_3.932: f32[128]) -> bf16[1,128,6144] {
-  %param_1.1842 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_3.932 = f32[128]{0:T(128)S(1)} parameter(3)
-  %param_2.1408 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.445 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1842, %param_3.932, %param_2.1408), kind=kLoop, calls=%fused_computation.217.clone.1
-  %param_0.1734 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.444 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1734), kind=kLoop, calls=%fused_computation.86.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  %convolution.135 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.445, %fusion.444), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.933 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.135), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+%fused_computation.130.clone.1 (param_0.1756: bf16[1,2048,6144], param_1.1855: bf16[2048], param_2.1417: bf16[1,128,2048], param_3.939: f32[128]) -> bf16[1,128,6144] {
+  %param_1.1855 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_3.939 = f32[128]{0:T(128)S(1)} parameter(3)
+  %param_2.1417 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.455 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1855, %param_3.939, %param_2.1417), kind=kLoop, calls=%fused_computation.223.clone.1
+  %param_0.1756 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.454 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1756), kind=kLoop, calls=%fused_computation.92.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %convolution.139 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.455, %fusion.454), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  ROOT %bitcast.945 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.139), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.100.clone.1 (param_0.1739: bf16[4,512,6144], param_1.1845: s32[]) -> bf16[1,512,6144] {
-  %param_0.1739 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1845 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.106.clone.1 (param_0.1761: bf16[4,512,6144], param_1.1858: s32[]) -> bf16[1,512,6144] {
+  %param_0.1761 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1858 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.89 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.194 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1739, %param_1.1845, %constant.415.clone.89, %constant.415.clone.89), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.192 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1761, %param_1.1858, %constant.415.clone.89, %constant.415.clone.89), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.218.clone.1 (param_0.1741: bf16[2048], param_1.1846: f32[128], param_2.1409: bf16[1,128,2048]) -> bf16[128,2048] {
-  %param_0.1741 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.601 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1741), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.224.clone.1 (param_0.1763: bf16[2048], param_1.1859: f32[128], param_2.1418: bf16[1,128,2048]) -> bf16[128,2048] {
+  %param_0.1763 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.601 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1763), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.225 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.601)
-  %param_2.1409 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %convert_element_type.1479 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1409), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1846 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2308 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1846), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2307 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1479, %mul.2308), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1478 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2307), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_2.1418 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %convert_element_type.1479 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1418), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %param_1.1859 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2317 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1859), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %mul.2316 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1479, %mul.2317), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %convert_element_type.1478 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2316), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
   %convert.226 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1478)
-  %dot_general.600 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.225, %convert.226), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %dot_general.600 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.225, %convert.226), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.227 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.600)
-  ROOT %bitcast.938 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.227)
+  ROOT %bitcast.950 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.227)
 }
 
-%fused_computation.94.clone.clone.clone.1 (param_0.1740: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1740 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.937 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1740), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+%fused_computation.100.clone.clone.clone.1 (param_0.1762: bf16[1,2048,6144]) -> bf16[2048,6144] {
+  %param_0.1762 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.949 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1762), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.123.clone.1 (param_0.1742: bf16[1,2048,6144], param_1.1847: bf16[2048], param_2.1410: bf16[1,128,2048], param_3.933: f32[128]) -> bf16[1,128,6144] {
-  %param_1.1847 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_3.933 = f32[128]{0:T(128)S(1)} parameter(3)
-  %param_2.1410 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.449 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1847, %param_3.933, %param_2.1410), kind=kLoop, calls=%fused_computation.218.clone.1
-  %param_0.1742 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.448 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1742), kind=kLoop, calls=%fused_computation.94.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convolution.137 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.449, %fusion.448), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.939 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.137), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+%fused_computation.129.clone.1 (param_0.1764: bf16[1,2048,6144], param_1.1860: bf16[2048], param_2.1419: bf16[1,128,2048], param_3.940: f32[128]) -> bf16[1,128,6144] {
+  %param_1.1860 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_3.940 = f32[128]{0:T(128)S(1)} parameter(3)
+  %param_2.1419 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.459 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1860, %param_3.940, %param_2.1419), kind=kLoop, calls=%fused_computation.224.clone.1
+  %param_0.1764 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.458 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1764), kind=kLoop, calls=%fused_computation.100.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %convolution.141 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.459, %fusion.458), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  ROOT %bitcast.951 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.141), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.144.clone.1 (param_0.1801: bf16[1,128,6144], param_1.1888: bf16[1,128,6144]) -> bf16[128,6144] {
-  %param_1.1888 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.265 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1888)
-  %constant.425.clone.25 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.45 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.25), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
-  %convert.266 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.45)
-  %neg.132 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.265), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %exp.78 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.132), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %add.1059 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.78, %convert.266), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %div.1029 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.266, %add.1059), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2378 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.265, %div.1029), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %param_0.1801 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.267 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1801)
-  %mul.2377 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2378, %convert.267), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.268 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2377)
-  ROOT %bitcast.999 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.268)
+%fused_computation.150.clone.1 (param_0.1817: bf16[1,128,6144], param_1.1895: bf16[1,128,6144]) -> bf16[128,6144] {
+  %param_1.1895 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.250 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1895)
+  %constant.425.clone.23 = bf16[]{:T(256)} constant(1)
+  %jit_silu_.44 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.23), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)" stack_frame_id=0}
+  %convert.251 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.44)
+  %neg.135 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.250), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %exp.81 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.135), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %add.1062 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.81, %convert.251), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %div.1032 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.251, %add.1062), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2376 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.250, %div.1032), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %param_0.1817 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.252 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1817)
+  %mul.2375 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2376, %convert.252), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.253 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2375)
+  ROOT %bitcast.1007 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.253)
 }
 
-%fused_computation.212.clone.1 (param_0.1800: bf16[1,128,2048]) -> bf16[128,2048] {
-  %param_0.1800 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.998 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1800)
+%fused_computation.218.clone.1 (param_0.1816: bf16[1,128,2048]) -> bf16[128,2048] {
+  %param_0.1816 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1006 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1816)
 }
 
-%fused_computation.143.clone.1 (param_0.1802: bf16[1,128,6144], param_1.1889: bf16[1,128,2048], param_2.1441: bf16[1,128,6144]) -> bf16[6144,2048] {
-  %param_0.1802 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %param_2.1441 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.468 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1802, %param_2.1441), kind=kLoop, calls=%fused_computation.144.clone.1
-  %param_1.1889 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.469 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1889), kind=kLoop, calls=%fused_computation.212.clone.1
-  ROOT %convolution.147 = bf16[6144,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.468, %fusion.469), dim_labels=fb_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.149.clone.1 (param_0.1818: bf16[1,128,6144], param_1.1896: bf16[1,128,2048], param_2.1445: bf16[1,128,6144]) -> bf16[6144,2048] {
+  %param_0.1818 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %param_2.1445 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.474 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1818, %param_2.1445), kind=kLoop, calls=%fused_computation.150.clone.1
+  %param_1.1896 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.475 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1896), kind=kLoop, calls=%fused_computation.218.clone.1
+  ROOT %convolution.149 = bf16[6144,2048]{1,0:T(8,128)(2,1)S(1)} convolution(%fusion.474, %fusion.475), dim_labels=fb_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.488.clone.1 (param_0.1754: f32[1,16,128,128]) -> (f32[1,16,128,1], f32[16,128]) {
-  %param_0.1754 = f32[1,16,128,128]{2,1,3,0:T(8,128)S(1)} parameter(0)
-  %slice.77 = f32[1,16,128,1]{2,1,3,0:T(8,128)} slice(%param_0.1754), slice={[0:1], [0:16], [0:128], [0:1]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/slice" stack_frame_id=0}
-  %bitcast.489.clone.3 = f32[16,128]{1,0:T(8,128)S(1)} bitcast(%slice.77), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}
-  ROOT %tuple.229 = (f32[1,16,128,1]{2,1,3,0:T(8,128)}, f32[16,128]{1,0:T(8,128)S(1)}) tuple(%slice.77, %bitcast.489.clone.3)
+%fused_computation.494.clone.1 (param_0.1776: f32[1,16,128,128]) -> (f32[1,16,128,1], f32[16,128]) {
+  %param_0.1776 = f32[1,16,128,128]{2,1,3,0:T(8,128)S(1)} parameter(0)
+  %slice.77 = f32[1,16,128,1]{2,1,3,0:T(8,128)} slice(%param_0.1776), slice={[0:1], [0:16], [0:128], [0:1]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/slice" stack_frame_id=0}
+  %bitcast.501.clone.3 = f32[16,128]{1,0:T(8,128)S(1)} bitcast(%slice.77), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}
+  ROOT %tuple.227 = (f32[1,16,128,1]{2,1,3,0:T(8,128)}, f32[16,128]{1,0:T(8,128)S(1)}) tuple(%slice.77, %bitcast.501.clone.3)
 }
 
-%fused_computation.99.clone.1 (param_0.1735: bf16[4,6144,512], param_1.1843: s32[]) -> bf16[1,6144,512] {
-  %param_0.1735 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1843 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.105.clone.1 (param_0.1757: bf16[4,6144,512], param_1.1856: s32[]) -> bf16[1,6144,512] {
+  %param_0.1757 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1856 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.88 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.193 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1735, %param_1.1843, %constant.415.clone.88, %constant.415.clone.88), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.191 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1757, %param_1.1856, %constant.415.clone.88, %constant.415.clone.88), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.90.clone.clone.clone.1 (param_0.1737: bf16[1,6144,2048]) -> bf16[6144,2048] {
-  %param_0.1737 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.935 = bf16[6144,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1737), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.96.clone.clone.clone.1 (param_0.1759: bf16[1,6144,2048]) -> bf16[6144,2048] {
+  %param_0.1759 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
+  ROOT %bitcast.947 = bf16[6144,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1759), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.213.clone.1 (param_0.1736: bf16[1,128,2048]) -> bf16[128,2048] {
-  %param_0.1736 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.934 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1736)
+%fused_computation.219.clone.1 (param_0.1758: bf16[1,128,2048]) -> bf16[128,2048] {
+  %param_0.1758 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
+  ROOT %bitcast.946 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1758)
 }
 
-%fused_computation.122.clone.1 (param_0.1738: bf16[1,6144,2048], param_1.1844: bf16[1,128,2048]) -> bf16[1,128,6144] {
-  %param_0.1738 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %fusion.446 = bf16[6144,2048]{1,0:T(8,128)(2,1)} fusion(%param_0.1738), kind=kLoop, calls=%fused_computation.90.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  %param_1.1844 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(1)
-  %fusion.447 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1844), kind=kLoop, calls=%fused_computation.213.clone.1
-  %convolution.136 = bf16[6144,128]{0,1:T(8,128)(2,1)} convolution(%fusion.446, %fusion.447), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  ROOT %bitcast.936 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.136), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.128.clone.1 (param_0.1760: bf16[1,6144,2048], param_1.1857: bf16[1,128,2048]) -> bf16[1,128,6144] {
+  %param_0.1760 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %fusion.456 = bf16[6144,2048]{1,0:T(8,128)(2,1)} fusion(%param_0.1760), kind=kLoop, calls=%fused_computation.96.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %param_1.1857 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(1)
+  %fusion.457 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1857), kind=kLoop, calls=%fused_computation.219.clone.1
+  %convolution.140 = bf16[6144,128]{0,1:T(8,128)(2,1)} convolution(%fusion.456, %fusion.457), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  ROOT %bitcast.948 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.140), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.147.clone.1 (param_0.1744: bf16[1,128,6144], param_1.1848: bf16[1,128,6144]) -> bf16[128,6144] {
-  %param_1.1848 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.228 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1848)
+%fused_computation.153.clone.1 (param_0.1766: bf16[1,128,6144], param_1.1861: bf16[1,128,6144]) -> bf16[128,6144] {
+  %param_1.1861 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.228 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1861)
   %constant.425.clone.21 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.41 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
-  %convert.229 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.41)
-  %neg.128 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.228), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %exp.74 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.128), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %add.1051 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.74, %convert.229), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %div.1017 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.229, %add.1051), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2310 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.228, %div.1017), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %param_0.1744 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.230 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1744)
-  %mul.2309 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2310, %convert.230), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.231 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2309)
-  ROOT %bitcast.941 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.231)
+  %jit_silu_.42 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)" stack_frame_id=0}
+  %convert.229 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.42)
+  %neg.133 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.228), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %exp.79 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.133), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %add.1056 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.79, %convert.229), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %div.1022 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.229, %add.1056), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2319 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.228, %div.1022), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %param_0.1766 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.230 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1766)
+  %mul.2318 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2319, %convert.230), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.231 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2318)
+  ROOT %bitcast.953 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.231)
 }
 
-%fused_computation.88.clone.1 (param_0.1743: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1743 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.940 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1743), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.94.clone.1 (param_0.1765: bf16[1,2048,6144]) -> bf16[2048,6144] {
+  %param_0.1765 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.952 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1765), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.87.clone.1 (param_0.1745: bf16[1,2048,6144], param_1.1849: bf16[1,128,6144], param_2.1411: bf16[1,128,6144]) -> bf16[128,2048] {
-  %param_1.1849 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.1411 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.451 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_1.1849, %param_2.1411), kind=kLoop, calls=%fused_computation.147.clone.1
-  %param_0.1745 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.450 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1745), kind=kLoop, calls=%fused_computation.88.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  ROOT %convolution.138 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.451, %fusion.450), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.93.clone.1 (param_0.1767: bf16[1,2048,6144], param_1.1862: bf16[1,128,6144], param_2.1420: bf16[1,128,6144]) -> bf16[128,2048] {
+  %param_1.1862 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.1420 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.461 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_1.1862, %param_2.1420), kind=kLoop, calls=%fused_computation.153.clone.1
+  %param_0.1767 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.460 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1767), kind=kLoop, calls=%fused_computation.94.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  ROOT %convolution.142 = bf16[128,2048]{1,0:T(8,128)(2,1)S(1)} convolution(%fusion.461, %fusion.460), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.142.clone.1.clone.clone.clone.1 (param_0.1747: bf16[1,128,6144], param_1.1850: bf16[1,128,6144], param_2.1412: bf16[1,128,6144]) -> bf16[128,6144] {
-  %param_1.1850 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.232 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1850)
-  %param_2.1412 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %convert.233 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_2.1412)
-  %mul.2315 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.232, %convert.233), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+%fused_computation.148.clone.1.clone.clone.clone.1 (param_0.1769: bf16[1,128,6144], param_1.1863: bf16[1,128,6144], param_2.1421: bf16[1,128,6144]) -> bf16[128,6144] {
+  %param_1.1863 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.232 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1863)
+  %param_2.1421 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %convert.233 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_2.1421)
+  %mul.2324 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.232, %convert.233), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %constant.425.clone.22 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.42 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.22), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
-  %convert.235 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.42)
-  %param_0.1747 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.234 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1747)
-  %neg.129 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.234), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %exp.75 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.129), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %add.1052 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.75, %convert.235), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %div.1018 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.235, %add.1052), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2314 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2315, %div.1018), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2313 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.234, %mul.2315), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %sub.118 = f32[1,128,6144]{2,1,0:T(8,128)} subtract(%convert.235, %div.1018), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/sub" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2312 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%div.1018, %sub.118), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2311 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2313, %mul.2312), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %add_any.208 = f32[1,128,6144]{2,1,0:T(8,128)} add(%mul.2314, %mul.2311), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/jit(silu)/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %jit_silu_.43 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.22), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)" stack_frame_id=0}
+  %convert.235 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.43)
+  %param_0.1769 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.234 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1769)
+  %neg.134 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.234), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %exp.80 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.134), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %add.1057 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.80, %convert.235), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %div.1023 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.235, %add.1057), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2323 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2324, %div.1023), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2322 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.234, %mul.2324), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %sub.118 = f32[1,128,6144]{2,1,0:T(8,128)} subtract(%convert.235, %div.1023), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/sub" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2321 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%div.1023, %sub.118), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2320 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2322, %mul.2321), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %add_any.208 = f32[1,128,6144]{2,1,0:T(8,128)} add(%mul.2323, %mul.2320), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/jit(silu)/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.236 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%add_any.208)
-  ROOT %bitcast.943 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.236)
+  ROOT %bitcast.955 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.236)
 }
 
-%fused_computation.92.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1746: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1746 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.942 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1746), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+%fused_computation.98.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1768: bf16[1,2048,6144]) -> bf16[2048,6144] {
+  %param_0.1768 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.954 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1768), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
 }
 
 %region_18.21 (reduce_sum.225: f32[], reduce_sum.226: f32[]) -> f32[] {
-  %reduce_sum.225 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum"}
-  %reduce_sum.226 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum"}
-  ROOT %reduce_sum.227 = f32[]{:T(128)} add(%reduce_sum.225, %reduce_sum.226), metadata={op_name="checkpoint/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce_sum.225 = f32[]{:T(128)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum"}
+  %reduce_sum.226 = f32[]{:T(128)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum"}
+  ROOT %reduce_sum.227 = f32[]{:T(128)} add(%reduce_sum.225, %reduce_sum.226), metadata={op_name="checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.177.clone.1 (param_0.1748: bf16[1,128,2048], param_1.1851: bf16[2048], param_2.1413: bf16[128,2048], param_3.934: bf16[1,2048,6144], param_4.552: bf16[1,128,6144], param_5.482: bf16[1,128,6144], param_6.339: bf16[1,128,6144]) -> (f32[128], bf16[1,128,2048]) {
-  %param_0.1748 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1481 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1748), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_2.1413 = bf16[128,2048]{1,0:T(8,128)(2,1)} parameter(2)
-  %convert.307 = f32[128,2048]{1,0:T(8,128)} convert(%param_2.1413)
-  %param_4.552 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(4)
-  %param_5.482 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(5)
+%fused_computation.183.clone.1 (param_0.1770: bf16[1,128,2048], param_1.1864: bf16[2048], param_2.1422: bf16[128,2048], param_3.941: bf16[1,2048,6144], param_4.557: bf16[1,128,6144], param_5.486: bf16[1,128,6144], param_6.339: bf16[1,128,6144]) -> (f32[128], bf16[1,128,2048]) {
+  %param_0.1770 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1481 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1770), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %param_2.1422 = bf16[128,2048]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %convert.307 = f32[128,2048]{1,0:T(8,128)} convert(%param_2.1422)
+  %param_4.557 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(4)
+  %param_5.486 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(5)
   %param_6.339 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(6)
-  %fusion.292.clone.3 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_4.552, %param_5.482, %param_6.339), kind=kLoop, calls=%fused_computation.142.clone.1.clone.clone.clone.1
-  %param_3.934 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %fusion.171.clone.3 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_3.934), kind=kLoop, calls=%fused_computation.92.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convolution.101.clone.3 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.292.clone.3, %fusion.171.clone.3), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  %convert.308 = f32[128,2048]{1,0:T(8,128)} convert(%convolution.101.clone.3)
-  %add_any.151.clone.3 = f32[128,2048]{1,0:T(8,128)} add(%convert.307, %convert.308), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  %fusion.302.clone.3 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_4.557, %param_5.486, %param_6.339), kind=kLoop, calls=%fused_computation.148.clone.1.clone.clone.clone.1
+  %param_3.941 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %fusion.181.clone.3 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_3.941), kind=kLoop, calls=%fused_computation.98.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %convolution.105.clone.3 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.302.clone.3, %fusion.181.clone.3), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/dot_general" stack_frame_id=0}
+  %convert.308 = f32[128,2048]{1,0:T(8,128)} convert(%convolution.105.clone.3)
+  %add_any.151.clone.3 = f32[128,2048]{1,0:T(8,128)} add(%convert.307, %convert.308), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
   %convert.309 = bf16[128,2048]{1,0:T(8,128)(2,1)} convert(%add_any.151.clone.3)
-  %bitcast.359.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.309), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}
-  %convert.310 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.359.clone.3)
-  %param_1.1851 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %dot_general.603 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_1.1851), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %bitcast.371.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.309), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_mlp/add_any" stack_frame_id=0}
+  %convert.310 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.371.clone.3)
+  %param_1.1864 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %dot_general.603 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_1.1864), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.311 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.603)
-  %dot_general.602 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.310, %convert.311), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.1480 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.602), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/convert_element_type" stack_frame_id=0}
-  %mul.2316 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1481, %convert_element_type.1480), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %dot_general.602 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.310, %convert.311), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.1480 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.602), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %mul.2325 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1481, %convert_element_type.1480), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
   %constant.416.clone.23 = f32[]{:T(128)} constant(0)
-  %reduce.267 = f32[128]{0:T(128)S(1)} reduce(%mul.2316, %constant.416.clone.23), dimensions={0,2}, to_apply=%region_18.21, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.226 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.267, %bitcast.359.clone.3)
+  %reduce.267 = f32[128]{0:T(128)S(1)} reduce(%mul.2325, %constant.416.clone.23), dimensions={0,2}, to_apply=%region_18.21, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.224 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.267, %bitcast.371.clone.3)
 }
 
-%fused_computation.313.clone.1 (param_0.1749: f32[128], param_1.1852: f32[128]) -> f32[128] {
-  %param_0.1749 = f32[128]{0:T(128)S(1)} parameter(0)
-  %bitcast.946 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1749), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/reduce_sum" stack_frame_id=0}
-  %param_1.1852 = f32[128]{0:T(128)S(1)} parameter(1)
+%fused_computation.319.clone.1 (param_0.1771: f32[128], param_1.1865: f32[128]) -> f32[128] {
+  %param_0.1771 = f32[128]{0:T(128)S(1)} parameter(0)
+  %bitcast.958 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1771), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/reduce_sum" stack_frame_id=0}
+  %param_1.1865 = f32[128]{0:T(128)S(1)} parameter(1)
   %constant.417.clone.11 = f32[]{:T(128)} constant(0.00048828125)
   %broadcast.1077 = f32[128]{0:T(128)} broadcast(%constant.417.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %div.1020 = f32[128]{0:T(128)} multiply(%param_1.1852, %broadcast.1077), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %div.1025 = f32[128]{0:T(128)} multiply(%param_1.1865, %broadcast.1077), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/div" stack_frame_id=0}
   %constant.418.clone.21 = f32[]{:T(128)} constant(1e-06)
   %broadcast.1076 = f32[128]{0:T(128)} broadcast(%constant.418.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %add.1053 = f32[128]{0:T(128)} add(%div.1020, %broadcast.1076), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.945 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1053), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.218 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.945), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  %div.1019 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.218, %bitcast.945), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %add.1058 = f32[128]{0:T(128)} add(%div.1025, %broadcast.1076), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/add" stack_frame_id=0}
+  %bitcast.957 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1058), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/add" stack_frame_id=0}
+  %rsqrt.218 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.957), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/rsqrt" stack_frame_id=0}
+  %div.1024 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.218, %bitcast.957), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/div" stack_frame_id=0}
   %constant.426.clone.9 = f32[]{:T(128)} constant(-0.5)
   %closed_call.58 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.426.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call" stack_frame_id=0}
-  %mul.2319 = f32[1,128]{1,0:T(1,128)} multiply(%div.1019, %closed_call.58), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2318 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.946, %mul.2319), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %mul.2328 = f32[1,128]{1,0:T(1,128)} multiply(%div.1024, %closed_call.58), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %mul.2327 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.958, %mul.2328), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
   %constant.427.clone.5 = f32[]{:T(128)} constant(0.0009765625)
-  %mul.2320 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.427.clone.5), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %mul.2317 = f32[1,128]{1,0:T(1,128)} multiply(%mul.2318, %mul.2320), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  ROOT %bitcast.944 = f32[128]{0:T(128)S(1)} bitcast(%mul.2317), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %mul.2329 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.427.clone.5), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %mul.2326 = f32[1,128]{1,0:T(1,128)} multiply(%mul.2327, %mul.2329), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  ROOT %bitcast.956 = f32[128]{0:T(128)S(1)} bitcast(%mul.2326), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
 }
 
 %region_23.27 (dot_general.209: bf16[], dot_general.210: bf16[]) -> bf16[] {
-  %dot_general.209 = bf16[]{:T(256)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general"}
-  %dot_general.210 = bf16[]{:T(256)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general"}
+  %dot_general.209 = bf16[]{:T(256)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general"}
+  %dot_general.210 = bf16[]{:T(256)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general"}
   ROOT %add.418 = bf16[]{:T(256)} add(%dot_general.209, %dot_general.210), metadata={op_name="add.70"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.230.clone.1 (param_0.1750: bf16[1,128,2048], param_1.1853: f32[128], param_2.1414: bf16[1,128,2048], param_3.935: bf16[1,128,2048], param_4.553: f32[128], param_5.483: bf16[2048]) -> (bf16[2048], bf16[1,128,2048]) {
-  %param_0.1750 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.312 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1750)
-  %param_2.1414 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %convert_element_type.1483 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1414), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1853 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2322 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1853), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2321 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1483, %mul.2322), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1482 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2321), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+%fused_computation.236.clone.1 (param_0.1772: bf16[1,128,2048], param_1.1866: f32[128], param_2.1423: bf16[1,128,2048], param_3.942: bf16[1,128,2048], param_4.558: f32[128], param_5.487: bf16[2048]) -> (bf16[2048], bf16[1,128,2048]) {
+  %param_0.1772 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.312 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1772)
+  %param_2.1423 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %convert_element_type.1483 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1423), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %param_1.1866 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2331 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1866), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %mul.2330 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1483, %mul.2331), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %convert_element_type.1482 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2330), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
   %convert.313 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1482)
-  %multiply.470 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.312, %convert.313), metadata={op_name="multiply.352"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.314 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%multiply.470)
+  %multiply.469 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.312, %convert.313), metadata={op_name="multiply.352"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.314 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%multiply.469)
   %constant.429.clone.9 = bf16[]{:T(256)} constant(0)
-  %reduce.268 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%convert.314, %constant.429.clone.9), dimensions={0,1}, to_apply=%region_23.27, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}
-  %param_3.935 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %convert.316 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_3.935)
-  %param_5.483 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(5)
-  %dot_general.448.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_5.483), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %reduce.268 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%convert.314, %constant.429.clone.9), dimensions={0,1}, to_apply=%region_23.27, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}
+  %param_3.942 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(3)
+  %convert.316 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_3.942)
+  %param_5.487 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(5)
+  %dot_general.448.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_5.487), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}
   %convert.315 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.448.clone.3)
-  %dot_general.364.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.312, %convert.315), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.1115.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.364.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/convert_element_type" stack_frame_id=0}
-  %mul.1564.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1115.clone.3, %mul.2322), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %param_4.553 = f32[128]{0:T(128)S(1)} parameter(4)
-  %mul.1583.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_4.553), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %mul.1563.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1483, %mul.1583.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %add_any.171.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%mul.1564.clone.3, %mul.1563.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}
-  %convert_element_type.1113.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%add_any.171.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/convert_element_type" stack_frame_id=0}
+  %dot_general.364.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.312, %convert.315), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.1115.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.364.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
+  %mul.1573.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1115.clone.3, %mul.2331), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %param_4.558 = f32[128]{0:T(128)S(1)} parameter(4)
+  %mul.1592.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_4.558), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %mul.1572.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1483, %mul.1592.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/mul" stack_frame_id=0}
+  %add_any.171.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%mul.1573.clone.3, %mul.1572.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/add_any" stack_frame_id=0}
+  %convert_element_type.1113.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%add_any.171.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/convert_element_type" stack_frame_id=0}
   %convert.317 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1113.clone.3)
-  %add_any.169.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.316, %convert.317), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %add_any.169.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.316, %convert.317), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/post_self_attention_layer/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %convert.318 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add_any.169.clone.3)
-  ROOT %tuple.227 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.268, %convert.318)
+  ROOT %tuple.225 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.268, %convert.318)
 }
 
-%fused_computation.211.clone.clone.clone.1 (param_0.1752: bf16[1,128,2048]) -> bf16[128,2048,1] {
-  %param_0.1752 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.948 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%param_0.1752)
+%fused_computation.217.clone.clone.clone.1 (param_0.1774: bf16[1,128,2048]) -> bf16[128,2048,1] {
+  %param_0.1774 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.960 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%param_0.1774)
 }
 
-%fused_computation.104.clone.clone.clone.1 (param_0.1751: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
-  %param_0.1751 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.947 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1751), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+%fused_computation.110.clone.clone.clone.1 (param_0.1773: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
+  %param_0.1773 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.959 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1773), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
 }
 
 %region_19.22 (dot_general.206: f32[], dot_general.207: f32[]) -> f32[] {
@@ -1905,96 +1905,96 @@ StackFrames
   ROOT %add.417 = f32[]{:T(128)} add(%dot_general.206, %dot_general.207), metadata={op_name="add.47"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.183.clone.1 (param_0.1753: bf16[16,128,128], param_1.1854: bf16[1,16,128,2048], param_2.1415: bf16[1,128,2048]) -> (f32[16,128], bf16[128,16,128]) {
-  %param_0.1753 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.950 = bf16[1,16,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1753), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/broadcast_in_dim" stack_frame_id=0}
-  %convert.193 = f32[1,16,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.950), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/convert" stack_frame_id=0}
-  %param_2.1415 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.212.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_2.1415), kind=kLoop, calls=%fused_computation.211.clone.clone.clone.1
-  %param_1.1854 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.110.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_1.1854), kind=kLoop, calls=%fused_computation.104.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convolution.67.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} convolution(%fusion.212.clone.3, %fusion.110.clone.3), window={size=16 pad=15_15 rhs_reversal=1}, dim_labels=bf0_0oi->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  %bitcast.949 = bf16[1,16,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%convolution.67.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/transpose" stack_frame_id=0}
-  %convert.192 = f32[1,16,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.949), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/convert.1" stack_frame_id=0}
-  %multiply.471 = f32[1,16,128,128]{3,2,1,0:T(8,128)} multiply(%convert.193, %convert.192), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/multiply" stack_frame_id=0}
+%fused_computation.189.clone.1 (param_0.1775: bf16[16,128,128], param_1.1867: bf16[1,16,128,2048], param_2.1424: bf16[1,128,2048]) -> (f32[16,128], bf16[128,16,128]) {
+  %param_0.1775 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %bitcast.962 = bf16[1,16,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1775), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.193 = f32[1,16,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.962), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/convert" stack_frame_id=0}
+  %param_2.1424 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.222.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_2.1424), kind=kLoop, calls=%fused_computation.217.clone.clone.clone.1
+  %param_1.1867 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.120.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_1.1867), kind=kLoop, calls=%fused_computation.110.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convolution.71.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} convolution(%fusion.222.clone.3, %fusion.120.clone.3), window={size=16 pad=15_15 rhs_reversal=1}, dim_labels=bf0_0oi->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %bitcast.961 = bf16[1,16,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%convolution.71.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/transpose" stack_frame_id=0}
+  %convert.192 = f32[1,16,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.961), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/convert.1" stack_frame_id=0}
+  %multiply.470 = f32[1,16,128,128]{3,2,1,0:T(8,128)} multiply(%convert.193, %convert.192), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/multiply" stack_frame_id=0}
   %constant.416.clone.24 = f32[]{:T(128)} constant(0)
-  %dot_general.604 = f32[16,128]{1,0:T(8,128)S(1)} reduce(%multiply.471, %constant.416.clone.24), dimensions={0,3}, to_apply=%region_19.22, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general" stack_frame_id=0}
-  ROOT %tuple.228 = (f32[16,128]{1,0:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) tuple(%dot_general.604, %convolution.67.clone.3)
+  %dot_general.604 = f32[16,128]{1,0:T(8,128)S(1)} reduce(%multiply.470, %constant.416.clone.24), dimensions={0,3}, to_apply=%region_19.22, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general" stack_frame_id=0}
+  ROOT %tuple.226 = (f32[16,128]{1,0:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) tuple(%dot_general.604, %convolution.71.clone.3)
 }
 
-%fused_computation.252.clone.1 (param_0.1791: bf16[8,128,128]) -> bf16[128,8,128] {
-  %param_0.1791 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.985 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1791)
+%fused_computation.258.clone.1 (param_0.1807: bf16[8,128,128]) -> bf16[128,8,128] {
+  %param_0.1807 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.993 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1807)
 }
 
-%fused_computation.114.clone.clone.clone.1 (param_0.1790: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
-  %param_0.1790 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.984 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1790), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.120.clone.clone.clone.1 (param_0.1806: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
+  %param_0.1806 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.992 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1806), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.155.clone.1 (param_0.1792: bf16[1,2048,8,128], param_1.1882: bf16[8,128,128]) -> bf16[128,2048] {
-  %param_1.1882 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.465 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_1.1882), kind=kLoop, calls=%fused_computation.252.clone.1
-  %param_0.1792 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.464 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1792), kind=kLoop, calls=%fused_computation.114.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  %convolution.145 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.465, %fusion.464), window={size=8}, dim_labels=b0f_o0i->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
-  ROOT %bitcast.986 = bf16[128,2048]{1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.145), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.161.clone.1 (param_0.1808: bf16[1,2048,8,128], param_1.1889: bf16[8,128,128]) -> bf16[128,2048] {
+  %param_1.1889 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.471 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_1.1889), kind=kLoop, calls=%fused_computation.258.clone.1
+  %param_0.1808 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.470 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1808), kind=kLoop, calls=%fused_computation.120.clone.clone.clone.1, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  %convolution.147 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.471, %fusion.470), window={size=8}, dim_labels=b0f_o0i->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
+  ROOT %bitcast.994 = bf16[128,2048]{1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.147), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.255.clone.1 (param_0.1777: bf16[8,128,128], param_1.1871: bf16[128,128]) -> bf16[1,128,8,128] {
-  %param_0.1777 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.973 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1777), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
-  %convert.319 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.973)
-  %param_1.1871 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %broadcast.1081 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_1.1871), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+%fused_computation.261.clone.1 (param_0.1795: bf16[8,128,128], param_1.1880: bf16[128,128]) -> bf16[1,128,8,128] {
+  %param_0.1795 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %bitcast.982 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1795), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.319 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.982)
+  %param_1.1880 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %broadcast.1081 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_1.1880), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
   %convert.320 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.1081)
-  %mul.2344 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.319, %convert.320), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.321 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.2344)
-  ROOT %bitcast.972 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convert.321), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
+  %mul.2349 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.319, %convert.320), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.321 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.2349)
+  ROOT %bitcast.981 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convert.321), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
 }
 
-%fused_computation.490.clone.1 (param_0.1778: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
-  %param_0.1778 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.79 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1778), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/split" stack_frame_id=0}
-  %slice.52.clone.3 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1778), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/split" stack_frame_id=0}
+%fused_computation.496.clone.1 (param_0.1796: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
+  %param_0.1796 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.79 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1796), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/split" stack_frame_id=0}
+  %slice.52.clone.3 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1796), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/split" stack_frame_id=0}
   %convert.322 = f32[1,128,8,64]{3,1,2,0:T(8,128)} convert(%slice.52.clone.3)
-  %neg.100.clone.3 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.322), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.323 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.100.clone.3)
-  ROOT %tuple.234 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%slice.79, %convert.323)
+  %neg.105.clone.3 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.322), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.323 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.105.clone.3)
+  ROOT %tuple.231 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%slice.79, %convert.323)
 }
 
 %region_25.29 (dot_general.213: bf16[], dot_general.214: bf16[]) -> bf16[] {
-  %dot_general.213 = bf16[]{:T(256)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general"}
-  %dot_general.214 = bf16[]{:T(256)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/...k,k->...k/dot_general"}
+  %dot_general.213 = bf16[]{:T(256)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general"}
+  %dot_general.214 = bf16[]{:T(256)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/...k,k->...k/dot_general"}
   ROOT %add.420 = bf16[]{:T(256)} add(%dot_general.213, %dot_general.214), metadata={op_name="add.72"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.256.clone.1 (param_0.1779: f32[1,128,8,128], param_1.1872: f32[128,8], param_2.1428: bf16[128,128], param_3.943: bf16[8,128,128], param_4.559: bf16[1,128,8,64], param_5.486: bf16[1,128,8,64]) -> (bf16[128], bf16[1,128,8,128]) {
-  %param_5.486 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
-  %constant.1081.clone.3 = bf16[]{:T(256)} constant(-inf)
-  %pad.61.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_5.486, %constant.1081.clone.3), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
+%fused_computation.262.clone.1 (param_0.1797: f32[1,128,8,128], param_1.1881: f32[128,8], param_2.1434: bf16[128,128], param_3.949: bf16[8,128,128], param_4.563: bf16[1,128,8,64], param_5.490: bf16[1,128,8,64]) -> (bf16[128], bf16[1,128,8,128]) {
+  %param_5.490 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
+  %constant.1083.clone.3 = bf16[]{:T(256)} constant(-inf)
+  %pad.61.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_5.490, %constant.1083.clone.3), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.324 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.61.clone.3)
-  %param_4.559 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(4)
-  %pad.60.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_4.559, %constant.1081.clone.3), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}
+  %param_4.563 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(4)
+  %pad.60.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_4.563, %constant.1083.clone.3), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}
   %convert.325 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.60.clone.3)
-  %maximum.49.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.324, %convert.325), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_3.943 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %bitcast.683.clone.3 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_3.943), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
-  %convert.326 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.683.clone.3)
-  %param_2.1428 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %broadcast.979.clone.3 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_2.1428), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %maximum.49.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.324, %convert.325), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_3.949 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %bitcast.695.clone.3 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_3.949), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.326 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.695.clone.3)
+  %param_2.1434 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %broadcast.979.clone.3 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_2.1434), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
   %convert.327 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.979.clone.3)
-  %mul.1980.clone.3 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.326, %convert.327), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.328 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.1980.clone.3)
-  %bitcast.682.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%convert.328), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/mul" stack_frame_id=0}
-  %convert.329 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%bitcast.682.clone.3)
-  %add_any.195.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%maximum.49.clone.3, %convert.329), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_0.1779 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} parameter(0)
-  %param_1.1872 = f32[128,8]{0,1:T(8,128)S(1)} parameter(1)
-  %mul.2346 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1872), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2345 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%param_0.1779, %mul.2346), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1497 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2345), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.330 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1497)
-  %multiply.475 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%add_any.195.clone.3, %convert.330), metadata={op_name="multiply.355"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.331 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%multiply.475)
+  %mul.1989.clone.3 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.326, %convert.327), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.328 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.1989.clone.3)
+  %bitcast.694.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%convert.328), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert.329 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%bitcast.694.clone.3)
+  %add_any.195.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%maximum.49.clone.3, %convert.329), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_0.1797 = f32[1,128,8,128]{3,1,2,0:T(8,128)S(1)} parameter(0)
+  %param_1.1881 = f32[128,8]{0,1:T(8,128)S(1)} parameter(1)
+  %mul.2351 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1881), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %mul.2350 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%param_0.1797, %mul.2351), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/mul" stack_frame_id=0}
+  %convert_element_type.1495 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2350), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/closed_call/checkpoint/rematted_computation/qwen3_decoder_layer/apply_attention_with_norm/apply_attention_with_norm/self_attention/convert_element_type" stack_frame_id=0}
+  %convert.330 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1495)
+  %multiply.473 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%add_any.195.clone.3, %convert.330), metadata={op_name="multiply.355"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.331 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%multiply.473)
   %constant.429.clone.11 = bf16[]{:T(256)} constant(0)


### PR DESCRIPTION
The current profiles don't provide enough information for optimization / profiling runs.

# Description

Adds more granular profiling named scope to improve debugging and optimizations.
- Not a functional change

Before: 
<img width="818" height="630" alt="image" src="https://github.com/user-attachments/assets/6836b536-4a1e-4df6-a198-285572f67146" />

After:
<img width="1602" height="714" alt="image" src="https://github.com/user-attachments/assets/eda67eab-034f-4bc0-af05-e562fc5474c3" />



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
