### PR TITLE
Remove all-to-all operation from TSP/CP in Attention Segmentation Mask

### DIFF
--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -31,6 +31,8 @@ Shape = Sequence[int]
 AxisNames = tuple[str, ...]
 AxisIdxes = tuple[int, ...]
 
+SEGMENT_ID_BATCH = "segment_ids_batch"
+
 BATCH = "activation_batch"
 BATCH_ATTN = "activation_batch_attn"
 

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -565,6 +565,7 @@ logical_axis_rules: [
                       # Standard MLP / Dense Layers / Model Structure
                       # ==========================================
                       # Dense Activations
+                      ['segment_ids_batch', ['data', 'stage', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['activation_mlp', ['tensor', 'tensor_sequence']],
                       # Note activation batch and length also get used in vocab
                       ['activation_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -590,6 +590,7 @@ logical_axis_rules: [
                       # Standard MLP / Dense Layers / Model Structure
                       # ==========================================
                       # Dense Activations
+                      ['segment_ids_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['activation_mlp', ['tensor', 'tensor_sequence']],
                       # Note activation batch and length also get used in vocab
                       ['activation_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -49,6 +49,7 @@ from maxtext.common.common_types import (
     CACHE_SCALE_SEQUENCE,
     CACHE_SEQUENCE,
     Config,
+    SEGMENT_ID_BATCH,
     DECODE_BATCH,
     DECODE_LENGTH,
     DECODING_ACTIVE_SEQUENCE_INDICATOR,
@@ -747,7 +748,15 @@ class AttentionOp(nnx.Module):
     if model_mode == MODEL_MODE_AUTOREGRESSIVE and decoder_segment_ids is not None:
       mask = decoder_segment_ids[:, None, None, None, :] == DECODING_ACTIVE_SEQUENCE_INDICATOR
     elif decoder_segment_ids is not None:
-      mask = decoder_segment_ids[:, :, None] == decoder_segment_ids[:, None, :]
+
+      # With TSP/CP, all-gather prior to broadcast to avoid large all-to-all on broadcasted ids.
+      if not self.config.using_pipeline_parallelism:
+        key_sharding = self._logical_to_mesh_axes((SEGMENT_ID_BATCH, None))
+        decoder_key_segment_ids = self._maybe_shard_with_pspec(decoder_segment_ids, key_sharding)
+      else:
+        decoder_key_segment_ids = decoder_segment_ids
+
+      mask = decoder_segment_ids[:, :, None] == decoder_key_segment_ids[:, None, :]
       mask = mask[:, None, None, :, :]
 
     _, q_seq_len, _, _ = query.shape

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -47,6 +47,7 @@ from maxtext.common.common_types import (
     CACHE_SCALE_SEQUENCE,
     CACHE_SEQUENCE,
     Config,
+    SEGMENT_ID_BATCH,
     DECODE_BATCH,
     DECODE_LENGTH,
     DECODING_ACTIVE_SEQUENCE_INDICATOR,
@@ -957,6 +958,12 @@ class AttentionOp(nnx.Module):
       mask = decoder_segment_ids[:, None, None, None, :] == DECODING_ACTIVE_SEQUENCE_INDICATOR
     elif decoder_segment_ids is not None:
       seg_kv = decoder_segment_ids_kv if decoder_segment_ids_kv is not None else decoder_segment_ids
+
+      # With TSP/CP, all-gather seq dim prior to broadcast to avoid large all-to-all on broadcasted ids.
+      key_sharding = self._logical_to_mesh_axes((SEGMENT_ID_BATCH, None))
+      decoder_segment_ids = self._maybe_shard_with_pspec(decoder_segment_ids, key_sharding)
+      seg_kv = self._maybe_shard_with_pspec(seg_kv, key_sharding)
+
       mask = (decoder_segment_ids[:, :, None] == seg_kv[:, None, :]) & (seg_kv[:, None, :] >= 0)
       mask = mask[:, None, None, :, :]
 

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -347,8 +347,11 @@ class BlockCausalMaskTest(unittest.TestCase):
         causal_block_size=4,
         context_parallel_load_balance=False,
         context_sharding="context",
+        shard_mode="auto",
+        debug_sharding=False,
+        eval_interval=-1,
     )
-    mesh = types.SimpleNamespace(shape={})
+    mesh = Mesh(jax.devices()[:1], ["context"])
     kwargs = {}
     if attention_type is not None:
       kwargs["attention_type"] = attention_type
@@ -474,13 +477,20 @@ class BlockCausalMaskTest(unittest.TestCase):
         causal_block_size=4,
         context_parallel_load_balance=True,
         context_sharding="context",
+        shard_mode="auto",
+        debug_sharding=False,
+        eval_interval=-1,
     )
+    devices = jax.devices()
+    if len(devices) < 2:
+      self.skipTest("Need at least 2 devices to test chunk mask")
+    mesh = Mesh(devices[:2], ["context"])
     op = AttentionOp(
         config=config,
         num_query_heads=1,
         num_kv_heads=1,
         max_target_length=sequence_length,
-        mesh=types.SimpleNamespace(shape={"context": 2}),
+        mesh=mesh,
         attention_kernel="dot_product",
         attention_type=AttentionType.BLOCK_DIFFUSION,
     )
@@ -714,8 +724,19 @@ class LoadBalancedMaskTest(unittest.TestCase):
     np.testing.assert_array_equal(mask[:, :], expected)
 
   def test_dot_product_local_mask_uses_segment_positions(self):
-    config = types.SimpleNamespace(context_parallel_load_balance=True, context_sharding="context")
-    mesh = types.SimpleNamespace(shape={"context": 4})
+    config = types.SimpleNamespace(
+        context_parallel_load_balance=True,
+        context_sharding="context",
+        using_pipeline_parallelism=False,
+        logical_axis_rules=[["segment_ids_batch", ["context"]]],
+        shard_mode="auto",
+        debug_sharding=False,
+        eval_interval=-1,
+    )
+    devices = jax.devices()
+    if len(devices) < 4:
+      self.skipTest("Need at least 4 devices to test chunk mask")
+    mesh = Mesh(devices[:4], ["context"])
     seq_len = 16
     sliding_window_size = 4
     positions = jnp.asarray(attention_op.LoadBalancedCausalMask(shape=(seq_len, seq_len), cp_size=4).q_sequence[None, :])
@@ -750,8 +771,19 @@ class LoadBalancedMaskTest(unittest.TestCase):
     np.testing.assert_array_equal(np.asarray(mask == 0.0)[0, 0, 0], expected_mask)
 
   def test_dot_product_chunk_mask_uses_segment_positions(self):
-    config = types.SimpleNamespace(context_parallel_load_balance=True, context_sharding="context")
-    mesh = types.SimpleNamespace(shape={"context": 4})
+    config = types.SimpleNamespace(
+        context_parallel_load_balance=True,
+        context_sharding="context",
+        using_pipeline_parallelism=False,
+        logical_axis_rules=[["segment_ids_batch", ["context"]]],
+        shard_mode="auto",
+        debug_sharding=False,
+        eval_interval=-1,
+    )
+    devices = jax.devices()
+    if len(devices) < 4:
+      self.skipTest("Need at least 4 devices to test chunk mask")
+    mesh = Mesh(devices[:4], ["context"])
     seq_len = 16
     chunk_size = 4
     positions = jnp.asarray(attention_op.LoadBalancedCausalMask(shape=(seq_len, seq_len), cp_size=4).q_sequence[None, :])
@@ -3480,7 +3512,9 @@ class MLATest(attention_test_util.MLATestBase):
           "indexer_topk": 32,
       },
   )
-  @pytest.mark.skip(reason="Indexer with all-gather context parallelism diverges from the dot_product reference; fix tracked in #4947.")
+  @pytest.mark.skip(
+      reason="Indexer with all-gather context parallelism diverges from the dot_product reference; fix tracked in #4947."
+  )
   @pytest.mark.tpu_only
   def test_tpu_flash_attention_context_parallel_with_indexer(
       self, context_parallel_load_balance, ici_context_parallelism=2, indexer_topk=256

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -370,8 +370,19 @@ class LoadBalancedMaskTest(unittest.TestCase):
     np.testing.assert_array_equal((causal_mask & chunk_mask)[:, :], expected_mask)
 
   def test_dot_product_local_mask_uses_segment_positions(self):
-    config = types.SimpleNamespace(context_parallel_load_balance=True, context_sharding="context")
-    mesh = types.SimpleNamespace(shape={"context": 4})
+    config = types.SimpleNamespace(
+        context_parallel_load_balance=True,
+        context_sharding="context",
+        using_pipeline_parallelism=False,
+        logical_axis_rules=[["segment_ids_batch", ["context"]]],
+        shard_mode="auto",
+        debug_sharding=False,
+        eval_interval=-1,
+    )
+    devices = jax.devices()
+    if len(devices) < 4:
+      self.skipTest("Need at least 4 devices to test chunk mask")
+    mesh = Mesh(devices[:4], ["context"])
     seq_len = 16
     sliding_window_size = 4
     positions = jnp.asarray(attention_op.LoadBalancedCausalMask(shape=(seq_len, seq_len), cp_size=4).q_sequence[None, :])
@@ -406,8 +417,19 @@ class LoadBalancedMaskTest(unittest.TestCase):
     np.testing.assert_array_equal(np.asarray(mask == 0.0)[0, 0, 0], expected_mask)
 
   def test_dot_product_chunk_mask_uses_segment_positions(self):
-    config = types.SimpleNamespace(context_parallel_load_balance=True, context_sharding="context")
-    mesh = types.SimpleNamespace(shape={"context": 4})
+    config = types.SimpleNamespace(
+        context_parallel_load_balance=True,
+        context_sharding="context",
+        using_pipeline_parallelism=False,
+        logical_axis_rules=[["segment_ids_batch", ["context"]]],
+        shard_mode="auto",
+        debug_sharding=False,
+        eval_interval=-1,
+    )
+    devices = jax.devices()
+    if len(devices) < 4:
+      self.skipTest("Need at least 4 devices to test chunk mask")
+    mesh = Mesh(devices[:4], ["context"])
     seq_len = 16
     chunk_size = 4
     positions = jnp.asarray(attention_op.LoadBalancedCausalMask(shape=(seq_len, seq_len), cp_size=4).q_sequence[None, :])


### PR DESCRIPTION
# Description

When performing TSP/CP with packed sequences, the segmentation mask produced for attention from ids could introduce a large all-to-all operation (transporting bytes on the order of `O(S^2)`). This PR avoids that by introducing an all-gather on the small non-broadcasted to reduce communication.

More specifically, this line
```
mask = decoder_segment_ids[:, :, None] == decoder_key_segment_ids[:, None, :]
```
would produce an all-to-all on the broadcasted `decoder_key_segment_ids[:, None, :]` when running with TSP/CP since `decoder_segment_ids` is `[B, S]` following the input data sharding. The sequence dimension is sharded under TSP/CP constraints; however, this introduces a large all-to-all collective when constructing the `mask`. 

To fix this, we add a sharding constraint on the right hand side of the equation. This all-gathers `decoder_key_segment_ids` on the sequence dimension for the right-hand side prior to broadcasting for a much smaller collective with the same sharded output. This reduces communication latency and can improve performance when training with large sequence lengths.

# Tests

I observed all-to-all operations (300-400us) in the HLO for a Llama3-70b training run executing with tensor_sequence_parallelism. Then, after running the same configuration but with the new changes, I did not observe an all-to-all instruction in the HLO, and instead, the operation was replaced with a small all-gather (30us latency).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
