### PR TITLE
Add rope_pairwise config flag to optimize YaRN RoPE

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -982,6 +982,9 @@ mscale: 1.0
 rope_interleave: true # RoPE with sin/cos interleaved vs concatenated
 rope_truncate: true # Floor lower bound and ceil upper bound for correction range
 rope_attention_scaling: false # Scale the rotary embedding output
+# Keep rank-5 pair tensor intact [batch_size, sequence_length, num_heads, half_dim, 2]
+# where half_dim is the number of 2D rotation planes and 2 contains [real, imag] coordinates, returning interleaved RoPE
+rope_pairwise: false
 
 # Ahead of time Compilation (aka AOT)
 # Only set these arguments if you are running train_compile or loading a compiled train step.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1853,6 +1853,21 @@ class YarnRope(BaseModel):
       False,
       description="Scale the rotary embedding output. Used by some models like gpt-oss.",
   )
+  rope_pairwise: bool = Field(
+      False,
+      description=(
+          "Keep rank-5 pair tensor intact "
+          "[batch_size, sequence_length, num_heads, half_dim, 2] "
+          "where half_dim represents the independent 2D rotation planes "
+          "and 2 represents the real/imag coordinates, returning interleaved RoPE."
+      ),
+  )
+
+  @model_validator(mode="after")
+  def validate_rope_pairwise(self) -> "YarnRope":
+    if self.rope_pairwise and not self.rope_interleave:
+      raise ValueError("rope_pairwise=True requires rope_interleave=True.")
+    return self
 
 
 class InferenceGeneral(BaseModel):

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -879,6 +879,7 @@ class Attention(nnx.Module):
           interleave=self.config.rope_interleave,
           truncate=self.config.rope_truncate,
           attention_scaling=self.config.rope_attention_scaling,
