### PR TITLE
Add RL GRPO gemma4-26b tutorial and fix doc conversion links

### DIFF
--- a/docs/tutorials/post_training_index.md
+++ b/docs/tutorials/post_training_index.md
@@ -38,6 +38,8 @@ MaxText was co-designed with key Google led innovations to provide a unified pos
   - [RL on Multi-Host TPUs](./posttraining/rl_on_multi_host.md)
   - [RL with Qwen3-30b-a3b-base](./posttraining/rl_qwen3_30b.md)
   - [RL with GPT-OSS 20B](./posttraining/rl_gptoss_20b.md)
+  - [RL with gemma4-e4b](./posttraining/rl_gemma4_e4b.md)
+  - [RL with gemma4-26b](./posttraining/rl_gemma4_26b.md)
 
 ## Step by step RL
 
@@ -77,6 +79,8 @@ posttraining/rl.md
 posttraining/rl_on_multi_host.md
 posttraining/rl_qwen3_30b.md
 posttraining/rl_gptoss_20b.md
+posttraining/rl_gemma4_e4b.md
+posttraining/rl_gemma4_26b.md
 posttraining/knowledge_distillation.md
 posttraining/lora.md
 posttraining/lora_on_multi_host.md

--- a/docs/tutorials/post_training_index.md
+++ b/docs/tutorials/post_training_index.md
@@ -39,6 +39,8 @@ MaxText was co-designed with key Google led innovations to provide a unified pos
   - [RL on Multi-Host TPUs](./posttraining/rl_on_multi_host.md)
   - [RL with Qwen3-30b-a3b-base](./posttraining/rl_qwen3_30b.md)
   - [RL with GPT-OSS 20B](./posttraining/rl_gptoss_20b.md)
+  - [RL with gemma4-e4b](./posttraining/rl_gemma4_e4b.md)
+  - [RL with gemma4-26b](./posttraining/rl_gemma4_26b.md)
 
 ## Step by step RL
 
@@ -78,6 +80,8 @@ posttraining/rl.md
 posttraining/rl_on_multi_host.md
 posttraining/rl_qwen3_30b.md
 posttraining/rl_gptoss_20b.md
+posttraining/rl_gemma4_e4b.md
+posttraining/rl_gemma4_26b.md
 posttraining/knowledge_distillation.md
 posttraining/lora.md
 posttraining/native_lora.md

--- a/docs/tutorials/posttraining/rl.md
+++ b/docs/tutorials/posttraining/rl.md
@@ -97,7 +97,7 @@ export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/
 
 ### Option 2: Converting from a Hugging Face checkpoint
 
