### PR TITLE
Add custom MLP vision projector and tests

### DIFF
--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -107,6 +107,22 @@ def _expected_and_restored_params(abstract_nnx_state, restored_linen):
   return want, have
 
 
+def _is_custom_projector_problem(path: str, want: dict) -> bool:
+  """Returns True if a weight mismatch belongs to a newly attached custom vision projector."""
+  parts = [p for p in path.replace(".", "/").split("/") if p and p != "params"]
+  if len(parts) >= 2 and parts[0] == "vision_encoder":
+    proj_name = parts[1]
+    proj_dict = want.get("vision_encoder", {}).get(proj_name, {})
+    if isinstance(proj_dict, dict) and any("custom_linear" in k for k in proj_dict.keys()):
+      max_logging.warning(
+          f"===Warning: weight mismatch found in custom vision projector: {proj_name}.\n"
+          f"Path: {path}\n"
+          "This custom vision projector will be initialized with random weights.==="
+      )
+      return True
+  return False
+
+
 def _raise_on_weight_mismatch(want, have, config=None):
   """Raises if the restored weights (`have`) don't match what the model expects (`want`).
 
@@ -120,6 +136,8 @@ def _raise_on_weight_mismatch(want, have, config=None):
     want = _filter_lora_trainable_state(want)
 
   problems = _weight_mismatches(want, have)
+  # Ignore the weight mismatches in the custom projector so it can stay randomly initialized
+  problems = [(p, why) for p, why in problems if not _is_custom_projector_problem(p, want)]
   if not problems:
     return
   lines = "\n".join(f"  - '{p}': {why}" for p, why in problems)

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2193,6 +2193,16 @@ class VisionProjector(BaseModel):
   projector_output_dim_for_vit: int = Field(4096, description="Output dimension for the vision projector.")
   pixel_shuffle_ratio_for_vit: float = Field(0.5, description="Pixel shuffle ratio for the Vision Transformer.")
   projector_dropout_for_vit: float = Field(0.0, description="Dropout rate for the vision projector.")
+  vision_projector_type: str = Field(
+      "default", description="Type of the vision projector to use. Supported: 'default', 'customized_vision_projector'."
+  )
+  vision_connector_num_layers: int = Field(2, description="Number of layers in custom vision projector.")
+  vision_connector_hidden_size: int = Field(
+      0,
+      description=("Hidden size for custom vision projector intermediate layers. 0 defaults to LLM hidden size."),
+  )
+  vision_connector_activation: str = Field("gelu", description="Activation function for custom vision projector.")
+  vision_connector_use_bias: bool = Field(True, description="Whether to use bias in custom vision projector.")
 
 
 class AudioEncoder(BaseModel):

--- a/src/maxtext/experimental/omni_poc/tests/custom_vision_projector_test.py
+++ b/src/maxtext/experimental/omni_poc/tests/custom_vision_projector_test.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for custom vision projector implementation in MaxText.
+
+"""
+
+import argparse
+import gc
+import os
+
+from flax import nnx
+import jax
+import jax.numpy as jnp
+
+from maxtext.configs import pyconfig
+from maxtext.inference.maxengine import maxengine
+from maxtext.multimodal import processor as mm_processor
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
+
+
+def test_load_custom_vision_projector(hf_access_token, param_path):
+  base_yml_path = os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")
+
+  config = pyconfig.initialize(
+      base_config=base_yml_path,
+      model_name="qwen3-vl-2b",
+      tokenizer_path="Qwen/Qwen3-VL-2B-Instruct",
+      tokenizer_type="huggingface",
+      load_parameters_path=param_path,
+      per_device_batch_size=1,
+      scan_layers=False,
+      use_multimodal=True,
+      prompt="Describe this image",
+      image_path="tests/assets/test_image.jpg",
+      max_prefill_predict_length=512,
+      max_target_length=768,
+      ici_tensor_parallelism=4,
+      override_model_config=True,
+      attention="dot_product",
+      hf_access_token=hf_access_token,
+      vision_projector_type="customized_vision_projector",
+      vision_connector_num_layers=2,
+      vision_connector_activation="gelu",
+      vision_connector_use_bias=True,
+  )
+
+  print("Customized model")
+  print(f"Active Vision Projector Type: {config.vision_projector_type}")
+  print(f"Num Layers: {config.vision_connector_num_layers}")
+
+  engine = maxengine.MaxEngine(config)
+
+  # Load the parameters from the checkpoint
+  rng = jax.random.PRNGKey(1234)
+  params = engine.load_params(rng=rng)
+  nnx.update(engine.model, params)
+
+  # Preprocess the example image using the provided image_path in the config
+  processor_outputs = mm_processor.preprocess_mm_data(config)
+
+  images = processor_outputs.pixel_values
+  print(f"Image pixel_values shape: {images.shape}")
+
+  # Extract the vision wrapper and its underlying parts
+  vision_wrapper = engine.model.vision_encoder
+  pure_encoder = getattr(vision_wrapper, vision_wrapper.encoder_name)
+  projector = getattr(vision_wrapper, vision_wrapper.projector_name)
+
+  # Pass the image through the pure vision tower (before projector)
+  encoder_output = pure_encoder(images)
+
+  vision_embeddings_customized = encoder_output[0] if isinstance(encoder_output, tuple) else encoder_output
+
+  print("vision embeddings:", vision_embeddings_customized.shape)
+  print(f"First 10 values:\n{vision_embeddings_customized.flatten()[:10]}")
+
+  # Pass the image through the vision tower (including projector)
+  projected_embeddings_customized = projector(vision_embeddings_customized)
+
+  print(f"projector_embeddings: {projected_embeddings_customized.shape}")
+  print(f"First 10 values:\n{projected_embeddings_customized.flatten()[:10]}")
+
+  del engine, params, vision_wrapper, pure_encoder, projector
+  gc.collect()
+
+  print("\nOriginal model")
+  config_original = pyconfig.initialize(
+      base_config=base_yml_path,
+      model_name="qwen3-vl-2b",
+      tokenizer_path="Qwen/Qwen3-VL-2B-Instruct",
+      tokenizer_type="huggingface",
+      load_parameters_path=param_path,
+      per_device_batch_size=1,
+      scan_layers=False,
+      use_multimodal=True,
+      prompt="Describe this image",
+      image_path="tests/assets/test_image.jpg",
+      max_prefill_predict_length=512,
+      max_target_length=768,
+      ici_tensor_parallelism=4,
+      override_model_config=True,
+      attention="dot_product",
+      hf_access_token=hf_access_token,
+  )
+
+  print(f"Original Vision Projector Type: {getattr(config_original, 'vision_projector_type', None)}")
+
+  engine_original = maxengine.MaxEngine(config_original)
+
+  params_original = engine_original.load_params(rng=rng)
+  nnx.update(engine_original.model, params_original)
+
+  processor_outputs_original = mm_processor.preprocess_mm_data(config_original)
+  images_original = processor_outputs_original.pixel_values
+
+  vision_wrapper_original = engine_original.model.vision_encoder
+  pure_encoder_original = getattr(vision_wrapper_original, vision_wrapper_original.encoder_name)
+  projector_original = getattr(vision_wrapper_original, vision_wrapper_original.projector_name)
+
+  encoder_output_original = pure_encoder_original(images_original)
+
+  vision_embeddings_original = (
+      encoder_output_original[0] if isinstance(encoder_output_original, tuple) else encoder_output_original
+  )
+
+  print("Original vision embeddings:", vision_embeddings_original.shape)
+  print(f"First 10 values:\n{vision_embeddings_original.flatten()[:10]}")
+
+  projected_embeddings_original = projector_original(vision_embeddings_original)
+
+  print(f"Original projector_embeddings: {projected_embeddings_original.shape}")
+  print(f"First 10 values:\n{projected_embeddings_original.flatten()[:10]}")
+
+  print("\n===================================")
+  print("Comparing customized vs original embeddings")
+  vision_embeddings_match = jnp.allclose(vision_embeddings_customized, vision_embeddings_original, atol=1e-5)
+  vision_max_diff = jnp.max(jnp.abs(vision_embeddings_customized - vision_embeddings_original))
+  print(f"Vision embeddings match: {vision_embeddings_match} (Max diff: {vision_max_diff})")
+
+  projector_embeddings_match = jnp.allclose(projected_embeddings_customized, projected_embeddings_original, atol=1e-5)
+  projector_max_diff = jnp.max(jnp.abs(projected_embeddings_customized - projected_embeddings_original))
+  print(f"Projector embeddings match: {projector_embeddings_match} (Max diff: {projector_max_diff})")
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--load_parameters_path", required=True)
+  parser.add_argument("--hf_access_token", default=os.getenv("HF_TOKEN", ""))
+
+  args = parser.parse_args()
+  test_load_custom_vision_projector(
+      hf_access_token=args.hf_access_token,
+      param_path=args.load_parameters_path,
+  )