+          pairwise=self.config.rope_pairwise,
           shard_mode=self.config.shard_mode,
           rngs=self.rngs,
       )

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -739,6 +739,7 @@ def yarn_rotary_embedding_as_linen(
     interleave: bool = True,
     truncate: bool = True,
     attention_scaling: bool = False,
+    pairwise: bool = False,
     shard_mode: ShardMode = ShardMode.AUTO,
 ):
   """Initializes the YarnRotaryEmbedding module and returns it as a Linen module.
@@ -772,6 +773,7 @@ def yarn_rotary_embedding_as_linen(
       interleave=interleave,
       truncate=truncate,
       attention_scaling=attention_scaling,
+      pairwise=pairwise,
       shard_mode=shard_mode,
   )
 
@@ -830,6 +832,7 @@ class YarnRotaryEmbedding(nnx.Module):
       interleave=True,
       truncate=True,
       attention_scaling=False,
+      pairwise=False,
       # Not used in YarnRotaryEmbedding but passed in by nnx.bridge.to_linen.
       # TODO: Remove when bridge no longer needed
       rngs: nnx.Rngs = None,
@@ -849,6 +852,10 @@ class YarnRotaryEmbedding(nnx.Module):
     self.mesh = mesh
     self.shard_mode = shard_mode
     self.attention_scaling = attention_scaling
+    self.pairwise = pairwise
+
+    if self.pairwise and not self.interleave:
+      raise ValueError("rope_pairwise=True requires rope_interleave=True.")
 
     self.freqs_sharding = (
         create_sharding(mesh, ("activation_batch", "activation_length", "q_heads"))
@@ -962,32 +969,49 @@ class YarnRotaryEmbedding(nnx.Module):
     freqs = self.freqs_cis.at[position].get(out_sharding=self.freqs_sharding)  # shape: [B, S, half_dim]
     freqs = freqs[:, :, jnp.newaxis, :]  # shape: [B, S, 1, half_dim]
 
-    if self.interleave:
-      # Inputs with interleaved format [real1, img1, real2, img2, ...] at last dimension
-      # Convert the last dimension into a complex representation.
-      # First reshape so that each pair of numbers represents the real and imaginary parts.
-      B, S, N, H = inputs.shape
-      half_dim = H // 2
-      inputs_reshaped = inputs.reshape(B, S, N, half_dim, 2)
-      first_half, second_half = inputs_reshaped[..., 0], inputs_reshaped[..., 1]
+    if self.interleave and self.pairwise:
+      with jax.named_scope("rope_pairwise"):
+        b, s, n, h = inputs.shape
+        half_dim = h // 2
+        pairs = inputs.reshape(b, s, n, half_dim, 2)
+        pairs = pairs.astype(jnp.float32)
+        cos = jnp.real(freqs)[..., jnp.newaxis]
+        sin = jnp.imag(freqs)[..., jnp.newaxis]
+        if self.shard_mode == ShardMode.EXPLICIT:
+          rotated_sharding = create_sharding(self.mesh, ("activation_batch", "activation_length", None, None, None))
+          cos = jnp.broadcast_to(cos, pairs.shape, out_sharding=rotated_sharding)
+          sin = jnp.broadcast_to(sin, pairs.shape, out_sharding=rotated_sharding)
+        swapped = jnp.flip(pairs, axis=-1)
+        sign = jnp.asarray([-1.0, 1.0], dtype=jnp.float32)
+        rotated_pairs = pairs * cos + swapped * sin * sign
+        output = rotated_pairs.reshape(b, s, n, h)
     else:
-      # Inputs with concatenated format [real1, real2, ..., img1, img2, ...] at last dimension
-      first_half, second_half = jnp.split(inputs, 2, axis=-1)
+      if self.interleave:
+        # Inputs with interleaved format [real1, img1, real2, img2, ...] at last dimension
+        # Convert the last dimension into a complex representation.
+        # First reshape so that each pair of numbers represents the real and imaginary parts.
+        b, s, n, h = inputs.shape
+        half_dim = h // 2
+        inputs_reshaped = inputs.reshape(b, s, n, half_dim, 2)
+        first_half, second_half = inputs_reshaped[..., 0], inputs_reshaped[..., 1]
+      else:
+        # Inputs with concatenated format [real1, real2, ..., img1, img2, ...] at last dimension
+        first_half, second_half = jnp.split(inputs, 2, axis=-1)
 
-    inputs_complex = first_half + 1j * second_half  # shape: [B, S, N, half_dim]
-    # Apply the rotary transformation via complex multiplication.
-    rotated_sharding = (
-        create_sharding(self.mesh, ("activation_batch", "activation_length", None, None))
-        if self.shard_mode == ShardMode.EXPLICIT
-        else None
-    )
-    freqs = jnp.broadcast_to(freqs, inputs_complex.shape, out_sharding=rotated_sharding)
-    rotated = jnp.multiply(inputs_complex, freqs)  # shape: [B, S, N, half_dim]
+      inputs_complex = first_half + 1j * second_half  # shape: [b, s, n, half_dim]
+      # Apply the rotary transformation via complex multiplication.
+      rotated_sharding = (
+          create_sharding(self.mesh, ("activation_batch", "activation_length", None, None))
+          if self.shard_mode == ShardMode.EXPLICIT
+          else None
+      )
+      freqs = jnp.broadcast_to(freqs, inputs_complex.shape, out_sharding=rotated_sharding)
+      rotated = jnp.multiply(inputs_complex, freqs)  # shape: [b, s, n, half_dim]
 
-    # Convert the complex result back to a real tensor.
-    # Split the complex number into its real and imaginary parts.
-    # [real1, real2, ..., img1, img2, ...]
-    output = jnp.concatenate([jnp.real(rotated), jnp.imag(rotated)], axis=-1)
+      # Convert the complex result back to a real tensor.
+      # Split the complex number into its real and imaginary parts.
+      # [real1, real2, ..., img1, img2, ...]
+      output = jnp.concatenate([jnp.real(rotated), jnp.imag(rotated)], axis=-1)
 
     if self.attention_scaling:
       attention_scaling = 1.0 if self.rope_factor <= 1 else (0.1 * math.log(self.rope_factor) + 1.0)

--- a/tests/end_to_end/tpu/deepseek/Run_DeepSeek.md
+++ b/tests/end_to_end/tpu/deepseek/Run_DeepSeek.md
@@ -379,6 +379,14 @@ To optimize Multi-Head Latent Attention (MLA) performance, you can enable sliced
 *   **Description**: When set to `True`, it slices the projection kernel weights before contraction in MLA, instead of running the full projection followed by `jnp.split`. This can improve performance.
 *   **Constraint**: Sliced contraction is only supported when quantization is disabled (`quant=None`).
 
+## YaRN RoPE Optimization
+
+To optimize YaRN Rotary Position Embedding (RoPE) performance, you can enable pairwise RoPE.
+
+*   **Flag**: `rope_pairwise` (default: `False`)
+*   **Description**: When set to `True`, it keeps the rank-5 pair tensor intact (shape `[batch_size, sequence_length, num_heads, half_dim, 2]`, where `half_dim` represents the independent 2D rotation planes and `2` contains `[real, imag]` coordinates) and returns interleaved RoPE, avoiding complex number creation and some tensor reshaping.
+*   **Constraint**: `rope_pairwise=True` requires `rope_interleave=True`.
+
 ## Supported MoE strategy
 * Dropless
   * [MegaBlocks](https://arxiv.org/abs/2211.15841) implementation with flag `sparse_matmul=True megablox=True`.

--- a/tests/unit/embeddings_test.py
+++ b/tests/unit/embeddings_test.py
@@ -197,6 +197,138 @@ class YarnRotaryEmbeddingTest(unittest.TestCase):
     expected = jnp.array([[[[1.0, 1.0, 1.0, 1.0]], [[-0.300781, 0.996094, 1.38281, 1.00781]]]])
     np.testing.assert_allclose(outputs, expected, atol=1e-5)
 
+  def test_pairwise_call(self):
+    layer = embeddings.YarnRotaryEmbedding(
+        embedding_dims=4,
+        mesh=self.mesh,
+        max_position_embeddings=16384,
+        original_max_position_embeddings=4096,
+        interleave=True,
+        pairwise=True,
+        rngs=self.rngs,
+    )
+    inputs = jnp.ones((1, 2, 1, 4))
+    position = jnp.array([[0, 1]])
+    outputs = layer(inputs, position=position)
+    self.assertEqual(outputs.shape, (1, 2, 1, 4))
+
+    # Compare against default implementation (pairwise=False, interleave=True)
+    default_layer = embeddings.YarnRotaryEmbedding(
+        embedding_dims=4,
+        mesh=self.mesh,
+        max_position_embeddings=16384,
+        original_max_position_embeddings=4096,
+        interleave=True,
+        pairwise=False,
+        rngs=self.rngs,
+    )
+    default_outputs = default_layer(inputs, position=position)
+    # Default YaRN RoPE returns concatenated layout [real0, real1, imag0, imag1];
+    # pairwise=True returns interleaved layout [real0, imag0, real1, imag1].
+    # Convert default concatenated layout to interleaved layout for comparison.
+    expected_interleaved = jnp.stack([default_outputs[..., :2], default_outputs[..., 2:]], axis=-1).reshape(
+        default_outputs.shape
+    )
+    np.testing.assert_allclose(outputs, expected_interleaved, atol=1e-5)
+
+  def test_pairwise_requires_interleave(self):
+    with self.assertRaises(ValueError):
+      embeddings.YarnRotaryEmbedding(
+          embedding_dims=4,
+          mesh=self.mesh,
+          max_position_embeddings=16384,
+          original_max_position_embeddings=4096,
+          interleave=False,
+          pairwise=True,
+          rngs=self.rngs,
+      )
+
+  def test_non_interleaved_call(self):
+    layer = embeddings.YarnRotaryEmbedding(
+        embedding_dims=4,
+        mesh=self.mesh,
+        max_position_embeddings=16384,
+        original_max_position_embeddings=4096,
+        interleave=False,
+        rngs=self.rngs,
+    )
+    inputs = jnp.ones((1, 2, 1, 4))
+    position = jnp.array([[0, 1]])
+    outputs = layer(inputs, position=position)
+    self.assertEqual(outputs.shape, (1, 2, 1, 4))
+
+    # Compare against default implementation (interleave=True)
+    default_layer = embeddings.YarnRotaryEmbedding(
+        embedding_dims=4,
+        mesh=self.mesh,
+        max_position_embeddings=16384,
+        original_max_position_embeddings=4096,
+        interleave=True,
+        rngs=self.rngs,
+    )
+    default_outputs = default_layer(inputs, position=position)
+    # For all-ones input, the output of non-interleaved RoPE matches interleaved RoPE
+    np.testing.assert_allclose(outputs, default_outputs, atol=1e-5)
+
+  def test_explicit_shard_mode_call(self):
+    layer = embeddings.YarnRotaryEmbedding(
+        embedding_dims=4,
+        mesh=self.mesh,
+        max_position_embeddings=16384,
+        original_max_position_embeddings=4096,
+        shard_mode=maxtext_utils.ShardMode.EXPLICIT,
+        rngs=self.rngs,
+    )
+    inputs = jnp.ones((1, 2, 1, 4))
+    position = jnp.array([[0, 1]])
+    outputs = layer(inputs, position=position)
+    self.assertEqual(outputs.shape, (1, 2, 1, 4))
+
+    # Compare against default shard_mode (AUTO) implementation
+    default_layer = embeddings.YarnRotaryEmbedding(
+        embedding_dims=4,
+        mesh=self.mesh,
+        max_position_embeddings=16384,
+        original_max_position_embeddings=4096,
+        rngs=self.rngs,
+    )
+    default_outputs = default_layer(inputs, position=position)
+    np.testing.assert_allclose(outputs, default_outputs, atol=1e-5)
+
+  def test_pairwise_explicit_shard_mode_call(self):
+    layer = embeddings.YarnRotaryEmbedding(
+        embedding_dims=4,
+        mesh=self.mesh,
+        max_position_embeddings=16384,
+        original_max_position_embeddings=4096,
+        interleave=True,
+        pairwise=True,
+        shard_mode=maxtext_utils.ShardMode.EXPLICIT,
+        rngs=self.rngs,
+    )
+    inputs = jnp.ones((1, 2, 1, 4))
+    position = jnp.array([[0, 1]])
+    outputs = layer(inputs, position=position)
+    self.assertEqual(outputs.shape, (1, 2, 1, 4))
+
+    # Compare against default implementation (pairwise=False, interleave=True)
+    default_layer = embeddings.YarnRotaryEmbedding(
+        embedding_dims=4,
+        mesh=self.mesh,
+        max_position_embeddings=16384,
+        original_max_position_embeddings=4096,
+        interleave=True,
+        pairwise=False,
+        shard_mode=maxtext_utils.ShardMode.EXPLICIT,
+        rngs=self.rngs,
+    )
+    default_outputs = default_layer(inputs, position=position)
+    # Convert default concatenated layout to interleaved layout for comparison
+    expected_interleaved = jnp.stack([default_outputs[..., :2], default_outputs[..., 2:]], axis=-1).reshape(
+        default_outputs.shape
+    )
+    np.testing.assert_allclose(outputs, expected_interleaved, atol=1e-5)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
# Description

Add `rope_pairwise` config flag to optimize YaRN RoPE computation in `YarnRotaryEmbedding`.

When enabled (`rope_pairwise: true`), it uses a pairwise interleaved implementation of RoPE in `YarnRotaryEmbedding` which keeps the rank-5 pair tensor intact, avoiding some data formatting during MLA.

# Tests

- Added `test_pairwise_call` to `YarnRotaryEmbeddingTest` in `tests/unit/embeddings_test.py`.
- Added `test_pairwise_requires_interleave` validation test.
- https://xmanager.corp.google.com/experiments/271579010

- Before: https://xprof.corp.google.com/trace_viewer/chengnuojin-11765148423170897263?view_start=1400.245&view_end=1420.311
- After: https://xprof.corp.google.com/trace_viewer/dandragona-1224952786495301116?view_start=2691.354&view_end=2701.054
- After: https://xprof.corp.google.com/trace_viewer/dandragona-8379284804318708435?view_start=109105.685&view_end=109109.290 (isolation mircrobench)

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests or unit tests.