### PR TITLE
Fix eval_start_step logic with eval_interval

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -984,7 +984,7 @@ decode_sampling_nucleus_p: -1 # set if you're doing nucleus / top-p
 decode_sampling_top_k: 0 # set if you're doing top-k
 decode_sampling_temperature: 1.
 
-eval_start_step: 0 # start eval after train step is >= eval_start_step
+eval_start_step: 0 # start eval when train step is >= eval_start_step
 eval_interval: -1  # the specific number of train step between eval_step
 eval_steps: -1  # run this number of steps for eval, recommend setting this to prevent error due to running out of evel data
 target_eval_loss: 0.  # early stop once reaching target eval_loss

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1587,7 +1587,8 @@ class TrainingLoop(BaseModel):
   log_period: int = Field(100, description="Frequency (in steps) to log metrics and flush Tensorboard.")
   eval_start_step: int = Field(
       0,
-      description="Start evaluation after training step is >= eval_start_step.",
+      ge=0,
+      description="Start evaluation when training step is >= eval_start_step.",
   )
   eval_interval: int = Field(
       -1,

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -718,7 +718,12 @@ def training_loop_iteration(
         all_host_upload=dump_hlo_upload_all,
     )
 
-  if eval_interval > 0 and step >= start_step and step >= eval_start_step and (step + 1) % eval_interval == 0:
+  if (
+      eval_interval > 0
+      and step >= start_step
+      and step >= eval_start_step
+      and (step - eval_start_step) % eval_interval == 0
+  ):
     assert eval_data_iterator
     # Explicitly reset the eval iterator and counters before starting the eval loop
     eval_data_iterator.reset()

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -332,6 +332,15 @@ class PyconfigTest(unittest.TestCase):
     )
     self.assertEqual(config_override.eval_start_step, 50)
 
+  def test_eval_start_step_negative_raises_error(self):
+    """Verifies that eval_start_step < 0 raises a validation error."""
+    with self.assertRaises((ValueError, Exception)):
+      pyconfig.initialize(
+          [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+          skip_jax_distributed_system=True,
+          eval_start_step=-1,
+      )
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
# Description

This PR resolves the logic conflict and confusion when both `eval_start_step` and `eval_interval` are specified.
- **Why is this change being made**:
  Previously, when users set both `eval_start_step` and `eval_interval`, the evaluation logic had conflicting behaviors—either waiting until the end of the first full interval before starting or misaligning the initial evaluation step with subsequent intervals.
- **The problem being solved and relevant context**:
  Standardizing the behavior so that evaluation explicitly starts at `eval_start_step` and subsequently follows `eval_interval` steps (`(step - eval_start_step) % eval_interval == 0`).
  - Users have a clean, intuitive way to decide when evaluation first starts and how frequently it repeats.
  - If users want the legacy behavior (e.g., `eval_interval=10` evaluating at steps 9, 19, 29...), they can achieve it under this unified model by setting `eval_start_step=9`.

FIXES: b/535641549



# Tests

Tested locally

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
