### PR TITLE
Restore Engram defaults in RLConfig

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -3738,6 +3738,7 @@ class MaxTextConfig(
 
 class RLConfig(
     LogitsAndLoss,
+    Engram,
     RematAndOffload,
     Attention,
     LayoutAndSharding,

--- a/tests/post_training/unit/train_rl_test.py
+++ b/tests/post_training/unit/train_rl_test.py
@@ -43,6 +43,14 @@ class TrainRLTest(unittest.TestCase):
   """Tests for train_rl.py."""
 
   @pytest.mark.cpu_only
+  def test_rl_config_includes_decoder_engram_defaults(self):
+    """RL models must expose Engram fields consumed by the shared decoder."""
+    config = types.RLConfig(model_name="gemma4-26b")
+
+    self.assertEqual(config.engram_layers, [])
+    self.assertEqual(config.engram_max_ngram_size, 3)
+
+  @pytest.mark.cpu_only
   def test_setup_configs_and_devices_pathways_split(self):
     """Test setup_configs_and_devices with multiple VMs and Pathways."""
     mock_devices = _get_mock_devices(8)


### PR DESCRIPTION
## Summary

- add the existing `Engram` configuration mixin to `RLConfig`
- add a focused regression test for the disabled Engram defaults

## Root cause

The dedicated `RLConfig` schema omitted `Engram` when RL configuration was split from `MaxTextConfig`. Shared decoder code reads `engram_layers` even when Engram is disabled, so RL models need those fields to satisfy the decoder configuration contract.

This change supplies the existing disabled defaults (`engram_layers=[]` and `engram_max_ngram_size=3`). It does not enable Engram or change Gemma 4 weights, architecture, or numerics.

# Tests

- `JAX_PLATFORMS=cpu pytest -q tests/post_training/unit/train_rl_test.py -k test_rl_config_includes_decoder_engram_defaults` — passed
- `git diff --check` — passed


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