--- a/src/maxtext/layers/encoders.py
+++ b/src/maxtext/layers/encoders.py
@@ -21,6 +21,7 @@ from jax.sharding import Mesh
 from maxtext.common.common_types import Config, VisionEncoderBlockType
 from maxtext.layers import nnx_wrappers
 from maxtext.layers import initializers
+from maxtext.layers import linears
 
 
 class VisionEncoder(nnx.Module):
@@ -43,7 +44,6 @@ class VisionEncoder(nnx.Module):
       projector_name = "VisionEmbedder_0"
       setattr(self, encoder_name, gemma3.Gemma3VisionEncoderLayer(config=self.config, mesh=self.mesh, rngs=self.rngs))
       setattr(self, projector_name, gemma3.VisionEmbedder(config=self.config, mesh=self.mesh, rngs=self.rngs))
-      return encoder_name, projector_name
     elif self.vision_encoder_block == VisionEncoderBlockType.LLAMA4:
       from maxtext.models import llama4  # pylint: disable=import-outside-toplevel
 
@@ -51,7 +51,6 @@ class VisionEncoder(nnx.Module):
       projector_name = "Llama4MultiModalProjector_0"
       setattr(self, encoder_name, llama4.Llama4VisionModel(config=self.config, mesh=self.mesh, rngs=self.rngs))
       setattr(self, projector_name, llama4.Llama4MultiModalProjector(config=self.config, mesh=self.mesh, rngs=self.rngs))
