### PR TITLE
Add flag-controlled sliced MLA projections

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -445,7 +445,7 @@ kv_lora_rank: 512
 qk_nope_head_dim: 128
 qk_rope_head_dim: 64
 v_head_dim: 128
-use_sliced_mla_projections: false # Whether to slice projection kernel weights before contraction in MLA instead of running full projection + jnp.split.
+use_sliced_mla_proj: false # Whether to slice projection kernel weights before contraction in MLA instead of running full projection + jnp.split.
 
 # Compressed Attention parameters
 o_lora_rank: 0 # Output LoRA rank for Compressed Attention.

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -445,6 +445,7 @@ kv_lora_rank: 512
 qk_nope_head_dim: 128
 qk_rope_head_dim: 64
 v_head_dim: 128
+use_sliced_mla_projections: false # Whether to slice projection kernel weights before contraction in MLA instead of running full projection + jnp.split.
 
 # Compressed Attention parameters
 o_lora_rank: 0 # Output LoRA rank for Compressed Attention.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -666,6 +666,13 @@ class MlaAttention(BaseModel):
   qk_nope_head_dim: NonNegativeInt = Field(128, description="Dimension for non-RoPE part of QK heads in MLA.")
   qk_rope_head_dim: NonNegativeInt = Field(64, description="Dimension for RoPE part of QK heads in MLA.")
   v_head_dim: NonNegativeInt = Field(128, description="Dimension of V heads in MLA.")
+  use_sliced_mla_projections: bool = Field(
+      False,
+      description=(
+          "Whether to slice projection kernel weights before contraction in MLA"
+          " instead of running full projection + jnp.split."
+      ),
+  )
 
 
 class CompressedAttention(BaseModel):

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -666,7 +666,7 @@ class MlaAttention(BaseModel):
   qk_nope_head_dim: NonNegativeInt = Field(128, description="Dimension for non-RoPE part of QK heads in MLA.")
   qk_rope_head_dim: NonNegativeInt = Field(64, description="Dimension for RoPE part of QK heads in MLA.")
   v_head_dim: NonNegativeInt = Field(128, description="Dimension of V heads in MLA.")
