### PR TITLE
Optimize chunked delta rule inversion.

### DIFF
--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -170,7 +170,7 @@ def naive_jax_chunk_gated_delta_rule(
 
     return new_last_recurrent_state, core_attn_out_i
 
-  final_state, core_attn_out_stacked = jax.lax.scan(scan_body, last_recurrent_state, xs)
+  final_state, core_attn_out_stacked = jax.lax.scan(scan_body, last_recurrent_state, xs, unroll=0)
 
   core_attn_out = jnp.transpose(core_attn_out_stacked, (1, 2, 0, 3, 4))
   core_attn_out = core_attn_out.reshape(batch_size, num_heads, -1, v_head_dim)
@@ -180,6 +180,57 @@ def naive_jax_chunk_gated_delta_rule(
   return core_attn_out, final_state if output_final_state else None
 
 
+@jax.custom_vjp
+def invert_unit_lower_triangular_log_depth(S):
+  """
+  Computes (I + S)^-1 for a strictly lower triangular matrix S
+  using log-depth Newton-Schulz iterations.
+
+  This is highly optimized for TPUs/GPUs and replaces
+  jax.scipy.linalg.solve_triangular for chunkwise linear attention.
+  """
+  chunk_size = S.shape[-1]
+
+  # Ensure S is strictly lower triangular (zero out diagonal and upper half)
+  # This guarantees mathematical correctness and stability
+  S_strict = jnp.tril(S, k=-1)
+
+  # Base identity matrix
+  identity = jnp.eye(chunk_size, dtype=S.dtype)
+
+  # Initial approximation and error term
+  A = identity - S_strict
+  E = jnp.tril(S_strict @ S_strict, k=-1)
+
+  # Log-depth Taylor series exact computation
+  steps = int(math.ceil(math.log2(chunk_size)))
+  for _ in range(steps - 1):
+    # Update inverse and error using batched matmuls
+    A = jnp.tril(A + A @ E)
+    E = jnp.tril(E @ E, k=-1)
+
+  return A
+
+
+@functools.partial(jax.named_call, name="invert_triangular_fwd")
+def _invert_unit_lower_triangular_log_depth_fwd(S):
+  A = invert_unit_lower_triangular_log_depth(S)
+  return A, A
+
+
+@functools.partial(jax.named_call, name="invert_triangular_bwd")
+def _invert_unit_lower_triangular_log_depth_bwd(res, g):
+  A = res
+  grad_S = jnp.tril(-(A.mT @ g @ A.mT), k=-1)
+  return (grad_S,)
+
+
+invert_unit_lower_triangular_log_depth.defvjp(
+    _invert_unit_lower_triangular_log_depth_fwd, _invert_unit_lower_triangular_log_depth_bwd
+)
+
+
+@functools.partial(jax.named_call, name="jax_chunked_delta_rule")
 def jax_chunk_gated_delta_rule(
     query: Array,
     key: Array,
@@ -264,11 +315,11 @@ def jax_chunk_gated_delta_rule(
   S = S * jnp.exp(g_diff)
   S = jnp.where(mask, S, 0.0)
 
-  # Inversion (A) - Strictly float32
-  identity = jnp.eye(chunk_size, dtype=jnp.float32)
-  identity_broadcasted = jnp.broadcast_to(identity, S.shape)
+  # Cast to float32 explicitly as you were doing before
+  S = S.astype(jnp.float32)
 
-  A = jax.scipy.linalg.solve_triangular(identity + S, identity_broadcasted, lower=True, unit_diagonal=True)
+  # Inversion (A) - Replaces solve_triangular entirely
+  A = invert_unit_lower_triangular_log_depth(S)
 
   # 5. WY Factors
   v_beta = v_c * beta_c[..., None]

--- a/tests/unit/qwen3_next_vs_reference_test.py
+++ b/tests/unit/qwen3_next_vs_reference_test.py
@@ -22,6 +22,7 @@ from flax import nnx
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
+from jax.test_util import check_grads
 from maxtext.configs import pyconfig
 from maxtext.layers import normalizations
 from maxtext.layers.normalizations import Qwen3NextRMSNorm, Qwen3NextRMSNormGated
@@ -1036,6 +1037,40 @@ class TestQwen3Next(unittest.TestCase):
         err_msg="Qwen3NextSparseMoeBlock does not match PyTorch reference!",
     )
     print("test_qwen3_next_sparse_moe_block passed!")
+
+  def test_invert_unit_lower_triangular_log_depth(self):
+    """Test for loss at chunk_size 256."""
+    jax.config.update("jax_enable_x64", True)  # Use float64 for precise testing
+    chunk_size = 256
+
+    # Generate a random matrix and make it strictly lower triangular
+    key = jax.random.PRNGKey(chunk_size)
+    S_random = jax.random.normal(key, (chunk_size, chunk_size), dtype=jnp.float64) / chunk_size
+    S = jnp.tril(S_random, k=-1)
+
+    # The matrix to invert is (I + S)
+    identity = jnp.eye(chunk_size, dtype=jnp.float64)
+    matrix_to_invert = identity + S
+
+    # Using our custom function
+    A = qwen3.invert_unit_lower_triangular_log_depth(S)
+
+    # The product A @ (I + S) should be exactly the identity matrix
+    # Wait, due to numerical precision, we should check for max error (loss)
+    reconstructed_identity = A @ matrix_to_invert
+
+    # Compute loss for forward pass
+    loss = jnp.max(jnp.abs(reconstructed_identity - identity))
+
+    # We expect the loss to be very small, around numerical precision
+    self.assertLess(loss, 1e-10, f"Failed for chunk_size {chunk_size} with loss {loss}")
+
+    # Verify backward pass accuracy using jax.test_util.check_grads
+    # This uses finite differences to check the correctness of the custom VJP
+    # We check the gradients for the function.
+    # `check_grads` will assert if finite difference gradients
+    # don't match the custom VJP gradients.
+    check_grads(qwen3.invert_unit_lower_triangular_log_depth, (S,), order=1, modes=["rev"])
 
   def test_gated_delta_net_full(self):
     """Tests the full Qwen3NextGatedDeltaNet layer for numerical correctness."""


### PR DESCRIPTION
- Replaced `jax.scipy.linalg.solve_triangular` with `invert_unit_lower_triangular_log_depth`, a highly optimized log-depth Newton-Schulz iteration implementation with a custom VJP for computing `(I+S)^-1`.
- Updated `jax.lax.scan` unroll parameters in the naive implementation.

# Description

1. Improves performance of triangular identity solver (adds a jax implementation). 
2. Unrolls jax.lax.scan given the small size of the loop XLA is able to optimize on the fly.
3. Tested on TPU v6e.

# Tests

Tested manually attached xprof results.
**Before Optimization**
For chunk_size: 128 
fwd : 96.96 ms
bwd: 127 ms
xprof:
<img width="982" height="668" alt="image" src="https://github.com/user-attachments/assets/dc758a1f-ba4f-4819-8566-743f47a80328" />

**After Optimization**
fwd: 23 ms
bwd: 52 ms
xprof:
<img width="936" height="610" alt="image" src="https://github.com/user-attachments/assets/57316e07-ddc5-4d42-9c84-28f51abaa29c" />

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
