### PR TITLE
fix v7x failure on fractional eval batch test

### DIFF
--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -689,6 +689,7 @@ class TrainTests(unittest.TestCase):
         "steps=5",
         "enable_checkpointing=False",
         "enable_goodput_recording=False",
+        "max_target_length=4096",
         "dataset_type=synthetic",
         "remat_policy=minimal",
         "per_device_batch_size=1",


### PR DESCRIPTION
# Description

Currently v7x test on fractional batch size for eval [fails](https://github.com/AI-Hypercomputer/maxtext/actions/runs/29981095619/job/89174708201) due to the contradictions among `max_target_length=2048` and `num_devices=8` and splash block size being 512. To fix this, we only need to increase seq length to 4096.

# Tests

See tpu7x run here: https://github.com/AI-Hypercomputer/maxtext/actions/runs/30033315981/job/89295608280

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
