### PR TITLE
Fix test_scan_layers_mismatch_tpu layer path assertion

### DIFF
--- a/tests/integration/checkpointing_test.py
+++ b/tests/integration/checkpointing_test.py
@@ -232,5 +232,5 @@ def test_scan_layers_mismatch_tpu():
   # reports them as missing rather than leaving them at their init values.
   message = str(excinfo.value)
   assert "Checkpoint does not match the model" in message
-  assert "decoder/layers/0/" in message
+  assert "decoder/layers_0/" in message
   assert "scan_layers" in message


### PR DESCRIPTION
# Description
Fix layer path assertion in `test_scan_layers_mismatch_tpu` from `decoder/layers/0/` to `decoder/layers_0/` to align with the unscanned layer naming structure refactored in PR #4504.

# Test
[Error Log](https://github.com/AI-Hypercomputer/maxtext/actions/runs/30025380185/job/89269034120)
[Fix](https://paste.googleplex.com/6300999542243328)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).