### PR TITLE
Fix roundtrip checkpoint conversion test

### DIFF
--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -1155,6 +1155,7 @@ if __name__ == "__main__":
   local_args, remaining_args = parser.parse_known_args()
   # Reconstruct model_args (script name + the args MaxText needs)
   model_args = [sys.argv[0]] + remaining_args
+  sys.argv = model_args
 
   # Set jax environment
   jax.config.update("jax_platforms", "cpu")

--- a/tests/integration/checkpoint_conversion_test.py
+++ b/tests/integration/checkpoint_conversion_test.py
@@ -50,6 +50,7 @@ class Qwen3CheckpointConversionTest(unittest.TestCase):
           "override_model_config=True",
           "scan_layers=False",
           "hardware=cpu",
+          "attention=dot_product",
           "skip_jax_distributed_system=True",
           "checkpoint_storage_use_ocdbt=False",
           "checkpoint_storage_use_zarr3=False",
@@ -83,6 +84,7 @@ class Qwen3CheckpointConversionTest(unittest.TestCase):
           "scan_layers=false",
           "weight_dtype=bfloat16",
           "hardware=cpu",
+          "attention=dot_product",
           "skip_jax_distributed_system=True",
           "--override_model_architecture=True",
       ]


### PR DESCRIPTION
# Description

The qwen3-30b-a3b roundtrip checkpoint conversion test was failing in CI ([logs](https://screenshot.googleplex.com/9vVHYB46LHkhju4)). There were **two underlying causes**:

1. **Unknown flag save_dtype**: This latent argument-isolation bug was recently exposed by the JAX 0.10.2 dependency upgrade, which changed when the Abseil-backed configuration was initialized. `--save_dtype` was parsed by the converter's local `argparse` parser but remained in the global `sys.argv`. When JAX initialized Abseil, Abseil attempted to parse the same argument and raised `UnrecognizedFlagError` because `save_dtype` is not an Abseil flag.  This change replaces `sys.argv` with the remaining MaxText arguments before JAX initialization.


2. **NotImplementedError on cpu**: For `flash` or `autoselected` attention kernels, `AttentionOp` assumed GPU hardware when the platform was not TPU. It did not check if the active platform was actually CPU, leading to it attempting to call the GPU-only `PallasTritonFlashAttention` and throwing a `NotImplementedError` on CPU. We fixed this by adding an explicit flag for `attention=dot_product` to fallback to standard dot-product attention for checkpoint conversion.
    - Recent updates in `attention_op` have actually changed the checkpoint conversion utils, as from now on we have to manually specify `attention=dot_product` to avoid crashes.



# Tests

Covered in CI ([logs](https://screenshot.googleplex.com/3HKEDzvgqTJUrim)), [logs](https://screenshot.googleplex.com/BiERWwVHGvrXSzk).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
