### PR TITLE
[DECOUPLED-MODE] checkpoint_conversion: import GCS via gcloud_stub in load_dynamic

### DIFF
--- a/src/maxtext/checkpoint_conversion/utils/load_dynamic.py
+++ b/src/maxtext/checkpoint_conversion/utils/load_dynamic.py
@@ -73,18 +73,22 @@ import time
 
 from flax import nnx
 import flax.traverse_util
-from google.cloud import storage
 import huggingface_hub
 import jax
 from maxtext.checkpoint_conversion.utils import hf_model_configs
 from maxtext.checkpoint_conversion.utils import param_mapping
 from maxtext.checkpoint_conversion.utils import tensor_handling
+from maxtext.common.gcloud_stub import gcs_storage
 from maxtext.utils import gcs_utils
 from maxtext.utils import globals as maxtext_globals
 from maxtext.utils import max_logging
 from orbax.checkpoint import v1 as ocp_v1
 from orbax.checkpoint._src.arrays import sharding as sharding_utils
 
+
+# Route GCS through the decoupling helper so this module imports cleanly in
+# decoupled environments where google-cloud-storage is intentionally absent.
+storage = gcs_storage()
 
 HF_MODEL_CONFIGS = hf_model_configs.HF_MODEL_CONFIGS
 get_hf_loading_function = tensor_handling.get_hf_loading_function

--- a/tests/unit/checkpointing_test.py
+++ b/tests/unit/checkpointing_test.py
@@ -149,7 +149,7 @@ class LoadDynamicTest(parameterized.TestCase):
   """Tests for cache downloads and dynamic loading of safetensors."""
 
   @mock.patch("huggingface_hub.HfFileSystem")
-  @mock.patch("google.cloud.storage.Client")
+  @mock.patch.object(load_dynamic.storage, "Client")
   def test_build_gcs_cache_worker_cache_hit(self, mock_storage_client, mock_hf_fs):
     mock_client_instance = mock_storage_client.return_value
     mock_bucket = mock_client_instance.bucket.return_value
@@ -161,7 +161,7 @@ class LoadDynamicTest(parameterized.TestCase):
     mock_blob.upload_from_file.assert_not_called()
 
   @mock.patch("huggingface_hub.HfFileSystem")
-  @mock.patch("google.cloud.storage.Client")
+  @mock.patch.object(load_dynamic.storage, "Client")
   def test_build_gcs_cache_worker_cache_miss_success(self, mock_storage_client, mock_hf_fs):
     mock_fs_instance = mock_hf_fs.return_value
     mock_remote_file = mock.MagicMock()
@@ -177,7 +177,7 @@ class LoadDynamicTest(parameterized.TestCase):
     mock_blob.upload_from_file.assert_called_once_with(mock_remote_file, client=mock_client_instance)
 
   @mock.patch("huggingface_hub.HfFileSystem")
-  @mock.patch("google.cloud.storage.Client")
+  @mock.patch.object(load_dynamic.storage, "Client")
   def test_build_gcs_cache_worker_retry_and_fail(self, mock_storage_client, mock_hf_fs):
     mock_fs_instance = mock_hf_fs.return_value
     mock_fs_instance.open.side_effect = Exception("Download failed")


### PR DESCRIPTION
## Problem
`src/maxtext/checkpoint_conversion/utils/load_dynamic.py` imports `google.cloud.storage` at module scope. In decoupled mode (`DECOUPLE_GCLOUD=TRUE`), where `google-cloud-storage` is intentionally not installed, this makes pytest collection of `tests/unit/checkpointing_test.py` fail outright, so the whole file is lost rather than just the GCS-dependent tests.
This is the same failure mode, and the same fix, as #4003 for `utils/utils.py`.
## Fix
- `load_dynamic.py`: bind `storage = gcs_storage()` instead of importing `google.cloud.storage` directly, following the existing `gcloud_stub` pattern already used elsewhere in the repo.
- `checkpointing_test.py`: three tests patched `google.cloud.storage.Client`, an attribute path that cannot be resolved when the package is absent. They now patch the module-level `load_dynamic.storage` binding, matching the existing `gcs_storage` test in the same file.
Non-decoupled behavior is unchanged: `gcs_storage()` returns the real `google.cloud.storage` module whenever it is installed.
## Test plan
- [x] `pytest tests/unit/checkpointing_test.py` with `google-cloud-storage` installed — unchanged, passes.
- [x] `DECOUPLE_GCLOUD=TRUE pytest tests/unit/checkpointing_test.py` without `google-cloud-storage` — collects and passes (previously a collection error).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
