### PR TITLE
Promote TPU nightly docker images to latest without verifying E2E Airflow tests

### DIFF
--- a/.github/workflows/tpu_nightly_images_pipeline.yml
+++ b/.github/workflows/tpu_nightly_images_pipeline.yml
@@ -107,6 +107,38 @@ jobs:
       maxtext_sha: ${{ github.sha }}
     secrets: inherit
 
+  # TODO: This is a workaround, to be removed when promote_docker_image.yml workflow is stable
+  tag_docker_image:
+    name: Promote ${{ matrix.image_name }} Docker Image
+    needs: run_ci_tests
+    if: needs.run_ci_tests.result == 'success'
+    runs-on: linux-x86-n2-16-buildkit
+    container: google/cloud-sdk:524.0.0
+    strategy:
+      fail-fast: false
+      matrix:
+        image_name:
+          - maxtext_jax_stable
+          - maxtext_jax_nightly
+          - maxtext_post_training_nightly
+    steps:
+      - name: Configure Docker
+        run: gcloud auth configure-docker us-docker.pkg.dev,gcr.io -q
+      - name: Add tags to Docker image
+        shell: bash
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          image_name=${{ inputs.image_suffix != '' && format('{0}_{1}', matrix.image_name, inputs.image_suffix) || matrix.image_name }}
+          SOURCE_IMAGE="gcr.io/${{ vars.PROJECT_NAME }}/${image_name}"
+
+          # Add the traceability tag to confirm it passed validation suite
+          gcloud container images add-tag "${SOURCE_IMAGE}:${GITHUB_RUN_ID}" \
+            "${SOURCE_IMAGE}:verified-${GITHUB_RUN_ID}" --quiet
+
+          # Add "latest" tag
+          gcloud container images add-tag "${SOURCE_IMAGE}:${GITHUB_RUN_ID}" "${SOURCE_IMAGE}:latest" --quiet
+
   notify_failure:
     name: Notify failed build
     needs: [build_and_push_docker_images, run_ci_tests, run_e2e_tests]


### PR DESCRIPTION
# Description

This PR updates the TPU nightly images pipeline to promote Docker images immediately after CI tests pass, bypassing the E2E Airflow tests.

## Motivation / Context
Currently, we need a way to promote the Docker images without waiting for the E2E Airflow tests. This is being introduced as a temporary workaround until the dedicated `promote_docker_image.yml` workflow is fully stable.

## Changes Made

- Added a new `tag_docker_image` job to `.github/workflows/tpu_nightly_images_pipeline.yml`.
- Configured the new job to run immediately upon the success of `run_ci_tests`.

FIXES: b/533456896


# Tests

https://github.com/AI-Hypercomputer/maxtext/actions/runs/29959108887

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
