### PR TITLE
Fix data iterator checkpointing and eval under CP load balancing

### DIFF
--- a/src/maxtext/utils/standalone_dataloader.py
+++ b/src/maxtext/utils/standalone_dataloader.py
@@ -29,7 +29,6 @@ import jax
 
 from maxtext.configs import pyconfig
 from maxtext.trainers.pre_train.train import get_first_step
-from maxtext.common.data_loader import DataLoader
 from maxtext.utils import max_logging
 from maxtext.utils.train_utils import validate_train_config, setup_train_loop
 
@@ -38,8 +37,7 @@ def data_load_loop(config, state=None):
   """Main data loader loop.
   Loads batches of data for each training step.
   """
-  _, _, _, model, mesh, _, data_iterator, _, _, _, state = setup_train_loop(config, recorder=None)
-  data_loader = DataLoader(config, mesh, data_iterator, None)
+  _, _, _, model, _, _, _, data_loader, _, _, state = setup_train_loop(config, recorder=None)
 
   example_batch = None
 

--- a/src/maxtext/utils/train_utils.py
+++ b/src/maxtext/utils/train_utils.py
@@ -204,6 +204,30 @@ def jit_train_and_eval_step(
   return p_train_step, p_eval_step
 
 
+class _ReorderedDataIterator:
+  """Applies a reorder function to each batch."""
+
+  def __init__(self, reorder_fn, data_iterator):
+    self.reorder_fn = reorder_fn
+    self.data_iterator = data_iterator
+
+  def __iter__(self):
+    return self
+
+  def __next__(self):
+    return self.reorder_fn(next(self.data_iterator))
+
+  def reset(self):
+    self.data_iterator.reset()
+
+
+def _reorder_data_iterator_for_loader(reorder_fn, data_iterator):
+  """Wraps the data iterator, or each element of an iterator list, with the reorder view."""
+  if isinstance(data_iterator, list):
+    return [_ReorderedDataIterator(reorder_fn, iterator) for iterator in data_iterator]
+  return _ReorderedDataIterator(reorder_fn, data_iterator)
+
+
 def setup_train_loop(config, recorder, devices=None):
   """Set up prerequisites for the training loop -
 
@@ -278,6 +302,7 @@ def setup_train_loop(config, recorder, devices=None):
         raise ValueError("Packing is only supported for load balanced ring attention with context parallelism for GPU.")
 
     # Apply reordering wrapper to data iterators if context parallelism is enabled
+    data_iterator_for_loader = data_iterator
     with jax.set_mesh(mesh):
       if context_parallel_size > 1 and config.context_parallel_load_balance:
 
@@ -294,12 +319,14 @@ def setup_train_loop(config, recorder, devices=None):
         reorder_fn = maxtext_utils.get_reorder_callable(
             context_parallel_size, config.shard_mode, reorder_strategy, config.hardware
         )
-        data_iterator = map(reorder_fn, data_iterator)
+        # data_iterator itself stays unwrapped because checkpointing dispatches on
+        # its concrete type; only batch consumers receive the reordered view.
+        data_iterator_for_loader = _reorder_data_iterator_for_loader(reorder_fn, data_iterator)
         if eval_data_iterator:
-          eval_data_iterator = map(reorder_fn, eval_data_iterator)
+          eval_data_iterator = _ReorderedDataIterator(reorder_fn, eval_data_iterator)
 
     # Create data_loader AFTER reordering wrapper is applied
-    data_loader = create_dataloader(config, mesh, data_iterator, recorder, rampup_manager)
+    data_loader = create_dataloader(config, mesh, data_iterator_for_loader, recorder, rampup_manager)
 
     state, _, state_mesh_shardings, data_iterator, _ = maxtext_utils.setup_training_state(
         data_iterator, config, mesh, checkpoint_manager, init_state_fn

--- a/src/maxtext/utils/train_utils.py
+++ b/src/maxtext/utils/train_utils.py
@@ -202,6 +202,30 @@ def jit_train_and_eval_step(
   return p_train_step, p_eval_step
 
 
+class _ReorderedDataIterator:
+  """Applies a reorder function to each batch."""
+
+  def __init__(self, reorder_fn, data_iterator):
+    self.reorder_fn = reorder_fn
+    self.data_iterator = data_iterator
+
+  def __iter__(self):
+    return self
+
+  def __next__(self):
+    return self.reorder_fn(next(self.data_iterator))
+
+  def reset(self):
+    self.data_iterator.reset()
+
+
+def _reorder_data_iterator_for_loader(reorder_fn, data_iterator):
+  """Wraps the data iterator, or each element of an iterator list, with the reorder view."""
+  if isinstance(data_iterator, list):
+    return [_ReorderedDataIterator(reorder_fn, iterator) for iterator in data_iterator]
+  return _ReorderedDataIterator(reorder_fn, data_iterator)
+
+
 def setup_train_loop(config, recorder, devices=None):
   """Set up prerequisites for the training loop -
 
@@ -277,6 +301,7 @@ def setup_train_loop(config, recorder, devices=None):
         raise ValueError("Packing is only supported for load balanced ring attention with context parallelism for GPU.")
 
     # Apply reordering wrapper to data iterators if context parallelism is enabled
+    data_iterator_for_loader = data_iterator
     with jax.set_mesh(mesh):
       if context_parallel_size > 1 and config.context_parallel_load_balance:
 
@@ -297,12 +322,14 @@ def setup_train_loop(config, recorder, devices=None):
         reorder_fn = maxtext_utils.get_reorder_callable(
             context_parallel_size, config.shard_mode, reorder_strategy, config.hardware
         )
-        data_iterator = map(reorder_fn, data_iterator)
+        # data_iterator itself stays unwrapped because checkpointing dispatches on
+        # its concrete type; only batch consumers receive the reordered view.
+        data_iterator_for_loader = _reorder_data_iterator_for_loader(reorder_fn, data_iterator)
         if eval_data_iterator:
-          eval_data_iterator = map(reorder_fn, eval_data_iterator)
+          eval_data_iterator = _ReorderedDataIterator(reorder_fn, eval_data_iterator)
 
     # Create data_loader AFTER reordering wrapper is applied
-    data_loader = create_dataloader(config, mesh, data_iterator, recorder, rampup_manager)
+    data_loader = create_dataloader(config, mesh, data_iterator_for_loader, recorder, rampup_manager)
 
     state, _, state_mesh_shardings, data_iterator, _ = maxtext_utils.setup_training_state(
         data_iterator, config, mesh, checkpoint_manager, init_state_fn

--- a/tests/integration/setup_train_loop_nnx_test.py
+++ b/tests/integration/setup_train_loop_nnx_test.py
@@ -31,7 +31,7 @@ import jax
 from maxtext.common import train_state_nnx
 from maxtext.configs import pyconfig
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
-from maxtext.utils.train_utils import setup_train_loop
+from maxtext.utils import train_utils
 from tests.utils.test_helpers import get_test_config_path
 import pytest
 
@@ -83,7 +83,7 @@ class SetupTrainLoopNNXIntegrationTest(unittest.TestCase):
         rampup_manager,
         eval_data_iterator,
         train_state,
-    ) = setup_train_loop(config, recorder=None)
+    ) = train_utils.setup_train_loop(config, recorder=None)
 
     # The NNX path returns a fully-merged TrainStateNNX (lines 352-354 in train_utils.py).
     self.assertIsInstance(train_state, train_state_nnx.TrainStateNNX)