-Refer to [Hugging Face to MaxText](hf-to-maxtext) to convert a Hugging Face checkpoint to MaxText format. After conversion finishes, set `MAXTEXT_CKPT_PATH` to the converted MaxText checkpoint path.
+Refer to [Hugging Face to MaxText](../../guides/checkpointing_solutions/convert_checkpoint.md#hugging-face-to-maxtext) to convert a Hugging Face checkpoint to MaxText format. After conversion finishes, set `MAXTEXT_CKPT_PATH` to the converted MaxText checkpoint path.
 
 ```bash
 export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items

--- a/docs/tutorials/posttraining/rl_gemma4_26b.md
+++ b/docs/tutorials/posttraining/rl_gemma4_26b.md
@@ -5,7 +5,7 @@
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-       https://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,17 +14,17 @@
  limitations under the License.
  -->
 
-# Reinforcement Learning with GPT-OSS 20B on Multi-Host TPUs
+# Reinforcement Learning with gemma4-26b on Multi-Host TPUs
 
 This tutorial provides step-by-step instructions for setting up the environment
-and training the GPT-OSS 20B model on the [GSM8K dataset](https://huggingface.co/datasets/openai/gsm8k) on a GKE cluster with `v5p-64` nodes.
+and training the gemma4-26b (26B-A4B MoE) model with GRPO on the [OpenMathInstruct-2 dataset](https://huggingface.co/datasets/nvidia/OpenMathInstruct-2) on a Cloud TPU v7x (Ironwood) GKE cluster using a `tpu7x-4x4x4` (64-chip) slice.
 
 ## Prerequisites
 
 Before starting, ensure you have:
 
 - Access to a Google Cloud Project with TPU quotas.
-- A Hugging Face account with an access token for downloading models.
+- A Hugging Face account with an access token for downloading models (the `google/gemma-4-26B-A4B` and `google/gemma-4-26B-A4B-it` repositories are gated; request access before proceeding).
 - Permissions for Google Artifact Registry (Artifact Registry Writer role).
 - Prerequisites for XPK installed (follow [official documentation](https://github.com/AI-Hypercomputer/xpk/blob/main/docs/installation.md#1-prerequisites)).
 - A Pathways-ready GKE cluster (see [create GKE cluster](https://docs.cloud.google.com/ai-hypercomputer/docs/workloads/pathways-on-cloud/create-gke-cluster)).
@@ -53,7 +53,7 @@ export BASE_OUTPUT_DIRECTORY=<GCS_BUCKET> # e.g., gs://my-bucket/maxtext-runs
 
 ## Authenticate with Hugging Face
 
-To download the `gpt-oss-20b` model checkpoint from Hugging Face, you need to authenticate using your Hugging Face account credentials. Run the following command and follow the prompts to log in:
+To download the `gemma4-26b` model checkpoint from Hugging Face, you need to authenticate using your Hugging Face account credentials. Run the following command and follow the prompts to log in:
 
 ```bash
 hf auth login
@@ -78,7 +78,19 @@ Refer to [Hugging Face to MaxText](../../guides/checkpointing_solutions/convert_
 export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
-> **Note:** Converting the 20B model requires approximately 40 GB of free disk space to download its safetensors. Please verify you have sufficient space before running the conversion.
+> **Note (Gemma 4 26B specifics):**
+>
+> - Run the conversion with `scan_layers=False` so the resulting unscanned checkpoint matches the `scan_layers=False` setting used for the RL run below.
+> - This RL recipe fine-tunes the **base** model (`google/gemma-4-26B-A4B`), not the instruction-tuned default. Pass `--hf_model_path=google/gemma-4-26B-A4B` explicitly when running `to_maxtext` — otherwise MaxText defaults to `HF_IDS[gemma4-26b]` = `google/gemma-4-26b-a4b-it`.
+
+## Chat Template Configuration
+
+Unlike an instruction-tuned tokenizer, the `google/gemma-4-26B-A4B` base tokenizer does **not** ship with a chat template, so the RL run must supply one explicitly. The [run_gemma4_26b_rl.sh](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/trainers/post_train/rl/scripts/run_gemma4_26b_rl.sh) script points at two files bundled with the repo (and therefore baked into your Docker image):
+
+- `data_template_path=maxtext/examples/chat_templates/openmathinstruct2_rl.json` — a stripped-down data template that injects only the system prompt and question (no turn markers). This avoids the doubled `<start_of_turn>` delimiters that would occur if the default `gsm8k_rl.json` (which bakes literal Gemma turn markers into the message content) were combined with the tokenizer's Jinja chat template.
+- `chat_template_path=maxtext/examples/chat_templates/gemma-3-27b-chat_template.json` — the Gemma 3 chat template, wrapped in a JSON object with a `chat_template` key. It is applied by the tokenizer as the single source of truth for turn-marker formatting.
+
+Both files are already included under `src/maxtext/examples/chat_templates/`, so no additional setup is required. If you want to customize the prompt formatting, edit these files (or point the config at your own) before building the Docker image.
 
 ## Run RL Workload
 
@@ -94,8 +106,10 @@ export CLOUD_IMAGE_NAME=<IMAGE_NAME>
 export DOCKER_IMAGE="gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?}"
 
 # Run the RL training script on your cluster
-run_tutorial maxtext/trainers/post_train/rl/scripts/run_gptoss_20b_rl.sh
+run_tutorial maxtext/trainers/post_train/rl/scripts/run_gemma4_26b_rl.sh
 ```
+
+> **Note:** The `run_gemma4_26b_rl.sh` script pins the Pathways component images to specific versions via the xpk `--server-image` and `--proxy-server-image` flags (set through the `PATHWAYS_SERVER_IMAGE` and `PATHWAYS_PROXY_SERVER_IMAGE` variables at the top of the script). The `--server-image` is used for both the Pathways resource-manager server and the workers (the reference config uses the same image for both). Update these variables if you need a different Pathways release.
 
 ### Monitor your workload
 
@@ -133,4 +147,6 @@ For a complete list of collected metrics, see the [Tunix Metrics Documentation](
 
 ## Convert Checkpoint to Hugging Face Format
 
-Refer to [MaxText to Hugging Face](../../guides/checkpointing_solutions/convert_checkpoint.md#maxtext-to-hugging-face) to convert a MaxText checkpoint back to Hugging Face format.
+Refer to [MaxText to Hugging Face](../../guides/checkpointing_solutions/convert_checkpoint.md#maxtext-to-hugging-face) to convert a MaxText checkpoint back to Hugging Face format. You can find an example script to convert the `gemma4-26b` model to Hugging Face format [here](https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh).
+
+> **Note (Gemma 4 26B specifics):** Because this recipe fine-tunes the **base** model, pass `--hf_model_path=google/gemma-4-26B-A4B` to `to_huggingface` so the exported checkpoint bundles the base tokenizer. Without it, `to_huggingface` sources the tokenizer from `HF_IDS[gemma4-26b]` = `google/gemma-4-26b-a4b-it` (the instruction-tuned model). Also keep `scan_layers=False`, matching the RL run that produced the checkpoint.

--- a/docs/tutorials/posttraining/rl_gemma4_26b.md
+++ b/docs/tutorials/posttraining/rl_gemma4_26b.md
@@ -14,17 +14,17 @@
  limitations under the License.
  -->
 
-# Reinforcement Learning with Qwen3-30b-a3b-base on Multi-Host TPUs
+# Reinforcement Learning with gemma4-26b on Multi-Host TPUs
 
 This tutorial provides step-by-step instructions for setting up the environment
-and training the Qwen3-30b-a3b-base model on the [OpenMathInstruct-2 dataset](https://huggingface.co/datasets/nvidia/OpenMathInstruct-2) on Ironwood GKE cluster with `tpu7x-128` nodes.
+and training the gemma4-26b (26B-A4B MoE) model with GRPO on the [OpenMathInstruct-2 dataset](https://huggingface.co/datasets/nvidia/OpenMathInstruct-2) on a Cloud TPU v7x (Ironwood) GKE cluster using a `tpu7x-4x4x4` (64-chip) slice.
 
 ## Prerequisites
 
 Before starting, ensure you have:
 
 - Access to a Google Cloud Project with TPU quotas.
-- A Hugging Face account with an access token for downloading models.
+- A Hugging Face account with an access token for downloading models (the `google/gemma-4-26B-A4B` and `google/gemma-4-26B-A4B-it` repositories are gated; request access before proceeding).
 - Permissions for Google Artifact Registry (Artifact Registry Writer role).
 - Prerequisites for XPK installed (follow [official documentation](https://github.com/AI-Hypercomputer/xpk/blob/main/docs/installation.md#1-prerequisites)).
 - A Pathways-ready GKE cluster (see [create GKE cluster](https://docs.cloud.google.com/ai-hypercomputer/docs/workloads/pathways-on-cloud/create-gke-cluster)).
@@ -53,7 +53,7 @@ export BASE_OUTPUT_DIRECTORY=<GCS_BUCKET> # e.g., gs://my-bucket/maxtext-runs
 
 ## Authenticate with Hugging Face
 
-To download the `qwen3-30b-a3b-base` model checkpoint from Hugging Face, you need to authenticate using your Hugging Face account credentials. Run the following command and follow the prompts to log in:
+To download the `gemma4-26b` model checkpoint from Hugging Face, you need to authenticate using your Hugging Face account credentials. Run the following command and follow the prompts to log in:
 
 ```bash
 hf auth login
@@ -72,13 +72,25 @@ export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/
 
 ### Option 2: Converting from a Hugging Face checkpoint
 
-Refer to [Hugging Face to MaxText](hf-to-maxtext) to convert a Hugging Face checkpoint to MaxText format. You can find an example script to convert `qwen3-30b-a3b-base`model to MaxText format [here](https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh). After conversion finishes, set `MAXTEXT_CKPT_PATH` to the converted MaxText checkpoint path.
+Refer to [Hugging Face to MaxText](hf-to-maxtext) to convert a Hugging Face checkpoint to MaxText format. After conversion finishes, set `MAXTEXT_CKPT_PATH` to the converted MaxText checkpoint path.
 
 ```bash
 export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
-> **Note:** Converting the 30B model requires approximately 62 GB of free disk space to download its safetensors. Please verify you have sufficient space before running the conversion script.
+> **Note (Gemma 4 26B specifics):**
+>
+> - Run the conversion with `scan_layers=False` so the resulting unscanned checkpoint matches the `scan_layers=False` setting used for the RL run below.
+> - This RL recipe fine-tunes the **base** model (`google/gemma-4-26B-A4B`), not the instruction-tuned default. Pass `--hf_model_path=google/gemma-4-26B-A4B` explicitly when running `to_maxtext` — otherwise MaxText defaults to `HF_IDS[gemma4-26b]` = `google/gemma-4-26b-a4b-it`.
+
+## Chat Template Configuration
+
+Unlike an instruction-tuned tokenizer, the `google/gemma-4-26B-A4B` base tokenizer does **not** ship with a chat template, so the RL run must supply one explicitly. The [run_gemma4_26b_rl.sh](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/trainers/post_train/rl/scripts/run_gemma4_26b_rl.sh) script points at two files bundled with the repo (and therefore baked into your Docker image):
+
+- `data_template_path=maxtext/examples/chat_templates/openmathinstruct2_rl.json` — a stripped-down data template that injects only the system prompt and question (no turn markers). This avoids the doubled `<start_of_turn>` delimiters that would occur if the default `gsm8k_rl.json` (which bakes literal Gemma turn markers into the message content) were combined with the tokenizer's Jinja chat template.
+- `chat_template_path=maxtext/examples/chat_templates/gemma-3-27b-chat_template.json` — the Gemma 3 chat template, wrapped in a JSON object with a `chat_template` key. It is applied by the tokenizer as the single source of truth for turn-marker formatting.
+
+Both files are already included under `src/maxtext/examples/chat_templates/`, so no additional setup is required. If you want to customize the prompt formatting, edit these files (or point the config at your own) before building the Docker image.
 
 ## Run RL Workload
 
@@ -94,8 +106,10 @@ export CLOUD_IMAGE_NAME=<IMAGE_NAME>
 export DOCKER_IMAGE="gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?}"
 
 # Run the RL training script on your cluster
-run_tutorial maxtext/trainers/post_train/rl/scripts/run_qwen3_30b_rl.sh
+run_tutorial maxtext/trainers/post_train/rl/scripts/run_gemma4_26b_rl.sh
 ```
+
+> **Note:** The `run_gemma4_26b_rl.sh` script pins the Pathways component images to specific versions via the xpk `--server-image` and `--proxy-server-image` flags (set through the `PATHWAYS_SERVER_IMAGE` and `PATHWAYS_PROXY_SERVER_IMAGE` variables at the top of the script). The `--server-image` is used for both the Pathways resource-manager server and the workers (the reference config uses the same image for both). Update these variables if you need a different Pathways release.
 
 ### Monitor your workload
 
@@ -133,4 +147,6 @@ For a complete list of collected metrics, see the [Tunix Metrics Documentation](
 
 ## Convert Checkpoint to Hugging Face Format
 
-Refer to [MaxText to Hugging Face](maxtext-to-hf) to convert a MaxText checkpoint back to Hugging Face format. You can find an example script to convert `qwen3-30b-a3b-base`model to Hugging Face format [here](https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh).
+Refer to [MaxText to Hugging Face](maxtext-to-hf) to convert a MaxText checkpoint back to Hugging Face format. You can find an example script to convert the `gemma4-26b` model to Hugging Face format [here](https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh).
+
+> **Note (Gemma 4 26B specifics):** Because this recipe fine-tunes the **base** model, pass `--hf_model_path=google/gemma-4-26B-A4B` to `to_huggingface` so the exported checkpoint bundles the base tokenizer. Without it, `to_huggingface` sources the tokenizer from `HF_IDS[gemma4-26b]` = `google/gemma-4-26b-a4b-it` (the instruction-tuned model). Also keep `scan_layers=False`, matching the RL run that produced the checkpoint.

--- a/docs/tutorials/posttraining/rl_gemma4_e4b.md
+++ b/docs/tutorials/posttraining/rl_gemma4_e4b.md
@@ -72,7 +72,7 @@ export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/
 
 ### Option 2: Converting from a Hugging Face checkpoint
 
-Refer to [Hugging Face to MaxText](hf-to-maxtext) to convert a Hugging Face checkpoint to MaxText format. After conversion finishes, set `MAXTEXT_CKPT_PATH` to the converted MaxText checkpoint path.
+Refer to [Hugging Face to MaxText](../../guides/checkpointing_solutions/convert_checkpoint.md#hugging-face-to-maxtext) to convert a Hugging Face checkpoint to MaxText format. After conversion finishes, set `MAXTEXT_CKPT_PATH` to the converted MaxText checkpoint path.
 
 ```bash
 export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
@@ -96,7 +96,7 @@ Both files are already included under `src/maxtext/examples/chat_templates/`, so
 
 ### Build and Upload MaxText Docker Image
 
-For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](../../build_maxtext.md).
+For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](../build_maxtext.md).
 
 ### Submit your workload
 
@@ -147,6 +147,6 @@ For a complete list of collected metrics, see the [Tunix Metrics Documentation](
 
 ## Convert Checkpoint to Hugging Face Format
 
-Refer to [MaxText to Hugging Face](maxtext-to-hf) to convert a MaxText checkpoint back to Hugging Face format.
+Refer to [MaxText to Hugging Face](../../guides/checkpointing_solutions/convert_checkpoint.md#maxtext-to-hugging-face) to convert a MaxText checkpoint back to Hugging Face format.
 
 > **Note (Gemma 4 E4B specifics):** Because this recipe fine-tunes the **base** model, pass `--hf_model_path=google/gemma-4-E4B` to `to_huggingface` so the exported checkpoint bundles the base tokenizer. Without it, `to_huggingface` sources the tokenizer from `HF_IDS[gemma4-e4b]` = `google/gemma-4-E4B-it` (the instruction-tuned model). Also keep `scan_layers=False`, since the `gemma4_small` decoder block is not compatible with scanned layers.

--- a/docs/tutorials/posttraining/rl_gemma4_e4b.md
+++ b/docs/tutorials/posttraining/rl_gemma4_e4b.md
@@ -96,7 +96,7 @@ Both files are already included under `src/maxtext/examples/chat_templates/`, so
 
 ### Build and Upload MaxText Docker Image
 
-For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](../../build_maxtext.md).
+For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](build-docker).
 
 ### Submit your workload
 

--- a/docs/tutorials/posttraining/rl_gptoss_20b.md
+++ b/docs/tutorials/posttraining/rl_gptoss_20b.md
@@ -84,7 +84,7 @@ export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/
 
 ### Build and Upload MaxText Docker Image
 
-For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](../../build_maxtext.md).
+For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](build-docker).
 
 ### Submit your workload
 

--- a/docs/tutorials/posttraining/rl_qwen3_30b.md
+++ b/docs/tutorials/posttraining/rl_qwen3_30b.md
@@ -72,7 +72,7 @@ export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/
 
 ### Option 2: Converting from a Hugging Face checkpoint
 
-Refer to [Hugging Face to MaxText](hf-to-maxtext) to convert a Hugging Face checkpoint to MaxText format. You can find an example script to convert `qwen3-30b-a3b-base`model to MaxText format [here](https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh). After conversion finishes, set `MAXTEXT_CKPT_PATH` to the converted MaxText checkpoint path.
+Refer to [Hugging Face to MaxText](../../guides/checkpointing_solutions/convert_checkpoint.md#hugging-face-to-maxtext) to convert a Hugging Face checkpoint to MaxText format. You can find an example script to convert `qwen3-30b-a3b-base`model to MaxText format [here](https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh). After conversion finishes, set `MAXTEXT_CKPT_PATH` to the converted MaxText checkpoint path.
 
 ```bash
 export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
@@ -84,7 +84,7 @@ export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/
 
 ### Build and Upload MaxText Docker Image
 
-For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](../../build_maxtext.md).
+For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](../build_maxtext.md).
 
 ### Submit your workload
 
@@ -135,4 +135,4 @@ For a complete list of collected metrics, see the [Tunix Metrics Documentation](
 
 ## Convert Checkpoint to Hugging Face Format
 
-Refer to [MaxText to Hugging Face](maxtext-to-hf) to convert a MaxText checkpoint back to Hugging Face format. You can find an example script to convert `qwen3-30b-a3b-base`model to Hugging Face format [here](https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh).
+Refer to [MaxText to Hugging Face](../../guides/checkpointing_solutions/convert_checkpoint.md#maxtext-to-hugging-face) to convert a MaxText checkpoint back to Hugging Face format. You can find an example script to convert `qwen3-30b-a3b-base`model to Hugging Face format [here](https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh).

--- a/src/maxtext/trainers/post_train/rl/scripts/run_gemma4_26b_rl.sh
+++ b/src/maxtext/trainers/post_train/rl/scripts/run_gemma4_26b_rl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script launches a Reinforcement Learning (RL) training workload for the
-# gemma4-e4b model on a GKE cluster using XPK.
+# gemma4-26b model on a GKE cluster using XPK.
 
 set -e
 
@@ -13,20 +13,20 @@ if ! pip show xpk &> /dev/null; then
 fi
 
 # --- Environment Variables ---
-export PROJECT_ID="${PROJECT_ID:-}" # GCP project ID where the v6e cluster is deployed
-export CLUSTER_NAME="${CLUSTER_NAME:-}" # Name of your v6e (Trillium) cluster
-export ZONE="${ZONE:-}" # Zone where your v6e cluster is deployed
+export PROJECT_ID="${PROJECT_ID:-}" # GCP project ID where the v7x cluster is deployed
+export CLUSTER_NAME="${CLUSTER_NAME:-}" # Name of your v7x (Ironwood) cluster
+export ZONE="${ZONE:-}" # Zone where your v7x cluster is deployed
 export BASE_OUTPUT_DIRECTORY="${BASE_OUTPUT_DIRECTORY:-}" # GCS bucket path for outputs (e.g., gs://my-bucket/outputs)
 export DOCKER_IMAGE="${DOCKER_IMAGE:-}" # Full path to the Docker image you pushed (e.g., gcr.io/my-project/my-image:tag)
 export MAXTEXT_CKPT_PATH="${MAXTEXT_CKPT_PATH:-}" # GCS path of the MaxText checkpoint you want to fine-tune from (e.g., gs://my-bucket/checkpoints/maxtext-ckpt)
-export TPU_TYPE="v6e-32"
+export TPU_TYPE="tpu7x-4x4x4" # v7x (Ironwood) 4x4x4 = 64-chip slice (tpu7x-standard-4t, 4 chips/VM)
 export WORKLOAD_NAME="rl-$(date +%Y%m%d-%H%M)"
 
 # Pathways component images, pinned to specific versions (mirrors the reference config).
 # Note: --server-image is used for BOTH the Pathways resource-manager server and the
 # workers; in the reference config the worker and pathwaysServer images are identical.
-export PATHWAYS_SERVER_IMAGE="us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server@sha256:d03068b39a8a2fab0621086ccb7c9445ce17ad34f1520159ca4ecd395346a162"
-export PATHWAYS_PROXY_SERVER_IMAGE="us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server@sha256:6342a3cae2818d2f887d396e9ae4156b3316f79fef186d71ff16d535b44e1724"
+export PATHWAYS_SERVER_IMAGE="us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server@sha256:6f5031086c3d603f275763c933e85e587e9332be1642fff515e9ecb52374950b"
+export PATHWAYS_PROXY_SERVER_IMAGE="us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server@sha256:8ffcc48a7bbd093a9071e0842ed7055d09d140d75f2b6c0a98bdb76cac77c44e"
 
 # --- Variable Validation ---
 if [ -z "$PROJECT_ID" ]; then
@@ -55,7 +55,7 @@ if [ -z "$MAXTEXT_CKPT_PATH" ]; then
     exit 1
 fi
 
-# XLA Flags (tuned for v6e / Trillium)
+# XLA Flags (tuned for v7x / Ironwood)
 XLA_FLAGS="--xla_tpu_scoped_vmem_limit_kib=65536 \
 --xla_tpu_bf16_emission_mode=NATIVE_EMISSION \
 --xla_tpu_enable_sparse_core_reduce_scatter_v2=true \
@@ -92,9 +92,9 @@ VLLM_ENGINE_READY_TIMEOUT_S=7200 \
 RPA_D_BLOCK_SIZES=1,1024,1,512 \
 TOKENIZERS_PARALLELISM=False \
 python3 -m maxtext.trainers.post_train.rl.train_rl \
-model_name=gemma4-e4b \
+model_name=gemma4-26b \
 tokenizer_type=huggingface \
-tokenizer_path=google/gemma-4-E4B \
+tokenizer_path=google/gemma-4-26B-A4B \
 run_name=$WORKLOAD_NAME \
 async_scheduling=True \
 base_output_directory=$BASE_OUTPUT_DIRECTORY \
@@ -112,8 +112,8 @@ sa_use_fused_bwd_kernel=True \
 sa_block_q=1024 \
 sa_block_kv=1024 \
 sa_block_kv_compute=512 \
-sa_block_q_dkv=1024 \
-sa_block_kv_dkv=1024 \
+sa_block_q_dkv=2048 \
+sa_block_kv_dkv=2048 \
 sa_block_kv_dkv_compute=256 \
 mu_dtype=bfloat16 \
 grad_dtype=bfloat16 \
@@ -122,7 +122,6 @@ batch_size=128 \
 num_batches=500 \
 learning_rate_schedule_steps=500 \
 num_test_batches=5 \
-eval_interval=100 \
 rl.num_generations=8 \
 rl.num_iterations=1 \
 rl.grpo_beta=0.05 \
@@ -140,28 +139,27 @@ eval_dataset_name=nvidia/OpenMathInstruct-2 \
 eval_split=test \
 learning_rate=1e-6 \
 max_prefill_predict_length=512 \
-max_target_length=4096 \
+max_target_length=8192 \
 kv_cache_buffer=512 \
-max_num_seqs=16 \
-max_num_batched_tokens=2048 \
+max_num_seqs=256 \
+max_num_batched_tokens=8192 \
 rollout_data_parallelism=8 \
-rollout_tensor_parallelism=2 \
-rollout_expert_parallelism=1 \
-rl.reshard_chunk_size=420 \
-enable_dp_attention=True \
-hbm_utilization_vllm=0.5 \
+rollout_tensor_parallelism=1 \
+rollout_expert_parallelism=8 \
+rl.reshard_chunk_size=50 \
+enable_dp_attention=False \
+hbm_utilization_vllm=0.8 \
 scan_layers=False \
 allow_split_physical_axes=True \
 enable_tunix_perf_metrics=True \
 checkpoint_period=25 \
 max_num_checkpoints_to_keep=30 \
 enable_checkpointing=True \
-train_micro_batch_size=1 \
-rollout_micro_batch_size=16 \
-ici_tensor_parallelism=2 \
+train_micro_batch_size=8 \
+rollout_micro_batch_size=128 \
 load_parameters_path=$MAXTEXT_CKPT_PATH \
 vllm_hf_overrides='{architectures: [\"MaxTextForCausalLM\"]}' \
-vllm_additional_config='{\"maxtext_config\": {\"model_name\": \"gemma4-e4b\", \"model_call_mode\": \"inference\", \"enable_dp_attention\": true, \"allow_split_physical_axes\": true, \"log_config\": false, \"weight_dtype\": \"bfloat16\", \"prefuse_moe_weights\": true}}'"
+vllm_additional_config='{\"maxtext_config\": {\"model_name\": \"gemma4-26b\", \"model_call_mode\": \"inference\", \"enable_dp_attention\": false, \"allow_split_physical_axes\": true, \"log_config\": false, \"weight_dtype\": \"bfloat16\", \"prefuse_moe_weights\": true}}'"
 
 # Workload Creation
 xpk workload create-pathways \


### PR DESCRIPTION
# Description

This PR adds a Reinforcement Learning (GRPO) tutorial and launch script for **gemma4-26b** (26B-A4B MoE) on Ironwood (Cloud TPU v7x), following the same format as the existing gemma4-e4b recipe. It also fixes several broken documentation links in the existing RL tutorials and registers the per-model Gemma RL tutorials in the docs table of contents.

## What's added
- **`docs/tutorials/posttraining/rl_gemma4_26b.md`** — step-by-step tutorial to run gemma4-26b GRPO on the OpenMathInstruct-2 dataset on a `tpu7x-4x4x4` (64-chip) slice. Mirrors the gemma4-e4b tutorial structure: prerequisites, HF auth, checkpoint conversion, chat-template setup, workload submission, monitoring, and export back to HF.
- **`src/maxtext/trainers/post_train/rl/scripts/run_gemma4_26b_rl.sh`** — XPK/Pathways launch script for the recipe. Mirrors `run_gemma4_e4b_rl.sh` and applies the 26B-specific configuration (model `gemma4-26b`, base tokenizer `google/gemma-4-26B-A4B`, MoE rollout expert-parallelism, `tpu7x-4x4x4` slice, pinned Pathways images, etc.).

## Docs housekeeping (fixes to existing RL tutorials)
- Registered `rl_gemma4_26b.md` **and** the previously-orphaned `rl_gemma4_e4b.md` in `post_training_index.md` (RL list + `toctree`).
- Fixed a broken relative link to the build guide (`../../build_maxtext.md` → `../build_maxtext.md`).
- Fixed broken MyST cross-references: the bare `[...](hf-to-maxtext)` / `[...](maxtext-to-hf)` links did not resolve. Replaced them with the working file+anchor form (`../../guides/checkpointing_solutions/convert_checkpoint.md#hugging-face-to-maxtext` and `#maxtext-to-hugging-face`), matching the pattern already used in `dpo.md` / `lora.md` / `rl_on_multi_host.md`.
- These link fixes were applied across `rl.md`, `rl_gemma4_e4b.md`, `rl_gptoss_20b.md`, and `rl_qwen3_30b.md` (scoped to the RL tutorials only).

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
