### PR TITLE
fix: refine scanned layers unroll logic for Gemma 3

### DIFF
--- a/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
@@ -41,13 +41,17 @@ from maxtext.integration.vllm.torchax_converter.qwen3_moe import Qwen3MaxTextToV
 from maxtext.integration.vllm.torchax_converter.qwen35_moe import Qwen35MaxTextToVLLMConverter
 
 
+from maxtext.integration.vllm.torchax_converter.gemma4_moe import Gemma4MaxTextToVLLMConverter
+
+
 def _create_model_converter(model_name: str, config: Any, mesh: jax.sharding.Mesh):
   """Instantiate the converter for a MaxText model name."""
-  if model_name in {"qwen3-30b-a3b", "qwen3-30b-a3b-base", "qwen3-235b-a22b"}:
-    return Qwen3MaxTextToVLLMConverter(config=config, mesh=mesh)
-  elif model_name in {"qwen3.5-35b-a3b"}:
+  if model_name.startswith("qwen3.5"):
     return Qwen35MaxTextToVLLMConverter(config=config, mesh=mesh)
-
+  elif model_name.startswith("qwen3"):
+    return Qwen3MaxTextToVLLMConverter(config=config, mesh=mesh)
+  elif model_name.startswith("gemma4"):
+    return Gemma4MaxTextToVLLMConverter(config=config, mesh=mesh)
   return None
 
 
@@ -98,7 +102,8 @@ def unroll_gemma_scanned_weights(weights):
       layer_sub_idx = int(k[container_idx + 1].split("layers_")[1])
       pattern_keys.add(layer_sub_idx)
       if hasattr(v, "shape") and len(v.shape) >= 2:
-        scan_length = max(scan_length, v.shape[1])
+        if "mlp" in k and "wi_0" in k:
+          scan_length = max(scan_length, v.shape[1])
 
   pattern_length = max(pattern_keys) + 1 if pattern_keys else 0
   logging.info("MaxTextVllmSampler: Discovered scan_length=%d, pattern_length=%d", scan_length, pattern_length)
@@ -106,17 +111,16 @@ def unroll_gemma_scanned_weights(weights):
   unrolled_count = 0
   for k, v in flat_w.items():
     if "dropout" in k or "rngs" in k:
-      new_flat_w[k] = v
       continue
 
     container_idx, container_name = _find_scanned_layer_idx(k)
 
     if container_idx != -1 and container_name in ("layers", "scanned_blocks"):
       layer_sub_idx = int(k[container_idx + 1].split("layers_")[1])
-      prefix = k[:container_idx] + ("layers",)
+      prefix = k[:container_idx]
       suffix = k[container_idx + 2 :]
 
-      if hasattr(v, "shape") and len(v.shape) > 1:
+      if hasattr(v, "shape") and len(v.shape) >= 2 and v.shape[1] == scan_length:
         v_swapped = jnp.swapaxes(v, 1, 0)
         unstacked = [v_swapped[i] for i in range(scan_length)]
       else:
@@ -124,17 +128,17 @@ def unroll_gemma_scanned_weights(weights):
 
       for i in range(scan_length):
         global_idx = i * pattern_length + layer_sub_idx
-        new_k = prefix + (global_idx,) + suffix
+        new_k = prefix + (f"layers_{global_idx}",) + suffix
         new_flat_w[new_k] = unstacked[i]
         unrolled_count += 1
 
     elif container_idx != -1 and container_name == "layers_remainder":
       layer_sub_idx = int(k[container_idx + 1].split("layers_")[1])
-      prefix = k[:container_idx] + ("layers",)
+      prefix = k[:container_idx]
       suffix = k[container_idx + 2 :]
 
       global_idx = scan_length * pattern_length + layer_sub_idx
-      new_k = prefix + (global_idx,) + suffix
+      new_k = prefix + (f"layers_{global_idx}",) + suffix
       new_flat_w[new_k] = v
       unrolled_count += 1
     else:

--- a/tests/post_training/unit/vllm_rollout_unroll_test.py
+++ b/tests/post_training/unit/vllm_rollout_unroll_test.py
@@ -69,6 +69,10 @@ class GemmaScannedWeightsUnrollTest(unittest.TestCase):
     arr0[:, 1, :] = 2
     arr0[:, 2, :] = 4
 
+    # Shared attention weight (broadcast across scan length)
+    attn0 = np.zeros((2, 1))
+    attn0[:, :] = 9
+
     # For layers_1, values should be 1, 3, 5
     arr1 = np.zeros((2, 3, 1))
     arr1[:, 0, :] = 1
@@ -79,15 +83,17 @@ class GemmaScannedWeightsUnrollTest(unittest.TestCase):
         "decoder": {
             "layers": {
                 "layers_0": {
-                    "attn": {"wq": arr0},
+                    "mlp": {"wi_0": arr0},
+                    "attn": {"wq": attn0},
+                    "dropout": {"rngs": {"params": {"count": np.ones((5,))}}},
                 },
                 "layers_1": {
-                    "attn": {"wq": arr1},
+                    "mlp": {"wi_0": arr1},
                 },
             },
             "layers_remainder": {
                 "layers_0": {
-                    "attn": {"wq": np.array([[6, 6]]).transpose()},  # shape (2, 1)
+                    "mlp": {"wi_0": np.array([[6, 6]]).transpose()},  # shape (2, 1)
                 }
             },
         }
@@ -98,25 +104,32 @@ class GemmaScannedWeightsUnrollTest(unittest.TestCase):
     # Check unrolled structure
     decoder_dict = unrolled["decoder"]
 
-    # Should contain keys 0 to 6 under layers
-    self.assertIn(0, decoder_dict["layers"])
-    self.assertIn(1, decoder_dict["layers"])
-    self.assertIn(2, decoder_dict["layers"])
-    self.assertIn(3, decoder_dict["layers"])
-    self.assertIn(4, decoder_dict["layers"])
-    self.assertIn(5, decoder_dict["layers"])
-    self.assertIn(6, decoder_dict["layers"])
+    # Should contain keys layers_0 to layers_6
+    self.assertIn("layers_0", decoder_dict)
+    self.assertIn("layers_1", decoder_dict)
+    self.assertIn("layers_2", decoder_dict)
+    self.assertIn("layers_3", decoder_dict)
+    self.assertIn("layers_4", decoder_dict)
+    self.assertIn("layers_5", decoder_dict)
+    self.assertIn("layers_6", decoder_dict)
 
-    self.assertIsInstance(list(decoder_dict["layers"].keys())[0], int)
+    self.assertIsInstance(list(decoder_dict.keys())[0], str)
+
+    # Verify dropout was dropped
+    self.assertNotIn("dropout", decoder_dict["layers_0"])
 
     # Check that values are correctly sliced
-    np.testing.assert_array_equal(decoder_dict["layers"][0]["attn"]["wq"], np.array([[0], [0]]))
-    np.testing.assert_array_equal(decoder_dict["layers"][1]["attn"]["wq"], np.array([[1], [1]]))
-    np.testing.assert_array_equal(decoder_dict["layers"][2]["attn"]["wq"], np.array([[2], [2]]))
-    np.testing.assert_array_equal(decoder_dict["layers"][3]["attn"]["wq"], np.array([[3], [3]]))
-    np.testing.assert_array_equal(decoder_dict["layers"][4]["attn"]["wq"], np.array([[4], [4]]))
-    np.testing.assert_array_equal(decoder_dict["layers"][5]["attn"]["wq"], np.array([[5], [5]]))
-    np.testing.assert_array_equal(decoder_dict["layers"][6]["attn"]["wq"], np.array([[6], [6]]))
+    np.testing.assert_array_equal(decoder_dict["layers_0"]["mlp"]["wi_0"], np.array([[0], [0]]))
+    np.testing.assert_array_equal(decoder_dict["layers_1"]["mlp"]["wi_0"], np.array([[1], [1]]))
+    np.testing.assert_array_equal(decoder_dict["layers_2"]["mlp"]["wi_0"], np.array([[2], [2]]))
+    np.testing.assert_array_equal(decoder_dict["layers_3"]["mlp"]["wi_0"], np.array([[3], [3]]))
+    np.testing.assert_array_equal(decoder_dict["layers_4"]["mlp"]["wi_0"], np.array([[4], [4]]))
+    np.testing.assert_array_equal(decoder_dict["layers_5"]["mlp"]["wi_0"], np.array([[5], [5]]))
+    np.testing.assert_array_equal(decoder_dict["layers_6"]["mlp"]["wi_0"], np.array([[6], [6]]))
+
+    # Check that shared attention weight was broadcasted
+    np.testing.assert_array_equal(decoder_dict["layers_0"]["attn"]["wq"], np.array([[9], [9]]))
+    np.testing.assert_array_equal(decoder_dict["layers_2"]["attn"]["wq"], np.array([[9], [9]]))
 
   @pytest.mark.cpu_only
   def test_correctly_unrolls_gemma3_gemma4_scanned_blocks(self):