@@ -109,13 +109,30 @@ class SetupTrainLoopNNXIntegrationTest(unittest.TestCase):
     # flag them as unused — they're part of the public return contract.
     del checkpoint_manager, rampup_manager, eval_data_iterator
 
+  def test_load_balanced_cp_keeps_checkpoint_iterator_unwrapped(self):
+    """The reordered view goes to the DataLoader and eval; the original iterator goes to checkpointing."""
+    config = _tiny_nnx_pyconfig(
+        ici_context_parallelism=2,
+        context_parallel_load_balance=True,
+        packing=False,
+        eval_interval=1,
+    )
+
+    *_, data_iterator, data_loader, _, eval_data_iterator, _ = train_utils.setup_train_loop(config, recorder=None)
+
+    # pylint: disable=protected-access
+    self.assertIsInstance(data_loader.data_iterator, train_utils._ReorderedDataIterator)
+    self.assertIs(data_loader.data_iterator.data_iterator, data_iterator)
+    self.assertNotIsInstance(data_iterator, train_utils._ReorderedDataIterator)
+    self.assertIsInstance(eval_data_iterator, train_utils._ReorderedDataIterator)
+
   def test_pure_nnx_setup_param_only_split_matches_model(self):
     """nnx.split(state.model, nnx.Param, ...) must yield a non-empty Param tree
 
     whose structure matches state_mesh_shardings.model after the same split.
     """
     config = _tiny_nnx_pyconfig()
