### PR TITLE
MHC Projection Fusion

### DIFF
--- a/src/maxtext/layers/mhc.py
+++ b/src/maxtext/layers/mhc.py
@@ -191,16 +191,13 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
         out_sharding=(None,),
     )
 
-  def res_mapping(self, x: Array):
-    """Helper function for residual mapping."""
+  def res_mapping(self, h_res: Array):
+    """Helper function for residual mapping after matmul."""
     # In MaxText, we match weight precision to activations before Matmul
-    res_alpha = jnp.asarray(self.res_alpha[...], self.dtype)
     res_beta = jnp.asarray(self.res_beta[...], self.dtype)
     res_alpha_scale = jnp.asarray(self.res_alpha_scale[...], self.dtype)
 
     if self.config.enable_mhc_lite:
-      # Apply projection: (b, s, k*d) @ (k*d, k!) -> (b, s, k!)
-      h_res = jnp.einsum("bsm,mn -> bsn", x, res_alpha, precision=self.matmul_precision)
       intermediate = res_alpha_scale * h_res + res_beta[None, None, :]
       # Use float32 for numerical stability during softmax
       weights = jax.nn.softmax(intermediate.astype(jnp.float32), axis=-1).astype(self.dtype)
@@ -214,22 +211,17 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
       )
       return output
     else:
-      # Apply projection: (b, s, k*d) @ (k*d, k*k) -> (b, s, k*k)
-      h_res = jnp.einsum("bsm,mn -> bsn", x, res_alpha, precision=self.matmul_precision)
       b, s, _ = h_res.shape
       h_res = jnp.reshape(h_res, (b, s, self.k, self.k))
       intermediate = res_alpha_scale * h_res + res_beta[None, None, :, :]
       output = sinkhorn(intermediate, self.sinkhorn_iterations)
       return output
 
-  def mapping(self, x: Array, alpha_scale: Array, alpha: Array, beta: Array, scale: float, eps: float = 0.0):
-    """Helper function for both pre and post mappings."""
+  def mapping(self, h: Array, alpha_scale: Array, beta: Array, scale: float, eps: float = 0.0):
+    """Helper function for both pre and post mappings after matmul."""
     # In MaxText, we match weight precision to activations before Matmul
-    alpha = jnp.asarray(alpha, self.dtype)
     beta = jnp.asarray(beta, self.dtype)
     alpha_scale = jnp.asarray(alpha_scale, self.dtype)
-    # Apply projection: (b, s, k*d) @ (k*d, k) -> (b, s, k)
-    h = jnp.einsum("bsm,mk -> bsk", x, alpha, precision=self.matmul_precision)
     intermediate = alpha_scale * h + beta[None, None, :]
     output = scale * jax.nn.sigmoid(intermediate) + eps
     return output
@@ -260,11 +252,24 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
     # 1. Flatten the tensor, and RMS normalization
     norm_x = self.mhc_norm(jnp.reshape(x, (b, s, k * d)))
 
+    # Fused Projections
+    pre_alpha = jnp.asarray(self.pre_alpha[...], self.dtype)
+    post_alpha = jnp.asarray(self.post_alpha[...], self.dtype)
+    res_alpha = jnp.asarray(self.res_alpha[...], self.dtype)
+
+    alpha_concat = jnp.concatenate([pre_alpha, post_alpha, res_alpha], axis=-1)
+
+    # MatMul on normalized input
+    h_concat = jnp.einsum("bsm,mn -> bsn", norm_x, alpha_concat, precision=self.matmul_precision)
+
+    h_pre = h_concat[..., : self.k]
+    h_post = h_concat[..., self.k : 2 * self.k]
+    h_res = h_concat[..., 2 * self.k :]
+
     # 2. Pre mapping
     pre_mapping = self.mapping(
-        norm_x,
+        h_pre,
         self.pre_alpha_scale[...],
-        self.pre_alpha[...],
         self.pre_beta[...],
         1.0,
         eps=1e-6,
@@ -289,9 +294,8 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
 
     # 5. Post mapping
     post_mapping = self.mapping(
-        norm_x,
+        h_post,
         self.post_alpha_scale[...],
-        self.post_alpha[...],
         self.post_beta[...],
         2.0,
     )
@@ -303,7 +307,7 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
     )
 
     # 6. Residual mapping, res_out shape as [batch, seq, expansion_rate, emb]
