### PR TITLE
Run selected tests in Decoupled mode on CPU in CI

### DIFF
--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -223,8 +223,9 @@ jobs:
       - name: Run Targeted Decoupled Tests
         if: inputs.flavor == 'cpu-unit'
         run: |
-          echo "Running targeted fragile tests in decoupled mode (DECOUPLE_GCLOUD=TRUE)..."
+          echo "Running targeted tests in decoupled mode (DECOUPLE_GCLOUD=TRUE)..."
           export DECOUPLE_GCLOUD=TRUE
+
           $PYTHON_EXE -m pytest -v -n auto -m "decoupled_target" \
             --junitxml=test-results-decoupled-targeted.xml
 

--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -220,6 +220,15 @@ jobs:
               ${INPUTS_PYTEST_EXTRA_ARGS}
           fi
 
+      - name: Run Targeted Decoupled Tests
+        if: inputs.flavor == 'cpu-unit'
+        run: |
+          echo "Running targeted fragile tests in decoupled mode (DECOUPLE_GCLOUD=TRUE)..."
+          export DECOUPLE_GCLOUD=TRUE
+          $PYTHON_EXE -m pytest -v -n auto -m "decoupled_target" \
+            --junitxml=test-results-decoupled-targeted.xml
+
+
         env:
           INPUTS_IS_SCHEDULED_RUN: ${{ inputs.is_scheduled_run }}
           INPUTS_PYTEST_MARKER: ${{ inputs.pytest_marker }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -36,7 +36,8 @@ markers =
     cpu_only: marks tests to be run on CPUs only
     decoupled: tests that validate offline / DECOUPLE_GCLOUD=TRUE mode.
 	       NOTE: this marker is not to be used manually, it is auto-
-	       applied to tests with external_* or tpu_only marker. 
+	       applied to tests without external_* or tpu_only marker. 
+
     scheduled_only: marks tests to run only on scheduled CI runs
     newly_added: newly introduced or modified tests in PRs, executed even if scheduled_only
     integration_test: tests exercising larger portions of the system,

--- a/pytest.ini
+++ b/pytest.ini
@@ -45,4 +45,7 @@ markers =
     external_serving: JetStream / serving / decode server components
     external_training: goodput integrations
     post_training: marks tests for post-training code paths.
+    decoupled_target: tests to be additionally validated in decoupled mode
+                      (DECOUPLE_GCLOUD=TRUE) on CPU in CI.
+
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -46,6 +46,9 @@ markers =
     external_training: goodput integrations
     post_training: marks tests for post-training code paths.
     decoupled_target: tests to be additionally validated in decoupled mode
-                      (DECOUPLE_GCLOUD=TRUE) on CPU in CI.
+                      (DECOUPLE_GCLOUD=TRUE) on CPU in CI. NOTE: conftest.py
+                      automatically applies the `decoupled` marker to these tests
+                      at runtime when DECOUPLE_GCLOUD=TRUE is enabled.
+
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -46,9 +46,11 @@ markers =
     external_training: goodput integrations
     post_training: marks tests for post-training code paths.
     decoupled_target: tests to be additionally validated in decoupled mode
-                      (DECOUPLE_GCLOUD=TRUE) on CPU in CI. NOTE: conftest.py
-                      automatically applies the `decoupled` marker to these tests
-                      at runtime when DECOUPLE_GCLOUD=TRUE is enabled.
+                      (DECOUPLE_GCLOUD=TRUE) on CPU in CI. NOTE: when running
+                      with DECOUPLE_GCLOUD=TRUE, conftest.py automatically
+                      selects at runtime only those tests that can run in
+                      decoupled mode (`decoupled` marker).
+
 
 
 

--- a/tests/integration/checkpoint_conversion_test.py
+++ b/tests/integration/checkpoint_conversion_test.py
@@ -23,7 +23,7 @@ import pytest
 
 from maxtext.checkpoint_conversion import to_maxtext
 
-pytestmark = [pytest.mark.integration_test]
+pytestmark = [pytest.mark.integration_test, pytest.mark.decoupled_target]
 
 
 class Qwen3CheckpointConversionTest(unittest.TestCase):

--- a/tests/unit/checkpointing_test.py
+++ b/tests/unit/checkpointing_test.py
@@ -35,7 +35,10 @@ from maxtext.common import checkpointing
 from maxtext.common import grain_utility
 import numpy as np
 import optax
+import pytest
 import safetensors.numpy
+
+pytestmark = [pytest.mark.decoupled_target]
 
 
 class BinaryChunkedStackTest(parameterized.TestCase):

--- a/tests/unit/correctness_tests_nnx_dispatch_test.py
+++ b/tests/unit/correctness_tests_nnx_dispatch_test.py
@@ -27,6 +27,10 @@ The GRPO NNX building blocks the other dispatch helpers call
 import os
 import sys
 import unittest
+import pytest
+
+pytestmark = [pytest.mark.decoupled_target]
+
 
 import jax
 import jax.numpy as jnp

--- a/tests/unit/deepseek_v4_vs_reference_test.py
+++ b/tests/unit/deepseek_v4_vs_reference_test.py
@@ -17,6 +17,10 @@
 import os
 import sys
 import unittest
+import pytest
+
+pytestmark = [pytest.mark.decoupled_target]
+
 
 # pylint: disable=import-outside-toplevel, reimported
 import jax

--- a/tests/unit/dequantize_mxfp4_test.py
+++ b/tests/unit/dequantize_mxfp4_test.py
@@ -15,7 +15,11 @@
 """Tests for dequantize_mxfp4.py (not run in GitHub runners)."""
 
 import unittest
+import pytest
 import torch
+
+pytestmark = [pytest.mark.decoupled_target]
+
 from maxtext.checkpoint_conversion.standalone_scripts import dequantize_mxfp4
 
 

--- a/tests/unit/dequantize_pack_quantized_int4_test.py
+++ b/tests/unit/dequantize_pack_quantized_int4_test.py
@@ -59,7 +59,6 @@ def _quantize_per_group(w_fp32: torch.Tensor, group_size: int = INT4_GROUP_SIZE)
 
 class DequantizePackQuantizedInt4Test(unittest.TestCase):
 
-
   def setUp(self):
     torch.manual_seed(0)
 
@@ -72,6 +71,7 @@ class DequantizePackQuantizedInt4Test(unittest.TestCase):
     w_int, _ = _quantize_per_group(w_fp)
     packed = pack_to_int32(w_int, num_bits=_NUM_BITS)
     self.assertEqual(packed.dtype, torch.int32)
+
     self.assertEqual(tuple(packed.shape), (out_features, in_features // 8))
 
     canonical = unpack_from_int32(packed, num_bits=_NUM_BITS, shape=torch.Size([out_features, in_features]))

--- a/tests/unit/dequantize_pack_quantized_int4_test.py
+++ b/tests/unit/dequantize_pack_quantized_int4_test.py
@@ -28,6 +28,9 @@ import unittest
 import pytest
 import torch
 
+pytestmark = [pytest.mark.cpu_only, pytest.mark.decoupled_target]
+
+
 from compressed_tensors.compressors.quantized_compressors.pack_quantized import (
     pack_to_int32,
     unpack_from_int32,
@@ -54,8 +57,8 @@ def _quantize_per_group(w_fp32: torch.Tensor, group_size: int = INT4_GROUP_SIZE)
   return w_int.reshape(out_features, in_features), scale.squeeze(-1)
 
 
-@pytest.mark.cpu_only
 class DequantizePackQuantizedInt4Test(unittest.TestCase):
+
 
   def setUp(self):
     torch.manual_seed(0)

--- a/tests/unit/grpo_nnx_test.py
+++ b/tests/unit/grpo_nnx_test.py
@@ -24,7 +24,11 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
+import pytest
 from flax import nnx
+
+pytestmark = [pytest.mark.decoupled_target]
+
 
 from maxtext.common import train_state_nnx
 from maxtext.experimental.rl import grpo_trainer

--- a/tests/unit/hf_checkpoint_conversion_test.py
+++ b/tests/unit/hf_checkpoint_conversion_test.py
@@ -18,6 +18,10 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.decoupled_target]
+
 from maxtext.utils.max_utils import permute_to_match_maxtext_rope, unpermute_from_match_maxtext_rope
 from maxtext.checkpoint_conversion import to_huggingface as to_hf
 from maxtext.checkpoint_conversion.to_huggingface import (

--- a/tests/unit/param_mapping_test.py
+++ b/tests/unit/param_mapping_test.py
@@ -17,6 +17,10 @@
 import unittest
 from unittest import mock
 import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.decoupled_target]
+
 
 from maxtext.checkpoint_conversion.utils import param_mapping
 


### PR DESCRIPTION
This PR adds a targeted decoupled test suite executed with `DECOUPLE_GCLOUD=TRUE` on CPU in CI to validate fragile offline components (checkpointing, quantization, GRPO NNX loss dispatch).

Changes:
1. **`pytest.ini`**: Registered `decoupled_target` marker ("tests to be additionally validated in decoupled mode (DECOUPLE_GCLOUD=TRUE) on CPU in CI.").
2. **Test Modules**: Tagged 9 target test files across `tests/unit/` and `tests/integration/` with `pytestmark = [pytest.mark.decoupled_target]`.
3. **CI Pipeline ([.github/workflows/run_tests_against_package.yml](file:///.github/workflows/run_tests_against_package.yml))**: Added a step under `inputs.flavor == 'cpu-unit'` executing `$PYTHON_EXE -m pytest -v -n auto -m "decoupled_target"`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