-      return encoder_name, projector_name
     elif self.vision_encoder_block == VisionEncoderBlockType.QWEN3_OMNI:
       from maxtext.models import qwen3  # pylint: disable=import-outside-toplevel
 
@@ -59,7 +58,6 @@ class VisionEncoder(nnx.Module):
       projector_name = "Qwen3OmniMoeVisionProjector_0"
       setattr(self, encoder_name, qwen3.Qwen3OmniMoeVisionEncoder(config=self.config, mesh=self.mesh, rngs=self.rngs))
       setattr(self, projector_name, qwen3.Qwen3OmniMoeVisionProjector(config=self.config, rngs=self.rngs))
-      return encoder_name, projector_name
     elif self.vision_encoder_block == VisionEncoderBlockType.GEMMA4:
       from maxtext.models import gemma4_vision  # pylint: disable=import-outside-toplevel
 
@@ -71,7 +69,6 @@ class VisionEncoder(nnx.Module):
       setattr(
           self, projector_name, gemma4_vision.Gemma4VisionProjector(config=self.config, mesh=self.mesh, rngs=self.rngs)
       )
-      return encoder_name, projector_name
     elif self.vision_encoder_block == VisionEncoderBlockType.QWEN3_5:
       from maxtext.models import qwen3_5_vision  # pylint: disable=import-outside-toplevel
 
