### PR TITLE
Optimize TPU Tokamax ring backward

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1111,6 +1111,7 @@ sa_q_layout: "HEAD_DIM_MINOR"
 sa_k_layout: "HEAD_DIM_MINOR"
 sa_v_layout: "HEAD_DIM_MINOR"
 use_splash_scheduler: false # to use tokamax splash attention scheduler.
+ring_scan_unroll: 1 # unroll factor for Tokamax ring attention scans; 0 or >= ring size fully unrolls.
 sa_fuse_reciprocal: true # defaults to true in Tokamax
 sa_use_base2_exp: true # defaults to true in Tokamax
 # local_sa_* variants apply to local (sliding window) attention layers;

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -745,6 +745,13 @@ class SplashAttention(BaseModel):
   sa_k_layout: str = Field("HEAD_DIM_MINOR", description="Layout for K in splash attention.")
   sa_v_layout: str = Field("HEAD_DIM_MINOR", description="Layout for V in splash attention.")
   use_splash_scheduler: bool = Field(False, description="Use experimental splash attention scheduler.")
+  ring_scan_unroll: NonNegativeInt = Field(
+      1,
+      description=(
+          "Unroll factor for the Tokamax ring attention scan. 0 fully unrolls; values at or above the ring size are "
+          "equivalent to full unrolling. Program size and compile time grow with the factor."
+      ),
+  )
   sa_fuse_reciprocal: bool = Field(True, description="Maps to fuse_reciprocal in SplashConfig.")
   sa_use_base2_exp: bool = Field(True, description="Maps to use_base2_exp in SplashConfig.")
   # If None, each local_sa_* flag inherits from the corresponding sa_* flag.
