### PR TITLE
Refactor layer-wise tests with torch

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -207,18 +207,6 @@ jobs:
       is_scheduled_run: ${{ github.event_name == 'schedule' }}
       maxtext_sha: ${{ needs.gate_test_run.outputs.maxtext_sha }}
 
-  maxtext_cpu_torch_reference_tests:
-    name: cpu-torch-reference tests
-    needs: [gate_test_run]
-    if: |
-      always() &&
-      needs.gate_test_run.result == 'success'
-    uses: ./.github/workflows/run_tests_coordinator.yml
-    with:
-      flavor: cpu-torch-reference
-      base_image: maxtext-unit-test-tpu:py312
-      is_scheduled_run: ${{ github.event_name == 'schedule' }}
-      maxtext_sha: ${{ needs.gate_test_run.outputs.maxtext_sha }}
 
   tpu7x-tests:
     name: TPU7X tests
@@ -320,7 +308,7 @@ jobs:
 
   all_tests_passed:
     name: All Required Tests Passed
-    needs: [build_and_upload_maxtext_package, gate_test_run, tpu-tests, tpu7x-tests, gpu-tests, cpu-tests, maxtext_cpu_torch_reference_tests, maxtext_tpu_pathways_unit_tests, maxtext_tpu_pathways_integration_tests, code_quality_check, docs_build_check]
+    needs: [build_and_upload_maxtext_package, gate_test_run, tpu-tests, tpu7x-tests, gpu-tests, cpu-tests, maxtext_tpu_pathways_unit_tests, maxtext_tpu_pathways_integration_tests, code_quality_check, docs_build_check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -333,7 +321,6 @@ jobs:
           echo "Gate result: ${NEEDS_GATE_TEST_RUN_RESULT}"
           echo "TPU Tests (Matrix) result: ${NEEDS_TPU_TESTS_RESULT}"
           echo "TPU7X Tests (Matrix) result: ${NEEDS_TPU7X_TESTS_RESULT}"
-          echo "CPU torch reference tests result: ${NEEDS_MAXTEXT_CPU_TORCH_REFERENCE_TESTS_RESULT}"
           echo "GPU Tests (Matrix) result: ${NEEDS_GPU_TESTS_RESULT}"
           echo "CPU Tests (Matrix) result: ${NEEDS_CPU_TESTS_RESULT}"
           echo "Pathways Unit result: ${NEEDS_MAXTEXT_TPU_PATHWAYS_UNIT_TESTS_RESULT}"
@@ -354,7 +341,6 @@ jobs:
           NEEDS_CPU_TESTS_RESULT: ${{ needs.cpu-tests.result }}
           NEEDS_TPU_TESTS_RESULT: ${{ needs.tpu-tests.result }}
           NEEDS_TPU7X_TESTS_RESULT: ${{ needs.tpu7x-tests.result }}
-          NEEDS_MAXTEXT_CPU_TORCH_REFERENCE_TESTS_RESULT: ${{ needs.maxtext_cpu_torch_reference_tests.result }}
           NEEDS_GPU_TESTS_RESULT: ${{ needs.gpu-tests.result }}
           NEEDS_MAXTEXT_TPU_PATHWAYS_UNIT_TESTS_RESULT: ${{ needs.maxtext_tpu_pathways_unit_tests.result }}
           NEEDS_MAXTEXT_TPU_PATHWAYS_INTEGRATION_TESTS_RESULT: ${{ needs.maxtext_tpu_pathways_integration_tests.result }}
@@ -390,7 +376,7 @@ jobs:
 
   notify_failure:
     name: Notify failed build # creates an issue or modifies last open existing issue for failed build
-    needs: [gate_test_run, tpu-tests, tpu7x-tests, gpu-tests, cpu-tests, maxtext_jupyter_notebooks, maxtext_cpu_torch_reference_tests, maxtext_tpu_pathways_unit_tests, maxtext_tpu_pathways_integration_tests, code_quality_check, docs_build_check]
+    needs: [gate_test_run, tpu-tests, tpu7x-tests, gpu-tests, cpu-tests, maxtext_jupyter_notebooks, maxtext_tpu_pathways_unit_tests, maxtext_tpu_pathways_integration_tests, code_quality_check, docs_build_check]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
@@ -404,7 +390,7 @@ jobs:
 
   investigate_failure:
     name: Investigate failed build # investigates failure of scheduled run and comments on tracking issue
-    needs: [gate_test_run, tpu-tests, tpu7x-tests, gpu-tests, cpu-tests, maxtext_jupyter_notebooks, maxtext_cpu_torch_reference_tests, maxtext_tpu_pathways_unit_tests, maxtext_tpu_pathways_integration_tests, code_quality_check, docs_build_check, notify_failure]
+    needs: [gate_test_run, tpu-tests, tpu7x-tests, gpu-tests, cpu-tests, maxtext_jupyter_notebooks, maxtext_tpu_pathways_unit_tests, maxtext_tpu_pathways_integration_tests, code_quality_check, docs_build_check, notify_failure]
     if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name == 'schedule' }}
     uses: ./.github/workflows/gemini_investigate.yml
     permissions:

