### PR TITLE
Fix DeepSeek decode running the prefill attention path under NNX

### DIFF
--- a/src/maxtext/inference/maxengine/maxengine.py
+++ b/src/maxtext/inference/maxengine/maxengine.py
@@ -145,11 +145,16 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
       # nnx.merge. `rest` (RNG state etc.) is materialized in load_params.
       graphdef, _, _, _ = nnx.split(abstract_model, nnx.Param, nnx.Cache, ...)
       self.graphdef = graphdef
+      # Layers may bake their construction-time model_mode into static attributes,
+      # so a call must be merged with the graphdef built for that same mode.
+      graphdef_ar, _, _, _ = nnx.split(abstract_model_ar, nnx.Param, nnx.Cache, ...)
+      self.graphdef_ar = graphdef_ar
       self._create_model_fn = _create_model
       self._nnx_rest_state = None
     else:
       self.model = models.transformer_as_linen(config, mesh=self._mesh, quant=quant, model_mode=MODEL_MODE_PREFILL)
       self.graphdef = None
+      self.graphdef_ar = None
       self._create_model_fn = None
     self.replicated_sharding = jax.sharding.NamedSharding(self._mesh, P(None))
 
@@ -218,10 +223,14 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
     """NNX equivalent of `model.apply(..., mutable=["cache"])`. Returns (logits, new_cache_dict)."""
     cache_state = self._nnx_cache_state_template(mode=model_mode)
     nnx.replace_by_pure_dict(cache_state, cache_dict)
+    # Merge with the graphdef built for this mode. Layers that captured their
+    # model_mode at construction (e.g. the DeepSeek layers) would otherwise run
+    # the prefill attention path during autoregressive decode.
+    graphdef = self.graphdef_ar if model_mode == MODEL_MODE_AUTOREGRESSIVE else self.graphdef
     # copy=True avoids reusing Variable objects across traces (TraceContextError),
     # mirroring the workaround in train.py's diff_wrapper.
     model = nnx.merge(
-        self.graphdef, params, cache_state, self._nnx_rest_state, copy=True
+        graphdef, params, cache_state, self._nnx_rest_state, copy=True
     )  # pyrefly: ignore[no-matching-overload]
     logits = model(
         decoder_input_tokens,

--- a/src/maxtext/models/deepseek.py
+++ b/src/maxtext/models/deepseek.py
@@ -211,6 +211,7 @@ class DeepSeekGenericLayer(nnx.Module):
       decoder_segment_ids,
       decoder_positions,
       deterministic,
+      model_mode,
       previous_chunk=None,
       slot: None | int = None,
   ):
@@ -221,7 +222,7 @@ class DeepSeekGenericLayer(nnx.Module):
         decoder_positions,
         decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
-        model_mode=self.model_mode,
+        model_mode=model_mode,
         out_sharding=self.out_sharding,
         previous_chunk=previous_chunk,
         slot=slot,
@@ -270,6 +271,7 @@ class DeepSeekGenericLayer(nnx.Module):
       decoder_segment_ids,
       decoder_positions,
       deterministic,
+      model_mode,
       previous_chunk=None,
       slot: None | int = None,
   ):
@@ -283,7 +285,7 @@ class DeepSeekGenericLayer(nnx.Module):
           decoder_segment_ids=decoder_segment_ids,
           inputs_positions=decoder_positions,
           deterministic=deterministic,
-          model_mode=self.model_mode,
+          model_mode=model_mode,
           out_sharding=self.out_sharding,
           previous_chunk=previous_chunk,
           slot=slot,
@@ -295,6 +297,7 @@ class DeepSeekGenericLayer(nnx.Module):
           decoder_segment_ids,
           decoder_positions,
           deterministic,
+          model_mode,
           previous_chunk,
           slot,
       )
@@ -368,6 +371,7 @@ class DeepSeekDenseLayer(DeepSeekGenericLayer):
         decoder_segment_ids,
         decoder_positions,
         deterministic,
+        model_mode,
         previous_chunk,
         slot,
     )
@@ -581,6 +585,7 @@ class DeepSeekMoELayer(DeepSeekGenericLayer):
         decoder_segment_ids,
         decoder_positions,
         deterministic,
+        model_mode,
         previous_chunk,
         slot,
     )

