### PR TITLE
feat: Support pre-training and post-training callbacks in promote_docker_image workflow

### DIFF
--- a/.github/workflows/promote_docker_image.yml
+++ b/.github/workflows/promote_docker_image.yml
@@ -40,12 +40,14 @@ jobs:
           DAG_RUN_ID: ${{ github.event.client_payload.dag_run_id }}
           SHA: ${{ github.event.client_payload.sha }}
           GITHUB_RUN_ID: ${{ github.event.client_payload.github_run_id }}
+          TEST_TYPE: ${{ github.event.client_payload.test_type }}
         run: |
           echo "================================"
           echo "Github Run ID: ${GITHUB_RUN_ID}"
           echo "DAG ID:        ${DAG_ID}"
           echo "DAG Run ID:    ${DAG_RUN_ID}"
           echo "Commit SHA:    ${SHA}"
+          echo "Test Type:     ${TEST_TYPE}"
           echo "State:         ${STATE}"
           echo "================================"
 
@@ -66,16 +68,17 @@ jobs:
   tag_docker_image:
     name: Promote ${{ matrix.image_name }} Docker Image
     needs: handle_result
-    if: needs.handle_result.result == 'success'
+    if: needs.handle_result.result == 'success' && (github.event.client_payload.test_type == '' || github.event.client_payload.test_type == matrix.test_type)
     runs-on: linux-x86-n2-16-buildkit
     container: google/cloud-sdk:524.0.0
     strategy:
       fail-fast: false
       matrix:
-        image_name:
-          - maxtext_jax_nightly
-          - maxtext_gpu_jax_nightly
-          - maxtext_post_training_nightly
+        include:
+          - test_type: pre_training
+            image_name: maxtext_jax_nightly
+          - test_type: post_training
+            image_name: maxtext_post_training_nightly
     steps:
       - name: Configure Docker
         run: gcloud auth configure-docker us-docker.pkg.dev,gcr.io -q
@@ -83,8 +86,10 @@ jobs:
         shell: bash
         env:
           GITHUB_RUN_ID: ${{ github.event.client_payload.github_run_id }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+          IMAGE_NAME: ${{ matrix.image_name }}
         run: |
-          SOURCE_IMAGE="gcr.io/${{ vars.PROJECT_NAME }}/${{ matrix.image_name }}"
+          SOURCE_IMAGE="gcr.io/${PROJECT_NAME}/${IMAGE_NAME}"
 
           # Add the traceability tag to confirm it passed validation suite
           gcloud container images add-tag "${SOURCE_IMAGE}:${GITHUB_RUN_ID}" \


### PR DESCRIPTION
# Description

Update `.github/workflows/promote_docker_image.yml` to handle both pre-training and post-training GitHub repository dispatch callbacks (`airflow-dag-complete`) independently.

- Log `TEST_TYPE` (`pre_training` / `post_training`) from `github.event.client_payload` in the `handle_result` step.
- Update the `tag_docker_image` matrix strategy to match `test_type` to its corresponding target Docker image:
  - `pre_training`: promotes `maxtext_jax_nightly` and `maxtext_gpu_jax_nightly`.
  - `post_training`: promotes `maxtext_post_training_nightly`.
- Added a check `(github.event.client_payload.test_type == '' || github.event.client_payload.test_type == matrix.test_type)` so that each callback promotes only its relevant Docker images, while preserving full backward compatibility if `test_type` is omitted.

# Tests

- Validated YAML syntax with `yamllint .github/workflows/promote_docker_image.yml`.
- Verified condition logic for `test_type` matrix evaluation (`pre_training` -> `maxtext_jax_nightly`, `maxtext_gpu_jax_nightly`; `post_training` -> `maxtext_post_training_nightly`; empty -> all images).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