--- a/.github/workflows/run_tests_coordinator.yml
+++ b/.github/workflows/run_tests_coordinator.yml
@@ -29,8 +29,7 @@ on:
             tpu7x-post-training-unit, tpu7x-post-training-integration,
             gpu-unit, gpu-integration,
             cpu-unit,
-            cpu-post-training-unit,
-            cpu-torch-reference
+            cpu-post-training-unit
           )
         required: true
         type: string
@@ -124,8 +123,7 @@ jobs:
           "gpu-unit": "cuda12",
           "gpu-integration": "cuda12",
           "cpu-unit": "cpu",
-          "cpu-post-training-unit": "cpu",
-          "cpu-torch-reference": "cpu"
+          "cpu-post-training-unit": "cpu"
         }')[inputs.flavor] }}
 
       device_name: >-
@@ -141,8 +139,7 @@ jobs:
           "gpu-unit": "a100-40gb-4",
           "gpu-integration": "a100-40gb-4",
           "cpu-unit": "X64",
-          "cpu-post-training-unit": "X64",
-          "cpu-torch-reference": "X64"
+          "cpu-post-training-unit": "X64"
         }')[inputs.flavor] }}
 
       cloud_runner: >-
@@ -158,8 +155,7 @@ jobs:
           "gpu-unit": "linux-x86-a2-48-a100-4gpu",
           "gpu-integration": "linux-x86-a2-48-a100-4gpu",
           "cpu-unit": "linux-x86-n2-32",
-          "cpu-post-training-unit": "linux-x86-n2-32",
-          "cpu-torch-reference": "linux-x86-n2-32"
+          "cpu-post-training-unit": "linux-x86-n2-32"
         }')[inputs.flavor] }}
       # Pytest Marker Mapping
       pytest_marker: >-
@@ -175,8 +171,7 @@ jobs:
             "gpu-unit": "not cpu_only and not tpu_only and not integration_test and not post_training",
             "gpu-integration": "not cpu_only and not tpu_only and integration_test and not post_training",
             "cpu-unit": "cpu_only and not post_training",
-            "cpu-post-training-unit": "cpu_only and post_training",
-            "cpu-torch-reference": "not post_training"
+            "cpu-post-training-unit": "cpu_only and post_training"
           }')[inputs.flavor] }}
 
       pytest_addopts: >-
@@ -192,8 +187,7 @@ jobs:
             "gpu-unit": "",
             "gpu-integration": "",
             "cpu-unit": "",
-            "cpu-post-training-unit": "tests/post_training/unit tests/unit",
-            "cpu-torch-reference": ""
+            "cpu-post-training-unit": "tests/post_training/unit tests/unit"
           }')[inputs.flavor] }}
 
       pytest_extra_args: >-
@@ -209,8 +203,7 @@ jobs:
             "gpu-unit": "--ignore=tests/post_training",
             "gpu-integration": "--ignore=tests/post_training",
             "cpu-unit": "--ignore=tests/post_training",