@@ -81,7 +78,6 @@ class VisionEncoder(nnx.Module):
           self, encoder_name, qwen3_5_vision.Qwen3_5MoeVisionEncoder(config=self.config, mesh=self.mesh, rngs=self.rngs)
       )
       setattr(self, projector_name, qwen3_5_vision.Qwen3_5MoeVisionProjector(config=self.config, rngs=self.rngs))
-      return encoder_name, projector_name
     elif self.vision_encoder_block == VisionEncoderBlockType.QWEN3_VL:
       from maxtext.models import qwen3_vl_vision  # pylint: disable=import-outside-toplevel
 
@@ -91,13 +87,24 @@ class VisionEncoder(nnx.Module):
           self, encoder_name, qwen3_vl_vision.Qwen3VLVisionEncoder(config=self.config, mesh=self.mesh, rngs=self.rngs)
       )
       setattr(self, projector_name, qwen3_vl_vision.Qwen3VLVisionProjector(config=self.config, rngs=self.rngs))
-      return encoder_name, projector_name
     else:
       supported_blocks = [block.value for block in VisionEncoderBlockType if block != VisionEncoderBlockType.NONE]
       raise ValueError(
           f"Unsupported vision_encoder_block={self.vision_encoder_block.value!r} "
           f"for model_name={self.config.model_name!r}. Supported values are: {supported_blocks}."
       )
+
+    # If vision_projector_type is explicitly set to 'customized_vision_projector',
+    # override the model's default projector with a custom MLP-based projector.
+    vision_projector_type_config = getattr(self.config, "vision_projector_type", "default")
+    if vision_projector_type_config == "customized_vision_projector":
+      setattr(
+          self,
+          projector_name,
+          MultimodalMLPProjector(config=self.config, mesh=self.mesh, rngs=self.rngs),
+      )
+
+    return encoder_name, projector_name
 
   def __call__(self, input_images, input_masks=None, video_grid_thw=None, deterministic=False):
     # vision encoder output, frozen params in many cases
@@ -125,6 +132,83 @@ class VisionEncoder(nnx.Module):
     embeddings = projector(embeddings)
 
     return embeddings, deep_feats