-  use_sliced_mla_projections: bool = Field(
+  use_sliced_mla_proj: bool = Field(
       False,
       description=(
           "Whether to slice projection kernel weights before contraction in MLA"
@@ -3821,6 +3821,8 @@ class MaxTextConfig(
       raise ValueError("`share_kv_projections` is not compatible with `fused_qkv`.")
     if self.share_kv_projections and self.attention_type == "mla":
       raise ValueError("`share_kv_projections` is not compatible with `attention_type='mla'`.")
+    if self.use_sliced_mla_proj and (self.quantization or self.use_qwix_quantization):
+      raise ValueError("`use_sliced_mla_proj` is not supported with quantization.")
 
     if self.use_manual_quantization and not self.use_batch_split_schedule:
       raise ValueError("manual quantization is only used when `use_batch_split_schedule=True`.")

--- a/src/maxtext/layers/attention_mla.py
+++ b/src/maxtext/layers/attention_mla.py
@@ -926,7 +926,7 @@ class MLA(Attention):
       low_rank_q = checkpoint_name(low_rank_q, "query_wa_proj")
       low_rank_q = self.q_norm(low_rank_q)  # RMSNorm on low rank
       low_rank_q = checkpoint_name(low_rank_q, "mla_q")
-      if self.config.use_sliced_mla_projections and self.wq_b.quant is None:
+      if self.config.use_sliced_mla_proj and self.wq_b.quant is None:
         q_nope = self.wq_b(
             low_rank_q,
             out_sharding=query_sharding,
@@ -966,7 +966,7 @@ class MLA(Attention):
       value_logical_name = self.value_axis_names
 
     wkva_out_sharding = create_sharding(self.mesh, key_logical_name)
-    if self.config.use_sliced_mla_projections and self.wkv_b.quant is None:
+    if self.config.use_sliced_mla_proj and self.wkv_b.quant is None:
       key_nope = self.wkv_b(
           low_rank_main,
           out_sharding=wkva_out_sharding,

--- a/src/maxtext/layers/attention_mla.py
+++ b/src/maxtext/layers/attention_mla.py
@@ -919,17 +919,30 @@ class MLA(Attention):
 
     if self.q_lora_rank == 0:
       q = self.query(inputs_q, out_sharding=query_sharding)
+      q_nope, q_pe = jnp.split(q, [self.qk_nope_head_dim], axis=-1)
     else:
       # LoRA path
       low_rank_q = self.wq_a(inputs_q, out_sharding=wqa_out_sharding)  # [B, L, q_lora_rank]
       low_rank_q = checkpoint_name(low_rank_q, "query_wa_proj")
       low_rank_q = self.q_norm(low_rank_q)  # RMSNorm on low rank
       low_rank_q = checkpoint_name(low_rank_q, "mla_q")
-      q = self.wq_b(low_rank_q, out_sharding=query_sharding)  # [B, L, n_heads, qk_head_dim]
+      if self.config.use_sliced_mla_projections and self.wq_b.quant is None:
+        q_nope = self.wq_b(
+            low_rank_q,
+            out_sharding=query_sharding,
+            slice_bounds=(0, self.qk_nope_head_dim),
+        )  # [B, L, n_heads, qk_nope_head_dim]
+        q_pe = self.wq_b(
+            low_rank_q,
+            out_sharding=query_sharding,
+            slice_bounds=(self.qk_nope_head_dim, self.qk_head_dim),
+        )  # [B, L, n_heads, qk_rope_head_dim]
+      else:
+        q = self.wq_b(low_rank_q, out_sharding=query_sharding)  # [B, L, n_heads, qk_head_dim]
+        q_nope, q_pe = jnp.split(q, [self.qk_nope_head_dim], axis=-1)
 
     # Partial RoPE: Split into non-positional and rotary parts.
     # last dimension: qk_nope_head_dim, qk_rope_head_dim
-    q_nope, q_pe = jnp.split(q, [self.qk_nope_head_dim], axis=-1)
     q_nope = self._maybe_shard_with_logical(q_nope, query_logical_name)
     q_pe = self.apply_rotary_embedding(q_pe, inputs_positions=inputs_positions)
     q_pe = self._maybe_shard_with_logical(q_pe, query_logical_name)
@@ -953,10 +966,24 @@ class MLA(Attention):
       value_logical_name = self.value_axis_names
 
     wkva_out_sharding = create_sharding(self.mesh, key_logical_name)
-    kv_out = self.wkv_b(low_rank_main, out_sharding=wkva_out_sharding)
-
-    # Split kv_out into key_nope and value parts.
-    key_nope, value = jnp.split(kv_out, [self.qk_nope_head_dim], axis=-1)
+    if self.config.use_sliced_mla_projections and self.wkv_b.quant is None:
+      key_nope = self.wkv_b(
+          low_rank_main,
+          out_sharding=wkva_out_sharding,
+          slice_bounds=(0, self.qk_nope_head_dim),
+      )  # [B, L, n_heads, qk_nope_head_dim]
+      value = self.wkv_b(
+          low_rank_main,
+          out_sharding=wkva_out_sharding,
+          slice_bounds=(
+              self.qk_nope_head_dim,
+              self.qk_nope_head_dim + self.v_head_dim,
+          ),
+      )  # [B, L, n_heads, v_head_dim]
+    else:
+      kv_out = self.wkv_b(low_rank_main, out_sharding=wkva_out_sharding)
+      # Split kv_out into key_nope and value parts.
+      key_nope, value = jnp.split(kv_out, [self.qk_nope_head_dim], axis=-1)
     key_rope = jnp.broadcast_to(key_rope, (key_nope.shape[0], key_nope.shape[1], self.num_query_heads, key_rope.shape[3]))
     key_nope = self._maybe_shard_with_logical(key_nope, key_logical_name)
     key_rope = self._maybe_shard_with_logical(key_rope, key_logical_name)

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -295,10 +295,8 @@ class DenseGeneral(nnx.Module):
       if self.quant is not None:
         raise ValueError("sliced contraction is only supported when quant is None")
       begin, end = slice_bounds
-      if not (0 <= begin < end <= kernel.shape[-1]):
-        raise ValueError(
-            f"slice_bounds {slice_bounds} must be valid and within [0, {kernel.shape[-1]}]"
-        )
+      if not 0 <= begin < end <= kernel.shape[-1]:
+        raise ValueError(f"slice_bounds {slice_bounds} must be valid and within [0, {kernel.shape[-1]}]")
       kernel = kernel[..., begin:end]
 
     kernel = self._maybe_two_stage_all_gather(kernel)

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -295,6 +295,10 @@ class DenseGeneral(nnx.Module):
       if self.quant is not None:
         raise ValueError("sliced contraction is only supported when quant is None")
       begin, end = slice_bounds
+      if not (0 <= begin < end <= kernel.shape[-1]):
+        raise ValueError(
+            f"slice_bounds {slice_bounds} must be valid and within [0, {kernel.shape[-1]}]"
+        )
       kernel = kernel[..., begin:end]
 
     kernel = self._maybe_two_stage_all_gather(kernel)

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -249,11 +249,21 @@ class DenseGeneral(nnx.Module):
     kernel = shard(kernel, stage2)
     return kernel
 
-  def __call__(self, inputs: Array, _initializing: bool = False, out_sharding: NamedSharding | None = None) -> Array:
+  def __call__(
+      self,
+      inputs: Array,
+      _initializing: bool = False,
+      out_sharding: NamedSharding | None = None,
+      slice_bounds: tuple[int, int] | None = None,
+  ) -> Array:
     """Applies a linear transformation to the inputs along multiple dimensions.
 
     Args:
       inputs: The nd-array to be transformed.
+      _initializing: Whether the module is initializing.
+      out_sharding: Optional sharding for the output.
+      slice_bounds: Optional tuple (begin, end) to slice the kernel and bias on
+        the last (output-feature) axis before contraction. Unquantized only.
 
     Returns:
       The transformed input.
@@ -281,6 +291,11 @@ class DenseGeneral(nnx.Module):
         kernel = jax.device_put(kernel, max_utils.device_space())
       kernel = jnp.asarray(kernel, self.dtype)
 
+    if slice_bounds is not None:
+      assert self.quant is None, "sliced contraction is only supported when quant is None"
+      begin, end = slice_bounds
+      kernel = kernel[..., begin:end]
+
     kernel = self._maybe_two_stage_all_gather(kernel)
 
     # out_sharding should be None for auto mesh axis
@@ -294,13 +309,16 @@ class DenseGeneral(nnx.Module):
         norm_axis,
         contract_ind,
         self.matmul_precision,
-        self.quant_dot_general,
+        self.quant_dot_general if slice_bounds is None else None,
         _initializing,
         out_sharding,
     )
 
     if self.bias is not None:
       bias = jnp.asarray(self.bias[...], self.dtype)
+      if slice_bounds is not None:
+        begin, end = slice_bounds
+        bias = bias[..., begin:end]
       output += bias
     return output
 

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -292,7 +292,8 @@ class DenseGeneral(nnx.Module):
       kernel = jnp.asarray(kernel, self.dtype)
 
     if slice_bounds is not None:
-      assert self.quant is None, "sliced contraction is only supported when quant is None"
+      if self.quant is not None:
+        raise ValueError("sliced contraction is only supported when quant is None")
       begin, end = slice_bounds
       kernel = kernel[..., begin:end]
 

--- a/tests/end_to_end/tpu/deepseek/Run_DeepSeek.md
+++ b/tests/end_to_end/tpu/deepseek/Run_DeepSeek.md
@@ -371,6 +371,14 @@ python3 -m tests.utils.forward_pass_logit_checker \
     --max_kl_div=0.75
 ```
 
+## MLA Optimization
+
+To optimize Multi-Head Latent Attention (MLA) performance, you can enable sliced projections.
+
+*   **Flag**: `use_sliced_mla_projections` (default: `False`)
+*   **Description**: When set to `True`, it slices the projection kernel weights before contraction in MLA, instead of running the full projection followed by `jnp.split`. This can improve performance.
+*   **Constraint**: Sliced contraction is only supported when quantization is disabled (`quant=None`).
+
 ## Supported MoE strategy
 * Dropless
   * [MegaBlocks](https://arxiv.org/abs/2211.15841) implementation with flag `sparse_matmul=True megablox=True`.

--- a/tests/end_to_end/tpu/deepseek/Run_DeepSeek.md
+++ b/tests/end_to_end/tpu/deepseek/Run_DeepSeek.md
@@ -375,7 +375,7 @@ python3 -m tests.utils.forward_pass_logit_checker \
 
 To optimize Multi-Head Latent Attention (MLA) performance, you can enable sliced projections.
 
-*   **Flag**: `use_sliced_mla_projections` (default: `False`)
+*   **Flag**: `use_sliced_mla_proj` (default: `False`)
 *   **Description**: When set to `True`, it slices the projection kernel weights before contraction in MLA, instead of running the full projection followed by `jnp.split`. This can improve performance.
 *   **Constraint**: Sliced contraction is only supported when quantization is disabled (`quant=None`).
 

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -2093,6 +2093,105 @@ class MLATest(attention_test_util.MLATestBase):
       self.assertEqual(mla_full_this_idx.shape, mla_idx.shape)
       self.assertTrue(jax.numpy.allclose(mla_full_this_idx, mla_idx, rtol=2e-02, atol=2e-02, equal_nan=False))
 
+  @pytest.mark.tpu_only
+  def test_sliced_mla_projections(self):
+    config_arguments = self.config_arguments.copy()
+
+    # Enable sliced projections for one config
+    config_arguments_sliced = config_arguments.copy()
+    config_arguments_sliced["use_sliced_mla_projections"] = True
+
+    cfg_normal, mla_normal = self.init_mla(config_arguments, rope_type="default")
+    cfg_sliced, mla_sliced = self.init_mla(config_arguments_sliced, rope_type="default")
+
+    # Sync weights
+    nnx.update(mla_sliced, nnx.state(mla_normal))
+
+    # Test TRAIN mode
+    lnx, decoder_segment_ids, decoder_positions = self.get_structured_data(cfg_normal, cfg_normal.dtype)
+
+    out_normal_train, _ = mla_normal(
+        lnx,
+        lnx,
+        decoder_segment_ids=decoder_segment_ids,
+        inputs_positions=decoder_positions,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+
+    out_sliced_train, _ = mla_sliced(
+        lnx,
+        lnx,
+        decoder_segment_ids=decoder_segment_ids,
+        inputs_positions=decoder_positions,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+
+    self.assertTrue(
+        jnp.allclose(out_normal_train, out_sliced_train, rtol=1e-05, atol=1e-05, equal_nan=False)
+    )
+
+    # Test PREFILL mode followed by AUTOREGRESSIVE mode to test caching
+    prefill_length = cfg_normal.max_prefill_predict_length
+    decode_total_length = cfg_normal.max_target_length
+
+    # Re-initialize to ensure clean cache
+    cfg_normal, mla_normal = self.init_mla(config_arguments, rope_type="default")
+    cfg_sliced, mla_sliced = self.init_mla(config_arguments_sliced, rope_type="default")
+    nnx.update(mla_sliced, nnx.state(mla_normal))
+
+    lnx_prefill = lnx[:, 0:prefill_length, :]
+    decoder_segment_ids_prefill = decoder_segment_ids[:, 0:prefill_length]
+    decoder_positions_prefill = decoder_positions[:, 0:prefill_length]
+
+    out_normal_prefill, _ = mla_normal(
+        lnx_prefill,
+        lnx_prefill,
+        decoder_segment_ids=decoder_segment_ids_prefill,
+        inputs_positions=decoder_positions_prefill,
+        deterministic=True,
+        model_mode=MODEL_MODE_PREFILL,
+    )
+
+    out_sliced_prefill, _ = mla_sliced(
+        lnx_prefill,
+        lnx_prefill,
+        decoder_segment_ids=decoder_segment_ids_prefill,
+        inputs_positions=decoder_positions_prefill,
+        deterministic=True,
+        model_mode=MODEL_MODE_PREFILL,
+    )
+
+    self.assertTrue(
+        jnp.allclose(out_normal_prefill, out_sliced_prefill, rtol=1e-05, atol=1e-05, equal_nan=False)
+    )
+
+    # Run autoregressive steps
+    for idx in range(prefill_length, decode_total_length):
+      lnx_idx = lnx[:, idx : idx + 1, :]
+      decoder_positions_idx = decoder_positions[:, idx : idx + 1]
+
+      out_normal_idx, _ = mla_normal(
+          lnx_idx,
+          lnx_idx,
+          inputs_positions=decoder_positions_idx,
+          deterministic=True,
+          model_mode=MODEL_MODE_AUTOREGRESSIVE,
+      )
+
+      out_sliced_idx, _ = mla_sliced(
+          lnx_idx,
+          lnx_idx,
+          inputs_positions=decoder_positions_idx,
+          deterministic=True,
+          model_mode=MODEL_MODE_AUTOREGRESSIVE,
+      )
+
+      self.assertTrue(
+          jnp.allclose(out_normal_idx, out_sliced_idx, rtol=1e-05, atol=1e-05, equal_nan=False)
+      )
+
   def test_projection_initialization(self):
     """Tests that MLA and Attention layers initialize the correct projection weights."""
     # 1. Initialize a standard Attention layer for comparison

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -2098,7 +2098,7 @@ class MLATest(attention_test_util.MLATestBase):
 
     # Enable sliced projections for one config
     config_arguments_sliced = config_arguments.copy()
-    config_arguments_sliced["use_sliced_mla_projections"] = True
+    config_arguments_sliced["use_sliced_mla_proj"] = True
 
     cfg_normal, mla_normal = self.init_mla(config_arguments, rope_type="default")
     _, mla_sliced = self.init_mla(config_arguments_sliced, rope_type="default")

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -2093,7 +2093,6 @@ class MLATest(attention_test_util.MLATestBase):
       self.assertEqual(mla_full_this_idx.shape, mla_idx.shape)
       self.assertTrue(jax.numpy.allclose(mla_full_this_idx, mla_idx, rtol=2e-02, atol=2e-02, equal_nan=False))
 
-  @pytest.mark.tpu_only
   def test_sliced_mla_projections(self):
     config_arguments = self.config_arguments.copy()
 
@@ -2102,7 +2101,7 @@ class MLATest(attention_test_util.MLATestBase):
     config_arguments_sliced["use_sliced_mla_projections"] = True
 
     cfg_normal, mla_normal = self.init_mla(config_arguments, rope_type="default")
-    cfg_sliced, mla_sliced = self.init_mla(config_arguments_sliced, rope_type="default")
+    _, mla_sliced = self.init_mla(config_arguments_sliced, rope_type="default")
 
     # Sync weights
     nnx.update(mla_sliced, nnx.state(mla_normal))
@@ -2128,9 +2127,7 @@ class MLATest(attention_test_util.MLATestBase):
         model_mode=MODEL_MODE_TRAIN,
     )
 
-    self.assertTrue(
-        jnp.allclose(out_normal_train, out_sliced_train, rtol=1e-05, atol=1e-05, equal_nan=False)
-    )
+    self.assertTrue(jnp.allclose(out_normal_train, out_sliced_train, rtol=1e-05, atol=1e-05, equal_nan=False))
 
     # Test PREFILL mode followed by AUTOREGRESSIVE mode to test caching
     prefill_length = cfg_normal.max_prefill_predict_length
@@ -2138,7 +2135,7 @@ class MLATest(attention_test_util.MLATestBase):
 
     # Re-initialize to ensure clean cache
     cfg_normal, mla_normal = self.init_mla(config_arguments, rope_type="default")
-    cfg_sliced, mla_sliced = self.init_mla(config_arguments_sliced, rope_type="default")
+    _, mla_sliced = self.init_mla(config_arguments_sliced, rope_type="default")
     nnx.update(mla_sliced, nnx.state(mla_normal))
 
     lnx_prefill = lnx[:, 0:prefill_length, :]
@@ -2163,9 +2160,7 @@ class MLATest(attention_test_util.MLATestBase):
         model_mode=MODEL_MODE_PREFILL,
     )
 
-    self.assertTrue(
-        jnp.allclose(out_normal_prefill, out_sliced_prefill, rtol=1e-05, atol=1e-05, equal_nan=False)
-    )
+    self.assertTrue(jnp.allclose(out_normal_prefill, out_sliced_prefill, rtol=1e-05, atol=1e-05, equal_nan=False))
 
     # Run autoregressive steps
     for idx in range(prefill_length, decode_total_length):
@@ -2188,9 +2183,7 @@ class MLATest(attention_test_util.MLATestBase):
           model_mode=MODEL_MODE_AUTOREGRESSIVE,
       )
 
-      self.assertTrue(
-          jnp.allclose(out_normal_idx, out_sliced_idx, rtol=1e-05, atol=1e-05, equal_nan=False)
-      )
+      self.assertTrue(jnp.allclose(out_normal_idx, out_sliced_idx, rtol=1e-05, atol=1e-05, equal_nan=False))
 
   def test_projection_initialization(self):
     """Tests that MLA and Attention layers initialize the correct projection weights."""

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -2128,6 +2128,7 @@ class MLATest(attention_test_util.MLATestBase):
         loss_fn, argnums=(0, 1), has_aux=True
     )(mla_sliced, lnx)
 
+    self.assertTrue(jnp.allclose(loss_normal, loss_sliced, rtol=1e-05, atol=1e-05, equal_nan=False))
     self.assertTrue(jnp.allclose(out_normal_train, out_sliced_train, rtol=1e-05, atol=1e-05, equal_nan=False))
     self.assertTrue(jnp.allclose(grad_x_normal, grad_x_sliced, rtol=1e-05, atol=1e-05, equal_nan=False))
 

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -2106,28 +2106,37 @@ class MLATest(attention_test_util.MLATestBase):
     # Sync weights
     nnx.update(mla_sliced, nnx.state(mla_normal))
 
-    # Test TRAIN mode
+    # Test TRAIN mode with gradient comparison
     lnx, decoder_segment_ids, decoder_positions = self.get_structured_data(cfg_normal, cfg_normal.dtype)
 
-    out_normal_train, _ = mla_normal(
-        lnx,
-        lnx,
-        decoder_segment_ids=decoder_segment_ids,
-        inputs_positions=decoder_positions,
-        deterministic=True,
-        model_mode=MODEL_MODE_TRAIN,
-    )
+    def loss_fn(model, x):
+      out, _ = model(
+          x,
+          x,
+          decoder_segment_ids=decoder_segment_ids,
+          inputs_positions=decoder_positions,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.mean(out.astype(jnp.float32) ** 2), out
 
-    out_sliced_train, _ = mla_sliced(
-        lnx,
-        lnx,
-        decoder_segment_ids=decoder_segment_ids,
-        inputs_positions=decoder_positions,
-        deterministic=True,
-        model_mode=MODEL_MODE_TRAIN,
-    )
+    (loss_normal, out_normal_train), (grad_model_normal, grad_x_normal) = nnx.value_and_grad(
+        loss_fn, argnums=(0, 1), has_aux=True
+    )(mla_normal, lnx)
+
+    (loss_sliced, out_sliced_train), (grad_model_sliced, grad_x_sliced) = nnx.value_and_grad(
+        loss_fn, argnums=(0, 1), has_aux=True
+    )(mla_sliced, lnx)
 
     self.assertTrue(jnp.allclose(out_normal_train, out_sliced_train, rtol=1e-05, atol=1e-05, equal_nan=False))
+    self.assertTrue(jnp.allclose(grad_x_normal, grad_x_sliced, rtol=1e-05, atol=1e-05, equal_nan=False))
+
+    grad_model_close = jax.tree_util.tree_map(
+        lambda x, y: jnp.allclose(x, y, rtol=1e-05, atol=1e-05, equal_nan=False),
+        grad_model_normal,
+        grad_model_sliced,
+    )
+    self.assertTrue(jax.tree_util.tree_all(grad_model_close))
 
     # Test PREFILL mode followed by AUTOREGRESSIVE mode to test caching
     prefill_length = cfg_normal.max_prefill_predict_length

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -361,7 +361,6 @@ class ConfigTest(absltest.TestCase):
     ]
     with self.assertRaises(pydantic.ValidationError):
       pyconfig.initialize(argv)
-
   def test_indexer_cutoff_threshold_remat_policy(self):
     """Tests custom remat policy and validation for indexer_cutoff_threshold."""
     # 1. Verify custom remat policy puts indexer_cutoff_threshold on device
@@ -402,6 +401,18 @@ class ConfigTest(absltest.TestCase):
     ]
     with self.assertRaises(ValueError):
       pyconfig.initialize(argv_invalid)
+
+  def test_sliced_mla_proj_disallows_quantization(self):
+    """Tests that use_sliced_mla_proj=True is incompatible with quantization."""
+    argv = [
+        "",
+        _BASE_CONFIG_PATH,
+        "run_name=test",
+        "use_sliced_mla_proj=true",
+        "quantization=int8",
+    ]
+    with self.assertRaises(pydantic.ValidationError):
+      pyconfig.initialize(argv)
 
 
 if __name__ == "__main__":

--- a/tests/unit/linears_test.py
+++ b/tests/unit/linears_test.py
@@ -16,6 +16,7 @@
 
 import sys
 import unittest
+from unittest.mock import MagicMock
 from flax import nnx
 from flax.linen import partitioning as nn_partitioning
 import jax
@@ -127,6 +128,33 @@ class DenseGeneralTest(unittest.TestCase):
 
     np.testing.assert_allclose(slice1, full_output[..., :3], rtol=1e-5, atol=1e-5)
     np.testing.assert_allclose(slice2, full_output[..., 3:], rtol=1e-5, atol=1e-5)
+
+  def test_slice_bounds_with_quantization(self):
+    batch_size = 2
+    in_features = 4
+    n_heads = 2
+    head_dim = 8
+
+    mock_quant = MagicMock()
+    mock_quant.quant_mode = None
+    # Configure mock for ToNNX initialization
+    mock_cls = mock_quant.dot_general_cls.return_value
+    mock_instance = mock_cls.return_value
+    mock_instance.init_with_output.return_value = (MagicMock(), {})
+    mock_instance.apply.return_value = (MagicMock(), {})
+
+    layer = linears.DenseGeneral(
+        in_features_shape=in_features,
+        out_features_shape=(n_heads, head_dim),
+        use_bias=True,
+        quant=mock_quant,
+        rngs=self.rngs,
+    )
+
+    inputs = jax.random.normal(jax.random.PRNGKey(0), (batch_size, in_features))
+
+    with self.assertRaises(AssertionError):
+      layer(inputs, slice_bounds=(0, 3))
 
   def _run_dense_test(self, axis, in_feat_shape, expected_shape):
     batch_size = 2

--- a/tests/unit/linears_test.py
+++ b/tests/unit/linears_test.py
@@ -103,6 +103,31 @@ class DenseGeneralTest(unittest.TestCase):
     self.assertEqual(outputs.shape, (batch_size, out_features))
     self.assertIsNotNone(layer.bias)
 
+  def test_slice_bounds(self):
+    batch_size = 2
+    in_features = 4
+    n_heads = 2
+    head_dim = 8
+
+    layer = linears.DenseGeneral(
+        in_features_shape=in_features,
+        out_features_shape=(n_heads, head_dim),
+        use_bias=True,
+        rngs=self.rngs,
+    )
+
+    inputs = jax.random.normal(jax.random.PRNGKey(0), (batch_size, in_features))
+    full_output = layer(inputs)
+
+    slice1 = layer(inputs, slice_bounds=(0, 3))
+    slice2 = layer(inputs, slice_bounds=(3, head_dim))
+
+    self.assertEqual(slice1.shape, (batch_size, n_heads, 3))
+    self.assertEqual(slice2.shape, (batch_size, n_heads, head_dim - 3))
+
+    np.testing.assert_allclose(slice1, full_output[..., :3], rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(slice2, full_output[..., 3:], rtol=1e-5, atol=1e-5)
+
   def _run_dense_test(self, axis, in_feat_shape, expected_shape):
     batch_size = 2
     seq_len = 3

--- a/tests/unit/linears_test.py
+++ b/tests/unit/linears_test.py
@@ -153,7 +153,7 @@ class DenseGeneralTest(unittest.TestCase):
 
     inputs = jax.random.normal(jax.random.PRNGKey(0), (batch_size, in_features))
 
-    with self.assertRaises(AssertionError):
+    with self.assertRaisesRegex(ValueError, "sliced contraction is only supported when quant is None"):
       layer(inputs, slice_bounds=(0, 3))
 
   def _run_dense_test(self, axis, in_feat_shape, expected_shape):

--- a/tests/unit/linears_test.py
+++ b/tests/unit/linears_test.py
@@ -156,6 +156,30 @@ class DenseGeneralTest(unittest.TestCase):
     with self.assertRaisesRegex(ValueError, "sliced contraction is only supported when quant is None"):
       layer(inputs, slice_bounds=(0, 3))
 
+  def test_slice_bounds_invalid(self):
+    batch_size = 2
+    in_features = 4
+    n_heads = 2
+    head_dim = 8
+
+    layer = linears.DenseGeneral(
+        in_features_shape=in_features,
+        out_features_shape=(n_heads, head_dim),
+        use_bias=True,
+        rngs=self.rngs,
+    )
+
+    inputs = jax.random.normal(jax.random.PRNGKey(0), (batch_size, in_features))
+
+    with self.assertRaisesRegex(ValueError, "slice_bounds .* must be valid and within"):
+      layer(inputs, slice_bounds=(3, 2))
+
+    with self.assertRaisesRegex(ValueError, "slice_bounds .* must be valid and within"):
+      layer(inputs, slice_bounds=(-1, 4))
+
+    with self.assertRaisesRegex(ValueError, "slice_bounds .* must be valid and within"):
+      layer(inputs, slice_bounds=(0, 100))
+
   def _run_dense_test(self, axis, in_feat_shape, expected_shape):
     batch_size = 2
     seq_len = 3


### PR DESCRIPTION
Performance optimizations that avoids an unnecessary split operation.

- Add use_sliced_mla_proj flag to base.yml and types.py.
- Support slice_bounds in DenseGeneral.__call__ to slice projection weights/bias prior to contraction for unquantized paths.
- Update mla_query_projection and mla_get_key_value in attention_mla.py to use sliced projections when enabled.
- Add unit test coverage in linears_test.py.

# Tests

- added unit tests
- https://xmanager.corp.google.com/experiments/271579010
- Before: https://xprof.corp.google.com/trace_viewer/chengnuojin-11765148423170897263?view_start=1400.245&view_end=1420.311
- After: https://xprof.corp.google.com/trace_viewer/dandragona-1224952786495301116?view_start=2691.354&view_end=2701.054
- After: https://xprof.corp.google.com/overview_page/dandragona-7513819543584336902 (isolation microbench)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

CHANGE_STEWARD=true