-            "cpu-post-training-unit": "",
-            "cpu-torch-reference": "-o addopts= -rf --import-mode=importlib --strict-markers tests/unit/gemma4_layers_test.py tests/unit/gemma4_small_layers_test.py tests/unit/qwen3_next_vs_reference_test.py tests/unit/qwen3_5_layers_test.py tests/unit/qwen3_omni_layers_test.py"
+            "cpu-post-training-unit": ""
           }')[inputs.flavor] }}
         ${{ inputs.additional_pytest_args }}
 
@@ -231,4 +224,4 @@ jobs:
       total_workers: ${{ fromJSON(needs.setup-parameters.outputs.total_workers) }}
       maxtext_sha: ${{ inputs.maxtext_sha }}
       is_update_hlo: ${{ inputs.is_update_hlo }}
-      install_torch_cpu: ${{ inputs.flavor == 'cpu-torch-reference' }}
+      install_torch_cpu: ${{ inputs.flavor == 'cpu-unit' && inputs.is_scheduled_run }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,7 +14,6 @@ addopts =
     --ignore=tests/unit/dequantize_mxfp4_test.py
     --ignore=tests/unit/dequantize_pack_quantized_int4_test.py
     --ignore=tests/unit/gemma3_layers_test.py
-    --ignore=tests/unit/gemma4_layers_test.py
     --ignore=tests/unit/gemma4_small_layers_test.py
     --ignore=tests/unit/gpt_vs_reference_test.py
     --ignore=tests/unit/llama4_layers_test.py

--- a/tests/unit/gemma4_layers_test.py
+++ b/tests/unit/gemma4_layers_test.py
@@ -16,6 +16,40 @@
 
 import os
 import unittest
+import pytest
+
+try:
+  import torch
+  from transformers.models.gemma4.configuration_gemma4 import (
+      Gemma4VisionConfig,
+      Gemma4TextConfig,
+  )
+  from transformers.models.gemma4.modeling_gemma4 import (
+      Gemma4VisionPatchEmbedder as TorchGemma4VisionPatchEmbedder,
+      Gemma4VisionRotaryEmbedding as TorchGemma4VisionRotaryEmbedding,
+      Gemma4VisionAttention as TorchGemma4VisionAttention,
+      Gemma4VisionEncoderLayer as TorchGemma4VisionEncoderLayer,
+      Gemma4VisionPooler as TorchGemma4VisionPooler,
+      Gemma4VisionModel as TorchGemma4VisionModel,
+      Gemma4MultimodalEmbedder as TorchGemma4MultimodalEmbedder,
+      apply_multidimensional_rope,
+  )
+  from tests.utils.multimodal_test_utils import (
+      assert_all_close_jax_torch,
+      copy_linear_weights,
+      copy_rmsnorm_weights,
+      create_random_jax_torch,
+  )
+
+  HAS_TORCH = True
+except ImportError:
+  HAS_TORCH = False
+
+pytestmark = [
+    pytest.mark.cpu_only,
+    pytest.mark.scheduled_only,
+    pytest.mark.skipif(not HAS_TORCH, reason="Torch or transformers not available"),
+]
 
 from flax import nnx
 import jax
@@ -34,30 +68,7 @@ from maxtext.models.gemma4_vision import (
     Gemma4VisionProjector as JaxGemma4VisionProjector,
     patchify,
 )
-from tests.utils.multimodal_test_utils import (
-    assert_all_close_jax_torch,
-    copy_linear_weights,
-    copy_rmsnorm_weights,
-    create_random_jax_torch,
-)
 import numpy as np
-import torch
-
-# PyTorch/transformers imports
-from transformers.models.gemma4.configuration_gemma4 import (
-    Gemma4VisionConfig,
-    Gemma4TextConfig,
-)
-from transformers.models.gemma4.modeling_gemma4 import (
-    Gemma4VisionPatchEmbedder as TorchGemma4VisionPatchEmbedder,
-    Gemma4VisionRotaryEmbedding as TorchGemma4VisionRotaryEmbedding,
-    Gemma4VisionAttention as TorchGemma4VisionAttention,
-    Gemma4VisionEncoderLayer as TorchGemma4VisionEncoderLayer,
-    Gemma4VisionPooler as TorchGemma4VisionPooler,
-    Gemma4VisionModel as TorchGemma4VisionModel,
-    Gemma4MultimodalEmbedder as TorchGemma4MultimodalEmbedder,
-    apply_multidimensional_rope,
-)
 
 # Initialize config once for all tests
 base_config_path = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "base.yml")
