### PR TITLE
Fix the error message in test_scan_layers_mismatch_tpu

### DIFF
--- a/tests/integration/checkpointing_test.py
+++ b/tests/integration/checkpointing_test.py
@@ -232,5 +232,5 @@ def test_scan_layers_mismatch_tpu():
   # reports them as missing rather than leaving them at their init values.
   message = str(excinfo.value)
   assert "Checkpoint does not match the model" in message
-  assert "decoder/layers/0/" in message
+  assert "decoder/layers_0/" in message
   assert "scan_layers" in message


### PR DESCRIPTION
# Description

Unit test failed with error:
```
FAILED tests/integration/checkpointing_test.py::test_scan_layers_mismatch_tpu - assert 'decoder/layers/0/' in "Checkpoint does not match the model:\n  - 'decoder/layers_0/mlp/wi_0/kernel': missing (model expects (128, 128) float32)\n  - 'decoder/layers_0/mlp/wi_1/kernel': missing (model expects (128, 128) float32)\n  - 'decoder/layers_0/mlp/wo/kernel': missing (model expects (128, 128) float32)\n  -...
```

With PR#4504 merged (https://github.com/AI-Hypercomputer/maxtext/pull/4504), the unscanned layer is now with format "/layers_0" instead of "/layers/0". Fix the message in the assert statement.

# Tests

pytest tests/integration/checkpointing_test.py -k "test_scan_layers_mismatch_tpu".

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