@@ -3520,6 +3527,11 @@ class MaxTextConfig(
         raise ValueError("TPU Tokamax ring attention does not support QK-Clip statistics yet.")
       if self.enable_dropout and self.dropout_rate > 0.0:
         raise ValueError("TPU Tokamax ring attention does not support dropout yet.")
+    if context_parallel_strategy != "ring" and self.ring_scan_unroll != 1:
+      raise ValueError(
+          f"ring_scan_unroll={self.ring_scan_unroll} was specified, but is only supported when "
+          "context_parallel_strategy='ring'."
+      )
     # STRIPED reorder strategy is a Transformer Engine feature and is GPU-only.
     # AUTO is resolved in training because test code paths may load the same
     # config but use a different reorder path.

--- a/src/maxtext/kernels/attention/tokamax_ring_attention.py
+++ b/src/maxtext/kernels/attention/tokamax_ring_attention.py
@@ -252,6 +252,9 @@ def build_splash_config(
         "TPU Tokamax ring attention with context_parallel_load_balance=True requires "
         f"sa_block_q_dkv ({block_q_dkv}) to be a multiple of {tokamax_splash_kernel.NUM_LANES} after clamping."
     )
+  # Ring uses the dynamic-grid dKV path, so mirror Splash's small-kv_steps guard here.
+  if dq_reduction_steps == 3 and kv_seq_len_per_shard // block_kv_dkv <= 3:
+    dq_reduction_steps = 0
   return tokamax_splash_kernel.SplashConfig(
       block_q=block_q,
       block_kv=block_kv,
@@ -274,6 +277,7 @@ def build_splash_config(
       else None,
       dq_reduction_steps=dq_reduction_steps if dq_reduction_steps > 0 else None,
       use_experimental_scheduler=config.use_splash_scheduler,
+      ring_scan_unroll=config.ring_scan_unroll,
   )
 
 

--- a/src/maxtext/kernels/tokamax_splash_attention/ring_attention_kernel.py
+++ b/src/maxtext/kernels/tokamax_splash_attention/ring_attention_kernel.py
@@ -21,6 +21,7 @@ import functools
 from typing import Any
 
 import jax
+from jax import ad_checkpoint
 from jax import lax
 from jax import tree_util
 import jax.numpy as jnp
@@ -169,7 +170,7 @@ def _ring_attention_forward(
       initial_carry,
       xs=jnp.arange(0, ring_axis_size),
       length=ring_axis_size,
-      unroll=False,
+      unroll=config.ring_scan_unroll,
   )  # type: ignore[arg-type]
   # Final normalization
   assert l_final.dtype == jnp.float32
@@ -211,32 +212,27 @@ def _ring_attention_bwd(
       axis_name=ring_axis,
       perm=[(i, (i + 1) % ring_axis_size) for i in range(ring_axis_size)],
   )
-  dq_accum = jnp.zeros(q.shape, dtype=jnp.float32)
+  use_dq_carry = config.dq_reduction_steps == 3
+  dq_accum = jnp.zeros((3, *q.shape), dtype=jnp.float32) if use_dq_carry else jnp.zeros(q.shape, dtype=jnp.float32)
   dk_accum = jnp.zeros(k.shape, dtype=jnp.float32)
   dv_accum = jnp.zeros(v.shape, dtype=jnp.float32)
   dsinks = sinks
 
-  def body(carry, i: int):
-    (
-        dq_accum,
-        dk_accum,
-        dv_accum,
-        k_current,
-        v_current,
-        segment_ids_current,
-        _,
-    ) = carry
+  def rotate_kv(k_current, v_current, segment_ids_current):
     k_next = shift(k_current)
     v_next = shift(v_current)
 
-    current_kv_shard_idx = (ring_axis_idx - i) % ring_axis_size
-    local_dkv_mask_info = _dynamic_slice_mask_info(dkv_mask_info, current_kv_shard_idx, ring_axis_size)
-    local_dkv_mask_info = _offset_q_sequence_for_kv_shard(local_dkv_mask_info, current_kv_shard_idx, k_current.shape[-2])
     if segment_ids is not None:
       kv_segment_ids_next = shift(segment_ids_current.kv)
       segment_ids_next = SegmentIds(segment_ids.q, kv_segment_ids_next)
     else:
       segment_ids_next = None
+    return k_next, v_next, segment_ids_next
+
+  def compute_step(i: int, k_current, v_current, segment_ids_current, dq_accum):
+    current_kv_shard_idx = (ring_axis_idx - i) % ring_axis_size
+    local_dkv_mask_info = _dynamic_slice_mask_info(dkv_mask_info, current_kv_shard_idx, ring_axis_size)
+    local_dkv_mask_info = _offset_q_sequence_for_kv_shard(local_dkv_mask_info, current_kv_shard_idx, k_current.shape[-2])
 
     residuals_for_chunk = (
         q,
@@ -259,30 +255,72 @@ def _ring_attention_bwd(
         fwd_mask_sparsity=fwd_mask_sparsity,
         dkv_mask_sparsity=dkv_mask_sparsity,
         return_fp32_grads=True,
+        return_unreduced_dq=use_dq_carry,
     )
-    _, _, dq_i, dk_i, dv_i, _, dsinks, _ = attn_bwd(res=residuals_for_chunk, grads=do)
-    dv_next = shift(dv_accum + dv_i.astype(jnp.float32))
-    dk_next = shift(dk_accum + dk_i.astype(jnp.float32))
-    dq_accum = dq_accum + dq_i.astype(jnp.float32)
+    _, _, dq_i, dk_i, dv_i, _, dsinks, _ = attn_bwd(
+        res=residuals_for_chunk,
+        grads=do,
+        dq_carry_in=dq_accum if use_dq_carry else None,
+    )
+    if not use_dq_carry:
+      dq_i = dq_accum + dq_i.astype(jnp.float32)
+    return dq_i, dk_i, dv_i, dsinks
 
+  dq_i, dk_pending, dv_pending, dsinks = compute_step(0, k, v, segment_ids, dq_accum)
+  dq_accum = dq_i
+  k_current, v_current, segment_ids_current = rotate_kv(k, v, segment_ids)
+
+  def body(carry, i: int):
+    (
+        dq_accum,
+        dk_accum,
+        dv_accum,
+        dk_pending,
+        dv_pending,
+        k_current,
+        v_current,
+        segment_ids_current,
+        _,
+    ) = carry
+    dk_next = shift(dk_accum + dk_pending.astype(jnp.float32))
+    dv_next = shift(dv_accum + dv_pending.astype(jnp.float32))
+    k_next, v_next, segment_ids_next = rotate_kv(k_current, v_current, segment_ids_current)
+    dq_i, dk_i, dv_i, dsinks = compute_step(i, k_current, v_current, segment_ids_current, dq_accum)
+    dq_accum = dq_i
     return (
         dq_accum,
         dk_next,
         dv_next,
+        dk_i,
+        dv_i,
         k_next,
         v_next,
         segment_ids_next,
         dsinks,
     ), None
 
-  initial_carry = (dq_accum, dk_accum, dv_accum, k, v, segment_ids, dsinks)
-  (dq, dk, dv, _, _, _, dsinks), _ = lax.scan(
+  initial_carry = (
+      dq_accum,
+      dk_accum,
+      dv_accum,
+      dk_pending,
+      dv_pending,
+      k_current,
+      v_current,
+      segment_ids_current,
+      dsinks,
+  )
+  (dq, dk, dv, dk_pending, dv_pending, _, _, _, dsinks), _ = lax.scan(
       body,
       initial_carry,
-      xs=jnp.arange(ring_axis_size),
-      length=ring_axis_size,
-      unroll=False,
+      xs=jnp.arange(1, ring_axis_size),
+      length=ring_axis_size - 1,
+      unroll=config.ring_scan_unroll,
   )
+  dk = shift(dk + dk_pending.astype(jnp.float32))
+  dv = shift(dv + dv_pending.astype(jnp.float32))
+  if use_dq_carry:
+    dq = dq.sum(axis=0)
 
   if sinks is not None:
     dsinks = jax.lax.psum(dsinks, axis_name=ring_axis)
@@ -363,6 +401,10 @@ def _ring_attention_fwd(
       ring_axis=ring_axis,
       expected_ring_size=expected_ring_size,
   )
+  # The ring backward reads the merged residuals, not the per-hop splash outputs.
+  if config.residual_checkpoint_name is not None:
+    out = ad_checkpoint.checkpoint_name(out, name=config.residual_checkpoint_name)
+    logsumexp = ad_checkpoint.checkpoint_name(logsumexp, name=config.residual_checkpoint_name)
   residuals = (q, k, v, segment_ids, sinks, out, logsumexp, dkv_mask_info)
   return out, residuals
 

--- a/src/maxtext/kernels/tokamax_splash_attention/splash_attention_kernel.py
+++ b/src/maxtext/kernels/tokamax_splash_attention/splash_attention_kernel.py
@@ -149,6 +149,7 @@ class SplashConfig:
   dq_reduction_steps: int | None = None
   # An experimental scheduler that sometimes produces better softmax overlap.
   use_experimental_scheduler: bool = False
+  ring_scan_unroll: int = 1
 
   def __post_init__(self):
     if self.block_kv_compute is None:
@@ -1350,6 +1351,8 @@ def _splash_attention_bwd_dkv(
     config: SplashConfig,
     dkv_mask_sparsity: float,
     return_fp32_grads: bool = False,
+    dq_carry_in: jax.Array | None = None,
+    return_unreduced_dq: bool = False,
 ):
   num_q_heads, q_seq_len, head_dim_qk = q.shape
   kv_seq_len, head_dim_v = v.shape[-2:]
@@ -1525,7 +1528,7 @@ def _splash_attention_bwd_dkv(
     dq_alias_spec = dq_spec
     dq_dtype = jnp.float32 if return_fp32_grads else q.dtype
     dq_shape = jax.ShapeDtypeStruct((3, *q.shape), dq_dtype)
-    dq = jnp.zeros_like(dq_shape)
+    dq = dq_carry_in if dq_carry_in is not None else jnp.zeros_like(dq_shape)
   else:
     dq_index_map = unravel(lambda h, i, j: (j, h, i, 0))
     dq_spec = pl.BlockSpec((None, None, bq, head_dim_qk), dq_index_map)
@@ -1726,6 +1729,8 @@ def _splash_attention_bwd_dkv(
         interpret=config.interpret,
         metadata=metadata,
     )(*args, dq, dk, dv)
+  if return_unreduced_dq and dq_reduction_steps == 3:
+    return dq_unreduced, dk.astype(jnp.float32), dv.astype(jnp.float32)
   dq = dq_unreduced.sum(axis=0)
   if return_fp32_grads:
     return dq.astype(jnp.float32), dk.astype(jnp.float32), dv.astype(jnp.float32)
@@ -1746,6 +1751,8 @@ def _splash_attention_bwd(
     res: base.SplashResidualsType,
     grads: jax.Array | tuple[jax.Array, dict[str, jax.Array]],
     return_fp32_grads: bool = False,
+    dq_carry_in: jax.Array | None = None,
+    return_unreduced_dq: bool = False,
 ) -> tuple[
     MaskInfo | None,  # fwd_mask_info
     MaskInfo | None,  # dvk_mask_info
@@ -1793,6 +1800,8 @@ def _splash_attention_bwd(
       config=config,
       dkv_mask_sparsity=dkv_mask_sparsity,
       return_fp32_grads=return_fp32_grads,
+      dq_carry_in=dq_carry_in,
+      return_unreduced_dq=return_unreduced_dq,
   )
   dsinks = None
   if sinks is not None:

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -1247,18 +1247,61 @@ class AttentionTest(parameterized.TestCase):
     )
 
   @parameterized.named_parameters(
-      {"testcase_name": "no_load_balance", "context_parallel_load_balance": False, "packing": False},
-      {"testcase_name": "load_balance", "context_parallel_load_balance": True, "packing": False},
-      {"testcase_name": "packed", "context_parallel_load_balance": False, "packing": True},
-      {"testcase_name": "packed_load_balance", "context_parallel_load_balance": True, "packing": True},
+      {
+          "testcase_name": "no_load_balance",
+          "context_parallel_load_balance": False,
+          "max_target_length": 512,
+          "dq_reduction_steps": 0,
+          "ring_scan_unroll": 1,
+          "packing": False,
+      },
+      {
+          "testcase_name": "load_balance",
+          "context_parallel_load_balance": True,
+          "max_target_length": 512,
+          "dq_reduction_steps": 0,
+          "ring_scan_unroll": 1,
+          "packing": False,
+      },
+      {
+          "testcase_name": "load_balance_dq_reduction_unroll",
+          "context_parallel_load_balance": True,
+          "max_target_length": 1024,
+          "dq_reduction_steps": 3,
+          "ring_scan_unroll": 2,
+          "packing": False,
+      },
+      {
+          "testcase_name": "packed",
+          "context_parallel_load_balance": False,
+          "max_target_length": 512,
+          "dq_reduction_steps": 0,
+          "ring_scan_unroll": 1,
+          "packing": True,
+      },
+      {
+          "testcase_name": "packed_load_balance",
+          "context_parallel_load_balance": True,
+          "max_target_length": 512,
+          "dq_reduction_steps": 0,
+          "ring_scan_unroll": 1,
+          "packing": True,
+      },
   )
   @pytest.mark.tpu_only
-  def test_tpu_flash_attention_ring_context_parallel_grad(self, context_parallel_load_balance, packing):
+  def test_tpu_flash_attention_ring_context_parallel_grad(
+      self,
+      context_parallel_load_balance,
+      max_target_length,
+      dq_reduction_steps,
+      ring_scan_unroll,
+      packing,
+  ):
     """Test gradient equivalence between dot_product and flash attention + ring context parallelism"""
 
     cfg_cp = pyconfig.initialize(
         [sys.argv[0], get_test_config_path()],
-        **self.config_arguments,
+        **{**self.config_arguments, "max_target_length": max_target_length},
         attention="flash",
         context_parallel_strategy="ring",
         context_parallel_load_balance=context_parallel_load_balance,
@@ -1267,6 +1310,8 @@ class AttentionTest(parameterized.TestCase):
         use_jax_splash=False,
         packing=packing,
         dtype="float32",
+        dq_reduction_steps=dq_reduction_steps,
+        ring_scan_unroll=ring_scan_unroll,
     )
     devices_array_cp = maxtext_utils.create_device_mesh(cfg_cp)
     mesh_cp = Mesh(devices_array_cp, cfg_cp.mesh_axes)
@@ -1349,7 +1394,8 @@ class AttentionTest(parameterized.TestCase):
     self.assertTrue(
         jax.numpy.allclose(generic_grad, ring_grad, rtol=1e-02, atol=1e-07, equal_nan=False),
         msg="Input gradients from generic dot product and flash attention + ring context parallelism are not close. "
-        f"context_parallel_load_balance={context_parallel_load_balance}, packing={packing}.",
+        f"context_parallel_load_balance={context_parallel_load_balance}, "
+        f"dq_reduction_steps={dq_reduction_steps}, ring_scan_unroll={ring_scan_unroll}, packing={packing}.",
     )
 
   @pytest.mark.tpu_only

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -107,6 +107,7 @@ class ConfigTest(absltest.TestCase):
         "context_parallel_strategy=ring",
         "context_parallel_load_balance=False",
         "ici_context_parallelism=2",
+        "ring_scan_unroll=2",
         "hardware=tpu",
         "packing=False",
         "dataset_type=synthetic",
@@ -118,6 +119,7 @@ class ConfigTest(absltest.TestCase):
 
     self.assertEqual(config.context_parallel_strategy, "ring")
     self.assertEqual(config.ici_context_parallelism, 2)
+    self.assertEqual(config.ring_scan_unroll, 2)
     self.assertEqual(config.attention, "flash")
     self.assertTrue(config.use_tokamax_splash)
 
@@ -206,6 +208,7 @@ class ConfigTest(absltest.TestCase):
         (["ici_context_parallelism=1"], ["ici_context_parallelism=2"], "context_parallel_size > 1"),
         (["context_sharding=expert", "ici_expert_parallelism=2"], [], "context_sharding"),
         (["dq_reduction_steps=2"], [], "dq_reduction_steps"),
+        (["ring_scan_unroll=-1"], [], "ring_scan_unroll"),
         (["max_target_length=2050"], [], "context_parallel_size squared"),
         (["attention=dot_product"], ["attention=flash"], "attention=flash"),
         (["use_tokamax_splash=False"], ["use_tokamax_splash=True"], "use_tokamax_splash"),

--- a/tests/unit/tokamax_ring_attention_test.py
+++ b/tests/unit/tokamax_ring_attention_test.py
@@ -17,14 +17,31 @@
 
 from __future__ import annotations
 
+import functools
 import types
 from unittest import mock
 
 from absl.testing import absltest
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from maxtext.kernels.attention import tokamax_ring_attention
+
+
+def _count_primitives(jaxpr, primitive_name, name_param=None):
+  """Counts primitive occurrences in a jaxpr, recursing into sub-jaxprs."""
+  count = 0
+  for eqn in jaxpr.eqns:
+    if eqn.primitive.name == primitive_name and (name_param is None or name_param in str(eqn.params.get("name", ""))):
+      count += 1
+    for value in eqn.params.values():
+      values = value if isinstance(value, (list, tuple)) else (value,)
+      for entry in values:
+        entry = getattr(entry, "jaxpr", entry)
+        if hasattr(entry, "eqns"):
+          count += _count_primitives(entry, primitive_name, name_param)
+  return count
 
 
 class TokamaxRingAttentionTest(absltest.TestCase):
@@ -117,6 +134,127 @@ class TokamaxRingAttentionTest(absltest.TestCase):
 
     self.assertIsInstance(out, jax.sharding.PartitionSpec)
     self.assertEqual(tuple(out), ("data", None, "context", "model"))
+
+  def test_build_splash_config_keeps_staged_dq_for_larger_kv_shards(self):
+    config = types.SimpleNamespace(
+        dq_reduction_steps=3,
+        sa_block_q=128,
+        sa_block_kv=128,
+        sa_block_kv_compute=128,
+        sa_block_q_dkv=128,
+        sa_block_kv_dkv=128,
+        sa_block_kv_dkv_compute=128,
+        sa_q_layout="HEAD_DIM_MINOR",
+        sa_k_layout="HEAD_DIM_MINOR",
+        sa_v_layout="HEAD_DIM_MINOR",
+        cost_estimate_flops_fwd=-1,
+        cost_estimate_flops_bwd=-1,
+        use_splash_scheduler=False,
+        ring_scan_unroll=2,
+        context_parallel_load_balance=False,
+    )
+
+    splash_config = tokamax_ring_attention.build_splash_config(
+        config,
+        q_seq_len=1024,
+        kv_seq_len=1024,
+        context_parallel_size=2,
+    )
+
+    self.assertEqual(splash_config.dq_reduction_steps, 3)
+    self.assertEqual(splash_config.ring_scan_unroll, 2)
+
+  def test_build_splash_config_disables_staged_dq_for_small_kv_shards(self):
+    config = types.SimpleNamespace(
+        dq_reduction_steps=3,
+        sa_block_q=128,
+        sa_block_kv=128,
+        sa_block_kv_compute=128,
+        sa_block_q_dkv=128,
+        sa_block_kv_dkv=128,
+        sa_block_kv_dkv_compute=128,
+        sa_q_layout="HEAD_DIM_MINOR",
+        sa_k_layout="HEAD_DIM_MINOR",
+        sa_v_layout="HEAD_DIM_MINOR",
+        cost_estimate_flops_fwd=-1,
+        cost_estimate_flops_bwd=-1,
+        use_splash_scheduler=False,
+        ring_scan_unroll=1,
+        context_parallel_load_balance=False,
+    )
+
+    splash_config = tokamax_ring_attention.build_splash_config(
+        config,
+        q_seq_len=512,
+        kv_seq_len=512,
+        context_parallel_size=2,
+    )
+
+    self.assertIsNone(splash_config.dq_reduction_steps)
+
+  def test_residual_checkpoint_name_enables_context_remat_policy(self):
+    """The named ring residuals let a save-context policy skip the forward recompute."""
+    if len(jax.devices()) < 2:
+      self.skipTest("Requires at least 2 devices for a ring mesh.")
+    config = types.SimpleNamespace(
+        context_parallel_strategy="ring",
+        context_parallel_load_balance=True,
+        dq_reduction_steps=-1,
+        sa_block_q=128,
+        sa_block_kv=128,
+        sa_block_kv_compute=128,
+        sa_block_q_dkv=128,
+        sa_block_kv_dkv=128,
+        sa_block_kv_dkv_compute=128,
+        sa_q_layout="HEAD_DIM_MINOR",
+        sa_k_layout="HEAD_DIM_MINOR",
+        sa_v_layout="HEAD_DIM_MINOR",
+        cost_estimate_flops_fwd=-1,
+        cost_estimate_flops_bwd=-1,
+        use_splash_scheduler=False,
+        ring_scan_unroll=1,
+        use_max_logit_estimate=-1,
+    )
+    devices = np.asarray(jax.devices()[:2]).reshape(1, 2)
+    # The ring axis is deliberately not named "context" so that the string
+    # only appears in the jaxpr through the residual checkpoint name.
+    mesh = jax.sharding.Mesh(devices, ("data", "ring"))
+    query = jnp.zeros((1, 1, 256, 128), jnp.bfloat16)
+
+    def shard_with_pspec(arr, spec):
+      return jax.device_put(arr, jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(*spec)))
+
+    _, ring_kernel, ring_kernel_spec = tokamax_ring_attention.make_sharded_ring_attention_kernel(
+        config,
+        query=query,
+        key=query,
+        context_parallel_size=2,
+        ring_axis="ring",
+        attn_logits_soft_cap=None,
+        maybe_shard_with_pspec=shard_with_pspec,
+    )
+    qkv_spec = jax.sharding.PartitionSpec(None, None, "ring", None)
+
+    @functools.partial(
+        jax.shard_map,
+        mesh=mesh,
+        in_specs=(ring_kernel_spec, qkv_spec, qkv_spec, qkv_spec),
+        out_specs=qkv_spec,
+        check_vma=False,
+    )
+    def ring_attn(ring_kernel, q, k, v):
+      return tokamax_ring_attention.call_ring_attention(q, k, v, None, None, ring_kernel)
+
+    def grad_jaxpr(policy):
+      remat = jax.checkpoint(lambda q, k, v: ring_attn(ring_kernel, q, k, v).astype(jnp.float32).sum(), policy=policy)
+      return jax.make_jaxpr(jax.grad(remat))(query, query, query).jaxpr
+
+    saved = grad_jaxpr(jax.checkpoint_policies.save_only_these_names("context"))
+    recomputed = grad_jaxpr(jax.checkpoint_policies.nothing_saveable)
+    self.assertGreaterEqual(_count_primitives(saved, "name", "context"), 2)
+    # Saving the named residuals removes the ring forward recompute, and with
+    # it that recompute's collective permutes, from the backward program.
+    self.assertLess(_count_primitives(saved, "ppermute"), _count_primitives(recomputed, "ppermute"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

**Problem:** Currently in the ring backward pass, each ring hop waits for the rotated dK/dV accumulators to arrive before starting the next hop's compute, so every hop cost compute + transfer. Additionally, every hop ran a full read, add, write pass over the dQ buffer, which is pure HBM traffic.

We introduce some optimizations

1/ We let the previous hop's dK/dV accumulators rotate while the current hop computes, so a hop costs max(compute, transfer) instead of (compute + transfer). 
2/ Currently each hop returns a reduced dQ and the outer loop added it into the full dQ buffer, a full read + write per hop. We pass the accumulator into the splash backward (`dq_carry_in`) as three partial buffers, so the kernel accumulates unreduced dQ partials in place, each partial buffer is read and written every third hop, and sum once after the scan. Only acctive when `dq_reduction_steps=3`.
3/ `ring_scan_unroll`: make the unroll configurable (was hardcoded to be off) for potential better scheduling.

The gain should grow with ring hop count because the optimizations reduce exposed comm and memory traffic from the backward loop.

# Tests

```
python3 -m pytest tests/unit/tokamax_ring_attention_test.py
```

```
python3 -m pytest tests/unit/configs_value_test.py -k tpu_tokamax_ring
```

```
python3 -m pytest tests/unit/tokamax_splash_attention_mask_test.py
```
TPU v5p (4 chips):
```
python3 -m pytest tests/unit/attention_test.py -k ring_context_parallel
```

all passed

## Benchmarks

On Llama-3.1-8B, 64 v5p chips



| | #4537 | This PR | MFU gain | Xprof |
|---|---|---|---|---|
| 256K, cp16, batch 2/shard | 177.3 TFLOP/s (38.6% MFU) | 185.8 (40.5%) | +1.9 pts ||
| 512K, cp16, batch 1/shard | 116.2 (25.3%) | 119.1 (25.9%) | +0.6 pts ||
| 1M, cp64, batch 2/shard  | 165.7 (36.1%) | 175.6 (38.3%) | +2.2 pts |[Xprof for base](http://xprof.corp.google.com/trace_viewer/htn-12015666495610921473),  [Xprof for opt](http://xprof.corp.google.com/trace_viewer/htn-5325066233409634149) , also see screenshot below|
| 1M, cp64, `dq_reduction_steps=0` | 128.8 (28.1%) | 129.5 (28.2%) | +0.1 pts ||


ring_scan_unroll | TFLOP/s/device | MFU
-- | -- | --
1 (default) | 175.6 | 38.3%
2 | 175.3 | 38.2%
4 | 168.8 | 36.8%
16 | 177.3 | 38.6%


For the 1M, cp64, batch 2/shard. Observe that the gap goes from 5.33 ms to 0.58 ms. At 1M cp64 that is 63 hops x 32 layers, about 9.6 s/step.

<img width="1514" height="618" alt="image" src="https://github.com/user-attachments/assets/493dd16c-5486-4557-8985-22cd148f35a6" />
<img width="1541" height="606" alt="image" src="https://github.com/user-attachments/assets/e96d2254-056b-40cd-8e5f-fc2ae086a8d2" />


Repro

```
export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=65472 --xla_tpu_use_enhanced_launch_barrier=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --xla_enable_async_collective_permute=true --xla_tpu_enable_sparse_core_collective_offload_all_reduce=true --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=true --xla_tpu_enable_sparse_core_collective_offload_3d_all_gather=true"

python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
  run_name=<name> base_output_directory=<gcs path> \
  model_name=llama3.1-8b dataset_type=synthetic enable_checkpointing=false \
  attention=flash use_tokamax_splash=true use_jax_splash=false \
  context_parallel_strategy=ring context_parallel_load_balance=true packing=false \
  dq_reduction_steps=3 remat_policy=full \
  sa_block_q=2048 sa_block_kv=2048 sa_block_q_dkv=2048 sa_block_kv_dkv=2048 \
  ici_tensor_parallelism=1 ici_context_parallelism=<cp> ici_fsdp_parallelism=<fsdp> \
  per_device_batch_size=<pdbs> max_target_length=<context> steps=10 \
  profiler=xplane profiler_steps=3 skip_first_n_steps_for_profiler=3
```

|  | S | CP | FSDP | pdbs |
|---|---|---|---|---|
| 256K | 262144 | 16 | 4 | 0.125 | 
| 512K | 524288 | 16 | 4 | 0.0625 |
| 1M  | 1048576 | 64 | 1 | 0.03125 | 


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).