-    res_mapping = self.res_mapping(norm_x)
+    res_mapping = self.res_mapping(h_res)
     res_out = jnp.einsum("bskd,bskm -> bsmd", x, res_mapping, precision=self.matmul_precision)
     return res_out + post_out, metadata
 

--- a/tests/unit/mhc_test.py
+++ b/tests/unit/mhc_test.py
@@ -243,8 +243,10 @@ class TestMHC(parameterized.TestCase):
       random_x = jax.random.normal(jax.random.PRNGKey(42), (b, s, k * d))
       norm_x = module.mhc_norm(random_x)
 
-      # Output from mHC-lite mapping
-      res_mapping_out = module.res_mapping(norm_x)
+      # Output from mHC-lite mapping (using post_matmul API)
+      res_alpha = jnp.asarray(module.res_alpha[...], module.dtype)
+      h_res = jnp.einsum("bsm,mn -> bsn", norm_x, res_alpha, precision=module.matmul_precision)
+      res_mapping_out = module.res_mapping(h_res)
 
       row_sums = jnp.sum(res_mapping_out, axis=-1)
       col_sums = jnp.sum(res_mapping_out, axis=-2)
@@ -252,6 +254,38 @@ class TestMHC(parameterized.TestCase):
       # Check if sums are close to 1.0
       np.testing.assert_allclose(row_sums, jnp.ones_like(row_sums), atol=1e-2)
       np.testing.assert_allclose(col_sums, jnp.ones_like(col_sums), atol=1e-2)
+
+  def test_weight_concatenation_equivalence(self):
+    """Verify that fused projection matches sequential projections."""
+    self._setup_mhc(4)
+    with nn_partitioning.axis_rules(self.config.logical_axis_rules):
+      module = mhc.ManifoldConstrainedHyperConnections(self.config, self.dim, self.mesh, self.rngs)
+
+      b, s, k, d = self.x.shape
+      x_flat = jnp.reshape(self.x, (b, s, k * d))
+      norm_x = module.mhc_norm(x_flat)
+
+      # Sequential Projections (Old way)
+      pre_alpha = jnp.asarray(module.pre_alpha[...], module.dtype)
+      post_alpha = jnp.asarray(module.post_alpha[...], module.dtype)
+      res_alpha = jnp.asarray(module.res_alpha[...], module.dtype)
+
+      h_pre_seq = jnp.einsum("bsm,mk -> bsk", norm_x, pre_alpha, precision=module.matmul_precision)
+      h_post_seq = jnp.einsum("bsm,mk -> bsk", norm_x, post_alpha, precision=module.matmul_precision)
+      h_res_seq = jnp.einsum("bsm,mn -> bsn", norm_x, res_alpha, precision=module.matmul_precision)
+
+      # Fused Projection (New way)
+      alpha_concat = jnp.concatenate([pre_alpha, post_alpha, res_alpha], axis=-1)
+      h_concat = jnp.einsum("bsm,mn -> bsn", norm_x, alpha_concat, precision=module.matmul_precision)
+
+      h_pre_fused = h_concat[..., : module.k]
+      h_post_fused = h_concat[..., module.k : 2 * module.k]
+      h_res_fused = h_concat[..., 2 * module.k :]
+
+      # Verify equivalence
+      np.testing.assert_allclose(h_pre_seq, h_pre_fused, rtol=1e-5, atol=1e-5)
+      np.testing.assert_allclose(h_post_seq, h_post_fused, rtol=1e-5, atol=1e-5)
+      np.testing.assert_allclose(h_res_seq, h_res_fused, rtol=1e-5, atol=1e-5)
 
   def test_feature_flag_gates_lite(self):
     """Verify that setting enable_mhc_lite=False falls back to Sinkhorn."""


### PR DESCRIPTION
# Description

This PR optimizes the Manifold-Constrained Hyper Connections (mHC) layer by fusing three independent projection matmuls (pre, post, and residual) into a single unified projection to reduce TPU kernel launch overhead.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.
- Manually tested for a custom model on v6e-256 chips and got a 0.3% imrpovement in TFLOPs
- Updated test_mhc_lite_doubly_stochastic to work with the updated post-matmul API. 
- Added test_weight_concatenation_equivalence to verify mathematical equivalence between the fused projection and the sequential baseline.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
