### PR TITLE
[MaxText][RL] Omit Redundant Weight Resharding Prior to Step 0 Evaluation

### DIFF
--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -17,7 +17,7 @@ RL Trainer
 
 This module provides a unified `rl_train` function that consolidates the common
 RL training logic. It handles model loading, reward function setup, dataset
-processing, and training orchestration. By default, we run Group Relative Policy Optimization (GRPO) on 
+processing, and training orchestration. By default, we run Group Relative Policy Optimization (GRPO) on
 GSM8K math reasoning benchmark. The script is also flexible enough to run Group Sequence Policy Optimization (GSPO).
 
 Usage Examples:
@@ -722,8 +722,9 @@ def _rl_train_impl(argv: Sequence[str], kwargs: dict):
 
   # Run evaluation before training
   if trainer_config.num_test_batches > 0:
-    # Update vllm with model parameters from checkpoint
-    rl_cluster.rollout.update_params(nnx.state(actor_model))
+    # `rl_cluster.rollout.update_params()` is intentionally omitted prior to step 0
+    # because `RLCluster` initialization (`create_rl_components`) already syncs the actor model weights
+    # during setup. Skipping this redundant parameter transfer eliminates unnecessary weight resharding.
 
     (corr, total, accuracy, partial_accuracy, format_accuracy, mean_reward), _ = evaluate(
         trainer_config,


### PR DESCRIPTION
# Description

This PR optimizes startup latency of `train_rl.py`.

Removed redundant `rl_cluster.rollout.update_params(nnx.state(actor_model))` call prior to step 0 evaluation in `train_rl.py`. `RLCluster` setup (`create_rl_components`) already synchronizes Actor model weights with vLLM engines during setup, eliminating ~65 seconds of unnecessary weight resharding latency.

BUGS: b/528378191

# Tests

Ran train_rl.py on TPU VM.
CI test.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
