### PR TITLE
fix: fallback to ```dot_product``` for autoselected attention on CPU to prevent Tokamax ```NotImplementedError```

### DIFF
--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -1073,6 +1073,7 @@ class AttentionOp(nnx.Module):
         self.attention_kernel == "dot_product"
         or (self.attention_kernel == "autoselected" and model_mode == MODEL_MODE_AUTOREGRESSIVE)
         or (self.attention_kernel == "autoselected" and length < 128)
+        or (self.attention_kernel == "autoselected" and target_hardware == "cpu")
         or (self.attention_kernel == "paged")
         or (self.attention_kernel in ("vllm_rpa", "vllm_batched_rpa"))
     ):


### PR DESCRIPTION
## Description           
                                                                                                                                        
This PR addresses a bug where running tasks that utilize `jax.eval_shape` (e.g., checkpoint conversions via `to_maxtext.py`) on CPU-only hardware crashes  abruptly due to an unsupported attention kernel device check.

[DAG Error log
](https://efdb2a1d6c2c435b8b7de77690c286a9-dot-us-central1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_pre_training/grid?search=maxtext_e2e_tpu_pre_training&tab=logs&tags=multipod_team&task_id=gemma3-4b.convert-to-maxtext-v5p-8.run_model.wait_for_workload_completion&dag_run_id=manual__2026-07-25T00%3A43%3A17.821219%2B00%3A00)

**Shortened Error Trace:**

```
python
      File ".../src/maxtext/layers/attention_op.py", line 2270, in __call__
        prefill_unnormalized_output, ... = self.apply_attention( ... )
      File ".../src/maxtext/layers/attention_op.py", line 1147, in apply_attention
        out = gpu_flash_attn(query, key, value, logits_scale=1.0, mask=mask)
      File ".../site-packages/tokamax/_src/ops/attention/base.py", line 400, in __call__
        return fwd_closed( ... )
      File ".../site-packages/tokamax/_src/ops/op.py", line 197, in __call__
        raise NotImplementedError(f"Not supported on {device.device_kind}.")
    NotImplementedError: Not supported on cpu.
```


## Root Cause     
                                                                                                                                               
The default configuration for attention in MaxText is `attention="autoselected"`. When `autoselected` falls into the non-TPU branch for the prefill / train mode, it attempts to use the GPU flash attention fallback.                                                                                                               

- **Before July 24th:** The codebase utilized `jax.experimental.pallas.ops.gpu.attention.mha`, which gracefully allowed dummy shape tracing (`jax.eval_shape`) on CPU devices.                                                                                                                                                       
- **After PR #4384 (commit e12d2fdcb):** The codebase migrated to Tokamax's GPU flash attention (`tokamax_pallas_triton`). Tokamax has strict hardware validations in its tracing logic. When it detects `device.device_kind == 'cpu'`, it immediately raises `NotImplementedError: Not supported on cpu`, entirely breaking abstract shape evaluation on CPU nodes.

## Solution                                                                                                                                                      
    
Modified the routing logic in `src/maxtext/layers/attention_op.py` (`apply_attention`).                                                                          
When `attention_kernel` is `"autoselected"` and `target_hardware` evaluates to `"cpu"`, it now safely falls back to standard JAX dot-product attention (`apply_attention_dot`). This completely bypasses the Tokamax flash attention branch on CPU devices, preventing unexpected crashes while maintaining standard performance optimizations for TPUs and GPUs.

# Tests

```
python3 -m maxtext.checkpoint_conversion.to_maxtext \
    model_name=gemma3-4b \
    base_output_directory=gs://runner-maxtext-logs/gemma3-4b/to_maxtext/unscanned/pre-20260725T004317 \
    use_multimodal=false \
    scan_layers=false \
    hardware=cpu skip_jax_distributed_system=True \
    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
    --lazy_load_tensors=False \
    --eager_load_method='transformers'
```

Log: https://paste.googleplex.com/6472437859483648

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