-    *_, state_mesh_shardings, model, _, _, _, _, _, _, train_state = setup_train_loop(config, recorder=None)
+    *_, state_mesh_shardings, model, _, _, _, _, _, _, train_state = train_utils.setup_train_loop(config, recorder=None)
 
     _, params, _ = nnx.split(train_state.model, nnx.Param, ...)
     _, params_shardings, _ = nnx.split(state_mesh_shardings.model, nnx.Param, ...)

--- a/tests/unit/train_utils_test.py
+++ b/tests/unit/train_utils_test.py
@@ -58,6 +58,59 @@ class MockConfig:
   use_iota_embed: bool = False
 
 
+class _FakeIterator:
+  """Minimal resettable iterator for reorder-view tests."""
+
+  def __init__(self, batches):
+    self._batches = batches
+    self._index = 0
+    self.reset_calls = 0
+
+  def __next__(self):
+    batch = self._batches[self._index]
+    self._index += 1
+    return batch
+
+  def reset(self):
+    self.reset_calls += 1
+    self._index = 0
+
+
+class TestReorderedDataIterator(unittest.TestCase):
+  """Tests for the load-balanced CP reorder view."""
+
+  # pylint: disable=protected-access
+
+  def test_reorders_batches_and_forwards_reset(self):
+    inner = _FakeIterator([1, 2])
+    wrapped = train_utils._ReorderedDataIterator(lambda batch: batch * 10, inner)
+
+    self.assertEqual(next(wrapped), 10)
+    self.assertEqual(next(wrapped), 20)
+    self.assertIs(iter(wrapped), wrapped)
+    wrapped.reset()
+    self.assertEqual(inner.reset_calls, 1)
+    self.assertEqual(next(wrapped), 10)
+
+  def test_loader_view_wraps_single_iterator(self):
+    inner = _FakeIterator([1])
+    view = train_utils._reorder_data_iterator_for_loader(lambda batch: batch * 10, inner)
+
+    self.assertIsInstance(view, train_utils._ReorderedDataIterator)
+    self.assertIs(view.data_iterator, inner)
+
+  def test_loader_view_wraps_each_list_element(self):
+    inners = [_FakeIterator([1]), _FakeIterator([2])]
+    view = train_utils._reorder_data_iterator_for_loader(lambda batch: batch * 10, inners)
+
+    self.assertIsInstance(view, list)
+    self.assertEqual(len(view), 2)
+    for wrapped, inner in zip(view, inners):
+      self.assertIsInstance(wrapped, train_utils._ReorderedDataIterator)
+      self.assertIs(wrapped.data_iterator, inner)
+    self.assertEqual(next(view[1]), 20)
+
+
 class TestValidateTrainConfig(unittest.TestCase):
   """Tests for validate_train_config."""
 

--- a/tests/unit/train_utils_test.py
+++ b/tests/unit/train_utils_test.py
@@ -14,12 +14,24 @@
 
 """Unit tests for train_utils.py."""
 
+import itertools
+import pathlib
+import tempfile
 import unittest
 from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import MagicMock
 
