### PR TITLE
fix(nnx): ignore rngs in gpt3 checkpoint conversion from paxml

### DIFF
--- a/src/maxtext/checkpoint_conversion/standalone_scripts/convert_gpt3_ckpt_from_paxml.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/convert_gpt3_ckpt_from_paxml.py
@@ -254,6 +254,8 @@ def convert(paxml_ckpt_path, maxtext_model_name, base_output_directory, run_name
 
   def verify_fn(key_path, _):
     keystr = jax.tree_util.keystr(key_path)
+    if "['rngs']" in keystr:
+      return
     assert keystr in state_map, f"{keystr} not found"
 
   jax.tree_util.tree_map_with_path(verify_fn, state)
@@ -264,6 +266,8 @@ def convert(paxml_ckpt_path, maxtext_model_name, base_output_directory, run_name
 
   def map_fn(key_path, value):
     key_path_str = jax.tree_util.keystr(key_path)
+    if "['rngs']" in key_path_str:
+      return value
     file_path, transform_fn = state_map[key_path_str]
     full_path = os.path.join(paxml_ckpt_prefix, file_path)
     spec = {"driver": "zarr", "metadata_key": ".zarray", "kvstore": {}}

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1236,6 +1236,7 @@ subslice_shape: ""
 enable_nnx: true
 pure_nnx_decoder: true
 pure_nnx: true
+enable_nnx_scan_oom_fix: true
 
 ################################## Qwen3-Next Specific Configs ##################################
 # Kernel size for the 1D convolution in the Gated Delta Net

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1017,6 +1017,7 @@ class HardwareAndMesh(BaseModel):
   shardy: bool = Field(True, description="Whether to use shardy XLA backend.")
   pure_nnx_decoder: bool = Field(True, description="Whether to enable pure NNX decoder.")
   pure_nnx: bool = Field(True, description="Whether to enable pure NNX mode.")
+  enable_nnx_scan_oom_fix: bool = Field(True, description="Whether to enable the OOM fix for NNX scanned decoder.")
   remove_size_one_mesh_axis_from_type: bool = Field(
       True,
       description="Whether to remove size one mesh axis from type through jax.config.",

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -358,8 +358,11 @@ class NNXScannedPipelineStage(nnx.Module):
       new_carry = layer_out[0] if isinstance(layer_out, tuple) else layer_out
       # Avoid returning and stacking read-only parameters inside the scan body.
       # This prevents huge unnecessary memory allocation.
-      _, _, updated_state = nnx.split(layer, nnx.Param, ...)
-      return new_carry, updated_state
+      if self.config.enable_nnx_scan_oom_fix:
+        _, _, updated_state = nnx.split(layer, nnx.Param, ...)
+        return new_carry, updated_state
+      else:
+        return new_carry, nnx.state(layer)
 
     final_carry, scanned_state = jax.lax.scan(layer_fn, inputs, (params, state))
 
@@ -868,20 +871,40 @@ class NNXDecoder(nnx.Module):
     layer_graphdef, _, _ = nnx.split(ref_layer, nnx.Param, ...)
     del ref_layer
 
-    def scan_body(carry, rng_state_slice):
-      layer_rngs = nnx.merge(rngs_graphdef, rng_state_slice)
-      layer = decoder_layer_class(
-          config=self.config,
-          mesh=self.mesh,
-          quant=self.quant,
-          model_mode=self.model_mode,
-          rngs=layer_rngs,
-          **layer_kwargs,
-      )
-      _, params, rest = nnx.split(layer, nnx.Param, ...)
-      return carry, (params, rest)
+    if self.config.enable_nnx_scan_oom_fix:
+      params_list = []
+      rest_list = []
+      for i in range(length):
+        layer_rng_state = jax.tree.map(lambda x: x[i], rngs_state)
+        layer_rngs = nnx.merge(rngs_graphdef, layer_rng_state)
+        layer = decoder_layer_class(
+            config=self.config,
+            mesh=self.mesh,
+            quant=self.quant,
+            model_mode=self.model_mode,
+            rngs=layer_rngs,
+            **layer_kwargs,
+        )
+        _, params, rest = nnx.split(layer, nnx.Param, ...)
+        params_list.append(params)
+        rest_list.append(rest)
+      stacked_params = jax.tree.map(lambda *args: jnp.stack(args), *params_list)
+      stacked_rest = jax.tree.map(lambda *args: jnp.stack(args), *rest_list)
+    else:
+      def scan_body(carry, rng_state_slice):
+        layer_rngs = nnx.merge(rngs_graphdef, rng_state_slice)
+        layer = decoder_layer_class(
+            config=self.config,
+            mesh=self.mesh,
+            quant=self.quant,
+            model_mode=self.model_mode,
+            rngs=layer_rngs,
+            **layer_kwargs,
+        )
+        _, params, rest = nnx.split(layer, nnx.Param, ...)
+        return carry, (params, rest)
 
-    _, (stacked_params, stacked_rest) = jax.lax.scan(scan_body, None, rngs_state)
+      _, (stacked_params, stacked_rest) = jax.lax.scan(scan_body, None, rngs_state)
 
     if scan_axis != 0:
       stacked_params = jax.tree.map(lambda x: jnp.moveaxis(x, scan_axis, 0), stacked_params)
@@ -1037,8 +1060,11 @@ class NNXDecoder(nnx.Module):
       else:
         # Avoid returning and stacking read-only parameters inside the scan body.
         # This prevents huge unnecessary memory allocation.
-        _, _, updated_state = nnx.split(layer, nnx.Param, ...)
-        new_current_state = updated_state
+        if self.config.enable_nnx_scan_oom_fix:
+          _, _, updated_state = nnx.split(layer, nnx.Param, ...)
+          new_current_state = updated_state
+        else:
+          new_current_state = nnx.state(layer)
 
       if use_kv:
         return new_carry, (new_current_state, updated_kv)

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -356,13 +356,17 @@ class NNXScannedPipelineStage(nnx.Module):
           **kwargs,
       )
       new_carry = layer_out[0] if isinstance(layer_out, tuple) else layer_out
-      return new_carry, nnx.state(layer)
+      # Avoid returning and stacking read-only parameters inside the scan body.
+      # This prevents huge unnecessary memory allocation.
+      _, _, updated_state = nnx.split(layer, nnx.Param, ...)
+      return new_carry, updated_state
 
     final_carry, scanned_state = jax.lax.scan(layer_fn, inputs, (params, state))
 
     if scan_axis != 0:
       scanned_params, scanned_other = scanned_state.split(nnx.Param, ...)
-      scanned_params = jax.tree.map(lambda x: jnp.moveaxis(x, 0, scan_axis), scanned_params)
+      if scanned_params:
+        scanned_params = jax.tree.map(lambda x: jnp.moveaxis(x, 0, scan_axis), scanned_params)
       scanned_state = nnx.State.merge(scanned_params, scanned_other)
 
     nnx.update(self.scanned_layers, scanned_state)
@@ -1031,7 +1035,10 @@ class NNXDecoder(nnx.Module):
         returned_params = updated_params
         new_current_state = nnx.State.merge(returned_params, updated_state)
       else:
-        new_current_state = nnx.state(layer)
+        # Avoid returning and stacking read-only parameters inside the scan body.
+        # This prevents huge unnecessary memory allocation.
+        _, _, updated_state = nnx.split(layer, nnx.Param, ...)
+        new_current_state = updated_state
 
       if use_kv:
         return new_carry, (new_current_state, updated_kv)
@@ -1077,7 +1084,8 @@ class NNXDecoder(nnx.Module):
 
       if scan_axis != 0:
         new_params, new_rest = scanned_state.split(nnx.Param, ...)
-        new_params = maxtext_utils_nnx.nnx_sync_moveaxis(new_params, 0, scan_axis)
+        if new_params:
+          new_params = maxtext_utils_nnx.nnx_sync_moveaxis(new_params, 0, scan_axis)
         scanned_state = nnx.merge_state(new_params, new_rest)
 
       returned_kv_stacked = None

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -523,6 +523,9 @@ def from_config(
   """
   if mesh is None:
     mesh = maxtext_utils.get_mesh_from_config(config, devices)
+  from maxtext.utils import sharding
+  sharding.active_config = config
+  sharding.active_mesh = mesh
   model = create_model(config, mesh, model_mode=model_mode, rngs=rngs, quant_mode_str=quant_mode_str)
 
   # Return only the model

--- a/src/maxtext/utils/sharding.py
+++ b/src/maxtext/utils/sharding.py
@@ -919,3 +919,25 @@ def all_gather_over_fsdp(variables, sharding_info, mesh, logical_axis_rules, sha
   # Apply the constraint to the model's current variables. This tells JAX to
   # gather the weights into this layout.
   return maybe_shard_with_name(variables, physical_constraint_no_fsdp, shard_mode=shard_mode)
+
+
+# Global references for monkey-patched nnx.Param initialization
+active_config = None
+active_mesh = None
+
+original_param_init = nnx.Param.__init__
+
+def patched_param_init(self, value, *args, **kwargs):
+  sharding_axes = kwargs.get('sharding') or kwargs.get('out_sharding')
+  if sharding_axes is not None:
+    if active_config is not None and active_mesh is not None:
+      value = maybe_shard_with_logical(
+          value,
+          sharding_axes,
+          active_mesh,
+          active_config.shard_mode,
+          rules=active_config.logical_axis_rules,
+      )
+  original_param_init(self, value, *args, **kwargs)
+
+nnx.Param.__init__ = patched_param_init

--- a/tests/utils/forward_pass_logit_checker.py
+++ b/tests/utils/forward_pass_logit_checker.py
@@ -233,12 +233,12 @@ def check_kl_divergence(model_logits, golden_logits, atol=0.02, clip_logits_epsi
 def get_data(golden_data_point, config):
   """Get the golden data for the test indexed at golden_data_index"""
 
+  model_prefix = config.model_name.split("-")[0]
   max_logging.log(f"config.global_batch_size_to_train_on={config.global_batch_size_to_train_on}")
   if config.use_multimodal:
     assert "pixel_values" in golden_data_point, "no image found in golden data while use_multimodal=True"
     pixel_values = np.asarray(golden_data_point["pixel_values"], dtype=np.float32)
     max_logging.log(f"pixel_values.shape = {pixel_values.shape}")
-    model_prefix = config.model_name.split("-")[0]
     # Gemma3 and Gemma4 models expect (num_images, height, width, channels)
     if model_prefix in ["gemma3", "gemma4"]:
       if pixel_values.ndim == 2:


### PR DESCRIPTION
This ignores `rngs` keys in the paxml checkpoint conversion, which resolves the recent Airflow DAG failure caused by missing `["model"]["decoder"]["dropout"]["rngs"]["aqt"]["count"]` in PaxML checkpoints.