@@ -76,33 +87,38 @@ jax_config = pyconfig.initialize(
     float32_qk_product=True,
 )
 
-# PyTorch vision encoder config
-torch_vision_config = Gemma4VisionConfig(
-    hidden_size=jax_config.hidden_size_for_vit,
-    intermediate_size=jax_config.intermediate_size_for_vit,
-    num_hidden_layers=jax_config.num_hidden_layers_for_vit,
-    num_attention_heads=jax_config.num_attention_heads_for_vit,
-    num_key_value_heads=jax_config.num_attention_heads_for_vit,
-    head_dim=jax_config.hidden_size_for_vit // jax_config.num_attention_heads_for_vit,
-    patch_size=jax_config.patch_size_for_vit,
-    position_embedding_size=jax_config.num_position_embeddings_for_vit,
-    rope_parameters={"rope_type": "default", "rope_theta": jax_config.rope_theta_for_vit},
-    pooling_kernel_size=3,
-    standardize=True,
-    rms_norm_eps=jax_config.normalization_layer_epsilon,
-)
-torch_vision_config._attn_implementation = "eager"  # pylint: disable=protected-access
+if HAS_TORCH:
+  # PyTorch vision encoder config
+  torch_vision_config = Gemma4VisionConfig(
+      hidden_size=jax_config.hidden_size_for_vit,
+      intermediate_size=jax_config.intermediate_size_for_vit,
+      num_hidden_layers=jax_config.num_hidden_layers_for_vit,
+      num_attention_heads=jax_config.num_attention_heads_for_vit,
+      num_key_value_heads=jax_config.num_attention_heads_for_vit,
+      head_dim=jax_config.hidden_size_for_vit // jax_config.num_attention_heads_for_vit,
+      patch_size=jax_config.patch_size_for_vit,
+      position_embedding_size=jax_config.num_position_embeddings_for_vit,
+      rope_parameters={"rope_type": "default", "rope_theta": jax_config.rope_theta_for_vit},
+      pooling_kernel_size=3,
+      standardize=True,
+      rms_norm_eps=jax_config.normalization_layer_epsilon,
+  )
+  torch_vision_config._attn_implementation = "eager"  # pylint: disable=protected-access
 
-# PyTorch text config for multimodal embedder
-torch_text_config = Gemma4TextConfig(hidden_size=jax_config.emb_dim)
+  # PyTorch text config for multimodal embedder
+  torch_text_config = Gemma4TextConfig(hidden_size=jax_config.emb_dim)
 
-torch.set_grad_enabled(False)
+  torch.set_grad_enabled(False)
+else:
+  torch_vision_config = None
+  torch_text_config = None
 
 
 def setup_test_seeds():
   """Set random seeds for reproducibility."""
   np.random.seed(42)
-  torch.manual_seed(42)
+  if HAS_TORCH:
+    torch.manual_seed(42)
 
 
 # =============================================================================


### PR DESCRIPTION
# Description

Reverts the standalone `cpu_torch_reference_tests` workflow and integrates `gemma4_layers_test.py` into the standard `cpu-unit` tests. The test is configured to run only on scheduled CI runs.
- Removed `maxtext_cpu_torch_reference_tests` workflow.
- Enabled `gemma4_layers_test.py` in `pytest.ini`, and marked it as `cpu_only` and `scheduled_only`.
- Configured torch installation for `cpu-unit` only during scheduled runs.

**TODO**: After this atomic PR, follow up with another PR refactoring `import torch` for other layer-wise tests, and add them to scheduled runs cleanly.

# Tests

```
JAX_PLATFORMS=cpu python -m pytest tests/unit/gemma4_layers_test.py
```

**Note**: GitHub Actions Scan is failing due to a very recent Google-wise security rollout on [07-27-2026](https://screenshot.googleplex.com/5jRDKaaYxvQo7ts).

Manual work-dispatch run (simulating scheduled runs) with torch installation: [successful](https://screenshot-v2.corp.google.com/3q7Trj3zWz5cC9f)
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