@@ -135,15 +148,15 @@ class GemmaScannedWeightsUnrollTest(unittest.TestCase):
         "decoder": {
             "scanned_blocks": {
                 "layers_0": {
-                    "attn": {"wq": arr0},
+                    "mlp": {"wi_0": arr0},
                 },
                 "layers_1": {
-                    "attn": {"wq": arr1},
+                    "mlp": {"wi_0": arr1},
                 },
             },
             "layers_remainder": {
                 "layers_0": {
-                    "attn": {"wq": np.array([[6, 6]]).transpose()},
+                    "mlp": {"wi_0": np.array([[6, 6]]).transpose()},
                 }
             },
         }
@@ -152,8 +165,8 @@ class GemmaScannedWeightsUnrollTest(unittest.TestCase):
     unrolled = unroll_gemma_scanned_weights(weights)
 
     decoder_dict = unrolled["decoder"]
-    self.assertIn(0, decoder_dict["layers"])
-    self.assertIn(6, decoder_dict["layers"])
-    self.assertIsInstance(list(decoder_dict["layers"].keys())[0], int)
-    np.testing.assert_array_equal(decoder_dict["layers"][0]["attn"]["wq"], np.array([[0], [0]]))
-    np.testing.assert_array_equal(decoder_dict["layers"][6]["attn"]["wq"], np.array([[6], [6]]))
+    self.assertIn("layers_0", decoder_dict)
+    self.assertIn("layers_6", decoder_dict)
+    self.assertIsInstance(list(decoder_dict.keys())[0], str)
+    np.testing.assert_array_equal(decoder_dict["layers_0"]["mlp"]["wi_0"], np.array([[0], [0]]))
+    np.testing.assert_array_equal(decoder_dict["layers_6"]["mlp"]["wi_0"], np.array([[6], [6]]))


### PR DESCRIPTION
# Description

   The `unroll_gemma_scanned_weights` workaround—specifically designed to unstack Gemma 3 scanned blocks due to Tunix's limitations—was previously formatting the unrolled keys incorrectly (using raw integers for the layer index). This PR fixes : 
1. the key generation logic to correctly format the unrolled layers as strings (e.g., changing the tuple injection from `(0,)` to `("layers_0",)`), which aligns with the expected dictionary structure for downstream weight mapping. 
2. it refines the `scan_length` detection to safely check for the `mlp.wi_0` architectural pattern.


# Tests

We run `train_rl.py` for both scanned and unscanned layers. Both should return normal sentences

## Scanned layers
Config: `scan_layers=true` and `use_standalone_converter=True`
- [script](https://paste.googleplex.com/6090437621317632)
- [log](https://paste.googleplex.com/6408436832141312)

## Unscanned layers
Config : `scan_layers=false` 
- [script](https://paste.googleplex.com/5547881313468416)
- [log](https://paste.googleplex.com/6483745568849920)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