+import grain
+import jax
+import numpy as np
+from jax.experimental import mesh_utils
+from jax.sharding import Mesh
+from orbax.checkpoint import v1 as ocp
+
+from maxtext.common import grain_utility
+from maxtext.input_pipeline import multihost_dataloading
 from maxtext.utils import train_utils
 from maxtext.utils.train_utils import (
     validate_train_config,
@@ -56,6 +68,90 @@ class MockConfig:
   steps: int = 100
   lr_schedule_type: str = "cosine"
   use_iota_embed: bool = False
+
+
+class _FakeIterator:
+  """Minimal resettable iterator for reorder-view tests."""
+
+  def __init__(self, batches):
+    self._batches = batches
+    self._index = 0
+    self.reset_calls = 0
+
+  def __next__(self):
+    batch = self._batches[self._index]
+    self._index += 1
+    return batch
+
+  def reset(self):
+    self.reset_calls += 1
+    self._index = 0
+
+
+class TestReorderedDataIterator(unittest.TestCase):
+  """Tests for the load-balanced CP reorder view."""
+
+  # pylint: disable=protected-access
+
+  def test_reorders_batches_and_forwards_reset(self):
+    inner = _FakeIterator([1, 2])
+    wrapped = train_utils._ReorderedDataIterator(lambda batch: batch * 10, inner)
+
+    self.assertEqual(next(wrapped), 10)
+    self.assertEqual(next(wrapped), 20)
+    self.assertIs(iter(wrapped), wrapped)
+    wrapped.reset()
+    self.assertEqual(inner.reset_calls, 1)
+    self.assertEqual(next(wrapped), 10)
+
+  def test_loader_view_wraps_single_iterator(self):
+    inner = _FakeIterator([1])
+    view = train_utils._reorder_data_iterator_for_loader(lambda batch: batch * 10, inner)
+
+    self.assertIsInstance(view, train_utils._ReorderedDataIterator)
+    self.assertIs(view.data_iterator, inner)
+
+  def test_loader_view_wraps_each_list_element(self):
+    inners = [_FakeIterator([1]), _FakeIterator([2])]
+    view = train_utils._reorder_data_iterator_for_loader(lambda batch: batch * 10, inners)
+
+    self.assertIsInstance(view, list)
+    self.assertEqual(len(view), 2)
+    for wrapped, inner in zip(view, inners):
+      self.assertIsInstance(wrapped, train_utils._ReorderedDataIterator)
+      self.assertIs(wrapped.data_iterator, inner)
+    self.assertEqual(next(view[1]), 20)
+
+  def test_grain_checkpoint_round_trip_through_reorder_view(self):
+    """Batches consumed through the view advance the saved Grain state, and an
+    in-place restore is visible through a view built before the restore."""
+    with tempfile.TemporaryDirectory() as d:
+      path = pathlib.Path(d) / "ckpt"
+      iterator = iter(grain.MapDataset.range(10).to_iter_dataset())
+      view = train_utils._ReorderedDataIterator(lambda batch: batch * 10, iterator)
+      self.assertEqual(next(view), 0)
+      self.assertEqual(next(view), 10)
+      ocp.save_checkpointables(str(path), {"iter": grain_utility.GrainCheckpointable_v1(iterator)})
+      self.assertTrue((path / "iter" / "process_0-of-1.json").exists())
+
+      restored = iter(grain.MapDataset.range(10).to_iter_dataset())
+      restored_view = train_utils._ReorderedDataIterator(lambda batch: batch * 10, restored)
+      ocp.load_checkpointables(str(path), {"iter": grain_utility.GrainCheckpointable_v1(restored)})
+      self.assertEqual(next(restored_view), 20)
+
+  def test_eval_view_consume_reset_consume(self):
+    """The eval view repeats identical reordered passes across a reset."""
+    mesh = Mesh(mesh_utils.create_device_mesh((len(jax.devices()),)), ("data",))
+    batches = [{"x": np.full((len(jax.devices()), 2), i, dtype=np.int32)} for i in range(2)]
+    eval_iterator = multihost_dataloading.MultiHostDataLoadIterator(batches, mesh)
+    view = train_utils._ReorderedDataIterator(lambda batch: {"x": batch["x"] + 100}, eval_iterator)
+
+    first_pass = [int(batch["x"][0, 0]) for batch in itertools.islice(view, 2)]
+    view.reset()
+    second_pass = [int(batch["x"][0, 0]) for batch in itertools.islice(view, 2)]
+
+    self.assertEqual(first_pass, [100, 101])
+    self.assertEqual(second_pass, first_pass)
 
 
 class TestValidateTrainConfig(unittest.TestCase):


### PR DESCRIPTION
# Description

When load balancing is on for context parallelism, the data iterator gets wrapped with map() to reorder batches which breaks the iterator. Eval calls reset() and grain checkpointing reads local_iterator and `map` has neither, so training crashes at the first eval/checkpoint save. This PR keeps the original iterator for checkpointing and only applies the reorder where batches are read. Also fixed standalone_dataloader to use the reordered loader.

# Tests

`python3 -m pytest tests/unit/train_utils_test.py`

22 passed

End-to end: grain + load-balanced CP + checkpointing + eval, 4 steps with checkpoint saves, then a second run restoring from step 3 and resuming through step 5.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).