### PR TITLE
Honour partial_rotary_factor on the MRoPE rotary path

### DIFF
--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -819,6 +819,7 @@ class Attention(nnx.Module):
           cast_as_fprop_dtype=True,
           fprop_dtype=self.dtype,
           mrope_section=self.mrope_section,
+          partial_rotary_factor=self.config.partial_rotary_factor,
           rngs=self.rngs,
       )
 

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -1668,6 +1668,7 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
       fprop_dtype: DType = jnp.bfloat16,
       mrope_section: tuple[int, int, int] | None = None,
       attention_scaling: float = 1.0,
+      partial_rotary_factor: float = 1.0,
       rngs: nnx.Rngs = None,
   ):
     """Initializes the Qwen3OmniMoeThinkerTextRotaryEmbedding module.
@@ -1681,13 +1682,19 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
       mrope_section: Tuple of (temporal_dim, height_dim, width_dim) for MRoPE.
                      Defaults to [24, 20, 20] if None.
       attention_scaling: Scaling factor applied to cos/sin embeddings. Defaults to 1.0.
+      partial_rotary_factor: Ratio of leading head dimensions to apply ROPE to;
+        the remaining dims pass through unchanged (Qwen3.5 uses 0.25). Defaults
+        to 1.0 (rotate the full head dim).
       rngs: rng keys passed in by nnx.bridge.to_linen.
     """