+
+
+class MultimodalMLPProjector(nnx.Module):
+  """A multi-layer perceptron (MLP) projector for multimodal models."""
+
+  def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs):
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
+
+    # Input and output dimensions
+    in_features = config.hidden_size_for_vit
+    out_features = config.emb_dim
+
+    # Custom MLP projector hyperparameters
+    self.num_layers = getattr(config, "vision_connector_num_layers", 2)
+    self.hidden_size = getattr(config, "vision_connector_hidden_size", out_features)
+    if self.hidden_size == 0:
+      self.hidden_size = out_features
+    self.activation_name = getattr(config, "vision_connector_activation", "gelu")
+    self.use_bias = getattr(config, "vision_connector_use_bias", True)
+
+    vision_block_str = str(config.vision_encoder_block).lower()
+
+    # Qwen model family uses 2x2 spatial patch merging (need extra reshape in forward pass)
+    if "qwen" in vision_block_str:
+      spatial_merge_size = getattr(config, "spatial_merge_size_for_vit", 2)
+    # Gemma, LLaMA 4, and other model families use 1:1 token projection in visual embedding
+    else:
+      spatial_merge_size = 1
+
+    self.tokens_per_block = spatial_merge_size**2
+
+    # Activations
+    activations = {
+        "gelu": jax.nn.gelu,
+        "silu": jax.nn.silu,
+        "swish": jax.nn.silu,
+        "relu": jax.nn.relu,
+        "sigmoid": jax.nn.sigmoid,
+        "tanh": jax.nn.tanh,
+    }
+    self.activation = activations.get(self.activation_name.lower(), jax.nn.gelu)
+
+    current_in = in_features * self.tokens_per_block
+    for i in range(self.num_layers):
+      current_out = out_features if i == self.num_layers - 1 else self.hidden_size
+      layer = linears.DenseGeneral(
+          in_features_shape=current_in,
+          out_features_shape=current_out,
+          dtype=config.dtype_mm,
+          weight_dtype=config.weight_dtype,
+          matmul_precision=config.matmul_precision,
+          use_bias=self.use_bias,
+          kernel_init=lambda key, shape, dtype, *args, **kwargs: jax.nn.initializers.normal(stddev=0.02)(
+              key, shape, dtype
+          ),
+          kernel_axes=("embed", "mlp"),
+          rngs=rngs,
+      )
+
+      setattr(self, f"custom_linear_{i}", layer)
+      current_in = current_out
+
+  def __call__(self, x: jax.Array) -> jax.Array:
+    # for qwen3 models, concatenate tokens per block (e.g. 2x2 spatial patches) along feature dimension
+    if self.tokens_per_block > 1 and x.ndim == 3 and x.shape[1] % self.tokens_per_block == 0:
+      batch_size, seq_len, in_dim = x.shape
+      num_blocks = seq_len // self.tokens_per_block
+      x = x.reshape((batch_size, num_blocks, self.tokens_per_block * in_dim))
+
+    for i in range(self.num_layers):
+      linear_layer = getattr(self, f"custom_linear_{i}")
+      x = linear_layer(x)
+      if i < self.num_layers - 1:
+        x = self.activation(x)
+    return x
 
 
 class AudioEncoder(nnx.Module):

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -1094,9 +1094,15 @@ def from_pretrained(
       # Free memory used by initial sharded_state before restore, to make room for the incoming checkpoint arrays.
       # Skip transient runtime variables (RngState, Cache, Intermediate, BatchStat) — they hold runtime state
       # that is not present in the checkpoint and must remain valid after the restore.
-      def _free_device_memory(node):
-        if isinstance(node, nnx.Variable) and not isinstance(
-            node, (nnx.RngState, nnx.Cache, nnx.Intermediate, nnx.BatchStat)
+      def _free_device_memory(path, node):
+        # Check if the path contains any name containing 'custom' which indicates a customized layer.
+        # If yes, skip freeing device memory for this node and its children so they can be
+        # initialized with random values.
+        is_custom = any("custom_linear" in str(getattr(p, "key", p)) for p in path)
+        if (
+            isinstance(node, nnx.Variable)
+            and not isinstance(node, (nnx.RngState, nnx.Cache, nnx.Intermediate, nnx.BatchStat))
+            and not is_custom
         ):
           inner = node.get_value() if hasattr(node, "get_value") else node[...]
           # AQT serve-mode `qrhs.frozen` wraps a QTensor (composite pytree) rather
@@ -1105,12 +1111,12 @@ def from_pretrained(
           for leaf in jax.tree_util.tree_leaves(inner):
             if isinstance(leaf, jax.Array) and not leaf.is_deleted():
               leaf.delete()
-        elif isinstance(node, jax.Array) and not node.is_deleted():
+        elif isinstance(node, jax.Array) and not node.is_deleted() and not is_custom:
           node.delete()
 
         return node
 
-      jax.tree_util.tree_map(_free_device_memory, sharded_state, is_leaf=lambda n: isinstance(n, nnx.Variable))
+      jax.tree_util.tree_map_with_path(_free_device_memory, sharded_state, is_leaf=lambda n: isinstance(n, nnx.Variable))
 
       restored = ckptr.restore(
           epath.Path(config.load_parameters_path),

--- a/tests/unit/model_creation_utils_test.py
+++ b/tests/unit/model_creation_utils_test.py
@@ -712,6 +712,32 @@ class TestCreateNnxModel(unittest.TestCase):
     self.assertIsInstance(model, models.Transformer)
 
   @patch("maxtext.utils.model_creation_utils.ocp")
+  def test_load_checkpoint_with_custom_vision_projector(self, mock_ocp):
+    """NNX checkpoint loading with customized_mlp vision projector runs _free_device_memory cleanly."""
+    mock_ckptr = MagicMock()
+    mock_ckptr.metadata.return_value = self._make_nnx_metadata_mock()
+    mock_ckptr.restore.side_effect = lambda path, item=None, **kw: item
+    mock_ocp.Checkpointer.return_value = mock_ckptr
+    mock_ocp.PyTreeCheckpointHandler.return_value = MagicMock()
+    mock_ocp.checkpoint_utils.construct_restore_args.return_value = {}
+    mock_ocp.ArrayRestoreArgs = ocp.ArrayRestoreArgs
+
+    cfg = _make_config(
+        enable_checkpointing=True,
+        load_parameters_path="gs://fake/custom_vision_ckpt",
+        use_multimodal=True,
+        model_name="qwen3-vl-2b",
+        override_model_config=True,
+        scan_layers=False,
+        vision_projector_type="customized_vision_projector",
+        vision_connector_num_layers=2,
+        vision_connector_activation="gelu",
+        vision_connector_use_bias=True,
+    )
+    model = model_creation_utils.from_pretrained(cfg, self.mesh)
+    self.assertIsInstance(model, models.Transformer)
+
+  @patch("maxtext.utils.model_creation_utils.ocp")
   def test_checkpoint_load_error_propagates(self, mock_ocp):
     """Non-mismatch exceptions during checkpoint loading should propagate directly."""
     mock_ckptr = MagicMock()


### PR DESCRIPTION
# Description

This PR adds support for configurable custom vision projectors in MaxText's multimodal models. It introduces new vision projector config options, handles checkpoint weight mismatches when attaching custom projector architectures to pre-trained base models, and adds a test script to verify projector initialization and embedding extraction.

Step 2 of a 5-step Proof-of-Concept for any-to-any multimodal alignment in MaxText. Overall goal is to align a pretrained vision encoders with another text-only LLM, and connecting the two with a dynamically configured adaptation layer (customized MLP connector), special tokenizer mapping for visual placeholder tokens, and train only the MLP using supervised fine tuning.


# Changes

## Custom MLP Projector Module
### `src/maxtext/layers/encoders.py`
- Implemented `MultimodalMLPProjector` (`nnx.Module`), supporting configurable layer, activations, hidden size, and layer biases.
- Updated `VisionEncoder._setup_vision_encoder_layers()` to conditionally override the default vision projector with `MultimodalMLPProjector` whenever `vision_projector_type == "customized_vision_projector"`.

## Config
### `src/maxtext/configs/types.py`
- Extended the `VisionProjector` configuration class for customizing projector architecture.

## Checkpoint Loading & Weight Mismatch Handling
### `src/maxtext/common/checkpointing.py`
- Added `_is_custom_projector_problem()` to check if missing/mismatched weight keys belong to custom vision projector layers.
- Updated `_raise_on_weight_mismatch()` to suppress weight mismatch errors for custom projector layers only, and raise a warning instead. This allows restoring base model parameters from standard checkpoints while leaving newly introduced custom projector weights randomly initialized.

### `src/maxtext/utils/model_creation_utils.py`
- Modified `_free_device_memory` inside `from_pretrained()`.
- Added path checks (`is_custom`) to skip deleting JAX arrays corresponding to custom layers (i.e., layers with "custom_linear" in their name).
  - Reason: Pretrained base model checkpoints do not contain weights for new custom components; if their device memory were freed prior to checkpoint restoration, their initializations would be deleted with no incoming checkpoint weights to replace them. Skipping deletion of these arrays ensures their randomly initialized state remains alive in device memory when base model parameters are loaded.

## Test Script
### `src/maxtext/experimental/omni_poc/tests/custom_vision_projector_test.py`
- Initializes a multimodal model (`qwen3-vl-2b`) with a customized MLP vision projector.
- Checks output embeddings against standard configurations.
### `tests/unit/model_creation_utils_test.py`
- Tests the model creation utility with newly added customized projector parts.


# Example Usage
```python
config = pyconfig.initialize(
    model_name="qwen3-vl-2b",
    tokenizer_path="Qwen/Qwen3-VL-2B-Instruct",
    tokenizer_type="huggingface",
    load_parameters_path=<PATH_TO_QWEN3_CHECKPOINT>,
    use_multimodal=True,
    prompt="Describe this image",
    image_path="tests/assets/test_image.jpg",
    override_model_config=True,
    hf_access_token=<HF_ACCESS_TOKEN>,
    vision_projector_type="customized_vision_projector",
    vision_connector_num_layers=2,
    vision_connector_activation="gelu",
    vision_connector_use_bias=True,
    ... # other standard multimodal arguments
    )
```

# Tests

## 1. Unit Tests

**Command:**
```bash
pytest tests/unit/model_creation_utils_test.py
```

**Output:**
```
============================= 63 passed in 45.95s ==============================
```

**Command:**
```bash
pytest tests/unit/checkpointing_nnx_load_test.py
```

**Output:**
```
=============================== 24 passed in 6.82s ===============================
```


## 2. Custom Vision Projector Verification
Validates that vision embeddings are:
- same between the standard model and custom-projector model before the projector layer, 
- differ after the projector layer due to randomly initialized projector.

**Command:**
```bash
python3 src/maxtext/experimental/omni_poc/tests/custom_vision_projector_test.py \
    --load_parameters_path=<your-path> \
    --hf_access_token=<your-token>
```

**Output:**
```
Image pixel_values shape: (1, 3, 2, 544, 640)
vision embeddings: (1, 1360, 1024)
First 10 values:
[-5.091886    1.7075098  -1.0072641  -0.16636705 -1.4430853  -5.3355365
  1.4629428   0.21186987 -2.9909272  -4.376259  ]
projector_embeddings: (1, 340, 2048)
First 10 values:
[  1.3062916   8.224888   16.922318   -7.4536076  -8.535779   33.199806
   3.0147345   2.200746  -18.904125    9.107975 ]

Original vision embeddings: (1, 1360, 1024)
First 10 values:
[-5.091886    1.7075098  -1.0072641  -0.16636705 -1.4430853  -5.3355365
  1.4629428   0.21186987 -2.9909272  -4.376259  ]
Original projector_embeddings: (1, 340, 2048)
First 10 values:
[-0.31920713  0.54748684  0.49574944 -0.88344455 -0.23951492 -0.14456059
  0.1383374   0.05032197  0.381779    0.00628588]

===================================
Comparing customized vs original embeddings
Vision embeddings match: True (Max diff: 0.0)
Projector embeddings match: False (Max diff: 313.9195556640625)
```


## 3. End-to-End Multimodal Decoding Checks

### A. Baseline Multimodal Run (Default Vision Projector)
Verifies standard multimodal inference functions normally.

**Command:**
```bash
python3 -m maxtext.inference.decode \
    src/maxtext/configs/base.yml \
    model_name=qwen3-vl-2b \
    tokenizer_path=Qwen/Qwen3-VL-2B-Instruct \
    tokenizer_type=huggingface \
    load_parameters_path=<your-path> \
    per_device_batch_size=1 \
    scan_layers=false \
    use_multimodal=true \
    prompt='Describe this image' \
    image_path='tests/assets/test_image.jpg' \
    max_prefill_predict_length=512 \
    max_target_length=768 \
    ici_tensor_parallelism=4 \
    override_model_config=true \
    attention='dot_product' \
    hf_access_token=<your-token>
```

**Output:**
```
Input `<|im_start|>user
<|vision_start|><|image_pad|><|vision_end|>Describe this image<|im_end|>
<|im_start|>assistant
` -> `This is a panoramic view of the Seattle skyline on a bright, sunny day. The image is taken from a high vantage point, looking down on the city.

The most prominent feature is the **Space Needle**, a distinctive observation tower located on the left side of the frame. It stands tall among the city's modern skyscrapers, which are a mix of glass and steel structures. The buildings are densely packed, creating a dense urban landscape.

In the background, a range of mountains is visible, with their peaks covered in snow, suggesting a high elevation. The sky is a clear, vibrant blue with a few scattered white clouds.

In the foreground, there are lush green trees and foliage, which add a natural element to the urban scene. The overall impression is one of a vibrant, modern city with a beautiful natural backdrop.
```

### B. Custom Vision Projector Pipeline Run
Verifies end-to-end data flow with custom projector flags (`customized_vision_projector`). Output text is bad due to random weight initialization, as expected.

**Command:**
```bash
python3 -m maxtext.inference.decode \
    src/maxtext/configs/base.yml \
    model_name=qwen3-vl-2b \
    tokenizer_path=Qwen/Qwen3-VL-2B-Instruct \
    tokenizer_type=huggingface \
    load_parameters_path=<your-path> \
    per_device_batch_size=1 \
    run_name=runner_image_2026-06-26-20-40 \
    scan_layers=false \
    use_multimodal=true \
    prompt='Describe this image' \
    image_path='tests/assets/test_image.jpg' \
    max_prefill_predict_length=512 \
    max_target_length=768 \
    ici_tensor_parallelism=4 \
    override_model_config=true \
    attention='dot_product' \
    hf_access_token=<your-token> \
    vision_projector_type=customized_vision_projector \
    vision_connector_num_layers=2 \
    vision_connector_activation=gelu \
    vision_connector_use_bias=true
```

**Output:**
```
Input `<|im_start|>user
<|vision_start|><|image_pad|><|vision_end|>Describe this image<|im_end|>
<|im_start|>assistant
` -> `The image is a detailed and intricate depiction of a complex, multi-layered, and highly detailed scene that appears to be a digital or conceptual representation rather than a physical photograph...
```


## 4. Text-Only Decoding Regression Check
Verifies custom vision projector configurations do not affect text-only inference mode (`use_multimodal=false`).

**Command:**
```bash
python3 -m maxtext.inference.decode \
    src/maxtext/configs/base.yml \
    model_name=qwen3-vl-2b \
    tokenizer_path=Qwen/Qwen3-VL-2B-Instruct \
    tokenizer_type=huggingface \
    load_parameters_path=<your-path> \
    per_device_batch_size=1 \
    max_prefill_predict_length=128 \
    max_target_length=256 \
    scan_layers=false \
    use_multimodal=false \
    prompt='How many times does the letter r appear in the word Strawberry?' \
    override_model_config=true \
    ici_fsdp_parallelism=1 \
    ici_tensor_parallelism=-1 \
    hf_access_token=<your-token> \
    vision_projector_type=customized_vision_projector \
    vision_connector_num_layers=2 \
    vision_connector_activation=gelu \
    vision_connector_use_bias=true
```

**Output:**
```
Input `How many times does the letter r appear in the word Strawberry?` -> ` To determine how many times the letter **r** appears in the word **Strawberry**, let's go step by step.

1. Write down the word: **Strawberry**
2. Break it down into individual letters:
   - S - t - r - a - w - b - e - r - r - y
3. Now, count how many times the letter **r** appears:
   - The first **r** is in the 3rd position.
   - The second **r** is in the 8`
```



# Step-by-Step Objectives
- `√` Multi-Directory Checkpoint Restoration: Implemented selective sub-tree parameter loading using Orbax such that we can initiaze a multimodal model with parameters from multiple checkpoints.
- `this` Dynamic MLP Connector: Add omni modal adapter layer (MLP) to connect vision tower output to the LLM decoder
- `next` Special Tokenizer & Placeholder Masking: Add special token <|image|> to tokenizer and make sure the masking is correct in the decoder.
- COCO-Narratives Data Pipeline Processing
- SFT Execution & Evaluation

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).