--- a/src/maxtext/models/deepseek4.py
+++ b/src/maxtext/models/deepseek4.py
@@ -151,6 +151,7 @@ class DeepSeek4DecoderLayer(deepseek.DeepSeekGenericLayer):
         decoder_segment_ids,
         decoder_positions,
         deterministic,
+        model_mode,
         previous_chunk,
         slot,
     )

--- a/tests/unit/decoder_layer_model_mode_test.py
+++ b/tests/unit/decoder_layer_model_mode_test.py
@@ -1,0 +1,180 @@
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A decoder layer must attend in the mode it is called with, not the one it was built in.
+
+Under NNX a model object is built once and reused across modes — MaxEngine builds it
+in PREFILL and then passes MODEL_MODE_AUTOREGRESSIVE per call while decoding. A layer
+that forwards its construction-time `self.model_mode` to attention instead of the
+`model_mode` argument therefore runs the prefill KV-cache path during decode and
+produces wrong tokens from the first generated one, with no error anywhere.
+
+The check stops at the attention boundary and asserts on the mode that arrives there,
+so it stays cheap and does not depend on any particular attention implementation.
+"""
+
+import sys
+import unittest
+from unittest import mock
+
+import jax
+import jax.numpy as jnp
+from absl.testing import parameterized
+from flax import nnx
+from flax.linen import partitioning as nn_partitioning
+
+from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL
+from maxtext.configs import pyconfig
+from maxtext.layers import attention_mla, attentions
+from maxtext.models import deepseek, gemma, gemma2, llama2, mistral, qwen2, qwen3
+from maxtext.utils import maxtext_utils
+from tests.utils.test_helpers import get_test_config_path
+
+# Config knobs shared by every family; small enough that construction is the only cost.
+_COMMON = {
+    "base_emb_dim": 64,
+    "base_mlp_dim": 64,
+    "base_num_query_heads": 4,
+    "base_num_kv_heads": 4,
+    "base_num_decoder_layers": 3,
+    "vocab_size": 64,
+    "max_prefill_predict_length": 8,
+    "max_target_length": 16,
+    "per_device_batch_size": 1,
+    "scan_layers": False,
+    "attention": "dot_product",
+    "sparse_matmul": False,
+    "dtype": "float32",
+    "weight_dtype": "float32",
+    "enable_checkpointing": False,
+    "skip_jax_distributed_system": True,
+    "pure_nnx": True,
+}
+
+_DEEPSEEK = {
+    "model_name": "deepseek2-16b",
+    "override_model_config": True,
+    "mla_naive_kvcache": False,
+    "first_num_dense_layers": 1,
+    "num_experts": 4,
+    "num_experts_per_tok": 2,
+    "shared_experts": 1,
+}
+
+# Each entry is (case name, layer class, extra config, extra constructor kwargs).
+_LAYERS = [
+    ("deepseek_dense", deepseek.DeepSeekDenseLayer, _DEEPSEEK, {}),
+    ("deepseek_moe", deepseek.DeepSeekMoELayer, _DEEPSEEK, {}),
+    ("llama2", llama2.LlamaDecoderLayer, {}, {}),
+    ("mistral", mistral.MistralDecoderLayer, {"decoder_block": "mistral"}, {}),
+    ("gemma", gemma.GemmaDecoderLayer, {"decoder_block": "gemma"}, {}),
+    ("gemma2", gemma2.Gemma2DecoderLayer, {"decoder_block": "gemma2"}, {}),
+    ("qwen2", qwen2.Qwen2DecoderLayer, {"decoder_block": "qwen2"}, {"quant": None}),
+    ("qwen3", qwen3.Qwen3DecoderLayer, {"decoder_block": "qwen3"}, {"quant": None}),
+]
+
+
+def _mesh(cfg):
+  """Builds the mesh over every available device.
+
+  ici_fsdp_parallelism keeps its base.yml default of -1, so the fsdp axis absorbs
+  however many devices the host has. Pinning the ICI axes instead would fix the mesh
+  at one device and fail everywhere except a single-device runner.
+
+  Args:
+    cfg: Model config.
+
+  Returns:
+    The device mesh.
+  """
+  return jax.sharding.Mesh(maxtext_utils.create_device_mesh(cfg), cfg.mesh_axes)
+
+
+class _StopAtAttention(Exception):
+  """Raised by the spy so the forward pass ends once the mode has been observed."""
+
+
+class DecoderLayerModelModeTest(parameterized.TestCase):
+  """Every decoder layer must forward the call-time model_mode to its attention."""
+
+  def _mode_seen_by_attention(self, layer_cls, extra_config, ctor_kwargs, build_mode, call_mode):
+    """Builds a layer in one mode and calls it in another.
+
+    Args:
+      layer_cls: Decoder layer class to instantiate.
+      extra_config: Config overrides this family needs, on top of _COMMON.
+      ctor_kwargs: Extra constructor arguments this family requires.
+      build_mode: Model mode the layer is constructed with.
+      call_mode: Model mode the layer is called with.
+
+    Returns:
+      The model mode that reached the attention module.
+    """
+    cfg = pyconfig.initialize([sys.argv[0], get_test_config_path()], **(_COMMON | extra_config))
+    mesh = _mesh(cfg)
+    seen = []
+
+    def spy(_self, *args, **kwargs):
+      # model_mode is the 5th positional parameter of Attention.__call__, but every
+      # in-tree caller passes it by keyword. Accept both so the spy is not brittle.
+      seen.append(kwargs.get("model_mode", args[4] if len(args) > 4 else None))
+      raise _StopAtAttention()
+
+    with nn_partitioning.axis_rules(cfg.logical_axis_rules), mesh:
+      layer = layer_cls(
+          config=cfg,
+          model_mode=build_mode,
+          mesh=mesh,
+          rngs=nnx.Rngs(params=0, dropout=0),
+          **ctor_kwargs,
+      )
+      batch = cfg.micro_batch_size_to_train_on
+      inputs = jnp.zeros((batch, 1, cfg.emb_dim), dtype=jnp.float32)
+      positions = jnp.zeros((batch, 1), dtype=jnp.int32)
+      segment_ids = jnp.ones((batch, 1), dtype=jnp.int32)
+      with (
+          mock.patch.object(attentions.Attention, "__call__", spy),
+          mock.patch.object(attention_mla.MLA, "__call__", spy),
+      ):
+        try:
+          layer(inputs, segment_ids, positions, True, call_mode)
+        except _StopAtAttention:
+          pass
+
+    self.assertEqual(len(seen), 1, f"expected exactly one attention call, saw {len(seen)}")
+    return seen[0]
+
+  @parameterized.named_parameters(*_LAYERS)
+  def test_decode_call_overrides_prefill_construction(self, layer_cls, extra_config, ctor_kwargs):
+    """Checks a layer built for prefill and called for decode, as MaxEngine does."""
+    seen = self._mode_seen_by_attention(
+        layer_cls, extra_config, ctor_kwargs, MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE
+    )
+    self.assertEqual(
+        seen,
+        MODEL_MODE_AUTOREGRESSIVE,
+        "attention ran in the layer's construction-time mode; decode would use the prefill KV-cache path",
+    )
+
+  @parameterized.named_parameters(*_LAYERS)
+  def test_prefill_call_overrides_decode_construction(self, layer_cls, extra_config, ctor_kwargs):
+    """Checks the reverse direction, so a layer cannot pass by hardcoding either mode."""
+    seen = self._mode_seen_by_attention(
+        layer_cls, extra_config, ctor_kwargs, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL
+    )
+    self.assertEqual(seen, MODEL_MODE_PREFILL, "attention ran in the layer's construction-time mode")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/deepseek_decode_consistency_test.py
+++ b/tests/unit/deepseek_decode_consistency_test.py
@@ -1,0 +1,268 @@
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Greedy decode through MaxEngine must match a teacher-forced forward pass.
+
+Golden-logit tests only cover the forward pass, so nothing catches a broken
+prefill -> autoregressive handoff. Here a tiny model is decoded greedily through
+prefill/insert/generate and compared against the argmax rollout of a plain forward
+pass over the same growing prefix, which is the same sequence by definition. That
+holds for any model, so new families can be added to the parameter list.
+
+DeepSeek is the case that motivated this: MaxEngine's NNX path builds the model once
+in PREFILL mode and passes the mode per call, so a layer that reads its
+construction-time model_mode instead of the argument runs the prefill attention path
+during decode and silently produces wrong tokens.
+"""
+
+import sys
+import unittest
+from unittest import mock
+
+import jax
+import jax.numpy as jnp
+import pytest
+from absl.testing import parameterized
+from flax import nnx
+from flax.linen import partitioning as nn_partitioning
+
+from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN
+from maxtext.configs import pyconfig
+from maxtext.models import deepseek
+from maxtext.utils import maxtext_utils, model_creation_utils
+
+pytest.importorskip("jetstream", reason="jetstream not installed")
+from maxtext.inference.maxengine import maxengine
+from tests.utils.test_helpers import get_test_config_path
+
+PROMPT = [3, 17, 42, 5, 9]
+STEPS = 4
+
+_COMMON = {
+    "base_emb_dim": 64,
+    "base_mlp_dim": 64,
+    "base_num_query_heads": 4,
+    "base_num_kv_heads": 4,
+    "base_num_decoder_layers": 3,
+    "vocab_size": 64,
+    "max_prefill_predict_length": 8,
+    "max_target_length": 16,
+    "per_device_batch_size": 1,
+    "scan_layers": False,
+    "attention": "dot_product",
+    "sparse_matmul": False,
+    "dtype": "float32",
+    "weight_dtype": "float32",
+    "matmul_precision": "highest",
+    "decode_sampling_strategy": "greedy",
+    "enable_checkpointing": False,
+    "skip_jax_distributed_system": True,
+    "pure_nnx": True,
+}
+
+_DEEPSEEK = {
+    "model_name": "deepseek2-16b",
+    "override_model_config": True,
+    "num_experts": 4,
+    "num_experts_per_tok": 2,
+    "shared_experts": 1,
+    # The naive MLA kv cache sizes its key cache with the value head dim, so prefill
+    # writes a wider key than the cache holds. Unrelated to decode consistency and it
+    # fails the same way on the Linen path.
+    "mla_naive_kvcache": False,
+}
+
+# MoE and dense DeepSeek layers take different paths to attention, so cover both.
+_DEEPSEEK_MOE = _DEEPSEEK | {"first_num_dense_layers": 1}
+_DEEPSEEK_DENSE = _DEEPSEEK | {"first_num_dense_layers": 3}
+
+
+def _make_config(**overrides):
+  return pyconfig.initialize([sys.argv[0], get_test_config_path()], **(_COMMON | overrides))
+
+
+def _mesh(cfg):
+  """Builds the mesh over every available device.
+
+  ici_fsdp_parallelism keeps its base.yml default of -1, so the fsdp axis absorbs
+  however many devices the host has. Pinning the ICI axes instead would fix the mesh
+  at one device and fail everywhere except a single-device runner.
+
+  Args:
+    cfg: Model config.
+
+  Returns:
+    The device mesh.
+  """
+  return jax.sharding.Mesh(maxtext_utils.create_device_mesh(cfg), cfg.mesh_axes)
+
+
+class DecodeConsistencyTest(parameterized.TestCase):
+  """Decode must agree with the forward pass it is supposed to be replaying."""
+
+  def _forward_rollout(self, cfg, mesh, params_state):
+    """Rolls out greedily, recomputing a full forward pass over the prefix each step.
+
+    Args:
+      cfg: Model config.
+      mesh: Device mesh the model is built on.
+      params_state: nnx.Param state to load into the model.
+
+    Returns:
+      The generated token ids.
+    """
+    with nn_partitioning.axis_rules(cfg.logical_axis_rules), mesh:
+      model = model_creation_utils.create_model(
+          cfg, mesh, model_mode=MODEL_MODE_TRAIN, rngs=nnx.Rngs(params=0, dropout=0)
+      )
+    nnx.update(model, params_state)
+
+    tokens = list(PROMPT)
+    generated = []
+    pad = cfg.max_target_length
+    batch = cfg.micro_batch_size_to_train_on
+    for _ in range(STEPS + 1):
+      ids = jnp.tile(jnp.asarray([tokens + [0] * (pad - len(tokens))], dtype=jnp.int32), (batch, 1))
+      positions = jnp.tile(jnp.asarray([list(range(pad))], dtype=jnp.int32), (batch, 1))
+      segment_ids = jnp.tile(jnp.asarray([[1] * len(tokens) + [0] * (pad - len(tokens))], dtype=jnp.int32), (batch, 1))
+      with nn_partitioning.axis_rules(cfg.logical_axis_rules), mesh:
+        logits = model(
+            ids,
+            positions,
+            decoder_segment_ids=segment_ids,
+            enable_dropout=False,
+            model_mode=MODEL_MODE_TRAIN,
+        )
+      next_token = int(jnp.argmax(logits[0, len(tokens) - 1]))
+      generated.append(next_token)
+      tokens.append(next_token)
+    return generated
+
+  def _engine_rollout(self, engine, params):
+    """Rolls out greedily through prefill, insert and generate.
+
+    Args:
+      engine: MaxEngine with params already loaded.
+      params: Params returned by load_params.
+
+    Returns:
+      The generated token ids.
+    """
+    padded = jnp.asarray(
+        PROMPT + [0] * (engine.config.max_prefill_predict_length - len(PROMPT)),
+        dtype=jnp.int32,
+    )
+    prefix, first_token = engine.prefill(params=params, padded_tokens=padded, true_length=len(PROMPT))
+    generated = [int(first_token.data[0, 0])]
+
+    decode_state = engine.init_decode_state()
+    decode_state = engine.insert(prefix, decode_state, slot=0)
+    for _ in range(STEPS):
+      decode_state, result = engine.generate(params, decode_state)
+      generated.append(int(result.data[0, 0]))
+    return generated
+
+  def _build(self, cfg):
+    """Builds a freshly initialized model.
+
+    Args:
+      cfg: Model config.
+
+    Returns:
+      A tuple of (mesh, params_state).
+    """
+    mesh = _mesh(cfg)
+    with nn_partitioning.axis_rules(cfg.logical_axis_rules), mesh:
+      model = model_creation_utils.create_model(
+          cfg, mesh, model_mode=MODEL_MODE_PREFILL, rngs=nnx.Rngs(params=0, dropout=0)
+      )
+    _, params_state, _ = nnx.split(model, nnx.Param, ...)
+    return mesh, params_state
+
+  @parameterized.named_parameters(
+      ("deepseek_moe", _DEEPSEEK_MOE),
+      ("deepseek_dense", _DEEPSEEK_DENSE),
+      ("generic", {}),
+  )
+  def test_greedy_decode_matches_forward_pass(self, overrides):
+    cfg = _make_config(**overrides)
+    mesh, params_state = self._build(cfg)
+
+    expected = self._forward_rollout(cfg, mesh, params_state)
+
+    engine = maxengine.MaxEngine(cfg, jax.devices())
+    params = engine.load_params(params=params_state)
+    actual = self._engine_rollout(engine, params)
+
+    self.assertEqual(
+        expected,
+        actual,
+        f"decode diverged from the forward pass: expected {expected}, got {actual}",
+    )
+
+
+class EngineGraphdefModeTest(unittest.TestCase):
+  """MaxEngine must merge the graphdef built for the mode it is running.
+
+  Layers are supposed to honor the call-time model_mode, but the engine should not
+  depend on that: merging a prefill graphdef for an autoregressive step leaves every
+  layer's `self.model_mode` reading "prefill". This guards the engine side on its own,
+  so the two defenses cannot regress together silently.
+  """
+
+  def test_generate_merges_autoregressive_graphdef(self):
+    cfg = _make_config(**_DEEPSEEK_MOE)
+    mesh = _mesh(cfg)
+    with nn_partitioning.axis_rules(cfg.logical_axis_rules), mesh:
+      model = model_creation_utils.create_model(
+          cfg, mesh, model_mode=MODEL_MODE_PREFILL, rngs=nnx.Rngs(params=0, dropout=0)
+      )
+    _, params_state, _ = nnx.split(model, nnx.Param, ...)
+
+    engine = maxengine.MaxEngine(cfg, jax.devices())
+    params = engine.load_params(params=params_state)
+
+    # The mode each merged layer was constructed with, recorded from inside the
+    # jitted prefill / generate bodies.
+    built_modes = []
+    original = deepseek.DeepSeekGenericLayer.attention_op
+
+    def recording_attention_op(self, *args, **kwargs):
+      built_modes.append(self.model_mode)
+      return original(self, *args, **kwargs)
+
+    padded = jnp.asarray(
+        PROMPT + [0] * (cfg.max_prefill_predict_length - len(PROMPT)),
+        dtype=jnp.int32,
+    )
+    with mock.patch.object(deepseek.DeepSeekGenericLayer, "attention_op", recording_attention_op):
+      prefix, _ = engine.prefill(params=params, padded_tokens=padded, true_length=len(PROMPT))
+      self.assertTrue(built_modes, "prefill did not reach the DeepSeek attention")
+      self.assertEqual(set(built_modes), {MODEL_MODE_PREFILL})
+
+      decode_state = engine.init_decode_state()
+      decode_state = engine.insert(prefix, decode_state, slot=0)
+      built_modes.clear()
+      engine.generate(params, decode_state)
+
+    self.assertTrue(built_modes, "generate did not reach the DeepSeek attention")
+    self.assertEqual(
+        set(built_modes),
+        {MODEL_MODE_AUTOREGRESSIVE},
+        "generate merged a graphdef built for another mode",
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Description

Decoding `deepseek2-16b` through MaxEngine on the NNX path emits a single repeated token. On the nightly checkpoint (v6e-8, `maxtext.inference.decode`, greedy, `mla_naive_kvcache=false`):

```
prompt: An attention function can be described as mapping a query and a set of key-value pairs to an output,
        where the query, keys, values, and outputs are all vectors. The output is

before:  a a a a a a a a a a a a a a a a a a a a a ...   (all 1024 tokens)
after:   a weighted sum of the values, where the weights are computed by a function of the query and the keys.
```

## Root cause

`DeepSeekGenericLayer.attention_op` passed `model_mode=self.model_mode` to attention — the value captured at `__init__` — instead of the `model_mode` its `__call__` receives. Same in `self_attention_with_norm_op` for the MHC branch.

MaxEngine's NNX path builds the model **once in PREFILL mode** and passes the mode per call: `_nnx_run_model` always merged `self.graphdef`, which is the prefill graphdef. So on every autoregressive step each DeepSeek layer still read `self.model_mode == "prefill"` and took the prefill KV-cache branch. Prefill logits stay correct, which is why the first token is right and everything after it is wrong.

Only DeepSeek is affected — llama2 and the other families already forward the call-time `model_mode`. A sweep of every non-`__init__` read of `self.model_mode` in `src/maxtext` found DeepSeek to be the only one feeding a stale mode into attention.

The bug was latent under Linen, which re-binds layers on each `apply` so `self.model_mode` is always current. It only surfaces once a model object is built once and reused across modes, which is exactly what pure NNX does.

## Fix

| File | Change |
|---|---|
| `models/deepseek.py` | `attention_op` and `self_attention_with_norm_op` take `model_mode` and forward the call-time value. |
| `models/deepseek4.py` | Updated call site (`DeepSeek4DecoderLayer` inherits both helpers). |
| `inference/maxengine/maxengine.py` | Cache a `graphdef_ar` and merge with the graphdef built for the requested mode. |

Either change alone restores correct output; both are included deliberately, so a future layer repeating the mistake cannot silently corrupt decode and the two protections cannot regress together unnoticed.

## Tests

Two new CPU-only files, neither needing a checkpoint. They close a real gap: golden-logit tests only exercise the forward pass, so nothing covered the prefill → autoregressive handoff.

**`tests/unit/decoder_layer_model_mode_test.py`** — 16 cases. Asserts at the attention boundary that a layer attends in the mode it was *called* with. Covers deepseek dense/moe, llama2, mistral, gemma, gemma2, qwen2 and qwen3, in **both** directions (built-prefill/called-AR and built-AR/called-prefill) so no layer can pass by hardcoding a mode.

**`tests/unit/deepseek_decode_consistency_test.py`** — 4 cases. Greedy decode through prefill/insert/generate must equal the argmax rollout of a plain forward pass over the same prefix. Parameterized over deepseek-moe, deepseek-dense and a generic model, so adding a family is one line. Includes a separate guard that `generate` merges an autoregressive graphdef, covering the engine side on its own.

## Verification

All on `wanglance-v6e-8` (TPU v6 lite, 8 chips). Rows marked *unmodified `main`* were run in a throwaway `git worktree`, so the branch was never reverted.

| Item | Result | Log |
| --- | --- | --- |
| Real-checkpoint decode, **with fix** | `-> a weighted sum of the values, where the weights are computed by a function of the query and the keys.` | [log](https://paste.googleplex.com/5269766309806080) |
| Real-checkpoint decode, **unmodified `main`** | `-> a a a a a a a a a ...` for all 1024 tokens — the bug reproduced | [log](https://paste.googleplex.com/5074171318108160) |

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