+    self.head_dim = embedding_dims
+    self.partial_rotary_factor = partial_rotary_factor
+    self.rotary_dim = int(self.head_dim * self.partial_rotary_factor)
     super().__init__(
         min_timescale=min_timescale,
         max_timescale=max_timescale,
         mesh=None,
-        embedding_dims=embedding_dims,
+        embedding_dims=self.rotary_dim,
         cast_as_fprop_dtype=cast_as_fprop_dtype,
         fprop_dtype=fprop_dtype,
         rngs=rngs,
@@ -1748,10 +1755,16 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
     """
     if len(inputs.shape) != 4:
       raise ValueError("Input is assumed to be a rank 4 tensor of shape [batch, sequence, heads, head_dim].")
-    if self.embedding_dims != inputs.shape[3]:
+    if self.head_dim != inputs.shape[3]:
       raise ValueError(
           "The embedding dims of the rotary position embedding must match the hidden dimension of the inputs."
       )
+
+    # Partial rotary: only the first `rotary_dim` channels are rotated, the rest pass through.
+    if self.rotary_dim < self.head_dim:
+      inputs_rot, inputs_pass = jnp.split(inputs, [self.rotary_dim], axis=-1)
+    else:
+      inputs_rot, inputs_pass = inputs, None
 
     # Handle both 2D (text-only) and 3D (multimodal) position IDs
     if position.ndim == 2:
@@ -1760,25 +1773,27 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
     elif position.ndim != 3 or position.shape[0] != 3:
       raise ValueError(f"Position IDs must be 2D (batch, seq) or 3D (3, batch, seq), got shape {position.shape}")
 
-    # Compute frequencies: (3, batch, seq, 1) @ (head_dim // 2, 1) -> (3, batch, seq, head_dim // 2)
-    inv_freq_expanded = (1.0 / self.timescale)[jnp.newaxis, jnp.newaxis, jnp.newaxis, :]  # (1, 1, 1, head_dim//2)
+    # Compute frequencies: (3, batch, seq, 1) @ (rotary_dim // 2, 1) -> (3, batch, seq, rotary_dim // 2)
+    inv_freq_expanded = (1.0 / self.timescale)[jnp.newaxis, jnp.newaxis, jnp.newaxis, :]  # (1, 1, 1, rotary_dim//2)
     position_expanded = position[..., jnp.newaxis]  # (3, batch, seq, 1)
-    freqs = position_expanded * inv_freq_expanded  # (3, batch, seq, head_dim//2)
+    freqs = position_expanded * inv_freq_expanded  # (3, batch, seq, rotary_dim//2)
 
     # Apply interleaved MRoPE pattern for 3D positions
-    freqs = self._apply_interleaved_mrope(freqs)  # (batch, seq, head_dim//2)
+    freqs = self._apply_interleaved_mrope(freqs)  # (batch, seq, rotary_dim//2)
 
     # Compute sin and cos
-    # Concatenate to get full head_dim: (batch, seq, head_dim//2) -> (batch, seq, head_dim)
+    # Concatenate to get full rotary_dim: (batch, seq, rotary_dim//2) -> (batch, seq, rotary_dim)
     emb = jnp.concatenate([freqs, freqs], axis=-1)  # Duplicate for both halves
-    cos_emb = jnp.cos(emb) * self.attention_scaling  # (batch, seq, head_dim)
-    sin_emb = jnp.sin(emb) * self.attention_scaling  # (batch, seq, head_dim)
+    cos_emb = jnp.cos(emb) * self.attention_scaling  # (batch, seq, rotary_dim)
+    sin_emb = jnp.sin(emb) * self.attention_scaling  # (batch, seq, rotary_dim)
 
-    # Expand for heads dimension: (batch, seq, head_dim) -> (batch, seq, 1, head_dim)
+    # Expand for heads dimension: (batch, seq, rotary_dim) -> (batch, seq, 1, rotary_dim)
     cos_emb = cos_emb[:, :, jnp.newaxis, :]
     sin_emb = sin_emb[:, :, jnp.newaxis, :]
 
-    x_out = self.apply_rotary(inputs, cos_emb, sin_emb)
+    x_out = self.apply_rotary(inputs_rot, cos_emb, sin_emb)
+    if inputs_pass is not None:
+      x_out = jnp.concatenate([x_out, inputs_pass], axis=-1)
 
     if self.cast_as_fprop_dtype:
       x_out = x_out.astype(self.fprop_dtype)

--- a/tests/unit/partial_rotary_embedding_test.py
+++ b/tests/unit/partial_rotary_embedding_test.py
@@ -30,7 +30,12 @@ from jax.sharding import Mesh
 from flax import nnx
 import numpy as np
 
-from maxtext.layers.embeddings import PartialRotaryEmbedding, RotaryEmbedding, Gemma4PartialRotaryEmbedding
+from maxtext.layers.embeddings import (
+    PartialRotaryEmbedding,
+    RotaryEmbedding,
+    Gemma4PartialRotaryEmbedding,
+    Qwen3OmniMoeThinkerTextRotaryEmbedding,
+)
 from maxtext.configs import pyconfig
 from maxtext.utils import maxtext_utils
 from tests.utils.test_helpers import get_test_config_path
@@ -307,6 +312,100 @@ class Gemma4PartialRotaryEmbeddingTest(unittest.TestCase):
 
     expected = jnp.array([[[[1.0, 1.0, 1.0, 1.0]], [[-0.300781, 1.0, 1.38281, 1.0]]]])
     np.testing.assert_allclose(outputs, expected, atol=1e-5)
+
+
+class MropePartialRotaryEmbeddingTest(unittest.TestCase):
+  """Partial rotary on the MRoPE path (`use_mrope: true`).
+
+  Models such as qwen3.5-35b-a3b and qwen3.5-397b-a17b set both `use_mrope` and
+  `partial_rotary_factor`, so the MRoPE rotary layer has to honour the factor the
+  same way `PartialRotaryEmbedding` does on the non-MRoPE path.
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.cfg = pyconfig.initialize(
+        [sys.argv[0], get_test_config_path()],
+        run_name="test_mrope_partial_rotary",
+        enable_checkpointing=False,
+    )
+    devices_array = maxtext_utils.create_device_mesh(self.cfg)
+    self.mesh = Mesh(devices_array, self.cfg.mesh_axes)
+    self.nnx_rng = nnx.Rngs(params=0)
+    self.batch, self.seq, self.heads, self.head_dim = 2, 8, 4, 16
+    self.inputs = jax.random.normal(
+        jax.random.PRNGKey(0), (self.batch, self.seq, self.heads, self.head_dim), dtype=jnp.float32
+    )
+    self.positions = jnp.broadcast_to(jnp.arange(self.seq, dtype=jnp.int32), (self.batch, self.seq))
+
+  def _layer(self, partial_rotary_factor=None):
+    kwargs = {} if partial_rotary_factor is None else {"partial_rotary_factor": partial_rotary_factor}
+    return Qwen3OmniMoeThinkerTextRotaryEmbedding(
+        min_timescale=1,
+        max_timescale=10000,
+        embedding_dims=self.head_dim,
+        cast_as_fprop_dtype=False,
+        mrope_section=(2, 1, 1),
+        rngs=self.nnx_rng,
+        **kwargs,
+    )
+
+  def test_trailing_dims_pass_through(self):
+    """Only the leading `head_dim * factor` channels are rotated."""
+    factor = 0.25
+    rotary_dim = int(self.head_dim * factor)
+    outputs = self._layer(factor)(self.inputs, self.positions)
+
+    self.assertEqual(outputs.shape, self.inputs.shape)
+    np.testing.assert_array_equal(
+        np.asarray(outputs[..., rotary_dim:]),
+        np.asarray(self.inputs[..., rotary_dim:]),
+        err_msg="Channels beyond rotary_dim must be passed through untouched.",
+    )
+    self.assertFalse(
+        np.allclose(np.asarray(outputs[..., :rotary_dim]), np.asarray(self.inputs[..., :rotary_dim])),
+        msg="The leading rotary_dim channels should have been rotated.",
+    )
+
+  def test_factor_is_not_ignored(self):
+    """A partial factor must not produce the fully rotated result.
+
+    This is the regression: the layer previously ignored the factor and rotated
+    every channel, silently disagreeing with the reference implementation for
+    every model that configures both MRoPE and a partial factor.
+    """
+    partial = self._layer(0.25)(self.inputs, self.positions)
+    full = self._layer(1.0)(self.inputs, self.positions)
+    self.assertFalse(
+        np.allclose(np.asarray(partial), np.asarray(full)),
+        msg="partial_rotary_factor had no effect on the MRoPE path.",
+    )
+
+  def test_default_factor_is_unchanged(self):
+    """Callers that do not pass a factor keep the previous full-rotation behaviour."""
+    explicit_full = self._layer(1.0)(self.inputs, self.positions)
+    default = self._layer()(self.inputs, self.positions)
+    np.testing.assert_allclose(np.asarray(default), np.asarray(explicit_full), rtol=1e-6, atol=1e-6)
+
+  def test_matches_non_mrope_partial_rotary(self):
+    """With 1D (text-only) positions MRoPE degenerates to ordinary RoPE.
+
+    The two code paths must therefore agree channel for channel, which is what
+    makes the MRoPE path safe for text-only training and inference.
+    """
+    factor = 0.25
+    mrope_out = self._layer(factor)(self.inputs, self.positions)
+    reference = PartialRotaryEmbedding(
+        min_timescale=1,
+        max_timescale=10000,
+        mesh=self.mesh,
+        embedding_dims=self.head_dim,
+        partial_rotary_factor=factor,
+        cast_as_fprop_dtype=False,
+        rngs=self.nnx_rng,
+    )(self.inputs, self.positions)
+
+    np.testing.assert_allclose(np.asarray(mrope_out), np.asarray(reference), rtol=1e-5, atol=1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Problem

`Attention.init_rotary_embedding` routes to `Qwen3OmniMoeThinkerTextRotaryEmbedding` whenever `use_mrope` is true. That class rotates the **full** head dimension and, before this change, had no `partial_rotary_factor` parameter at all — so the config value was silently dropped for every model on the MRoPE path.

Two shipped configs are affected, both of which set `use_mrope: true` together with `partial_rotary_factor: 0.25`:

- `src/maxtext/configs/models/qwen3.5-35b-a3b.yml`
- `src/maxtext/configs/models/qwen3.5-397b-a17b.yml`

For these, RoPE was applied to every channel of the head instead of the leading quarter. Nothing raises and every shape stays valid, so the disagreement with the reference implementation is silent.

`PartialRotaryEmbedding` already implements the intended behaviour, but only the non-MRoPE path can reach it.

### Reproduction on `main`

```python
layer = Qwen3OmniMoeThinkerTextRotaryEmbedding(
    min_timescale=1, max_timescale=10000, embedding_dims=16,
    cast_as_fprop_dtype=False, mrope_section=(2, 1, 1), rngs=nnx.Rngs(params=0),
)
out = layer(inputs, positions)          # inputs: [2, 8, 4, 16]
np.allclose(out[..., 4:], inputs[..., 4:])
# -> False   (with partial_rotary_factor 0.25 only the first 4 channels may rotate)
```

Passing the factor explicitly fails outright on `main`:

```
TypeError: __init__() got an unexpected keyword argument 'partial_rotary_factor'
```

### Fix

The layer now takes `partial_rotary_factor` (default `1.0`), splits off the leading `rotary_dim = head_dim * factor` channels, builds `inv_freq` over `rotary_dim` rather than `head_dim`, and concatenates the untouched remainder back. This is the same construction `PartialRotaryEmbedding` uses, so the two paths stay consistent by design.

`Attention.init_rotary_embedding` passes `config.partial_rotary_factor` through — a one-line change.

The default of `1.0` keeps the existing `qwen3-vl-*` and `qwen3-omni-*` behaviour bit-identical; those configs do not set the factor.

### Tests

`MropePartialRotaryEmbeddingTest` in `tests/unit/partial_rotary_embedding_test.py`:

- trailing channels are passed through untouched, leading ones are rotated
- a partial factor no longer produces the fully rotated result (the regression itself)
- omitting the factor reproduces the previous full-rotation output
- for text-only 1D positions, where MRoPE degenerates to ordinary RoPE, the MRoPE path agrees channel for channel with `PartialRotaryEmbedding` (`rtol=1e-5`)

All four pass against this branch; the third and fourth fail on `main`.
