### PR TITLE
Fix pyconfig strict validation for multimodal keys in text-only runs

### DIFF
--- a/src/maxtext/configs/pyconfig.py
+++ b/src/maxtext/configs/pyconfig.py
@@ -257,9 +257,17 @@ def _prepare_for_pydantic(raw_keys: dict[str, Any], config_class: type[Any] = ty
   pydantic_kwargs = {}
   valid_fields = config_class.model_fields
 
+  # Check if multimodal is enabled in the current configuration
+  use_multimodal = raw_keys.get("use_multimodal", False)
+
   for key, value in raw_keys.items():
     check_flag = _check_for_invalid_keys(key, valid_fields)
     if not check_flag:
+      # Bypass the error for multimodal keys if use_multimodal is False
+      if not use_multimodal and key in types.Multimodal.model_fields:
+        logger.warning("Ignoring multimodal field %s because use_multimodal is False.", repr(key))
+        continue
+
       logger.warning("Ignoring invalid/unsupported field from YAML/CLI: %s", repr(key))
       raise ValueError(f"{key!r} not in {', '.join(map(repr, valid_fields))}.")
 

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2171,6 +2171,10 @@ class AudioEncoder(BaseModel):
   max_sample_len_for_audio: int = Field(10000, description="Maximum sample length for audio input.")
 
 
+class Multimodal(MultimodalGeneral, VisionTower, VisionProjector, AudioEncoder):
+  """Configurations for multimodal"""
+
+
 class RLCluster(BaseModel):
   """Cluster configurations specific to RL training."""
 
@@ -3706,20 +3710,23 @@ class RLConfig(
     LogitsAndLoss,
     RematAndOffload,
     Attention,
-    PositionalEmbedding,
     LayoutAndSharding,
     InferenceLayout,
     InferenceGeneral,
     Decoding,
-    Rope,
     IciParallelism,
     DcnParallelism,
     HardwareAndMesh,
     ModelArchitecture,
     MoBa,
+    # Positional Embeddings
+    PositionalEmbedding,
+    Rope,
+    YarnRope,
     # Mixture of Experts
     MoEGeneral,
     MoEKernels,
+    DeepSeekMoE,
     # General MaxText Configs
     RunInfo,
     Checkpointing,


### PR DESCRIPTION
# Description

Fix pyconfig strict validation for multimodal keys in text-only runs

The Pydantic configuration validation in `pyconfig.py` was overly strict for text-only workflows (such as RL training). When processing model YAMLs that included multimodal parameters (like `vision_encoder_block` or `image_size_for_vit`), it would crash with a ValueError because those keys are not always in the active schema.

This commit updates `_prepare_for_pydantic` to check the `use_multimodal` flag. If `use_multimodal` is False, the parser now gracefully ignores these specific vision keys and drops them instead of crashing.

FIXES: b/538001451

# Tests

Local run

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
