### PR TITLE
Add Simple-evals supports to maxtext runner

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         args:
           - '-w'
           - '--skip="*.txt,pylintrc,.*,src/maxtext/assets/*,src/maxtext/input_pipeline/protos/*"'
-          - '-L ND,nd,sems,TE,ROUGE,rouge,astroid,ags,dout'
+          - '-L ND,nd,sems,TE,te,als,ROUGE,rouge,astroid,ags,dout'
           - '.'
         additional_dependencies:
           - tomli
@@ -30,7 +30,7 @@ repos:
         args:
           - '--disable=R0401,R0917,W0201,W0613'
           - "--ignore-patterns='.pytype,.*pyi$'"
-          - '--ignore-paths=src/maxtext/input_pipeline/protos'
+          - '--ignore-paths=src/maxtext/input_pipeline/protos|src/maxtext/eval/simple_evals_template'
 
   #  - repo: https://github.com/google/pytype
   #    rev: 2024.10.11

--- a/pylintrc
+++ b/pylintrc
@@ -9,7 +9,7 @@
 
 # Add files or directories to the blocked list. They should be base names, not
 # paths.
-ignore=third_party
+ignore=simple_evals_template
 
 # Add files or directories matching the regex patterns to the blocked list. The
 # regex matches against base names, not paths.

--- a/src/maxtext/eval/README.md
+++ b/src/maxtext/eval/README.md
@@ -7,7 +7,7 @@ A vLLM-native evaluation framework for MaxText models supporting harness-based e
 All runners share a single entry point:
 
 ```bash
-python -m maxtext.eval.runner.run --runner <eval|lm_eval|evalchemy> [flags]
+python -m maxtext.eval.runner.run --runner <eval|lm_eval|evalchemy|simple_evals> [flags]
 ```
 
 ### Custom dataset (MLPerf OpenOrca, ROUGE scoring, Other)
@@ -76,6 +76,66 @@ python -m maxtext.eval.runner.run \
   --max_model_len 8192 \
   --tensor_parallel_size 4 \
   --hf_token $HF_TOKEN
+```
+
+### Simple Evals (OpenAI simple-evals)
+
+Runs OpenAI's [simple-evals](https://github.com/openai/simple-evals) benchmarks
+against the vLLM server's OpenAI-compatible `/v1/chat/completions` endpoint.
+
+Requires: `pip install aiohttp openai jinja2 numpy pandas scipy requests tqdm`
+
+Phase 1 supports grader-free evals only: `mmlu`, `gpqa`, `gsm8k`, `drop`, `mgsm`,
+`mgsm_en`, `aime2024`, `aime2025`. Grader-dependent evals (math, simpleqa, browsecomp,
+healthbench) need an LLM grader endpoint and are not yet supported.
+
+`mmlu`, `gpqa`, `drop`, `mgsm` are based on the vendored implementations from
+[openai/simple-evals](https://github.com/openai/simple-evals); `gsm8k` and
+`aime2024`/`aime2025` are not part of upstream simple-evals and are
+MaxText-authored (`maxtext.eval.simple_evals_template`) following the same
+grader-free Eval conventions. `mgsm` matches upstream's 11-language suite;
+`mgsm_en` is the explicitly named English-only variant.
+
+```bash
+python -m maxtext.eval.runner.run \
+  --runner simple_evals \
+  --checkpoint_path gs://<bucket>/checkpoints/0/items \
+  --model_name llama3.1-8b \
+  --hf_path meta-llama/Llama-3.1-8B-Instruct \
+  --tasks mmlu gpqa gsm8k drop mgsm aime2024 aime2025 \
+  --base_output_directory gs://<bucket>/ \
+  --run_name simple_evals_run \
+  --max_model_len 8192 \
+  --tensor_parallel_size 4 \
+  --num_samples 50 \
+  --hf_token $HF_TOKEN
+```
+
+Simple-evals specific flags:
+
+| Flag | Description |
+|---|---|
+| `--tasks` | Space-separated task names (`mmlu`, `gpqa`, `gsm8k`, `drop`, `mgsm`, `mgsm_en`, `aime2024`, `aime2025`). |
+| `--num_samples` | Limit examples per task; for MGSM variants this is per language (None = full dataset). |
+| `--n_repeats` | Repeats per example (defaults: upstream GPQA=4, AIME=1; forced to 1 with `--num_samples`). |
+| `--max_tokens` | Max tokens per generation (default: 2048). |
+| `--temperature` | Sampling temperature (upstream default: 0.5). |
+| `--concurrency` | Task worker count and maximum in-flight requests. Omit for automatic selection from CPU count, accelerator count, `max_num_seqs`, and chat batch capacity. This is the only request-pressure setting users normally need to tune. |
+| `--log-debug-info` | Write a timestamp-matched `.debug.txt` report beside the result JSON. The report includes request/token throughput, latency percentiles, retry and terminal-error rates, output truncation, answer-extraction failures, confidence intervals, and bounded samples of final, reasoning, and raw model output. Reasoning and raw output remain diagnostic-only and are never graded. |
+| `--continue-on-request-error` | Score terminal request failures as zero instead of aborting. This is independent of debug logging. |
+
+Debug logging is observational and does not change request-failure behavior.
+When `--continue-on-request-error` is enabled, failed requests count as zero in
+official accuracy. The debug report also shows diagnostic accuracy excluding
+infrastructure failures; that diagnostic must not be used as the published
+benchmark score.
+
+Before a long TPU benchmark, run the simple-evals unit suite, which checks
+Harmony output separation, request-error behavior, concurrency, and result
+reporting:
+
+```bash
+pytest tests/unit/eval/test_simple_evals_runner.py
 ```
 
 ## Common Flags

--- a/src/maxtext/eval/reporting/simple_evals_debug_reporter.py
+++ b/src/maxtext/eval/reporting/simple_evals_debug_reporter.py
@@ -1,0 +1,318 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Human-readable diagnostics for the OpenAI simple-evals runner."""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import statistics
+import threading
+import time
+from collections import Counter, defaultdict
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SimpleEvalsDebugCollector:
+  """Thread-safe collection of logical request diagnostics."""
+
+  def __init__(self) -> None:
+    self._lock = threading.Lock()
+    self._next_id = 1
+    self._active = 0
+    self.peak_in_flight = 0
+    self.current_task = "unknown"
+    self.records: list[dict[str, Any]] = []
+
+  def set_task(self, task: str) -> None:
+    with self._lock:
+      self.current_task = task
+
+  def begin(self, messages: list[dict[str, Any]]) -> dict[str, Any]:
+    with self._lock:
+      request_id = self._next_id
+      self._next_id += 1
+      self._active += 1
+      self.peak_in_flight = max(self.peak_in_flight, self._active)
+      task = self.current_task
+    return {
+        "request_id": request_id,
+        "task": task,
+        "prompt_messages": messages,
+        "started_monotonic": time.monotonic(),
+        "attempt_count": 0,
+        "attempt_errors": [],
+    }
+
+  def finish(self, record: dict[str, Any]) -> None:
+    record["latency_s"] = time.monotonic() - record.pop("started_monotonic")
+    with self._lock:
+      self.records.append(record)
+      self._active -= 1
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+  if not values:
+    return None
+  ordered = sorted(values)
+  position = (len(ordered) - 1) * percentile
+  lower = math.floor(position)
+  upper = math.ceil(position)
+  if lower == upper:
+    return ordered[lower]
+  return ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower)
+
+
+def _fmt_number(value: float | int | None, digits: int = 2) -> str:
+  if value is None:
+    return "n/a"
+  if isinstance(value, int):
+    return str(value)
+  return f"{value:.{digits}f}"
+
+
+def _rate(numerator: int, denominator: int) -> str:
+  return "n/a" if denominator == 0 else f"{numerator / denominator:.2%} ({numerator}/{denominator})"
+
+
+def _latency_line(records: list[dict[str, Any]]) -> str:
+  values = [float(r["latency_s"]) for r in records if r.get("latency_s") is not None]
+  if not values:
+    return "n/a"
+  return (
+      f"mean={statistics.fmean(values):.3f}s p50={_percentile(values, 0.50):.3f}s "
+      f"p90={_percentile(values, 0.90):.3f}s p95={_percentile(values, 0.95):.3f}s "
+      f"p99={_percentile(values, 0.99):.3f}s max={max(values):.3f}s"
+  )
+
+
+def _token_line(records: list[dict[str, Any]], key: str) -> str:
+  values = [int(r[key]) for r in records if r.get(key) is not None]
+  if not values:
+    return "n/a"
+  return (
+      f"mean={statistics.fmean(values):.1f} p50={_percentile(values, 0.50):.1f} "
+      f"p95={_percentile(values, 0.95):.1f} max={max(values)}"
+  )
+
+
+def _attempt_latency_line(records: list[dict[str, Any]]) -> str:
+  """Format latency statistics across failed and successful attempts."""
+  values = [
+      float(error["latency_s"])
+      for record in records
+      for error in record.get("attempt_errors", [])
+      if error.get("latency_s") is not None
+  ]
+  values.extend(
+      float(record["successful_attempt_latency_s"])
+      for record in records
+      if record.get("successful_attempt_latency_s") is not None
+  )
+  if not values:
+    return "n/a"
+  return (
+      f"mean={statistics.fmean(values):.3f}s p50={_percentile(values, 0.50):.3f}s "
+      f"p95={_percentile(values, 0.95):.3f}s max={max(values):.3f}s"
+  )
+
+
+def _clip(value: Any, limit: int) -> str:
+  text = str(value)
+  if len(text) <= limit:
+    return text
+  return text[:limit] + f"\n... [report-clipped {len(text) - limit} characters]"
+
+
+def _prompt_text(record: dict[str, Any]) -> str:
+  return "\n\n".join(
+      f"[{message.get('role', 'unknown')}] {message.get('content', '')}" for message in record.get("prompt_messages", [])
+  )
+
+
+def _example_map(eval_results: dict[str, Any]) -> dict[int, dict[str, Any]]:
+  examples: dict[int, dict[str, Any]] = {}
+  for result in eval_results.values():
+    metadata = (result.metadata or {}).get("example_level_metadata", [])
+    for item in metadata:
+      if item and item.get("request_id") is not None:
+        examples[int(item["request_id"])] = item
+  return examples
+
+
+def _wilson_interval(correct: int, total: int) -> tuple[float, float] | None:
+  if total == 0:
+    return None
+  z = 1.96
+  p = correct / total
+  denominator = 1 + z * z / total
+  center = (p + z * z / (2 * total)) / denominator
+  margin = z * math.sqrt(p * (1 - p) / total + z * z / (4 * total * total)) / denominator
+  return center - margin, center + margin
+
+
+def build_debug_report(
+    collector: SimpleEvalsDebugCollector,
+    eval_results: dict[str, Any],
+    task_durations: dict[str, float],
+    model_name: str,
+    max_tokens: int,
+    max_model_len: int,
+) -> str:
+  """Build a bounded plain-text report from request and grading records."""
+  records = sorted(collector.records, key=lambda record: int(record["request_id"]))
+  examples = _example_map(eval_results)
+  lines = [
+      "SIMPLE-EVALS DEBUG REPORT",
+      "=" * 80,
+      f"model: {model_name}",
+      f"tasks: {', '.join(eval_results)}",
+      f"max_tokens: {max_tokens}",
+      f"max_model_len: {max_model_len}",
+      f"logical_requests: {len(records)}",
+      f"peak_in_flight: {collector.peak_in_flight}",
+      "",
+  ]
+
+  for task in list(eval_results) + ["OVERALL"]:
+    task_records = records if task == "OVERALL" else [r for r in records if r.get("task") == task]
+    successful = [r for r in task_records if r.get("status") == "success"]
+    terminal = [r for r in task_records if r.get("status") in ("error", "bad_request")]
+    retried = [r for r in task_records if int(r.get("attempt_count", 0)) > 1]
+    recovered = [r for r in successful if int(r.get("attempt_count", 0)) > 1]
+    truncated = [r for r in successful if r.get("finish_reason") == "length"]
+    empty = [r for r in successful if not str(r.get("response_text") or "").strip()]
+    missing_usage = [r for r in successful if r.get("prompt_tokens") is None or r.get("completion_tokens") is None]
+    saturated = [r for r in successful if int(r.get("completion_tokens") or 0) >= max_tokens]
+    attempts = sum(int(r.get("attempt_count", 0)) for r in task_records)
+    failed_attempts = sum(len(r.get("attempt_errors", [])) for r in task_records)
+    duration = sum(task_durations.values()) if task == "OVERALL" else task_durations.get(task, 0.0)
+    prompt_tokens = sum(int(r.get("prompt_tokens") or 0) for r in successful)
+    completion_tokens = sum(int(r.get("completion_tokens") or 0) for r in successful)
+    task_examples = [examples[int(r["request_id"])] for r in task_records if int(r["request_id"]) in examples]
+    incorrect = [e for e in task_examples if float(e.get("score") or 0.0) == 0.0]
+    extraction_failures = [e for e in task_examples if e.get("extracted_answer") is None]
+    scorable_noninfra = [e for e in task_examples if e.get("request_status") not in ("error", "bad_request")]
+    adjusted_correct = sum(float(e.get("score") or 0.0) > 0.0 for e in scorable_noninfra)
+    correct = sum(float(e.get("score") or 0.0) > 0.0 for e in task_examples)
+    truncated_ids = {int(r["request_id"]) for r in truncated}
+    truncated_examples = [examples[request_id] for request_id in truncated_ids if request_id in examples]
+    nontruncated_examples = [
+        examples[int(r["request_id"])]
+        for r in successful
+        if int(r["request_id"]) not in truncated_ids and int(r["request_id"]) in examples
+    ]
+    truncated_correct = sum(float(e.get("score") or 0.0) > 0.0 for e in truncated_examples)
+    nontruncated_correct = sum(float(e.get("score") or 0.0) > 0.0 for e in nontruncated_examples)
+    interval = _wilson_interval(correct, len(task_examples))
+    context_pressure = [r for r in successful if int(r.get("prompt_tokens") or 0) + max_tokens >= 0.9 * max_model_len]
+
+    lines.extend(
+        [
+            f"[{task}]",
+            f"wall_time_s: {_fmt_number(duration)}",
+            f"throughput_requests_per_s: {_fmt_number(len(task_records) / duration if duration else None)}",
+            f"throughput_completion_tokens_per_s: {_fmt_number(completion_tokens / duration if duration else None)}",
+            "throughput_total_tokens_per_s: "
+            + _fmt_number((prompt_tokens + completion_tokens) / duration if duration else None),
+            f"latency: {_latency_line(task_records)}",
+            f"physical_attempt_latency: {_attempt_latency_line(task_records)}",
+            f"prompt_tokens: {_token_line(successful, 'prompt_tokens')}",
+            f"completion_tokens: {_token_line(successful, 'completion_tokens')}",
+            f"terminal_error_rate: {_rate(len(terminal), len(task_records))}",
+            f"physical_attempt_failure_rate: {_rate(failed_attempts, attempts)}",
+            f"retry_rate: {_rate(len(retried), len(task_records))}",
+            f"recovered_after_retry_rate: {_rate(len(recovered), len(task_records))}",
+            f"empty_response_rate: {_rate(len(empty), len(successful))}",
+            f"missing_usage_metadata_rate: {_rate(len(missing_usage), len(successful))}",
+            f"output_truncation_rate: {_rate(len(truncated), len(successful))}",
+            f"completion_token_saturation_rate: {_rate(len(saturated), len(successful))}",
+            f"context_pressure_at_least_90pct: {_rate(len(context_pressure), len(successful))}",
+            f"incorrect_answer_rate: {_rate(len(incorrect), len(task_examples))}",
+            f"answer_extraction_failure_rate: {_rate(len(extraction_failures), len(task_examples))}",
+            f"grading_coverage: {_rate(len(task_examples), len(task_records))}",
+            f"official_accuracy: {_rate(correct, len(task_examples))}",
+            f"diagnostic_accuracy_excluding_infrastructure_errors: {_rate(adjusted_correct, len(scorable_noninfra))}",
+            f"truncated_response_accuracy: {_rate(truncated_correct, len(truncated_examples))}",
+            f"nontruncated_response_accuracy: {_rate(nontruncated_correct, len(nontruncated_examples))}",
+            "accuracy_95pct_wilson_interval: " + (f"[{interval[0]:.2%}, {interval[1]:.2%}]" if interval else "n/a"),
+            f"finish_reasons: {dict(Counter(str(r.get('finish_reason')) for r in successful))}",
+            "error_types: " + str(dict(Counter(str(r.get("error_type")) for r in terminal if r.get("error_type")))),
+            "",
+        ]
+    )
+
+  categories: dict[str, list[dict[str, Any]]] = defaultdict(list)
+  for record in records:
+    example = examples.get(int(record["request_id"]), {})
+    status = record.get("status")
+    if status in ("error", "bad_request"):
+      categories["terminal inference failures"].append(record)
+    if record.get("finish_reason") == "length":
+      categories["truncated responses"].append(record)
+    if example and example.get("extracted_answer") is None:
+      categories["answer extraction failures"].append(record)
+    elif float(example.get("score") or 0.0) == 0.0 and status == "success":
+      categories["incorrect answers"].append(record)
+  categories["slowest successful requests"] = sorted(
+      (r for r in records if r.get("status") == "success"),
+      key=lambda r: float(r.get("latency_s") or 0.0),
+      reverse=True,
+  )
+
+  lines.extend(["DIAGNOSTIC SAMPLES", "=" * 80, "Each category is capped at five examples.", ""])
+  for category, samples in categories.items():
+    lines.append(f"-- {category} --")
+    for record in samples[:5]:
+      example = examples.get(int(record["request_id"]), {})
+      sample_lines = [
+          f"request_id={record['request_id']} task={record.get('task')} status={record.get('status')} "
+          f"latency_s={float(record.get('latency_s') or 0.0):.3f}",
+          f"attempts={record.get('attempt_count')} finish_reason={record.get('finish_reason')} "
+          f"prompt_tokens={record.get('prompt_tokens')} completion_tokens={record.get('completion_tokens')}",
+          f"score={example.get('score')} correct_answer={example.get('correct_answer')!r} "
+          f"extracted_answer={example.get('extracted_answer')!r}",
+          f"error={_clip(record.get('error_detail') or '', 1000)}",
+          "prompt:\n" + _clip(_prompt_text(record), 2000),
+          "final_output:\n" + _clip(record.get("response_text") or "", 4000),
+      ]
+      if record.get("reasoning_text") is not None:
+        sample_lines.append("reasoning (diagnostic-only):\n" + _clip(record["reasoning_text"], 4000))
+      if record.get("raw_response_text") is not None:
+        sample_lines.append("raw_output (diagnostic-only):\n" + _clip(record["raw_response_text"], 4000))
+      sample_lines.append("")
+      lines.extend(sample_lines)
+    if not samples:
+      lines.append("none\n")
+  return "\n".join(lines).rstrip() + "\n"
+
+
+def write_debug_report(report: str, results_path: str, json_local_path: str) -> str:
+  """Write a debug report beside its JSON artifact and return the local path."""
+  debug_filename = os.path.splitext(os.path.basename(json_local_path))[0] + ".debug.txt"
+  local_path = os.path.join(os.path.dirname(json_local_path), debug_filename)
+  with open(local_path, "w", encoding="utf-8") as report_file:
+    report_file.write(report)
+  if results_path.startswith("gs://"):
+    from maxtext.utils.gcs_utils import upload_blob  # pylint: disable=import-outside-toplevel
+
+    upload_blob(f"{results_path.rstrip('/')}/{debug_filename}", local_path)
+    logger.info("Debug report written to %s/%s", results_path.rstrip("/"), debug_filename)
+  else:
+    logger.info("Debug report written to %s", local_path)
+  return os.path.abspath(local_path)

--- a/src/maxtext/eval/runner/async_client.py
+++ b/src/maxtext/eval/runner/async_client.py
@@ -32,6 +32,13 @@ _DEFAULT_MAX_TOKENS = 1024
 _DEFAULT_TEMPERATURE = 0.0
 _COMPLETIONS_PATH = "/v1/completions"
 _REQUEST_TIMEOUT_S = 600
+_DEFAULT_MAX_RETRIES = 3
+_RETRY_BACKOFF_S = 5.0
+
+
+def _is_retryable_http_status(status: int) -> bool:
+  """Return whether an HTTP response may succeed when retried."""
+  return status in (408, 409, 429) or status >= 500
 
 
 @dataclass
@@ -61,6 +68,7 @@ async def generate_batch_async(
     temperature: float = _DEFAULT_TEMPERATURE,
     concurrency: int = _DEFAULT_CONCURRENCY,
     request_timeout: int = _REQUEST_TIMEOUT_S,
+    max_retries: int = _DEFAULT_MAX_RETRIES,
 ) -> list[GenerationResult]:
   """Send all prompts concurrently and return results in prompt order.
 
@@ -72,6 +80,8 @@ async def generate_batch_async(
     temperature: Sampling temperature.
     concurrency: Maximum number of in-flight requests at once.
     request_timeout: Per-request wall-clock timeout in seconds.
+    max_retries: Retries on timeout/connection error before giving up
+      (0 = single attempt, no retry).
 
   Returns:
     List of GenerationResult in the same order as prompts.
@@ -89,26 +99,41 @@ async def generate_batch_async(
         "max_tokens": max_tokens,
         "temperature": temperature,
     }
-    async with semaphore:
-      t0 = time.monotonic()
+    t0 = time.monotonic()
+    last_error = ""
+    for attempt in range(max_retries + 1):
+      retryable = True
       try:
-        async with session.post(api_url, json=payload) as resp:
-          if resp.status != 200:
-            body = await resp.text()
-            return GenerationResult(error=f"HTTP {resp.status}: {body[:200]}")
-          data = await resp.json()
+        async with semaphore:
+          async with session.post(api_url, json=payload) as resp:
+            if resp.status != 200:
+              body = await resp.text()
+              last_error = f"HTTP {resp.status}: {body[:200]}"
+              retryable = _is_retryable_http_status(resp.status)
+            else:
+              data = await resp.json()
+              latency = time.monotonic() - t0
+              choice = data["choices"][0]
+              usage = data.get("usage", {})
+              return GenerationResult(
+                  text=choice.get("text", ""),
+                  prompt_tokens=usage.get("prompt_tokens", 0),
+                  completion_tokens=usage.get("completion_tokens", 0),
+                  latency_s=latency,
+              )
       except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-        return GenerationResult(error=str(exc))
-      latency = time.monotonic() - t0
+        last_error = str(exc)
 
-    choice = data["choices"][0]
-    usage = data.get("usage", {})
-    return GenerationResult(
-        text=choice.get("text", ""),
-        prompt_tokens=usage.get("prompt_tokens", 0),
-        completion_tokens=usage.get("completion_tokens", 0),
-        latency_s=latency,
-    )
+      if not retryable:
+        return GenerationResult(error=last_error, latency_s=time.monotonic() - t0)
+
+      if attempt < max_retries:
+        logger.warning("Request failed (attempt %d/%d): %s. Retrying.", attempt + 1, max_retries + 1, last_error)
+        # The semaphore covers only active I/O. Release the concurrency slot
+        # before backoff so another request can use it.
+        await asyncio.sleep(_RETRY_BACKOFF_S * (attempt + 1))
+
+    return GenerationResult(error=last_error, latency_s=time.monotonic() - t0)
 
   async with aiohttp.ClientSession(timeout=timeout) as session:
     return list(await asyncio.gather(*[_generate_one(session, p) for p in prompts]))
@@ -122,6 +147,7 @@ def generate_batch(
     temperature: float = _DEFAULT_TEMPERATURE,
     concurrency: int = _DEFAULT_CONCURRENCY,
     request_timeout: int = _REQUEST_TIMEOUT_S,
+    max_retries: int = _DEFAULT_MAX_RETRIES,
 ) -> list[GenerationResult]:
   """Synchronous wrapper around generate_batch_async."""
   return asyncio.run(
@@ -133,5 +159,6 @@ def generate_batch(
           temperature=temperature,
           concurrency=concurrency,
           request_timeout=request_timeout,
+          max_retries=max_retries,
       )
   )

--- a/src/maxtext/eval/runner/common.py
+++ b/src/maxtext/eval/runner/common.py
@@ -29,7 +29,12 @@ def resolve_token(cfg: dict, hf_token: str | None) -> str | None:
   return hf_token or os.environ.get("HF_TOKEN") or None
 
 
-def build_server_manager(cfg: dict, token: str | None) -> "VllmServerManager":
+def build_server_manager(
+    cfg: dict,
+    token: str | None,
+    *,
+    enable_chat_api: bool = False,
+) -> "VllmServerManager":
   """Build a VllmServerManager from a merged config dict.
 
   Args:
@@ -37,6 +42,7 @@ def build_server_manager(cfg: dict, token: str | None) -> "VllmServerManager":
       optional keys: tensor_parallel_size, server_host, server_port,
       max_num_batched_tokens, max_num_seqs, hf_mode, enable_expert_parallel.
     token: HuggingFace token (or None).
+    enable_chat_api: Whether this runner needs /v1/chat/completions.
 
   Returns:
     A VllmServerManager instance ready for use as a context manager.
@@ -64,6 +70,9 @@ def build_server_manager(cfg: dict, token: str | None) -> "VllmServerManager":
   expert_parallel_size = int(cfg.get("expert_parallel_size") or 1)
   data_parallel_size = int(cfg.get("data_parallel_size") or 1)
   hbm_memory_utilization = float(cfg.get("hbm_memory_utilization") or 0.3)
+  concurrency = cfg.get("concurrency")
+  if concurrency is not None:
+    concurrency = int(concurrency)
 
   server_env = {"HF_TOKEN": token} if token else None
 
@@ -80,6 +89,8 @@ def build_server_manager(cfg: dict, token: str | None) -> "VllmServerManager":
       max_num_batched_tokens=max_num_batched_tokens,
       max_num_seqs=max_num_seqs,
       hbm_memory_utilization=hbm_memory_utilization,
+      enable_chat_api=enable_chat_api,
+      concurrency=concurrency,
       env=server_env,
   )
 

--- a/src/maxtext/eval/runner/debug_utils.py
+++ b/src/maxtext/eval/runner/debug_utils.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optional memory and request diagnostics for evaluation servers."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _host_rss_bytes() -> int:
+  """Return resident host memory in bytes, or -1 when unavailable."""
+  try:
+    with open("/proc/self/status", "r", encoding="utf-8") as status_file:
+      for line in status_file:
+        if line.startswith("VmRSS:"):
+          return int(line.split()[1]) * 1024
+  except OSError:
+    pass
+
+  try:
+    import resource  # pylint: disable=import-outside-toplevel
+
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return rss if sys.platform == "darwin" else rss * 1024
+  except Exception:  # pylint: disable=broad-except
+    return -1
+
+
+def _hbm_stats() -> dict[str, int]:
+  """Return aggregate JAX device-memory statistics."""
+  try:
+    import jax  # pylint: disable=import-outside-toplevel
+
+    devices = jax.local_devices()
+    stats = {"in_use": 0, "peak": 0, "limit": 0, "ndev": len(devices)}
+    for device in devices:
+      memory = device.memory_stats() or {}
+      stats["in_use"] += memory.get("bytes_in_use", 0)
+      stats["peak"] += memory.get("peak_bytes_in_use", 0)
+      stats["limit"] += memory.get("bytes_limit", 0)
+    return stats
+  except Exception:  # pylint: disable=broad-except
+    return {}
+
+
+def _kv_cache_usage(llm: Any) -> float | None:
+  """Return vLLM KV-cache utilization when its metrics API is available."""
+  try:
+    get_metrics = getattr(getattr(llm, "llm_engine", None), "get_metrics", None)
+    if not callable(get_metrics):
+      return None
+    for metric in get_metrics():
+      name = getattr(metric, "name", "")
+      if "kv_cache_usage" in name or "gpu_cache_usage" in name:
+        return float(getattr(metric, "value"))
+  except Exception:  # pylint: disable=broad-except
+    pass
+  return None
+
+
+def memory_summary(llm: Any) -> str:
+  """Return a compact host, HBM, and KV-cache memory snapshot."""
+  hbm = _hbm_stats()
+  return (
+      f"host_rss={_host_rss_bytes()} "
+      f"hbm_in_use={hbm.get('in_use', -1)} hbm_peak={hbm.get('peak', -1)} "
+      f"hbm_limit={hbm.get('limit', -1)} ndev={hbm.get('ndev', -1)} "
+      f"kv_usage={_kv_cache_usage(llm)}"
+  )
+
+
+def log_request_diagnostics(
+    llm: Any,
+    request_count: int,
+    prompt_tokens: int,
+    completion_tokens: int,
+    finish_reason: str | None,
+) -> None:
+  """Log periodic request and memory diagnostics."""
+  if request_count % 100 != 0 and finish_reason != "length":
+    return
+  logger.info(
+      "req=%d prompt_tok=%d completion_tok=%d finish=%s %s",
+      request_count,
+      prompt_tokens,
+      completion_tokens,
+      finish_reason,
+      memory_summary(llm),
+  )
+
+
+class MemoryMonitor:
+  """Optional periodic memory logger controlled by EVAL_MEM_MONITOR_SEC."""
+
+  def __init__(self, llm: Any, rank: int):
+    self._llm = llm
+    self._rank = rank
+    self._stop = threading.Event()
+    self._thread: threading.Thread | None = None
+
+  def start(self) -> None:
+    """Start the monitor when EVAL_MEM_MONITOR_SEC is positive."""
+    try:
+      interval = float(os.environ.get("EVAL_MEM_MONITOR_SEC", "0") or 0)
+    except ValueError:
+      interval = 0.0
+    if interval <= 0:
+      return
+
+    def _loop() -> None:
+      while not self._stop.wait(interval):
+        logger.info("MEM_MONITOR rank=%d %s", self._rank, memory_summary(self._llm))
+
+    self._thread = threading.Thread(target=_loop, daemon=True, name="mem-monitor")
+    self._thread.start()
+    logger.info("Memory monitor started (rank=%d, every %.0fs).", self._rank, interval)
+
+  def stop(self) -> None:
+    self._stop.set()
+    if self._thread is not None:
+      self._thread.join(timeout=5)
+      self._thread = None

--- a/src/maxtext/eval/runner/eval_runner.py
+++ b/src/maxtext/eval/runner/eval_runner.py
@@ -103,6 +103,8 @@ def run_eval(cfg: dict, hf_token: str | None = None) -> dict:
   max_tokens = int(cfg.get("max_tokens", 1024))
   temperature = float(cfg.get("temperature", 0.0))
   concurrency = int(cfg.get("concurrency", 64))
+  request_timeout = int(cfg.get("request_timeout", 600))
+  max_retries = int(cfg.get("max_retries", 3))
   if "max_model_len" not in cfg:
     raise ValueError("Error: max_model_len is required.")
   gcs_results_path = cfg.get("gcs_results_path")
@@ -145,6 +147,8 @@ def run_eval(cfg: dict, hf_token: str | None = None) -> dict:
           max_tokens=max_tokens,
           temperature=temperature,
           concurrency=concurrency,
+          request_timeout=request_timeout,
+          max_retries=max_retries,
       )
       elapsed = time.time() - t0
       logger.info("Generation completed in %.1fs (%.1f samples/s).", elapsed, len(prompts) / elapsed)
@@ -210,6 +214,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
   parser.add_argument("--max_tokens", type=int, help="Max tokens per generation.")
   parser.add_argument("--temperature", type=float, help="Sampling temperature.")
   parser.add_argument("--concurrency", type=int, help="HTTP request concurrency.")
+  parser.add_argument("--request_timeout", type=int, help="Per-request HTTP timeout in seconds.")
+  parser.add_argument("--max_retries", type=int, help="Retries per request on timeout/connection error.")
   parser.add_argument("--tensor_parallel_size", type=int, help="vLLM tensor parallelism.")
   parser.add_argument("--max_model_len", type=int, help="vLLM max context length.")
   parser.add_argument("--server_host", help="vLLM server host.")

--- a/src/maxtext/eval/runner/harness_runner.py
+++ b/src/maxtext/eval/runner/harness_runner.py
@@ -147,7 +147,7 @@ def run_harness(cfg: dict, hf_token: str | None = None) -> dict:
   lm_model_type = "local-chat-completions" if backend == "evalchemy" else "local-completions"
   raw_results: dict = {}
 
-  with build_server_manager(cfg, token) as server:
+  with build_server_manager(cfg, token, enable_chat_api=backend == "evalchemy") as server:
     import jax as _jax
     from jax.experimental import multihost_utils as _multihost_utils
 

--- a/src/maxtext/eval/runner/run.py
+++ b/src/maxtext/eval/runner/run.py
@@ -16,11 +16,13 @@
 
 Dispatches to the appropriate runner based on --runner:
 
-  eval       Custom dataset runner. Requires --config.
-  lm_eval    lm-evaluation-harness runner.
-  evalchemy  evalchemy runner.
+  eval          Custom dataset runner. Requires --config.
+  lm_eval       lm-evaluation-harness runner.
+  evalchemy     evalchemy runner.
+  simple_evals  OpenAI simple-evals runner (grader-free evals).
 
-Both lm_eval and evalchemy dispatch to harness_runner.py.
+lm_eval and evalchemy dispatch to harness_runner.py; simple_evals uses
+simple_evals_runner.py.
 
 Usage::
 
@@ -77,7 +79,7 @@ def main() -> None:
   pre_parser.add_argument(
       "--runner",
       required=True,
-      choices=["eval", "lm_eval", "evalchemy"],
+      choices=["eval", "lm_eval", "evalchemy", "simple_evals"],
       help="Which evaluation runner to use.",
   )
   pre_args, remaining = pre_parser.parse_known_args()
@@ -90,6 +92,10 @@ def main() -> None:
     _main()
   elif pre_args.runner == "lm_eval":
     from maxtext.eval.runner.harness_runner import main as _main  # pylint: disable=import-outside-toplevel
+
+    _main()
+  elif pre_args.runner == "simple_evals":
+    from maxtext.eval.runner.simple_evals_runner import main as _main  # pylint: disable=import-outside-toplevel
 
     _main()
   else:  # evalchemy

--- a/src/maxtext/eval/runner/server_manager.py
+++ b/src/maxtext/eval/runner/server_manager.py
@@ -16,6 +16,9 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Mapping
+import importlib
 import logging
 import os
 import threading
@@ -25,10 +28,80 @@ from typing import Any
 
 import requests
 
+from maxtext.eval.runner.debug_utils import (
+    MemoryMonitor,
+    log_request_diagnostics,
+)
+
 logger = logging.getLogger(__name__)
 
 
 _HEALTH_ENDPOINT = "/health"
+_AUTO_REQUESTS_PER_ACCELERATOR = 4
+_CHAT_BATCH_WAIT_S = 0.02
+_HARMONY_UTILS_MODULE = "vllm.entrypoints.openai.parser.harmony_utils"
+
+
+def _load_harmony_utils() -> Any:
+  """Load vLLM's version-specific Harmony helper module lazily."""
+  return importlib.import_module(_HARMONY_UTILS_MODULE)
+
+
+def _is_harmony_model(llm: Any) -> bool:
+  """Whether the in-process vLLM model uses GPT-OSS Harmony messages."""
+  model_config = getattr(llm, "model_config", None)
+  hf_config = getattr(model_config, "hf_config", None)
+  return getattr(hf_config, "model_type", None) == "gpt_oss"
+
+
+def _get_harmony_stop_token_ids() -> list[int]:
+  """Return stop IDs only for vLLM revisions that explicitly override them.
+
+  vLLM removed get_stop_tokens_for_assistant_actions in #44009 together with
+  its frontend stop_token_ids override. Newer revisions rely on model/engine
+  EOS handling, so an absent helper deliberately means "do not override".
+  """
+  harmony_utils = _load_harmony_utils()
+  get_stop_tokens = getattr(harmony_utils, "get_stop_tokens_for_assistant_actions", None)
+  if get_stop_tokens is None:
+    logger.info("vLLM uses model/engine-managed GPT-OSS stop tokens; no frontend override needed.")
+    return []
+  return list(get_stop_tokens())
+
+
+def _parse_harmony_chat_output(token_ids: list[int]) -> tuple[str | None, str | None, bool]:
+  """Parse GPT-OSS token IDs with the parser used by vLLM's OpenAI server."""
+  harmony_utils = _load_harmony_utils()
+  parse_chat_output = getattr(harmony_utils, "parse_chat_output", None)
+  if parse_chat_output is None:
+    raise RuntimeError(f"Installed vLLM does not provide {_HARMONY_UTILS_MODULE}.parse_chat_output.")
+  return parse_chat_output(token_ids)
+
+
+def _render_harmony_chat_prompt(messages: list[dict[str, Any]], reasoning_effort: str | None) -> list[int]:
+  """Render GPT-OSS messages exactly as vLLM's OpenAI chat server does."""
+  harmony_utils = _load_harmony_utils()
+  required_helpers = (
+      "get_system_message",
+      "parse_chat_inputs_to_harmony_messages",
+      "render_for_completion",
+  )
+  missing_helpers = [name for name in required_helpers if not callable(getattr(harmony_utils, name, None))]
+  if missing_helpers:
+    raise RuntimeError(f"Installed vLLM Harmony API is missing required helper(s): {', '.join(missing_helpers)}.")
+
+  if reasoning_effort == "none":
+    raise ValueError("Harmony does not support reasoning_effort='none'.")
+  harmony_messages = [
+      harmony_utils.get_system_message(
+          reasoning_effort=reasoning_effort,
+          browser_description=None,
+          python_description=None,
+          with_custom_tools=True,
+      )
+  ]
+  harmony_messages.extend(harmony_utils.parse_chat_inputs_to_harmony_messages(messages))
+  return list(harmony_utils.render_for_completion(harmony_messages))
 
 
 def _top_logprobs_dict(tokenizer: Any, lp_dict: dict | None) -> "dict[str, float] | None":
@@ -37,7 +110,72 @@ def _top_logprobs_dict(tokenizer: Any, lp_dict: dict | None) -> "dict[str, float
   return {tokenizer.decode([tid]): lp.logprob for tid, lp in lp_dict.items()}
 
 
-def _build_app(llm: Any) -> Any:
+class _ChatBatchQueue:
+  """Collect chat requests into short, bounded vLLM generation batches."""
+
+  def __init__(self, llm: Any, max_batch: int):
+    self._llm = llm
+    self._max_batch = max_batch
+    self._pending: list[tuple[Any, Any, "asyncio.Future"]] = []
+    self._timer: "asyncio.TimerHandle | None" = None
+
+  async def submit(self, prompt: Any, sampling_params: Any) -> Any:
+    """Queue one rendered prompt and await its vLLM RequestOutput."""
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    item = (prompt, sampling_params, future)
+    self._pending.append(item)
+    if len(self._pending) >= self._max_batch:
+      if self._timer is not None:
+        self._timer.cancel()
+      self._timer = None
+      self._flush()
+    elif self._timer is None:
+      self._timer = loop.call_later(_CHAT_BATCH_WAIT_S, self._flush)
+    try:
+      return await future
+    except asyncio.CancelledError:
+      if item in self._pending:
+        self._pending.remove(item)
+        if not self._pending and self._timer is not None:
+          self._timer.cancel()
+          self._timer = None
+      raise
+
+  def _flush(self) -> None:
+    """Submit the pending batch and resolve each request future."""
+    self._timer = None
+    batch, self._pending = self._pending, []
+    if not batch:
+      return
+    prompts = [item[0] for item in batch]
+    sampling_params = [item[1] for item in batch]
+    try:
+      outputs = self._llm.generate(prompts, sampling_params)
+    except BaseException as exc:  # noqa: B902  pylint: disable=broad-except
+      if isinstance(exc, Exception):
+        logger.exception("Batched generate() failed for %d requests [%s]: %s", len(batch), type(exc).__name__, exc)
+        for _, _, future in batch:
+          if not future.done():
+            future.set_exception(exc)
+        return
+      logger.critical(
+          "Fatal error in batched generate() [%s]: %s -- terminating process.",
+          type(exc).__name__,
+          exc,
+          exc_info=exc,
+      )
+      os._exit(1)  # pylint: disable=protected-access
+    for (_, _, future), output in zip(batch, outputs):
+      if not future.done():
+        future.set_result(output)
+
+
+def _build_app(
+    llm: Any,
+    enable_chat_api: bool = False,
+    request_concurrency: int = 16,
+) -> Any:
   """Return a FastAPI app that wraps an in-process vLLM LLM instance."""
   import fastapi  # pylint: disable=import-outside-toplevel
   from vllm.sampling_params import SamplingParams  # pylint: disable=import-outside-toplevel
@@ -55,8 +193,11 @@ def _build_app(llm: Any) -> Any:
     body = await request.json()
 
     raw_prompt = body.get("prompt", "")
+    # raw_prompt can be: str, list[int] (single token-ID prompt), list[str] (batch of
+    # text prompts), or list[list[int]] (batch of token-ID prompts).  Normalise to a
+    # list where each element is either a str or a list[int].
     if isinstance(raw_prompt, list) and raw_prompt and isinstance(raw_prompt[0], int):
-      prompts = [raw_prompt]
+      prompts = [raw_prompt]  # single prompt sent as token IDs
     else:
       prompts = raw_prompt if isinstance(raw_prompt, list) else [raw_prompt]
     model_name = body.get("model", "")
@@ -151,6 +292,18 @@ def _build_app(llm: Any) -> Any:
         },
     }
 
+  if not enable_chat_api:
+    return app
+
+  app.state.request_count = 0
+  app.state.use_harmony = _is_harmony_model(llm)
+  app.state.harmony_stop_token_ids = _get_harmony_stop_token_ids() if app.state.use_harmony else []
+  configured_max_model_len = getattr(getattr(llm, "model_config", None), "max_model_len", None)
+  app.state.max_model_len = (
+      configured_max_model_len if isinstance(configured_max_model_len, int) and configured_max_model_len > 0 else None
+  )
+  app.state.chat_batch_queue = _ChatBatchQueue(llm, max_batch=request_concurrency)
+
   @app.post("/v1/chat/completions")
   async def chat_completions(request: fastapi.Request):  # pylint: disable=unused-variable
     """OpenAI-compatible chat completions endpoint.
@@ -160,27 +313,110 @@ def _build_app(llm: Any) -> Any:
     body = await request.json()
     messages = body.get("messages", [])
     model_name = body.get("model", "")
-    max_tokens = int(body["max_tokens"]) if body.get("max_tokens") is not None else 256
-    temperature = float(body.get("temperature") or 0.0)
+    try:
+      max_tokens = int(body["max_tokens"]) if body.get("max_tokens") is not None else 256
+      temperature = float(body.get("temperature") or 0.0)
+    except (TypeError, ValueError) as exc:
+      raise fastapi.HTTPException(status_code=400, detail="max_tokens and temperature must be numeric.") from exc
     stop = body.get("stop")
+    # Sent by the sampler via extra_body; OpenAI client hoists it to top-level body.
+    reasoning_effort = body.get("reasoning_effort")
+    include_reasoning = bool(body.get("include_reasoning", True))
+    include_raw_output = bool(body.get("include_raw_output", False))
 
-    tokenizer = llm.get_tokenizer()
-    prompt = tokenizer.apply_chat_template(
-        messages,
-        tokenize=False,
-        add_generation_prompt=True,
+    try:
+      if not isinstance(messages, list):
+        raise ValueError("messages must be a list.")
+      if max_tokens <= 0:
+        raise ValueError("max_tokens must be positive.")
+
+      if app.state.use_harmony:
+        prompt_token_ids = _render_harmony_chat_prompt(messages, reasoning_effort)
+      else:
+        tokenizer = llm.get_tokenizer()
+        template_kwargs = {"reasoning_effort": reasoning_effort} if reasoning_effort else {}
+        prompt_token_ids = tokenizer.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            **template_kwargs,
+        )
+
+      if isinstance(prompt_token_ids, Mapping):
+        prompt_token_ids = prompt_token_ids["input_ids"]
+      prompt_token_ids = list(prompt_token_ids)
+      if app.state.max_model_len is not None:
+        if len(prompt_token_ids) >= app.state.max_model_len:
+          raise ValueError(
+              f"Input length ({len(prompt_token_ids)}) must be shorter than the model's maximum "
+              f"context length ({app.state.max_model_len})."
+          )
+        # Match vLLM's OpenAI serving behavior: cap the requested output budget
+        # to the context space remaining after chat rendering.
+        max_tokens = min(max_tokens, app.state.max_model_len - len(prompt_token_ids))
+      prompt = {"prompt_token_ids": list(prompt_token_ids)}
+
+      sp_kwargs: dict = {"max_tokens": max_tokens, "temperature": temperature}
+      if stop:
+        sp_kwargs["stop"] = [stop] if isinstance(stop, str) else list(stop)
+      if app.state.use_harmony:
+        requested_stop_token_ids = body.get("stop_token_ids") or []
+        if isinstance(requested_stop_token_ids, int):
+          requested_stop_token_ids = [requested_stop_token_ids]
+        if not isinstance(requested_stop_token_ids, list) or not all(
+            isinstance(token_id, int) for token_id in requested_stop_token_ids
+        ):
+          raise ValueError("stop_token_ids must be an integer or a list of integers.")
+        harmony_stop_token_ids = list(dict.fromkeys([*requested_stop_token_ids, *app.state.harmony_stop_token_ids]))
+        if harmony_stop_token_ids:
+          sp_kwargs["stop_token_ids"] = harmony_stop_token_ids
+    except Exception as exc:  # pylint: disable=broad-except
+      raise fastapi.HTTPException(status_code=400, detail=f"Request formatting failed: {exc}") from exc
+
+    try:
+      sampling_params = SamplingParams(**sp_kwargs)
+      output = await app.state.chat_batch_queue.submit(prompt, sampling_params)
+    except BaseException as exc:
+      logger.exception("chat_completions generate failed [%s]: %s", type(exc).__name__, exc)
+      if isinstance(exc, Exception):
+        raise fastapi.HTTPException(status_code=500, detail=str(exc)) from exc
+      raise
+
+    gen = output.outputs[0]
+    prompt_tokens = len(output.prompt_token_ids)
+    completion_tokens = len(gen.token_ids)
+    raw_output = gen.text
+    reasoning = None
+    final_content = raw_output
+    if app.state.use_harmony:
+      try:
+        reasoning, final_content, _ = _parse_harmony_chat_output(list(gen.token_ids))
+      except Exception as exc:  # pylint: disable=broad-except
+        logger.exception("Failed to parse GPT-OSS Harmony output token IDs: %s", exc)
+        logger.debug("Unparsed GPT-OSS raw output: %r", raw_output)
+        raise fastapi.HTTPException(status_code=500, detail="Failed to parse GPT-OSS Harmony output.") from exc
+      logger.debug(
+          "Parsed GPT-OSS Harmony output: raw=%r reasoning=%r final=%r",
+          raw_output,
+          reasoning,
+          final_content,
+      )
+
+    app.state.request_count += 1
+    log_request_diagnostics(
+        llm,
+        app.state.request_count,
+        prompt_tokens,
+        completion_tokens,
+        gen.finish_reason,
     )
 
-    sp_kwargs: dict = {"max_tokens": max_tokens, "temperature": temperature}
-    if stop:
-      sp_kwargs["stop"] = [stop] if isinstance(stop, str) else list(stop)
+    message: dict[str, Any] = {"role": "assistant", "content": final_content}
+    if include_reasoning and reasoning is not None:
+      # Matches the field emitted by vLLM's OpenAI-compatible ChatMessage.
+      message["reasoning"] = reasoning
 
-    outputs = llm.generate([prompt], SamplingParams(**sp_kwargs))
-    gen = outputs[0].outputs[0]
-    prompt_tokens = len(outputs[0].prompt_token_ids)
-    completion_tokens = len(gen.token_ids)
-
-    return {
+    response = {
         "id": f"chatcmpl-{uuid.uuid4().hex}",
         "object": "chat.completion",
         "created": int(time.time()),
@@ -188,7 +424,7 @@ def _build_app(llm: Any) -> Any:
         "choices": [
             {
                 "index": 0,
-                "message": {"role": "assistant", "content": gen.text},
+                "message": message,
                 "finish_reason": gen.finish_reason or "stop",
                 "logprobs": None,
             }
@@ -199,6 +435,11 @@ def _build_app(llm: Any) -> Any:
             "total_tokens": prompt_tokens + completion_tokens,
         },
     }
+    if include_raw_output:
+      # Non-standard, opt-in diagnostics extension. Raw Harmony output must not
+      # leak into message.content because graders should see final content only.
+      response["diagnostics"] = {"raw_output": raw_output}
+    return response
 
   return app
 
@@ -220,6 +461,9 @@ class VllmServerManager:
     max_num_seqs: Max concurrent sequences (None = vLLM default).
     startup_timeout: Seconds to wait for /health to return healthy.
     hbm_memory_utilization: Fraction of HBM reserved for KV cache.
+    enable_chat_api: Whether to expose /v1/chat/completions.
+    concurrency: Maximum chat request concurrency. None selects an automatic
+      value from CPU, accelerator count, and max_num_seqs.
     env: Optional environment-variable overrides.
     additional_vllm_kwargs: Extra kwargs merged into the vLLM LLM() constructor.
   """
@@ -240,6 +484,8 @@ class VllmServerManager:
       max_num_seqs: int | None = None,
       startup_timeout: int = 600,
       hbm_memory_utilization: float = 0.3,
+      enable_chat_api: bool = False,
+      concurrency: int | None = None,
       env: dict[str, str] | None = None,
       additional_vllm_kwargs: dict | None = None,
   ):
@@ -264,16 +510,41 @@ class VllmServerManager:
     self.max_num_seqs = max_num_seqs
     self.startup_timeout = startup_timeout
     self.hbm_memory_utilization = hbm_memory_utilization
+    self.enable_chat_api = enable_chat_api
+    if concurrency is not None and concurrency <= 0:
+      raise ValueError("concurrency must be positive when specified.")
+    self._requested_concurrency = concurrency
+    self._concurrency: int | None = None
     self.env = env
     self.additional_vllm_kwargs = additional_vllm_kwargs or {}
 
     self._llm: Any | None = None
     self._uvicorn_server: Any | None = None
     self._server_thread: threading.Thread | None = None
+    self._memory_monitor: MemoryMonitor | None = None
 
   @property
   def base_url(self) -> str:
     return f"http://{self.host}:{self.port}"
+
+  @property
+  def concurrency(self) -> int:
+    """Resolved request concurrency; available after the server starts."""
+    if self._concurrency is None:
+      raise RuntimeError("Request concurrency is not resolved until the server starts.")
+    return self._concurrency
+
+  def _resolve_concurrency(self, cpu_count: int, accelerator_count: int) -> int:
+    """Resolve the sole request-pressure knob from host and accelerator capacity."""
+    if self._requested_concurrency is not None:
+      return self._requested_concurrency
+    limits = [
+        max(1, cpu_count),
+        max(1, accelerator_count * _AUTO_REQUESTS_PER_ACCELERATOR),
+    ]
+    if self.max_num_seqs is not None:
+      limits.append(max(1, self.max_num_seqs))
+    return min(limits)
 
   def start(self) -> None:
     """Initialize the in-process vLLM LLM and start the HTTP server."""
@@ -345,12 +616,31 @@ class VllmServerManager:
 
     import jax as _jax  # pylint: disable=import-outside-toplevel
 
+    if self.enable_chat_api:
+      detected_accelerators = max(1, _jax.device_count())
+      active_accelerators = min(
+          detected_accelerators,
+          max(1, self.tensor_parallel_size * self.data_parallel_size),
+      )
+      self._concurrency = self._resolve_concurrency(
+          cpu_count=os.cpu_count() or 1,
+          accelerator_count=active_accelerators,
+      )
+      logger.info("Chat request concurrency=%d", self._concurrency)
+
     logger.info("Rank %d: vLLM LLM ready.", _jax.process_index())
+
+    self._memory_monitor = MemoryMonitor(self._llm, _jax.process_index())
+    self._memory_monitor.start()
 
     if _jax.process_index() == 0:
       import uvicorn  # pylint: disable=import-outside-toplevel
 
-      app = _build_app(self._llm)
+      app = _build_app(
+          self._llm,
+          enable_chat_api=self.enable_chat_api,
+          request_concurrency=self.concurrency if self.enable_chat_api else 1,
+      )
       config = uvicorn.Config(
           app,
           host=self.host,
@@ -386,6 +676,9 @@ class VllmServerManager:
 
   def stop(self) -> None:
     """Stop the HTTP server and release the LLM."""
+    if self._memory_monitor is not None:
+      self._memory_monitor.stop()
+      self._memory_monitor = None
     if self._uvicorn_server is not None:
       logger.info("Stopping vLLM HTTP server.")
       self._uvicorn_server.should_exit = True

--- a/src/maxtext/eval/runner/simple_evals_runner.py
+++ b/src/maxtext/eval/runner/simple_evals_runner.py
@@ -1,0 +1,569 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run OpenAI simple-evals tasks against a local vLLM chat server."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import random
+import threading
+import time
+from typing import Any
+
+# Matches OpenAI simple-evals' default system message (OPENAI_SYSTEM_MESSAGE_API)
+# so scores stay comparable to their published baselines.
+DEFAULT_SYSTEM_MESSAGE = "You are a helpful assistant."
+_MAX_ATTEMPTS = 3
+_REQUEST_TIMEOUT_S = 600.0
+
+from maxtext.eval.runner.common import (
+    add_server_args,
+    build_server_manager,
+    maybe_upload_to_gcs,
+    resolve_token,
+)
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_TASKS = ("mmlu", "gpqa", "gsm8k", "drop", "mgsm", "mgsm_en", "aime2024", "aime2025")
+
+
+def _describe_api_error(exc: Exception | None) -> str:
+  """Format an OpenAI API exception with request and response context."""
+  if exc is None:
+    return "n/a"
+  parts = [f"{type(exc).__name__}: {exc}"]
+  request = getattr(exc, "request", None)
+  if request is not None:
+    parts.append(f"request={getattr(request, 'method', '?')} {getattr(request, 'url', '?')}")
+  response = getattr(exc, "response", None)
+  if response is not None:
+    body = getattr(exc, "body", None)
+    text = str(body) if body is not None else getattr(response, "text", "")
+    parts.append(f"status={getattr(response, 'status_code', '?')} body={text[:500]}")
+  if exc.__cause__ is not None:
+    parts.append(f"cause={type(exc.__cause__).__name__}: {exc.__cause__}")
+  return " | ".join(parts)
+
+
+def _build_vllm_sampler(
+    base_url: str,
+    model_name: str,
+    max_tokens: int,
+    temperature: float,
+    system_message: str | None = DEFAULT_SYSTEM_MESSAGE,
+    reasoning_effort: str | None = None,
+    debug_collector=None,
+    concurrency: int = 1,
+    continue_on_request_error: bool = False,
+):
+  """Build a bounded, retrying OpenAI-compatible chat sampler."""
+  # Optional dependencies are imported only when this runner is selected.
+  # pylint: disable=import-outside-toplevel
+  try:
+    import openai
+    from openai import OpenAI
+  except ImportError as exc:
+    raise ImportError("Install openai (pip install openai).") from exc
+
+  from maxtext.eval.simple_evals_template.types import SamplerBase, SamplerResponse
+
+  class _VllmChatSampler(SamplerBase):
+    """Sample from a vLLM server via the OpenAI chat completions API."""
+
+    def __init__(self) -> None:
+      # vLLM ignores the API key but the OpenAI client requires a non-empty one.
+      # max_retries=0: we already retry with our own backoff below. Leaving the
+      # SDK's default (2) stacks a *second*, uncoordinated retry loop underneath
+      # ours -- each of our trials silently becomes up to 3 real HTTP attempts,
+      # which is pure amplification against an already-overloaded server.
+      self.client = OpenAI(
+          base_url=f"{base_url}/v1",
+          api_key="EMPTY",
+          max_retries=0,
+          timeout=_REQUEST_TIMEOUT_S,
+      )
+      self.model = model_name
+      self.max_tokens = max_tokens
+      self.temperature = temperature
+      self.system_message = system_message
+      self.reasoning_effort = reasoning_effort
+      self.request_semaphore = threading.BoundedSemaphore(concurrency)
+      self.continue_on_request_error = continue_on_request_error
+
+    def _pack_message(self, role: str, content: Any) -> dict:
+      return {"role": str(role), "content": content}
+
+    def __call__(self, message_list):
+      with self.request_semaphore:
+        return self._sample(message_list)
+
+    @staticmethod
+    def _is_retryable(exc: Exception) -> bool:
+      status = getattr(getattr(exc, "response", None), "status_code", None)
+      return isinstance(exc, (openai.APITimeoutError, openai.APIConnectionError)) or (
+          status in (408, 409, 429) or (status is not None and status >= 500)
+      )
+
+    @staticmethod
+    def _record_attempt_error(debug_record, exc: Exception, attempt_start: float) -> None:
+      if debug_record is None:
+        return
+      debug_record["attempt_errors"].append(
+          {
+              "type": type(exc).__name__,
+              "status": getattr(getattr(exc, "response", None), "status_code", None),
+              "detail": _describe_api_error(exc),
+              "latency_s": time.monotonic() - attempt_start,
+          }
+      )
+
+    def _failure_response(
+        self,
+        message_list,
+        debug_record,
+        exc: Exception,
+        *,
+        status: str,
+        error_message: str,
+    ):
+      """Return a zero-gradeable response or raise for a terminal failure."""
+      response_metadata = {"usage": None, "status": status}
+      if debug_record is not None:
+        debug_record.update(
+            status=status,
+            response_text="",
+            finish_reason=None,
+            prompt_tokens=None,
+            completion_tokens=None,
+            total_tokens=None,
+            error_type=type(exc).__name__,
+            error_status=getattr(getattr(exc, "response", None), "status_code", None),
+            error_detail=_describe_api_error(exc),
+        )
+        debug_collector.finish(debug_record)
+        response_metadata.update(debug_record)
+      if self.continue_on_request_error:
+        return SamplerResponse(
+            response_text="",
+            response_metadata=response_metadata,
+            actual_queried_message_list=message_list,
+        )
+      raise RuntimeError(error_message) from exc
+
+    @staticmethod
+    def _success_response(message_list, response, debug_record, attempt_start: float):
+      """Convert a successful OpenAI response to a simple-evals response."""
+      choice = response.choices[0]
+      message = choice.message
+      # An analysis-only GPT-OSS truncation is a valid model result:
+      # Harmony returns reasoning plus final_content=None with
+      # finish_reason="length". Preserve that as an empty scored answer.
+      content = message.content or ""
+      usage = response.usage
+      response_metadata = {"usage": usage}
+      if debug_record is not None:
+        response_extra = getattr(response, "model_extra", None) or {}
+        diagnostics = response_extra.get("diagnostics") or getattr(response, "diagnostics", None) or {}
+        debug_record.update(
+            status="success",
+            response_text=content,
+            reasoning_text=getattr(message, "reasoning", None),
+            raw_response_text=diagnostics.get("raw_output"),
+            successful_attempt_latency_s=time.monotonic() - attempt_start,
+            finish_reason=getattr(choice, "finish_reason", None),
+            prompt_tokens=getattr(usage, "prompt_tokens", None),
+            completion_tokens=getattr(usage, "completion_tokens", None),
+            total_tokens=getattr(usage, "total_tokens", None),
+        )
+        debug_collector.finish(debug_record)
+        response_metadata.update(debug_record)
+      return SamplerResponse(
+          response_text=content,
+          response_metadata=response_metadata,
+          actual_queried_message_list=message_list,
+      )
+
+    def _sample(self, message_list):
+      """Submit one request, retrying only failures that may be transient."""
+      if self.system_message:
+        message_list = [self._pack_message("system", self.system_message)] + message_list
+      debug_record = debug_collector.begin(message_list) if debug_collector else None
+      call_start = time.monotonic()
+      last_exc: Exception | None = None
+      for trial in range(_MAX_ATTEMPTS):
+        attempt_start = time.monotonic()
+        if debug_record is not None:
+          debug_record["attempt_count"] += 1
+        try:
+          extra_body = {
+              # Evaluators grade only message.content. Reasoning and raw output
+              # are opt-in diagnostic data and are never copied into it.
+              "include_reasoning": debug_record is not None,
+              "include_raw_output": debug_record is not None,
+          }
+          if self.reasoning_effort:
+            extra_body["reasoning_effort"] = self.reasoning_effort
+          response = self.client.chat.completions.create(
+              model=self.model,
+              messages=message_list,
+              temperature=self.temperature,
+              max_tokens=self.max_tokens,
+              extra_body=extra_body,
+          )
+          return self._success_response(message_list, response, debug_record, attempt_start)
+        except openai.BadRequestError as exc:
+          logger.warning("vLLM rejected an invalid request: %s", _describe_api_error(exc))
+          self._record_attempt_error(debug_record, exc, attempt_start)
+          return self._failure_response(
+              message_list,
+              debug_record,
+              exc,
+              status="bad_request",
+              error_message="vLLM rejected the evaluation request as invalid.",
+          )
+        except Exception as exc:  # pylint: disable=broad-except
+          last_exc = exc
+          self._record_attempt_error(debug_record, exc, attempt_start)
+          if not self._is_retryable(exc):
+            logger.error("Non-retryable vLLM response failure: %s", _describe_api_error(exc))
+            break
+          if trial + 1 < _MAX_ATTEMPTS:
+            backoff = random.uniform(0, min(30.0, float(2**trial)))
+            logger.warning(
+                "vLLM request failed (trial %d/%d) [%s] cause=%s attempt_elapsed=%.1fs "
+                "total_elapsed=%.1fs thread=%s; retrying in %.1fs: %s",
+                trial + 1,
+                _MAX_ATTEMPTS,
+                type(exc).__name__,
+                type(getattr(exc, "__cause__", None)).__name__ if getattr(exc, "__cause__", None) else "n/a",
+                time.monotonic() - attempt_start,
+                time.monotonic() - call_start,
+                threading.current_thread().name,
+                backoff,
+                _describe_api_error(exc),
+            )
+            time.sleep(backoff)
+      assert last_exc is not None
+      attempts_made = trial + 1
+      if debug_record is not None:
+        attempts_made = debug_record.get("attempt_count", attempts_made)
+      logger.error(
+          "vLLM request failed after %d attempt(s) and %.1fs total (thread=%s): %s",
+          attempts_made,
+          time.monotonic() - call_start,
+          threading.current_thread().name,
+          _describe_api_error(last_exc),
+          exc_info=last_exc,
+      )
+      return self._failure_response(
+          message_list,
+          debug_record,
+          last_exc,
+          status="error",
+          error_message=f"vLLM request failed after {attempts_made} attempt(s).",
+      )
+
+  return _VllmChatSampler()
+
+
+def _effective_repeats(task: str, num_examples: int | None, n_repeats: int | None) -> int:
+  """Resolve upstream-compatible repeat defaults for tasks that support them."""
+  if task not in ("gpqa", "aime2024", "aime2025"):
+    return 1
+  if num_examples is not None:
+    return 1
+  if n_repeats is not None:
+    return n_repeats
+  return 4 if task == "gpqa" else 1
+
+
+def _build_eval(task: str, num_examples: int | None, n_repeats: int | None):
+  """Instantiate a simple-evals Eval object for a supported task.
+
+  Note: instantiating an eval downloads its dataset, so this is not called in
+  unit tests. Task validation happens in run_simple_evals before this is called.
+  """
+  # pylint: disable=import-outside-toplevel
+  if task == "mmlu":
+    from maxtext.eval.simple_evals_template.mmlu_eval import MMLUEval
+
+    return MMLUEval(num_examples=num_examples)
+  if task == "gpqa":
+    from maxtext.eval.simple_evals_template.gpqa_eval import GPQAEval
+
+    # GPQA forbids n_repeats > 1 when subsetting examples.
+    repeats = _effective_repeats(task, num_examples, n_repeats)
+    return GPQAEval(num_examples=num_examples, n_repeats=repeats)
+  if task == "drop":
+    from maxtext.eval.simple_evals_template.drop_eval import DropEval
+
+    return DropEval(num_examples=num_examples)
+  if task == "mgsm":
+    from maxtext.eval.simple_evals_template.mgsm_eval import MGSMEval
+
+    # Match upstream: evaluate every language. num_samples is per language.
+    return MGSMEval(num_examples_per_lang=num_examples or 250)
+  if task == "mgsm_en":
+    from maxtext.eval.simple_evals_template.mgsm_eval import MGSMEval
+
+    return MGSMEval(num_examples_per_lang=num_examples or 250, languages=["en"])
+  if task == "gsm8k":
+    from maxtext.eval.simple_evals_template.gsm8k_eval import GSM8KEval
+
+    return GSM8KEval(num_examples=num_examples)
+  if task in ("aime2024", "aime2025"):
+    from maxtext.eval.simple_evals_template.aime_eval import AIMEEval
+
+    # AIME forbids n_repeats > 1 when subsetting examples (mirrors GPQA).
+    repeats = _effective_repeats(task, num_examples, n_repeats)
+    year = 2024 if task == "aime2024" else 2025
+    return AIMEEval(year=year, num_examples=num_examples, n_repeats=repeats)
+  raise ValueError(f"Unsupported simple_evals task: {task}. Supported: {list(SUPPORTED_TASKS)}.")
+
+
+def _map_scores(task: str, eval_result) -> dict:
+  """Flatten a simple-evals EvalResult into a flat scores dict.
+
+  The top-line score is reported as a percentage under '{task}_accuracy';
+  remaining numeric metrics are passed through under '{task}_{metric}'.
+  """
+  scores: dict[str, float] = {}
+  if eval_result.score is not None:
+    scores[f"{task}_accuracy"] = round(float(eval_result.score) * 100, 2)
+  for name, value in (eval_result.metrics or {}).items():
+    if isinstance(value, (int, float)):
+      scores[f"{task}_{name}"] = round(float(value), 4)
+  return scores
+
+
+def _validate_tasks(tasks: list[str]) -> None:
+  """Raise ValueError if any task is unsupported in Phase 1."""
+  unsupported = [t for t in tasks if t not in SUPPORTED_TASKS]
+  if unsupported:
+    raise ValueError(
+        f"Unsupported simple_evals task(s): {unsupported}. "
+        f"Phase 1 supports grader-free evals only: {list(SUPPORTED_TASKS)}."
+    )
+
+
+def run_simple_evals(cfg: dict, hf_token: str | None = None) -> dict:
+  """Run selected simple-evals tasks and write their aggregate results."""
+  # Heavy and optional runtime dependencies stay lazy for other eval modes.
+  # pylint: disable=import-outside-toplevel
+  from maxtext.eval.reporting.json_reporter import write_results
+  from maxtext.eval.runner.warmup import warmup_chat_server
+
+  model_name = cfg["model_name"]
+  tasks = cfg["tasks"]
+  results_path = cfg["results_path"]
+  num_samples = cfg.get("num_samples")
+  n_repeats = cfg.get("n_repeats")
+  if n_repeats is not None:
+    n_repeats = int(n_repeats)
+  max_tokens = int(cfg.get("max_tokens") or 2048)
+  temperature_value = cfg.get("temperature")
+  temperature = float(0.5 if temperature_value is None else temperature_value)
+  system_message = cfg.get("system_message", DEFAULT_SYSTEM_MESSAGE)
+  reasoning_effort = cfg.get("reasoning_effort")
+  log_debug_info = bool(cfg.get("log_debug_info", False))
+  continue_on_request_error = bool(cfg.get("continue_on_request_error", False))
+  gcs_results_path = cfg.get("gcs_results_path")
+  token = resolve_token(cfg, hf_token)
+
+  _validate_tasks(tasks)
+
+  scores: dict[str, float] = {}
+  eval_results: dict[str, Any] = {}
+  task_durations: dict[str, float] = {}
+  debug_collector = None
+  if log_debug_info:
+    from maxtext.eval.reporting.simple_evals_debug_reporter import SimpleEvalsDebugCollector
+
+    debug_collector = SimpleEvalsDebugCollector()
+  is_rank0 = False  # set inside with block; initialized here so post-block ref is safe
+  with build_server_manager(cfg, token, enable_chat_api=True) as server:
+    import jax as _jax
+    from jax.experimental import multihost_utils as _multihost_utils
+
+    is_rank0 = _jax.process_index() == 0
+
+    if is_rank0:
+      from maxtext.eval.simple_evals_template import common as simple_evals_common
+
+      simple_evals_common.set_default_num_threads(server.concurrency)
+      if not cfg.get("skip_warmup"):
+        warmup_chat_server(
+            base_url=server.base_url,
+            model=model_name,
+            concurrency=server.concurrency,
+            max_model_len=int(cfg["max_model_len"]),
+            system_message=system_message,
+            reasoning_effort=reasoning_effort,
+            max_tokens=min(16, max_tokens),
+        )
+
+      sampler = _build_vllm_sampler(
+          base_url=server.base_url,
+          model_name=model_name,
+          max_tokens=max_tokens,
+          temperature=temperature,
+          system_message=system_message,
+          reasoning_effort=reasoning_effort,
+          debug_collector=debug_collector,
+          concurrency=server.concurrency,
+          continue_on_request_error=continue_on_request_error,
+      )
+      for task in tasks:
+        logger.info("Running simple_evals task '%s' at %s", task, server.base_url)
+        eval_obj = _build_eval(task, num_samples, n_repeats)
+        if debug_collector is not None:
+          debug_collector.set_task(task)
+        task_start = time.monotonic()
+        eval_result = eval_obj(sampler)
+        task_durations[task] = time.monotonic() - task_start
+        eval_results[task] = eval_result
+        task_scores = _map_scores(task, eval_result)
+        logger.info("simple_evals task '%s' scores: %s", task, task_scores)
+        scores.update(task_scores)
+
+    _multihost_utils.sync_global_devices("simple_evals_complete")
+
+  if not is_rank0:
+    return {}
+
+  output = write_results(
+      benchmark="+".join(tasks),
+      model_name=model_name,
+      scores=scores,
+      generation_stats={
+          "num_samples": num_samples,
+          "n_repeats": n_repeats,
+          "effective_repeats": {task: _effective_repeats(task, num_samples, n_repeats) for task in tasks},
+          "task_variants": {
+              task: ("all_11_languages" if task == "mgsm" else "english_only" if task == "mgsm_en" else "default")
+              for task in tasks
+          },
+          "effective_concurrency": server.concurrency,
+          "protocol_version": "openai-simple-evals-652c89d-maxtext-v2",
+      },
+      config=cfg,
+      results_path=results_path,
+  )
+  maybe_upload_to_gcs(output, gcs_results_path)
+  if debug_collector is not None:
+    from maxtext.eval.reporting.simple_evals_debug_reporter import build_debug_report, write_debug_report
+
+    report = build_debug_report(
+        collector=debug_collector,
+        eval_results=eval_results,
+        task_durations=task_durations,
+        model_name=model_name,
+        max_tokens=max_tokens,
+        max_model_len=int(cfg["max_model_len"]),
+    )
+    debug_local_path = write_debug_report(report, results_path, output["local_path"])
+    output["debug_local_path"] = debug_local_path
+    if gcs_results_path:
+      secondary_debug_path = (
+          gcs_results_path if gcs_results_path.endswith("/") else f"{gcs_results_path.rsplit('.', 1)[0]}.debug.txt"
+      )
+      maybe_upload_to_gcs({"local_path": debug_local_path}, secondary_debug_path)
+  return output
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+  """Build argument parser."""
+  parser = argparse.ArgumentParser(
+      description="MaxText OpenAI simple-evals runner (Phase 1: grader-free evals).",
+      formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+  )
+  add_server_args(parser)
+  parser.add_argument(
+      "--tasks",
+      nargs="+",
+      default=["mmlu"],
+      help=f"simple-evals task names. Phase 1 supports grader-free evals only: {list(SUPPORTED_TASKS)}.",
+  )
+  parser.add_argument(
+      "--num_samples",
+      type=int,
+      help="Limit examples per task (for mgsm/mgsm_en, this is per language; None = full dataset).",
+  )
+  parser.add_argument(
+      "--n_repeats",
+      type=int,
+      default=None,
+      help=(
+          "Number of repeats per example (gpqa and aime2024/aime2025 only; defaults to upstream GPQA=4 "
+          "and AIME=1, and is forced to 1 when --num_samples is set)."
+      ),
+  )
+  parser.add_argument("--max_tokens", type=int, default=2048, help="Max tokens per generation.")
+  parser.add_argument("--temperature", type=float, default=0.5, help="Sampling temperature (upstream default: 0.5).")
+  parser.add_argument(
+      "--concurrency",
+      type=int,
+      default=None,
+      help=(
+          "Maximum in-flight inference requests. By default, choose automatically from CPU count, "
+          "accelerator count, and max_num_seqs."
+      ),
+  )
+  parser.add_argument(
+      "--log-debug-info",
+      action="store_true",
+      help="Write inference reliability, speed, truncation, and error-case diagnostics to a text file.",
+  )
+  parser.add_argument(
+      "--continue-on-request-error",
+      action="store_true",
+      help="Score terminal inference failures as zero instead of aborting the benchmark.",
+  )
+  parser.add_argument(
+      "--system_message",
+      type=str,
+      default=DEFAULT_SYSTEM_MESSAGE,
+      help="System message prepended to each prompt (matches OpenAI simple-evals default).",
+  )
+  parser.add_argument(
+      "--reasoning_effort",
+      type=str,
+      choices=["low", "medium", "high"],
+      default=None,
+      help="Reasoning effort level passed as extra_body to /v1/chat/completions (reasoning models only).",
+  )
+  return parser
+
+
+def main() -> None:
+  parser = _build_arg_parser()
+  args = parser.parse_args()
+
+  logging.basicConfig(
+      level=getattr(logging, args.log_level),
+      format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+  )
+
+  results_path = f"{args.base_output_directory.rstrip('/')}/{args.run_name}/eval_results"
+  cfg = {k: v for k, v in vars(args).items() if k not in ("log_level", "hf_token")}
+  cfg["results_path"] = results_path
+
+  run_simple_evals(cfg, hf_token=args.hf_token)
+
+
+if __name__ == "__main__":
+  main()

--- a/src/maxtext/eval/runner/warmup.py
+++ b/src/maxtext/eval/runner/warmup.py
@@ -24,6 +24,7 @@ from maxtext.eval.datasets.base import SampleRequest
 logger = logging.getLogger(__name__)
 
 _COMPLETIONS_PATH = "/v1/completions"
+_CHAT_COMPLETIONS_PATH = "/v1/chat/completions"
 _SIMPLE_WARMUP_PROMPT = "What is 1 + 1?"
 _WARMUP_BUCKETS = [0, 16, 32, 64, 128, 256, 512, 1024]
 
@@ -92,3 +93,70 @@ def warmup_server(
     pairs = [(_SIMPLE_WARMUP_PROMPT, max_tokens)]
 
   asyncio.run(_send_warmup_requests(api_url, model, pairs))
+
+
+async def _send_chat_warmup_batch(
+    api_url: str,
+    model: str,
+    messages: list[dict[str, str]],
+    concurrency: int,
+    max_tokens: int,
+    reasoning_effort: str | None,
+) -> None:
+  """Warm one representative chat shape at the resolved request concurrency."""
+  import aiohttp  # pylint: disable=import-outside-toplevel
+
+  payload = {
+      "model": model,
+      "messages": messages,
+      "max_tokens": max_tokens,
+      "temperature": 0.0,
+  }
+  if reasoning_effort:
+    payload["reasoning_effort"] = reasoning_effort
+  timeout = aiohttp.ClientTimeout(total=600)
+  async with aiohttp.ClientSession(timeout=timeout) as session:
+    responses = await asyncio.gather(*[session.post(api_url, json=payload) for _ in range(concurrency)])
+    failures = []
+    for response in responses:
+      if response.status != 200:
+        failures.append(f"HTTP {response.status}: {(await response.text())[:500]}")
+      response.release()
+  if failures:
+    raise RuntimeError(f"Chat warmup failed for {len(failures)}/{concurrency} requests: {failures[0]}")
+
+
+def warmup_chat_server(
+    base_url: str,
+    model: str,
+    concurrency: int,
+    max_model_len: int,
+    system_message: str | None,
+    reasoning_effort: str | None = None,
+    max_tokens: int = 16,
+) -> None:
+  """Warm the real simple-evals chat, template, and batching path."""
+  api_url = f"{base_url}{_CHAT_COMPLETIONS_PATH}"
+  max_words = max(8, (max_model_len - max_tokens) // 4)
+  word_counts = sorted({min(size, max_words) for size in (32, 128, 512)})
+  for word_count in word_counts:
+    messages = []
+    if system_message:
+      messages.append({"role": "system", "content": system_message})
+    messages.append({"role": "user", "content": ("warmup " * word_count).strip()})
+    logger.info(
+        "Running chat warmup (approx_words=%d concurrency=%d max_tokens=%d).",
+        word_count,
+        concurrency,
+        max_tokens,
+    )
+    asyncio.run(
+        _send_chat_warmup_batch(
+            api_url=api_url,
+            model=model,
+            messages=messages,
+            concurrency=concurrency,
+            max_tokens=max_tokens,
+            reasoning_effort=reasoning_effort,
+        )
+    )

--- a/src/maxtext/eval/simple_evals_template/__init__.py
+++ b/src/maxtext/eval/simple_evals_template/__init__.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Vendored subset of OpenAI's simple-evals (https://github.com/openai/simple-evals).
+# Vendored from upstream commit: 652c89d
+#
+# These files are copied verbatim from the upstream project and are licensed
+# under the upstream license (see LICENSE in this directory), with one mechanical
+# deviation: in common.py, the MULTILINGUAL_ANSWER_REGEXES entries containing
+# "\s" were given raw-string (r"...") prefixes to silence Python 3.12's
+# SyntaxWarning for invalid escape sequences. The string values are unchanged.
+# Only the grader-free evals required by the MaxText simple_evals runner are
+# vendored:
+#
+#   types.py       Eval / Sampler / Result base types.
+#   common.py      Shared helpers (HTML report, answer extraction, aggregation).
+#   mmlu_eval.py   MMLU eval (no grader model required).
+#   gpqa_eval.py   GPQA eval (no grader model required).
+#   drop_eval.py   DROP eval (no grader model required).
+#   mgsm_eval.py   MGSM eval (no grader model required).
+#
+# Grader-dependent evals (math, simpleqa, browsecomp, healthbench) are
+# intentionally not vendored yet; they require an LLM grader endpoint.
+#
+# GSM8K and AIME are not part of upstream simple-evals. Their Eval
+# implementations live under maxtext.eval.native_evals instead of here, since
+# this package is for verbatim third-party vendoring only; see that package
+# for details.

--- a/src/maxtext/eval/simple_evals_template/aime_eval.py
+++ b/src/maxtext/eval/simple_evals_template/aime_eval.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AIME 2024 and 2025 simple-evals tasks.
+
+Run via the simple_evals runner:
+  python -m maxtext.eval.runner.run \
+      --runner simple_evals \
+      --tasks aime2024|aime2025 \
+      --checkpoint_path <checkpoint_path> \
+      --model_name <model_name> \
+      --hf_path <hf_path> \
+      --base_output_directory <output_dir> \
+      --run_name <run_name> \
+      --max_model_len <max_model_len> \
+      --tensor_parallel_size <tensor_parallel_size> \
+      --hf_token "$HF_TOKEN"
+"""
+
+from __future__ import annotations
+
+import random
+import re
+
+import pandas
+
+from maxtext.eval.simple_evals_template import common
+from maxtext.eval.simple_evals_template.common import HTML_JINJA
+from maxtext.eval.simple_evals_template.types import Eval, EvalResult, SamplerBase, SingleEvalResult
+
+# SamplerBase intentionally preserves the vendored simple-evals API.
+# pylint: disable=protected-access
+
+_AIME_2024_URL = (
+    "https://huggingface.co/datasets/Maxwell-Jia/AIME_2024/resolve/refs%2Fconvert%2Fparquet/default/train/0000.parquet"
+)
+_AIME_2025_URL = (
+    "https://huggingface.co/datasets/math-ai/aime25/resolve/refs%2Fconvert%2Fparquet/default/test/0000.parquet"
+)
+
+_DATASET_BY_YEAR = {
+    2024: (_AIME_2024_URL, "Problem", "Answer"),
+    2025: (_AIME_2025_URL, "problem", "answer"),
+}
+
+QUERY_TEMPLATE = (
+    "Solve this competition math problem. The final answer is always an integer between 0 and 999. "
+    "Think step by step, then write the final answer by itself on the last line in the format "
+    '"Answer: $N" (without quotes), where $N is the integer answer.\n\n{problem}'
+)
+
+_ANSWER_LINE_RE = re.compile(r"(?i)(?:^|\n)\s*Answer\s*:\s*\$?([0-9]{1,3})\$?\s*\Z")
+
+
+def extract_answer(response_text: str) -> str | None:
+  """Pull the integer answer out of a response.
+
+  Requires the explicit final-line format requested by QUERY_TEMPLATE.
+  """
+  match = _ANSWER_LINE_RE.search(response_text)
+  return match.group(1) if match else None
+
+
+class AIMEEval(Eval):
+  """AIME eval for a single contest year (2024 or 2025)."""
+
+  def __init__(self, year: int, num_examples: int | None = None, n_repeats: int = 1):
+    if year not in _DATASET_BY_YEAR:
+      raise ValueError(f"Unsupported AIME year: {year}. Supported: {sorted(_DATASET_BY_YEAR)}.")
+    url, problem_col, answer_col = _DATASET_BY_YEAR[year]
+    try:
+      from huggingface_hub import hf_hub_download  # pylint: disable=import-outside-toplevel
+      # Map raw URL to hf_hub_download parameters
+      if "AIME_2024" in url:
+        parquet_path = hf_hub_download(
+            repo_id="Maxwell-Jia/AIME_2024", repo_type="dataset", filename="default/train/0000.parquet"
+        )
+      else:
+        parquet_path = hf_hub_download(
+            repo_id="math-ai/aime25", repo_type="dataset", filename="default/test/0000.parquet"
+        )
+    except Exception as exc:
+      raise RuntimeError(f"Could not download AIME dataset: {exc}") from exc
+    df = pandas.read_parquet(parquet_path)
+    examples = [{"problem": row[problem_col], "answer": str(int(row[answer_col]))} for _, row in df.iterrows()]
+    rng = random.Random(0)
+    if num_examples:
+      assert n_repeats == 1, "n_repeats only supported for num_examples = None"
+      examples = rng.sample(examples, num_examples)
+    self.examples = examples * n_repeats
+    self.year = year
+
+  def __call__(self, sampler: SamplerBase) -> EvalResult:
+    def fn(row: dict):
+      prompt_messages = [sampler._pack_message(content=QUERY_TEMPLATE.format(problem=row["problem"]), role="user")]
+      sampler_response = sampler(prompt_messages)
+      response_text = sampler_response.response_text
+      actual_queried_prompt_messages = sampler_response.actual_queried_message_list
+      extracted_answer = extract_answer(response_text) if common.request_succeeded(sampler_response) else None
+      score = 1.0 if extracted_answer is not None and int(extracted_answer) == int(row["answer"]) else 0.0
+      html = common.jinja_env.from_string(HTML_JINJA).render(
+          prompt_messages=actual_queried_prompt_messages,
+          next_message={"content": response_text, "role": "assistant"},
+          score=score,
+          correct_answer=row["answer"],
+          extracted_answer=extracted_answer,
+      )
+      convo = actual_queried_prompt_messages + [{"content": response_text, "role": "assistant"}]
+      return SingleEvalResult(
+          html=html,
+          score=score,
+          convo=convo,
+          metrics={"chars": len(response_text)},
+          example_level_metadata={
+              "request_id": sampler_response.response_metadata.get("request_id"),
+              "request_status": sampler_response.response_metadata.get("status", "success"),
+              "score": score,
+              "correct_answer": row["answer"],
+              "extracted_answer": extracted_answer,
+          },
+      )
+
+    results = common.map_with_progress(fn, self.examples)
+    return common.aggregate_results(results)

--- a/src/maxtext/eval/simple_evals_template/common.py
+++ b/src/maxtext/eval/simple_evals_template/common.py
@@ -1,0 +1,435 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Original implementation from https://github.com/openai/simple-evals.
+"""
+import io
+import os
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from multiprocessing.pool import ThreadPool
+from typing import Any, Callable
+
+import jinja2
+import numpy as np
+import requests
+from tqdm import tqdm
+
+from .types import EvalResult, Message, SamplerBase, SamplerResponse, SingleEvalResult
+
+QUERY_TEMPLATE_MULTICHOICE = """
+Answer the following multiple choice question. The last line of your response should be of the following format: 'Answer: $LETTER' (without quotes) where LETTER is one of ABCD. Think step by step before answering.
+
+{Question}
+
+A) {A}
+B) {B}
+C) {C}
+D) {D}
+""".strip()
+
+ANSWER_PATTERN_MULTICHOICE = r"(?i)Answer[ \t]*:[ \t]*\$?([A-D])\$?"
+ANSWER_PATTERN = r"(?i)Answer\s*:\s*([^\n]+)"
+MULTILINGUAL_ANSWER_PATTERN_TEMPLATE = "(?i){}[ \t]*([A-D]|[أ-د]|[অ]|[ব]|[ড]|[ঢ]|[Ａ]|[Ｂ]|[Ｃ]|[Ｄ])"
+# All the different ways "Answer" is written in different languages
+MULTILINGUAL_ANSWER_REGEXES = [
+    r"Answer\s*:",
+    r"Answer\s*:​​​​​​",  # Korean invisible character
+    r"উত্তর\s*:",
+    r"उत्तर\s*:",
+    "উত্তরঃ",
+    r"উত্তর\s*:",
+    r"Antwort\s*:",
+    r"답변\s*:",
+    r"정답\s*:",
+    r"답\s*:",
+    r"答案\s*：",
+    r"答案\s*:",
+    r"答\s*：",
+    r"答\s*:",
+    r"答复\s*：",
+    r"答曰\s*：",
+    "الإجابة:",
+    "الجواب:",
+    "إجابة:",
+    "الإجابة النهائية:",
+    "الإجابة الصحيحة:",
+    "الإجابة الصحيحة هي:",
+    "الإجابة هي:",
+    "الجواب النهائي:",
+    r"Respuesta\s*:",
+    r"Risposta\s*:",
+    r"答え\s*:",
+    r"答え\s*：",
+    r"回答\s*:",
+    r"回答\s*：",
+    r"解答\s*:",
+    r"Jawaban\s*:",
+    r"Réponse\s*:",
+    r"Resposta\s*:",
+    r"Jibu\s*:",
+    r"Idahun\s*:",
+    r"Ìdáhùn\s*:",
+    r"Idáhùn\s*:",
+    r"Àmọ̀nà\s*:",
+    r"Àdáhùn\s*:",
+    r"Ànúgọ\s*:",
+    r"Àṣàyàn\s*:",
+]
+
+_DEFAULT_NUM_THREADS = os.cpu_count() or 10
+
+
+def request_succeeded(response: SamplerResponse) -> bool:
+  """Return whether a sampler response is safe for task-level grading."""
+  return response.response_metadata.get("status", "success") == "success"
+
+
+def set_default_num_threads(num_threads: int) -> None:
+  """Set the bounded worker count used by simple-evals task mapping."""
+  if num_threads <= 0:
+    raise ValueError("num_threads must be positive")
+  global _DEFAULT_NUM_THREADS
+  _DEFAULT_NUM_THREADS = num_threads
+
+
+EQUALITY_TEMPLATE = r"""
+Look at the following two expressions (answers to a math problem) and judge whether they are equivalent. Only perform trivial simplifications
+
+Examples:
+
+    Expression 1: $2x+3$
+    Expression 2: $3+2x$
+
+Yes
+
+    Expression 1: 3/2
+    Expression 2: 1.5
+
+Yes
+
+    Expression 1: $x^2+2x+1$
+    Expression 2: $y^2+2y+1$
+
+No
+
+    Expression 1: $x^2+2x+1$
+    Expression 2: $(x+1)^2$
+
+Yes
+
+    Expression 1: 3245/5
+    Expression 2: 649
+
+No
+(these are actually equal, don't mark them equivalent if you need to do nontrivial simplifications)
+
+    Expression 1: 2/(-3)
+    Expression 2: -2/3
+
+Yes
+(trivial simplifications are allowed)
+
+    Expression 1: 72 degrees
+    Expression 2: 72
+
+Yes
+(give benefit of the doubt to units)
+
+    Expression 1: 64
+    Expression 2: 64 square feet
+
+Yes
+(give benefit of the doubt to units)
+
+---
+
+YOUR TASK
+
+
+Respond with only "Yes" or "No" (without quotes). Do not include a rationale.
+
+    Expression 1: %(expression1)s
+    Expression 2: %(expression2)s
+""".strip()
+
+
+HTML_JINJA = """
+<h3>Prompt conversation</h3>
+{% for message in prompt_messages %}
+{{ message_to_html(message) | safe }}
+{% endfor %}
+<h3>Sampled message</h3>
+{{ message_to_html(next_message) | safe }}
+<h3>Results</h3>
+<p>Correct Answer: {{ correct_answer }}</p>
+<p>Extracted Answer: {{ extracted_answer }}</p>
+<p>Score: {{ score }}</p>
+"""
+
+
+def format_multichoice_question(row):
+  return QUERY_TEMPLATE_MULTICHOICE.format(**row)
+
+
+def check_equality(sampler: SamplerBase, expr1: str, expr2: str):
+  prompt = EQUALITY_TEMPLATE % {"expression1": expr1, "expression2": expr2}
+  sampler_response = sampler([dict(content=prompt, role="user")])
+  response_text = sampler_response.response_text
+  return response_text.lower().strip() == "yes"
+
+
+def _compute_stat(values: list, stat: str):
+  if stat == "mean":
+    return np.mean(values)
+  elif stat == "std":
+    return np.std(values)
+  elif stat == "min":
+    return np.min(values)
+  elif stat == "max":
+    return np.max(values)
+  elif stat == "n_samples":
+    return len(values)
+  elif stat == "bootstrap_std":
+    return np.std([np.mean(np.random.choice(values, len(values))) for _ in range(1000)])
+  else:
+    raise ValueError(f"Unknown {stat =}")
+
+
+def aggregate_results(
+    single_eval_results: list[SingleEvalResult],
+    default_stats: tuple[str, ...] = ("mean", "std"),
+    name2stats: dict[str, tuple[str]] | None = None,
+) -> EvalResult:
+  """
+  Aggregate results from multiple evaluations into a single EvalResult.
+  """
+  name2stats = name2stats or {}
+  name2values = defaultdict(list)
+  htmls = []
+  convos = []
+  metadata = []
+  for single_eval_result in single_eval_results:
+    for name, value in single_eval_result.metrics.items():
+      name2values[name].append(value)
+    if single_eval_result.score is not None:
+      name2values["score"].append(single_eval_result.score)
+    htmls.append(single_eval_result.html)
+    convos.append(single_eval_result.convo)
+    metadata.append(single_eval_result.example_level_metadata)
+  final_metrics = {}
+  for name, values in name2values.items():
+    stats = name2stats.get(name, default_stats)
+    for stat in stats:
+      key = name if stat == "mean" else f"{name}:{stat}"
+      final_metrics[key] = _compute_stat(values, stat)
+  return EvalResult(
+      score=final_metrics.pop("score", None),
+      metrics=final_metrics,
+      htmls=htmls,
+      convos=convos,
+      metadata={"example_level_metadata": metadata},
+  )
+
+
+def map_with_progress(
+    f: Callable,
+    xs: list[Any],
+    num_threads: int | None = None,
+    pbar: bool = True,
+):
+  """
+  Apply f to each element of xs, using a ThreadPool, and show progress.
+  """
+  pbar_fn = tqdm if pbar else lambda x, *args, **kwargs: x
+  resolved_num_threads = num_threads if num_threads is not None else _DEFAULT_NUM_THREADS
+
+  if os.getenv("debug"):
+    return list(map(f, pbar_fn(xs, total=len(xs))))
+  else:
+    with ThreadPool(min(resolved_num_threads, len(xs))) as pool:
+      return list(pbar_fn(pool.imap(f, xs), total=len(xs)))
+
+
+jinja_env = jinja2.Environment(
+    loader=jinja2.BaseLoader(),
+    undefined=jinja2.StrictUndefined,
+    autoescape=jinja2.select_autoescape(["html", "xml"]),
+)
+_message_template = """
+<div class="message {{ role }}">
+    <div class="role">
+    {{ role }}
+    {% if variant %}<span class="variant">({{ variant }})</span>{% endif %}
+    </div>
+    <div class="content">
+    <pre>{{ content }}</pre>
+    </div>
+</div>
+"""
+
+
+def message_to_html(message: Message) -> str:
+  """
+  Generate HTML snippet (inside a <div>) for a message.
+  """
+  return jinja_env.from_string(_message_template).render(
+      role=message["role"],
+      content=message["content"],
+      variant=message.get("variant", None),
+  )
+
+
+jinja_env.globals["message_to_html"] = message_to_html
+
+
+_report_template = """<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            .message {
+                padding: 8px 16px;
+                margin-bottom: 8px;
+                border-radius: 4px;
+            }
+            .message.user {
+                background-color: #B2DFDB;
+                color: #00695C;
+            }
+            .message.assistant {
+                background-color: #B39DDB;
+                color: #4527A0;
+            }
+            .message.system {
+                background-color: #EEEEEE;
+                color: #212121;
+            }
+            .role {
+                font-weight: bold;
+                margin-bottom: 4px;
+            }
+            .variant {
+                color: #795548;
+            }
+            table, th, td {
+                border: 1px solid black;
+            }
+            pre {
+                white-space: pre-wrap;
+            }
+        </style>
+    </head>
+    <body>
+    {% if metrics %}
+    <h1>Metrics</h1>
+    <table>
+    <tr>
+        <th>Metric</th>
+        <th>Value</th>
+    </tr>
+    <tr>
+        <td><b>Score</b></td>
+        <td>{{ score | float | round(3) }}</td>
+    </tr>
+    {% for name, value in metrics.items() %}
+    <tr>
+        <td>{{ name }}</td>
+        <td>{{ value }}</td>
+    </tr>
+    {% endfor %}
+    </table>
+    {% endif %}
+    <h1>Examples</h1>
+    {% for html in htmls %}
+    {{ html | safe }}
+    <hr>
+    {% endfor %}
+    </body>
+</html>
+"""
+
+
+def make_report(eval_result: EvalResult) -> str:
+  """
+  Create a standalone HTML report from an EvalResult.
+  """
+  return jinja_env.from_string(_report_template).render(
+      score=eval_result.score,
+      metrics=eval_result.metrics,
+      htmls=eval_result.htmls,
+  )
+
+
+def make_report_from_example_htmls(htmls: list[str]):
+  """
+  Create a standalone HTML report from a list of example htmls
+  """
+  return jinja_env.from_string(_report_template).render(score=None, metrics={}, htmls=htmls)
+
+
+def normalize_response(response: str) -> str:
+  """
+  Normalize the response by removing markdown and LaTeX formatting that may prevent a match.
+  """
+
+  return (
+      response.replace("**", "")
+      .replace("$\\boxed{", "")
+      .replace("}$", "")
+      .replace("\\$", "")
+      .replace("$\\text{", "")
+      .replace("$", "")
+      .replace("\\mathrm{", "")
+      .replace("\\{", "")
+      .replace("\\text", "")
+      .replace("\\(", "")
+      .replace("\\mathbf{", "")
+      .replace("{", "")
+      .replace("\\boxed", "")
+  )
+
+
+def normalize_extracted_answer(extracted_answer: str) -> str:
+  return (
+      # In arabic these are the letters used for A-D in multiple choice questions
+      extracted_answer.replace("أ", " A")
+      .replace("ب", " B")
+      .replace("ج", " C")
+      .replace("د", " D")
+      # In Bengali these are the letters used for A-D in multiple choice questions
+      .replace("অ", " A")
+      .replace("ব", " B")
+      .replace("ড", " C")
+      .replace("ঢ", " D")
+      # In Japanese these are the letters sometimes used for A-D in multiple choice questions
+      .replace("Ａ", " A")
+      .replace("Ｂ", " B")
+      .replace("Ｃ", " C")
+      .replace("Ｄ", " D")
+      .strip()
+  )
+
+
+def url_to_fileobj(url: str, binary=False) -> Any:
+  response = requests.get(url)
+  response.raise_for_status()
+  return io.BytesIO(response.content) if binary else io.StringIO(response.text)
+
+
+def has_only_user_assistant_messages(messages: list[Message]) -> bool:
+  """
+  Check if the messages only contain user and assistant messages.
+  """
+  return all(m["role"] in ("user", "assistant") for m in messages)

--- a/src/maxtext/eval/simple_evals_template/drop_eval.py
+++ b/src/maxtext/eval/simple_evals_template/drop_eval.py
@@ -1,0 +1,319 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+DROP: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Paragraphs
+Dheeru Dua, Yizhong Wang, Pradeep Dasigi, Gabriel Stanovsky, Sameer Singh, Matt Gardner
+https://arxiv.org/abs/1903.00161
+
+Original implementation from https://github.com/openai/simple-evals.
+"""
+
+import gzip
+import json
+import random
+import re
+import string
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+import numpy as np
+from scipy.optimize import linear_sum_assignment
+
+from . import common
+from .common import ANSWER_PATTERN, HTML_JINJA
+from .types import Eval, EvalResult, SamplerBase, SingleEvalResult
+
+"""
+From here through _normalize_answer was originally copied from:
+https://worksheets.codalab.org/rest/bundles/0x6b567e1cf2e041ec80d7098f031c5c9e/contents/blob/
+Then cleaned up and modified a bit.
+
+The rest was originally copied from https://github.com/allenai/allennlp-reading-comprehension/blob/master/allennlp_rc
+/eval/drop_eval.py
+"""
+
+
+def _remove_articles(text: str) -> str:
+  regex = re.compile(r"\b(a|an|the)\b", re.UNICODE)
+  return re.sub(regex, " ", text)
+
+
+def _white_space_fix(text: str) -> str:
+  return " ".join(text.split())
+
+
+EXCLUDE = set(string.punctuation)
+
+
+def _remove_punc(text: str) -> str:
+  if not _is_number(text):
+    return "".join(ch for ch in text if ch not in EXCLUDE)
+  else:
+    return text
+
+
+def _lower(text: str) -> str:
+  return text.lower()
+
+
+def _tokenize(text: str) -> List[str]:
+  return re.split(" |-", text)
+
+
+def _normalize_answer(text: str) -> str:
+  """Lower text and remove punctuation, articles and extra whitespace."""
+
+  parts = [
+      _white_space_fix(_remove_articles(_normalize_number(_remove_punc(_lower(token))))) for token in _tokenize(text)
+  ]
+  parts = [part for part in parts if part.strip()]
+  normalized = " ".join(parts).strip()
+  return normalized
+
+
+def _is_number(text: str) -> bool:
+  try:
+    float(text)
+    return True
+  except ValueError:
+    return False
+
+
+def _normalize_number(text: str) -> str:
+  if _is_number(text):
+    return str(float(text))
+  else:
+    return text
+
+
+def _answer_to_bags(answer: Union[str, List[str], Tuple[str, ...]]) -> Tuple[List[str], List[Set[str]]]:
+  if isinstance(answer, (list, tuple)):
+    raw_spans = answer
+  else:
+    raw_spans = [answer]
+  normalized_spans: List[str] = []
+  token_bags = []
+  for raw_span in raw_spans:
+    normalized_span = _normalize_answer(raw_span)
+    normalized_spans.append(normalized_span)
+    token_bags.append(set(normalized_span.split()))
+  return normalized_spans, token_bags
+
+
+def _align_bags(predicted: List[Set[str]], gold: List[Set[str]]) -> List[float]:
+  """
+  Takes gold and predicted answer sets and first finds the optimal 1-1 alignment
+  between them and gets maximum metric values over all the answers.
+  """
+  scores = np.zeros([len(gold), len(predicted)])
+  for gold_index, gold_item in enumerate(gold):
+    for pred_index, pred_item in enumerate(predicted):
+      if _match_numbers_if_present(gold_item, pred_item):
+        scores[gold_index, pred_index] = _compute_f1(pred_item, gold_item)
+  row_ind, col_ind = linear_sum_assignment(-scores)
+
+  max_scores = np.zeros([max(len(gold), len(predicted))])
+  for row, column in zip(row_ind, col_ind):
+    max_scores[row] = max(max_scores[row], scores[row, column])
+  return max_scores
+
+
+def _compute_f1(predicted_bag: Set[str], gold_bag: Set[str]) -> float:
+  intersection = len(gold_bag.intersection(predicted_bag))
+  if not predicted_bag:
+    precision = 1.0
+  else:
+    precision = intersection / float(len(predicted_bag))
+  if not gold_bag:
+    recall = 1.0
+  else:
+    recall = intersection / float(len(gold_bag))
+  f1 = ((2 * precision * recall) / (precision + recall) if not (precision == 0.0 and recall == 0.0) else 0.0) * 100
+  return f1
+
+
+def _match_numbers_if_present(gold_bag: Set[str], predicted_bag: Set[str]) -> bool:
+  gold_numbers = set()
+  predicted_numbers = set()
+  for word in gold_bag:
+    if _is_number(word):
+      gold_numbers.add(word)
+  for word in predicted_bag:
+    if _is_number(word):
+      predicted_numbers.add(word)
+  if (not gold_numbers) or gold_numbers.intersection(predicted_numbers):
+    return True
+  return False
+
+
+def get_drop_metrics(
+    predicted: Union[str, List[str], Tuple[str, ...]], gold: Union[str, List[str], Tuple[str, ...]]
+) -> Tuple[float, float]:
+  """
+  Takes a predicted answer and a gold answer (that are both either a string or a list of
+  strings), and returns exact match and the DROP F1 metric for the prediction.  If you are
+  writing a script for evaluating objects in memory (say, the output of predictions during
+  validation, or while training), this is the function you want to call, after using
+  :func:`answer_json_to_strings` when reading the gold answer from the released data file.
+  """
+  predicted_bags = _answer_to_bags(predicted)
+  gold_bags = _answer_to_bags(gold)
+
+  if set(predicted_bags[0]) == set(gold_bags[0]) and len(predicted_bags[0]) == len(gold_bags[0]):
+    exact_match = 1.0
+  else:
+    exact_match = 0.0
+
+  f1_per_bag = _align_bags(predicted_bags[1], gold_bags[1])
+  f1 = np.mean(f1_per_bag)
+  f1 = round(f1, 2)
+  return exact_match, f1
+
+
+def answer_json_to_strings(answer: Dict[str, Any]) -> Tuple[Tuple[str, ...], str]:
+  """
+  Takes an answer JSON blob from the DROP data release and converts it into strings used for
+  evaluation.
+  """
+  if "number" in answer and answer["number"]:
+    return tuple([str(answer["number"])]), "number"
+  elif "spans" in answer and answer["spans"]:
+    return tuple(answer["spans"]), "span" if len(answer["spans"]) == 1 else "spans"
+  elif "date" in answer:
+    return (
+        tuple(["{0} {1} {2}".format(answer["date"]["day"], answer["date"]["month"], answer["date"]["year"]).strip()]),
+        "date",
+    )
+  else:
+    raise ValueError(f"Answer type not found, should be one of number, spans or date at: {json.dumps(answer)}")
+
+
+def answer_json_to_string(answer_json):
+  return json.dumps(answer_json_to_strings(answer_json))
+
+
+def normalize(s: str) -> str:
+  """Lower text and remove punctuation, articles and extra whitespace."""
+  s = s.lower()
+  exclude = set(string.punctuation)
+  s = "".join(char for char in s if char not in exclude)
+  s = re.sub(r"\b(a|an|the)\b", " ", s)
+  s = " ".join(s.split())
+  return s
+
+
+def fuzzy_match(s1: str, s2: str) -> bool:
+  s1 = normalize(s1)
+  s2 = normalize(s2)
+
+  if s1 == "" or s2 == "":
+    return s1 == s2
+
+  return s1 in s2 or s2 in s1
+
+
+def drop_metric(sample: str, reference: list[str]) -> Tuple[float, float]:
+  em_scores = []
+  f1_scores = []
+  for answer in reference:
+    if answer.strip() != "":
+      em, f1 = get_drop_metrics(sample, answer)
+      em_scores.append(em)
+      f1_scores.append(f1)
+  return (max(em_scores), max(f1_scores))
+
+
+class DropEval(Eval):
+
+  def __init__(self, num_examples: int | None = None, train_samples_per_prompt: int = 3):
+    self.seed = 42
+    self._num_examples = num_examples
+    self._train_samples_per_prompt = train_samples_per_prompt
+    self.train_jsonl = "https://openaipublic.blob.core.windows.net/simple-evals/drop_v0_train.jsonl.gz"
+    self.test_jsonl = "https://openaipublic.blob.core.windows.net/simple-evals/drop_v0_dev.jsonl.gz"
+    with gzip.GzipFile(fileobj=common.url_to_fileobj(self.train_jsonl, binary=True), mode="rb") as f:
+      self.train_samples = list(map(json.loads, f.readlines()))
+    with gzip.GzipFile(fileobj=common.url_to_fileobj(self.test_jsonl, binary=True), mode="rb") as f:
+      self.test_samples = list(map(json.loads, f.readlines()))
+      if self._num_examples:
+        self.test_samples = random.Random(self.seed).sample(self.test_samples, self._num_examples)
+
+  def __call__(self, sampler: SamplerBase) -> EvalResult:
+    rng = random.Random(self.seed)
+    examples_with_stuffing = [
+        (example, rng.sample(self.train_samples, self._train_samples_per_prompt)) for example in self.test_samples
+    ]
+
+    def fn(example_with_stuffing: tuple[dict[str, str], list[dict[str, str]]]):
+      example, stuffing = example_with_stuffing
+      # prompt = """TASK: Read the provided passage, then identify the correct answer to questions below."""
+      prompt = """You will be asked to read a passage and answer a question. Some examples of passages and Q&A are provided below."""
+      prompt += "\n\n# Examples"
+      samples = stuffing + [example]
+      for i, sample in enumerate(samples):
+        is_test = i == len(stuffing)
+        prompt += "\n# Your Task\n" if is_test else ""
+        prompt += f"""
+---
+{sample["context"]} """
+
+        a = sample["completion"]
+        correct_answers = sample["ref_text"].split("|")
+
+        if not is_test:
+          prompt += a + "\n"
+        else:
+          prompt += """\n
+Think step by step, then write a line of the form "Answer: $ANSWER" at the end of your response.
+                    """
+          prompt_messages = [sampler._pack_message(content=prompt, role="user")]
+          sampler_response = sampler(prompt_messages)
+          response_text = sampler_response.response_text
+          actual_queried_prompt_messages = sampler_response.actual_queried_message_list
+          if common.request_succeeded(sampler_response):
+            match = re.search(ANSWER_PATTERN, response_text)
+            extracted_answer = match.group(1) if match else response_text
+            em_score, f1_score = drop_metric(extracted_answer, correct_answers)
+            matches = [fuzzy_match(extracted_answer, correct_answer) for correct_answer in correct_answers]
+          else:
+            match = None
+            extracted_answer = ""
+            em_score, f1_score = 0.0, 0.0
+            matches = [False] * len(correct_answers)
+          extracted_answers = [extracted_answer for i in range(len(correct_answers)) if matches[i]]
+          score = True in matches
+          html = common.jinja_env.from_string(HTML_JINJA).render(
+              prompt_messages=actual_queried_prompt_messages,
+              next_message=dict(content=extracted_answer, role="assistant"),
+              score=score,
+              correct_answer=correct_answers,
+              extracted_answer=extracted_answers,
+          )
+          convo = actual_queried_prompt_messages + [dict(content=extracted_answer, role="assistant")]
+          return SingleEvalResult(
+              html=html,
+              score=score,
+              convo=convo,
+              metrics={"em_score": em_score, "f1_score": f1_score},
+              example_level_metadata={
+                  "request_id": sampler_response.response_metadata.get("request_id"),
+                  "request_status": sampler_response.response_metadata.get("status", "success"),
+                  "score": score,
+                  "correct_answer": correct_answers,
+                  "extracted_answer": match.group(1) if match else None,
+              },
+          )
+
+    results = common.map_with_progress(fn, examples_with_stuffing)
+    return common.aggregate_results(results)

--- a/src/maxtext/eval/simple_evals_template/gpqa_eval.py
+++ b/src/maxtext/eval/simple_evals_template/gpqa_eval.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+GPQA: A Graduate-Level Google-Proof Q&A Benchmark
+David Rein, Betty Li Hou, Asa Cooper Stickland, Jackson Petty, Richard Yuanzhe Pang, Julien Dirani, Julian Michael, Samuel R. Bowman
+https://arxiv.org/abs/2311.12022
+
+Original implementation from https://github.com/openai/simple-evals.
+"""
+
+import random
+import re
+
+import pandas
+
+from . import common
+from .common import ANSWER_PATTERN_MULTICHOICE, HTML_JINJA, format_multichoice_question
+from .types import Eval, EvalResult, MessageList, SamplerBase, SingleEvalResult
+
+
+class GPQAEval(Eval):
+
+  def __init__(
+      self,
+      n_repeats: int = 4,
+      variant: str = "diamond",
+      num_examples: int | None = None,  # restrict to a subset of the data for debugging
+  ):
+    df = pandas.read_csv(f"https://openaipublic.blob.core.windows.net/simple-evals/gpqa_{variant}.csv")
+    examples = [row.to_dict() for _, row in df.iterrows()]
+    rng = random.Random(0)
+    if num_examples:
+      assert n_repeats == 1, "n_repeats only supported for num_examples = None"
+      examples = rng.sample(examples, num_examples)
+    examples = examples * n_repeats
+    examples = [example | {"permutation": rng.sample(range(4), 4)} for example in examples]
+    self.examples = examples
+    self.n_repeats = n_repeats
+
+  def __call__(self, sampler: SamplerBase) -> EvalResult:
+    def fn(row: dict):
+      choices = [
+          row["Correct Answer"],
+          row["Incorrect Answer 1"],
+          row["Incorrect Answer 2"],
+          row["Incorrect Answer 3"],
+      ]
+      choices = [choices[i] for i in row["permutation"]]
+      correct_index = choices.index(row["Correct Answer"])
+      correct_answer = "ABCD"[correct_index]
+      choices_dict = dict(A=choices[0], B=choices[1], C=choices[2], D=choices[3], Question=row["Question"])
+      prompt_messages = [sampler._pack_message(content=format_multichoice_question(choices_dict), role="user")]
+      sampler_response = sampler(prompt_messages)
+      response_text = sampler_response.response_text
+      actual_queried_prompt_messages = sampler_response.actual_queried_message_list
+      request_succeeded = common.request_succeeded(sampler_response)
+      match = re.search(ANSWER_PATTERN_MULTICHOICE, response_text) if request_succeeded else None
+      extracted_answer = match.group(1) if match else None
+      score = 1.0 if extracted_answer == correct_answer else 0.0
+      html = common.jinja_env.from_string(HTML_JINJA).render(
+          prompt_messages=actual_queried_prompt_messages,
+          next_message=dict(content=response_text, role="assistant"),
+          score=score,
+          correct_answer=correct_answer,
+          extracted_answer=extracted_answer,
+      )
+      convo = actual_queried_prompt_messages + [dict(content=response_text, role="assistant")]
+      return SingleEvalResult(
+          html=html,
+          score=score,
+          convo=convo,
+          metrics={"chars": len(response_text)},
+          example_level_metadata={
+              "request_id": sampler_response.response_metadata.get("request_id"),
+              "request_status": sampler_response.response_metadata.get("status", "success"),
+              "score": score,
+              "correct_answer": correct_answer,
+              "extracted_answer": extracted_answer,
+          },
+      )
+
+    results = common.map_with_progress(fn, self.examples)
+    return common.aggregate_results(results)

--- a/src/maxtext/eval/simple_evals_template/gsm8k_eval.py
+++ b/src/maxtext/eval/simple_evals_template/gsm8k_eval.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GSM8K simple-evals task.
+
+Run via the simple_evals runner:
+  python -m maxtext.eval.runner.run \
+      --runner simple_evals \
+      --tasks gsm8k \
+      --checkpoint_path <checkpoint_path> \
+      --model_name <model_name> \
+      --hf_path <hf_path> \
+      --base_output_directory <output_dir> \
+      --run_name <run_name> \
+      --max_model_len <max_model_len> \
+      --tensor_parallel_size <tensor_parallel_size> \
+      --hf_token "$HF_TOKEN"
+"""
+
+from __future__ import annotations
+
+import random
+import re
+
+import pandas
+
+from maxtext.eval.simple_evals_template import common
+from maxtext.eval.simple_evals_template.common import HTML_JINJA
+from maxtext.eval.simple_evals_template.mgsm_eval import score_mgsm
+from maxtext.eval.simple_evals_template.types import Eval, EvalResult, SamplerBase, SingleEvalResult
+
+# SamplerBase intentionally preserves the vendored simple-evals API.
+# pylint: disable=protected-access
+
+_DATASET_REPO_ID = "openai/gsm8k"
+_TEST_PARQUET_FILENAME = "main/test-00000-of-00001.parquet"
+
+QUERY_TEMPLATE = (
+    "Solve this math problem. Give the reasoning steps before giving the final answer on the last line "
+    'by itself in the format of "Answer:". Do not add anything other than the integer answer after '
+    '"Answer:".\n\n{question}'
+)
+
+_ANSWER_LINE_RE = re.compile(r"(?i)(?:^|\n)\s*Answer\s*:\s*(-?[\d,]+(?:\.\d+)?)\s*\Z")
+
+
+def extract_answer(response_text: str) -> str | None:
+  """Extract the last answer that obeys GSM8K's requested final-line format."""
+  match = _ANSWER_LINE_RE.search(response_text)
+  return match.group(1).replace(",", "") if match else None
+
+
+def _load_gsm8k_examples() -> list[dict]:
+  """Download/cache the canonical GSM8K test parquet through HF Hub."""
+  try:
+    from huggingface_hub import hf_hub_download  # pylint: disable=import-outside-toplevel
+  except ImportError as exc:
+    raise ImportError(
+        "GSM8K evaluation requires huggingface_hub. Install it with `pip install huggingface_hub`."
+    ) from exc
+
+  try:
+    parquet_path = hf_hub_download(
+        repo_id=_DATASET_REPO_ID,
+        repo_type="dataset",
+        filename=_TEST_PARQUET_FILENAME,
+    )
+  except Exception as exc:  # pylint: disable=broad-except
+    raise RuntimeError(
+        "Could not download the canonical GSM8K main/test split from Hugging Face. "
+        "Check outbound Hub access and HF_TOKEN for any proxy policy."
+    ) from exc
+
+  df = pandas.read_parquet(parquet_path)
+  examples = [row.to_dict() for _, row in df.iterrows()]
+  if len(examples) != 1319:
+    raise ValueError(f"Expected 1319 GSM8K main/test examples, found {len(examples)}.")
+  return examples
+
+
+class GSM8KEval(Eval):
+  """GSM8K eval: zero-shot CoT prompt, gold answer parsed from the '#### N' suffix."""
+
+  def __init__(self, num_examples: int | None = None):
+    examples = _load_gsm8k_examples()
+    for example in examples:
+      example["target"] = example["answer"].split("####")[-1].strip().replace(",", "")
+    if num_examples:
+      examples = random.Random(0).sample(examples, num_examples)
+    self.examples = examples
+
+  def __call__(self, sampler: SamplerBase) -> EvalResult:
+    def fn(row: dict):
+      prompt_messages = [sampler._pack_message(content=QUERY_TEMPLATE.format(question=row["question"]), role="user")]
+      sampler_response = sampler(prompt_messages)
+      response_text = sampler_response.response_text
+      actual_queried_prompt_messages = sampler_response.actual_queried_message_list
+      extracted_answer = extract_answer(response_text) if common.request_succeeded(sampler_response) else None
+      score = score_mgsm(row["target"], extracted_answer or "")
+      html = common.jinja_env.from_string(HTML_JINJA).render(
+          prompt_messages=actual_queried_prompt_messages,
+          next_message={"content": response_text, "role": "assistant"},
+          score=score,
+          correct_answer=row["target"],
+          extracted_answer=extracted_answer or None,
+      )
+      convo = actual_queried_prompt_messages + [{"content": response_text, "role": "assistant"}]
+      return SingleEvalResult(
+          html=html,
+          score=score,
+          convo=convo,
+          example_level_metadata={
+              "request_id": sampler_response.response_metadata.get("request_id"),
+              "request_status": sampler_response.response_metadata.get("status", "success"),
+              "score": score,
+              "correct_answer": row["target"],
+              "extracted_answer": extracted_answer or None,
+          },
+      )
+
+    results = common.map_with_progress(fn, self.examples)
+    return common.aggregate_results(results)

--- a/src/maxtext/eval/simple_evals_template/mgsm_eval.py
+++ b/src/maxtext/eval/simple_evals_template/mgsm_eval.py
@@ -1,0 +1,206 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+MGSM: Multilingual Grade School Math Benchmark (MGSM) is a benchmark of grade-school math problems.
+Language Models are Multilingual Chain-of-Thought Reasoners
+Freda Shi, Mirac Suzgun, Markus Freitag, Xuezhi Wang, Suraj Srivats, Soroush Vosoughi, Hyung Won Chung, Yi Tay, Sebastian Ruder, Denny Zhou, Dipanjan Das, Jason Wei
+https://arxiv.org/abs/2210.03057 reference: https://github.com/google-research/url-nlp
+
+Original implementation from https://github.com/openai/simple-evals.
+"""
+
+import re
+from typing import Optional
+
+from . import common
+from .mmlu_eval import HTML_JINJA
+from .types import Eval, EvalResult, SamplerBase, SingleEvalResult
+
+ALL_LANGUAGES = ["bn", "de", "en", "es", "fr", "ja", "ru", "sw", "te", "th", "zh"]
+LATIN_LANGUAGES = ["de", "en", "es", "fr", "sw"]
+NON_LATIN_LANGUAGES = ["bn", "ja", "ru", "te", "th", "zh"]
+
+LANG_TO_FPATH = {
+    "bn": "https://openaipublic.blob.core.windows.net/simple-evals/mgsm_bn.tsv",
+    "de": "https://openaipublic.blob.core.windows.net/simple-evals/mgsm_de.tsv",
+    "en": "https://openaipublic.blob.core.windows.net/simple-evals/mgsm_en.tsv",
+    "es": "https://openaipublic.blob.core.windows.net/simple-evals/mgsm_es.tsv",
+    "fr": "https://openaipublic.blob.core.windows.net/simple-evals/mgsm_fr.tsv",
+    "ja": "https://openaipublic.blob.core.windows.net/simple-evals/mgsm_ja.tsv",
+    "ru": "https://openaipublic.blob.core.windows.net/simple-evals/mgsm_ru.tsv",
+    "sw": "https://openaipublic.blob.core.windows.net/simple-evals/mgsm_sw.tsv",
+    "te": "https://openaipublic.blob.core.windows.net/simple-evals/mgsm_te.tsv",
+    "th": "https://openaipublic.blob.core.windows.net/simple-evals/mgsm_th.tsv",
+    "zh": "https://openaipublic.blob.core.windows.net/simple-evals/mgsm_zh.tsv",
+}
+LANG_TO_INSTRUCTIONS = {
+    "en": """Solve this math problem. Give the reasoning steps before giving the final answer on the last line by itself in the format of "Answer:". Do not add anything other than the integer answer after "Answer:".
+
+{input}""",
+    "bn": """এই গণিতের সমস্যাটি সমাধান করুন। চূড়ান্ত উত্তর দেওয়ার আগে যুক্তিসম্পন্ন পদক্ষেপ প্রদান করুন। চূড়ান্ত উত্তরটি একক সংখ্যা হিসাবে "উত্তর:" এর পরে শেষ লাইনে দিন। "উত্তর:" এর পরে অন্য কিছু যুক্ত করবেন না।.
+
+{input}""",
+    "de": """Löse dieses Mathematikproblem. Gib die Schritte zur Begründung an, bevor du die endgültige Antwort in der letzten Zeile alleine im Format "Antwort:" gibst. Füge nichts anderes als die ganzzahlige Antwort nach "Antwort:" hinzu.
+
+{input}""",
+    "es": """Resuelve este problema matemático. Proporciona los pasos de razonamiento antes de dar la respuesta final en la última línea por sí misma en el formato de "Respuesta:". No añadas nada más que la respuesta entera después de "Respuesta:".
+
+{input}""",
+    "fr": """Résolvez ce problème de mathématiques. Donnez les étapes de raisonnement avant de fournir la réponse finale sur la dernière ligne elle-même dans le format de "Réponse:". N'ajoutez rien d'autre que la réponse entière après "Réponse:".
+
+{input}""",
+    "ja": """の数学の問題を解いてください。最終的な答えを出す前に、解答の推論過程を記述してください。そして最後の行には "答え:" の形式で答えを記述し、その後には整数の答え以外何も追加しないでください。
+
+{input}""",
+    "ru": """Решите эту математическую задачу. Объясните шаги рассуждения перед тем, как дать окончательный ответ в последней строке сам по себе в формате "Ответ:". Не добавляйте ничего, кроме целочисленного ответа после "Ответ:".
+
+{input}""",
+    "sw": """Suluhisha tatizo hili la hesabu. Toa hatua za mantiki kabla ya kutoa jibu la mwisho kwenye mstari wa mwisho peke yake katika muundo wa "Jibu:". Usiongeze chochote kingine isipokuwa jibu la integer baada ya "Jibu:".
+
+{input}""",
+    "te": """ఈ గణిత సమస్యను పరిష్కరించండి. చివరి సమాధానాన్ని ఇవ్వదానికి ముందు తర్కాత్మక అదుగులను ఇవ్వండి. చివరి పంక్తిలో మాత్రమే 'సమాధానం:' అనే ఆకారంలో చివరి సమాధానాద్ని ఇవ్వండి సమాధానం: తర్వాత పూర్ణాంక సమాధానానికి తప్పించి ఎదేనా చేర్చవద్దు.
+
+{input}""",
+    "th": """แก้ปัญหาคณิตศาสตร์นี้ ให้ให้ขั้นตอนการใช้เหตุผลก่อนที่จะให้คำตอบสุดท้ายในบรรทัดสุดท้ายโดยอยู่ในรูปแบบ "คำตอบ:" ไม่ควรเพิ่มอะไรนอกจากคำตอบที่เป็นจำนวนเต็มหลังจาก "คำตอบ:"
+
+{input}""",
+    "zh": """解决这个数学问题。在最后一行给出答案前，请提供推理步骤。最后一行应该以 "答案: " 的形式独立给出答案。在 "答案：" 后不要添加除整数答案之外的任何内容。
+
+{input}""",
+}
+
+LANG_TO_ANSWER_PREFIX = {
+    "en": "Answer",
+    "bn": "উত্তর",
+    "de": "Antwort",
+    "es": "Respuesta",
+    "fr": "Réponse",
+    "ja": "答え",
+    "ru": "Ответ",
+    "sw": "Jibu",
+    "te": "సమాధానం",
+    "th": "คำตอบ",
+    "zh": "答案",
+}
+
+
+def parse_answer(answer: str, answer_prefix: str) -> str:
+  if answer_prefix not in answer:
+    return ""
+
+  answer_text = answer.split(answer_prefix)[-1].strip()
+
+  # find all the numbers (including decimals) in the string
+  numbers = re.findall(r"\d+\.?\d*", answer_text.replace(",", ""))
+
+  # return the first number (removing trailing decimal point if present),
+  # or an empty string if there were no numbers
+  return numbers[-1].rstrip(".") if numbers else ""
+
+
+def score_mgsm(target: str, prediction: str) -> bool:
+  if "." in prediction:
+    prediction = prediction.rstrip("0").rstrip(".")
+
+  target = target.replace(",", "")
+  prediction = prediction.replace(",", "")
+
+  return target == prediction
+
+
+def get_lang_examples(lang: str) -> list[dict[str, str]]:
+  fpath = LANG_TO_FPATH[lang]
+  examples = []
+  with common.url_to_fileobj(fpath, binary=True) as f:
+    for raw_line in f:
+      line = raw_line.decode("utf-8").strip()
+      inputs, targets = line.split("\t")
+      if "." in targets:
+        raise ValueError(f"targets {targets} contains a decimal point.")
+      # targets = int(targets.replace(",", ""))
+      examples.append({"inputs": inputs, "targets": targets, "lang": lang})
+  return examples
+
+
+def get_all_examples() -> list[dict[str, str]]:
+  examples = []
+  for lang in ALL_LANGUAGES:
+    if lang != "en":
+      continue
+    examples += get_lang_examples(lang)
+  return examples
+
+
+class MGSMEval(Eval):
+
+  def __init__(
+      self,
+      num_examples_per_lang: int = 250,  # restrict to a subset of the data for debugging
+      languages: Optional[list[str]] = ALL_LANGUAGES,
+  ):
+    if languages is None:
+      languages = ALL_LANGUAGES
+    else:
+      for language in languages:
+        if language not in ALL_LANGUAGES:
+          raise ValueError(f"language {language} is not a valid language. " f"It should be one in {ALL_LANGUAGES}")
+    self._languages = languages
+    self._num_examples_per_lang = num_examples_per_lang
+
+    examples = []
+    for lang in self._languages:
+      lang_examples = get_lang_examples(lang)
+      examples.extend(lang_examples[: self._num_examples_per_lang])
+    self.examples = examples
+
+  def __call__(self, sampler: SamplerBase) -> EvalResult:
+    def fn(example: dict[str, str]):
+      language = example["lang"]
+      latin_language = "group_latin" if language in LATIN_LANGUAGES else "group_non_latin"
+      correct_answer = example["targets"]
+      instruction = LANG_TO_INSTRUCTIONS[language]
+      prompt_messages = [sampler._pack_message(content=instruction.format(input=example["inputs"]), role="user")]
+      sampler_response = sampler(prompt_messages)
+      response_text = sampler_response.response_text
+      actual_queried_prompt_messages = sampler_response.actual_queried_message_list
+
+      answer_prefix = LANG_TO_ANSWER_PREFIX[language]
+      extracted_answer = parse_answer(response_text, answer_prefix) if common.request_succeeded(sampler_response) else ""
+
+      score = score_mgsm(correct_answer, extracted_answer)
+      html = common.jinja_env.from_string(HTML_JINJA).render(
+          prompt_messages=actual_queried_prompt_messages,
+          next_message=dict(content=response_text, role="assistant"),
+          score=score,
+          correct_answer=correct_answer,
+          extracted_answer=extracted_answer or None,
+      )
+      convo = actual_queried_prompt_messages + [dict(content=response_text, role="assistant")]
+      return SingleEvalResult(
+          html=html,
+          score=score,
+          convo=convo,
+          metrics={language: score, latin_language: score},
+          example_level_metadata={
+              "request_id": sampler_response.response_metadata.get("request_id"),
+              "request_status": sampler_response.response_metadata.get("status", "success"),
+              "score": score,
+              "correct_answer": correct_answer,
+              "extracted_answer": extracted_answer or None,
+          },
+      )
+
+    results = common.map_with_progress(fn, self.examples)
+    return common.aggregate_results(results, default_stats=("mean", "std"))

--- a/src/maxtext/eval/simple_evals_template/mmlu_eval.py
+++ b/src/maxtext/eval/simple_evals_template/mmlu_eval.py
@@ -1,0 +1,154 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Measuring Massive Multitask Language Understanding
+Dan Hendrycks, Collin Burns, Steven Basart, Andy Zou, Mantas Mazeika, Dawn Song, Jacob Steinhardt
+https://arxiv.org/abs/2009.03300
+
+Original implementation from https://github.com/openai/simple-evals.
+"""
+
+import random
+import re
+
+import pandas
+
+from . import common
+from .common import (
+    HTML_JINJA,
+    MULTILINGUAL_ANSWER_PATTERN_TEMPLATE,
+    MULTILINGUAL_ANSWER_REGEXES,
+    format_multichoice_question,
+    normalize_extracted_answer,
+    normalize_response,
+)
+from .types import Eval, EvalResult, SamplerBase, SingleEvalResult
+
+subject2category = {
+    "abstract_algebra": "stem",
+    "anatomy": "other",
+    "astronomy": "stem",
+    "business_ethics": "other",
+    "clinical_knowledge": "other",
+    "college_biology": "stem",
+    "college_chemistry": "stem",
+    "college_computer_science": "stem",
+    "college_mathematics": "stem",
+    "college_medicine": "other",
+    "college_physics": "stem",
+    "computer_security": "stem",
+    "conceptual_physics": "stem",
+    "econometrics": "social_sciences",
+    "electrical_engineering": "stem",
+    "elementary_mathematics": "stem",
+    "formal_logic": "humanities",
+    "global_facts": "other",
+    "high_school_biology": "stem",
+    "high_school_chemistry": "stem",
+    "high_school_computer_science": "stem",
+    "high_school_european_history": "humanities",
+    "high_school_geography": "social_sciences",
+    "high_school_government_and_politics": "social_sciences",
+    "high_school_macroeconomics": "social_sciences",
+    "high_school_mathematics": "stem",
+    "high_school_microeconomics": "social_sciences",
+    "high_school_physics": "stem",
+    "high_school_psychology": "social_sciences",
+    "high_school_statistics": "stem",
+    "high_school_us_history": "humanities",
+    "high_school_world_history": "humanities",
+    "human_aging": "other",
+    "human_sexuality": "social_sciences",
+    "international_law": "humanities",
+    "jurisprudence": "humanities",
+    "logical_fallacies": "humanities",
+    "machine_learning": "stem",
+    "management": "other",
+    "marketing": "other",
+    "medical_genetics": "other",
+    "miscellaneous": "other",
+    "moral_disputes": "humanities",
+    "moral_scenarios": "humanities",
+    "nutrition": "other",
+    "philosophy": "humanities",
+    "prehistory": "humanities",
+    "professional_accounting": "other",
+    "professional_law": "humanities",
+    "professional_medicine": "other",
+    "professional_psychology": "social_sciences",
+    "public_relations": "social_sciences",
+    "security_studies": "social_sciences",
+    "sociology": "social_sciences",
+    "us_foreign_policy": "social_sciences",
+    "virology": "other",
+    "world_religions": "humanities",
+}
+
+
+class MMLUEval(Eval):
+
+  def __init__(self, num_examples: int | None = None, language: str = "EN-US"):
+    if language != "EN-US":
+      url = f"https://openaipublic.blob.core.windows.net/simple-evals/mmlu_{language}.csv"
+    else:
+      url = "https://openaipublic.blob.core.windows.net/simple-evals/mmlu.csv"
+    df = pandas.read_csv(url)
+    examples = [row.to_dict() for _, row in df.iterrows()]
+    if num_examples:
+      examples = random.Random(0).sample(examples, num_examples)
+    self.examples = examples
+
+  def __call__(self, sampler: SamplerBase) -> EvalResult:
+    def fn(row: dict):
+      prompt_messages = [sampler._pack_message(content=format_multichoice_question(row), role="user")]
+      sampler_response = sampler(prompt_messages)
+      response_text = sampler_response.response_text
+      actual_queried_prompt_messages = sampler_response.actual_queried_message_list
+      request_succeeded = common.request_succeeded(sampler_response)
+      response_text = normalize_response(response_text) if request_succeeded else ""
+      extracted_answer = None
+      if request_succeeded:
+        for answer_regex in MULTILINGUAL_ANSWER_REGEXES:
+          regex = MULTILINGUAL_ANSWER_PATTERN_TEMPLATE.format(answer_regex)
+          match = re.search(regex, response_text)
+          if match:
+            extracted_answer = normalize_extracted_answer(match.group(1))
+            break
+      score = 1.0 if extracted_answer == row["Answer"] else 0.0
+      html = common.jinja_env.from_string(HTML_JINJA).render(
+          prompt_messages=actual_queried_prompt_messages,
+          next_message=dict(content=response_text, role="assistant"),
+          score=score,
+          correct_answer=row["Answer"],
+          extracted_answer=extracted_answer,
+      )
+      convo = actual_queried_prompt_messages + [dict(content=response_text, role="assistant")]
+      category = subject2category.get(row["Subject"], "other")
+      return SingleEvalResult(
+          html=html,
+          score=score,
+          metrics={category: score},
+          convo=convo,
+          example_level_metadata={
+              "request_id": sampler_response.response_metadata.get("request_id"),
+              "request_status": sampler_response.response_metadata.get("status", "success"),
+              "score": score,
+              "correct_answer": row["Answer"],
+              "extracted_answer": extracted_answer,
+          },
+      )
+
+    results = common.map_with_progress(fn, self.examples)
+    return common.aggregate_results(results)

--- a/src/maxtext/eval/simple_evals_template/types.py
+++ b/src/maxtext/eval/simple_evals_template/types.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Original implementation from https://github.com/openai/simple-evals.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, overload
+
+Message = dict[str, Any]  # keys role, content
+MessageList = list[Message]
+
+
+@dataclass
+class SamplerResponse:
+  """
+  Response from a sampler.
+  """
+
+  response_text: str
+  actual_queried_message_list: MessageList
+  response_metadata: dict[str, Any]
+
+
+class SamplerBase:
+  """
+  Base class for defining a sampling model, which can be evaluated,
+  or used as part of the grading process.
+  """
+
+  def __call__(
+      self,
+      message_list: MessageList,
+  ) -> SamplerResponse:
+    raise NotImplementedError
+
+
+@dataclass
+class EvalResult:
+  """
+  Result of running an evaluation (usually consisting of many samples)
+  """
+
+  score: float | None  # top-line metric
+  metrics: dict[str, float] | None  # other metrics
+  htmls: list[str]  # strings of valid HTML
+  convos: list[MessageList]  # sampled conversations
+  metadata: dict[str, Any] | None  # Extra data such as rubric scores or sollen
+
+
+@dataclass
+class SingleEvalResult:
+  """
+  Result of evaluating a single sample
+  """
+
+  score: float | None
+  metrics: dict[str, float] = field(default_factory=dict)
+  html: str | None = None
+  convo: MessageList | None = None  # sampled conversation
+  example_level_metadata: dict[str, Any] | None = None  # Extra data such as rubric scores or sollen
+
+
+class Eval:
+  """
+  Base class for defining an evaluation.
+  """
+
+  def __call__(self, sampler: SamplerBase) -> EvalResult:
+    raise NotImplementedError

--- a/tests/unit/eval/test_build_app.py
+++ b/tests/unit/eval/test_build_app.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import sys
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -47,7 +49,7 @@ def _make_mock_llm(generated_text="hello", prompt_token_ids=(1, 2, 3), generated
 
   mock_tokenizer = MagicMock()
   mock_tokenizer.decode.side_effect = lambda ids: "".join(f"tok{i}" for i in ids)
-  mock_tokenizer.apply_chat_template.return_value = "rendered_prompt"
+  mock_tokenizer.apply_chat_template.return_value = [101, 102, 103]
 
   mock_llm = MagicMock()
   mock_llm.generate.return_value = [mock_output]
@@ -80,7 +82,7 @@ class TestBuildApp(unittest.TestCase):
     from maxtext.eval.runner.server_manager import _build_app  # pylint: disable=import-outside-toplevel
     from starlette.testclient import TestClient  # pylint: disable=import-outside-toplevel
 
-    self.app = _build_app(self.mock_llm)
+    self.app = _build_app(self.mock_llm, enable_chat_api=True)
     self.client = TestClient(self.app)
 
   def tearDown(self):
@@ -91,6 +93,45 @@ class TestBuildApp(unittest.TestCase):
     resp = self.client.get("/health")
     self.assertEqual(resp.status_code, 200)
     self.assertEqual(resp.json(), {"status": "ok"})
+
+  def test_harmony_prompt_helper_uses_vllm_harmony_utilities(self):
+    from maxtext.eval.runner.server_manager import _render_harmony_chat_prompt  # pylint: disable=import-outside-toplevel
+
+    harmony_utils = MagicMock()
+    harmony_utils.get_system_message.return_value = "canonical-system"
+    harmony_utils.parse_chat_inputs_to_harmony_messages.return_value = ["user-message"]
+    harmony_utils.render_for_completion.return_value = [1, 2, 3]
+    messages = [{"role": "user", "content": "question"}]
+    with patch.dict(
+        sys.modules,
+        {"vllm.entrypoints.openai.parser.harmony_utils": harmony_utils},
+    ):
+      token_ids = _render_harmony_chat_prompt(messages, "high")
+
+    self.assertEqual(token_ids, [1, 2, 3])
+    harmony_utils.get_system_message.assert_called_once_with(
+        reasoning_effort="high",
+        browser_description=None,
+        python_description=None,
+        with_custom_tools=True,
+    )
+    harmony_utils.parse_chat_inputs_to_harmony_messages.assert_called_once_with(messages)
+    harmony_utils.render_for_completion.assert_called_once_with(["canonical-system", "user-message"])
+
+  def test_harmony_stop_ids_use_older_vllm_helper_when_available(self):
+    from maxtext.eval.runner.server_manager import _get_harmony_stop_token_ids  # pylint: disable=import-outside-toplevel
+
+    harmony_utils = SimpleNamespace(get_stop_tokens_for_assistant_actions=lambda: [99, 100])
+    with patch.dict(sys.modules, {"vllm.entrypoints.openai.parser.harmony_utils": harmony_utils}):
+      self.assertEqual(_get_harmony_stop_token_ids(), [99, 100])
+
+  def test_harmony_stop_ids_are_unset_for_newer_vllm_api(self):
+    from maxtext.eval.runner.server_manager import _get_harmony_stop_token_ids  # pylint: disable=import-outside-toplevel
+
+    # vLLM #44009 removed both the helper and its OpenAI frontend override.
+    harmony_utils = SimpleNamespace()
+    with patch.dict(sys.modules, {"vllm.entrypoints.openai.parser.harmony_utils": harmony_utils}):
+      self.assertEqual(_get_harmony_stop_token_ids(), [])
 
   def test_completions_basic(self):
     resp = self.client.post(
@@ -222,6 +263,124 @@ class TestBuildApp(unittest.TestCase):
     call_args = tokenizer.apply_chat_template.call_args
     passed_messages = call_args[0][0] if call_args[0] else call_args[1].get("conversation")
     self.assertIsNotNone(passed_messages)
+    self.assertTrue(call_args.kwargs["tokenize"])
+    generated_prompts = self.mock_llm.generate.call_args[0][0]
+    self.assertEqual(generated_prompts, [{"prompt_token_ids": [101, 102, 103]}])
+
+  def test_harmony_chat_uses_vllm_rendering_and_returns_only_final_content(self):
+    from maxtext.eval.runner.server_manager import _build_app  # pylint: disable=import-outside-toplevel
+    from starlette.testclient import TestClient  # pylint: disable=import-outside-toplevel
+
+    mock_llm = _make_mock_llm(
+        generated_text="<raw harmony output>",
+        prompt_token_ids=[10, 11],
+        generated_token_ids=[21, 22, 23],
+    )
+    mock_llm.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(model_type="gpt_oss"),
+        max_model_len=128,
+    )
+    self.mock_sampling_params_cls.reset_mock()
+    with (
+        patch("maxtext.eval.runner.server_manager._get_harmony_stop_token_ids", return_value=[99, 100]),
+        patch("maxtext.eval.runner.server_manager._render_harmony_chat_prompt", return_value=[10, 11]) as render,
+        patch(
+            "maxtext.eval.runner.server_manager._parse_harmony_chat_output",
+            return_value=("private reasoning", "Answer: 42", False),
+        ) as parse,
+    ):
+      client = TestClient(_build_app(mock_llm, enable_chat_api=True))
+      response = client.post(
+          "/v1/chat/completions",
+          json={
+              "model": "gpt-oss-20b",
+              "messages": [{"role": "user", "content": "question"}],
+              "max_tokens": 20,
+              "reasoning_effort": "high",
+              "include_raw_output": True,
+          },
+      )
+
+    self.assertEqual(response.status_code, 200)
+    data = response.json()
+    self.assertEqual(data["choices"][0]["message"]["content"], "Answer: 42")
+    self.assertEqual(data["choices"][0]["message"]["reasoning"], "private reasoning")
+    self.assertEqual(data["diagnostics"]["raw_output"], "<raw harmony output>")
+    self.assertNotIn("<raw harmony output>", data["choices"][0]["message"]["content"])
+    render.assert_called_once_with([{"role": "user", "content": "question"}], "high")
+    parse.assert_called_once_with([21, 22, 23])
+    mock_llm.get_tokenizer.assert_not_called()
+    sampling_kwargs = self.mock_sampling_params_cls.call_args.kwargs
+    self.assertEqual(sampling_kwargs["stop_token_ids"], [99, 100])
+
+  def test_harmony_reasoning_and_raw_output_are_opt_in(self):
+    from maxtext.eval.runner.server_manager import _build_app  # pylint: disable=import-outside-toplevel
+    from starlette.testclient import TestClient  # pylint: disable=import-outside-toplevel
+
+    mock_llm = _make_mock_llm(generated_text="raw", generated_token_ids=[21])
+    mock_llm.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(model_type="gpt_oss"),
+        max_model_len=128,
+    )
+    self.mock_sampling_params_cls.reset_mock()
+    with (
+        patch("maxtext.eval.runner.server_manager._get_harmony_stop_token_ids", return_value=[]),
+        patch("maxtext.eval.runner.server_manager._render_harmony_chat_prompt", return_value=[10]),
+        patch(
+            "maxtext.eval.runner.server_manager._parse_harmony_chat_output",
+            return_value=("private", "final", False),
+        ),
+    ):
+      response = TestClient(_build_app(mock_llm, enable_chat_api=True)).post(
+          "/v1/chat/completions",
+          json={
+              "model": "gpt-oss-20b",
+              "messages": [{"role": "user", "content": "question"}],
+              "include_reasoning": False,
+          },
+      )
+
+    message = response.json()["choices"][0]["message"]
+    self.assertEqual(message["content"], "final")
+    self.assertNotIn("reasoning", message)
+    self.assertNotIn("diagnostics", response.json())
+    self.assertNotIn("stop_token_ids", self.mock_sampling_params_cls.call_args.kwargs)
+
+  def test_chat_context_budget_caps_max_tokens(self):
+    from maxtext.eval.runner.server_manager import _build_app  # pylint: disable=import-outside-toplevel
+    from starlette.testclient import TestClient  # pylint: disable=import-outside-toplevel
+
+    mock_llm = _make_mock_llm(prompt_token_ids=[1, 2, 3])
+    mock_llm.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(model_type="other"),
+        max_model_len=5,
+    )
+    self.mock_sampling_params_cls.reset_mock()
+    response = TestClient(_build_app(mock_llm, enable_chat_api=True)).post(
+        "/v1/chat/completions",
+        json={"model": "m", "messages": [{"role": "user", "content": "q"}], "max_tokens": 10},
+    )
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(self.mock_sampling_params_cls.call_args.kwargs["max_tokens"], 2)
+
+  def test_chat_template_error_is_a_bad_request_without_silent_fallback(self):
+    from maxtext.eval.runner.server_manager import _build_app  # pylint: disable=import-outside-toplevel
+    from starlette.testclient import TestClient  # pylint: disable=import-outside-toplevel
+
+    mock_llm = _make_mock_llm()
+    mock_llm.model_config = SimpleNamespace(hf_config=SimpleNamespace(model_type="other"))
+    mock_llm.get_tokenizer.return_value.apply_chat_template.side_effect = TypeError("bad template")
+    response = TestClient(_build_app(mock_llm, enable_chat_api=True)).post(
+        "/v1/chat/completions",
+        json={
+            "model": "m",
+            "messages": [{"role": "user", "content": "q"}],
+            "reasoning_effort": "high",
+        },
+    )
+    self.assertEqual(response.status_code, 400)
+    self.assertIn("bad template", response.json()["detail"])
+    mock_llm.generate.assert_not_called()
 
   def test_completions_token_id_prompt_normalised_as_single(self):
     """A list-of-ints prompt must be treated as one token-ID prompt, not a batch of ints."""
@@ -242,6 +401,7 @@ class TestBuildApp(unittest.TestCase):
 
   def test_completions_top_logprobs_populated(self):
     """When logprobs is requested, top_logprobs entries must be non-None dicts."""
+
     mock_output = _make_mock_output(generated_text="hi", prompt_token_ids=[1], generated_token_ids=[4, 5])
     mock_output.outputs[0].logprobs = [
         {4: SimpleNamespace(logprob=-0.5), 6: SimpleNamespace(logprob=-1.0)},
@@ -273,6 +433,111 @@ class TestBuildApp(unittest.TestCase):
     # tokenizer.decode([1, 2, 3]) → "tok1tok2tok3" (see _make_mock_llm side_effect)
     self.assertTrue(text.startswith("tok1tok2tok3"), f"Expected decoded prompt prefix, got: {text!r}")
     self.assertIn(" world", text)
+
+
+class TestChatCompletionsBatching(unittest.IsolatedAsyncioTestCase):
+  """Tests for _ChatBatchQueue: concurrent /v1/chat/completions requests must
+  coalesce into one llm.generate() call instead of serializing one-at-a-time
+  (the bottleneck that caused the surrounding server to only ever process a
+  single sequence regardless of concurrent client load).
+  """
+
+  def setUp(self):
+    self.mock_sampling_params_cls = MagicMock(side_effect=lambda **kw: kw)
+    self._vllm_patcher = patch.dict(
+        "sys.modules",
+        {
+            "vllm": MagicMock(),
+            "vllm.sampling_params": MagicMock(SamplingParams=self.mock_sampling_params_cls),
+        },
+    )
+    self._vllm_patcher.start()
+    self.addCleanup(self._vllm_patcher.stop)
+
+  def _make_llm(self, generate_side_effect):
+    mock_llm = MagicMock()
+    mock_llm.get_tokenizer.return_value.apply_chat_template.side_effect = lambda messages, **kw: [
+        int(messages[0]["content"][-1])
+    ]
+    mock_llm.generate.side_effect = generate_side_effect
+    return mock_llm
+
+  async def _post_chat(self, app, content):
+    import httpx  # pylint: disable=import-outside-toplevel
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+      return await client.post(
+          "/v1/chat/completions",
+          json={"model": "m", "messages": [{"role": "user", "content": content}], "max_tokens": 5},
+      )
+
+  async def test_concurrent_requests_coalesce_into_one_generate_call(self):
+    from maxtext.eval.runner.server_manager import _build_app  # pylint: disable=import-outside-toplevel
+
+    calls = []
+
+    def fake_generate(prompts, _sampling_params):
+      calls.append(list(prompts))
+      return [_make_mock_output(generated_text=f"reply-to-msg{p['prompt_token_ids'][0]}") for p in prompts]
+
+    mock_llm = self._make_llm(fake_generate)
+    # Wide window so all 5 concurrent requests land in the same pending batch
+    # before the timer fires -- this asserts real coalescing, not a timing fluke.
+    app = _build_app(mock_llm, enable_chat_api=True)
+
+    responses = await asyncio.gather(*[self._post_chat(app, f"msg{i}") for i in range(5)])
+
+    self.assertEqual(len(calls), 1, f"expected 1 batched generate() call, got {len(calls)}: {calls}")
+    self.assertEqual(len(calls[0]), 5)
+    for i, resp in enumerate(responses):
+      self.assertEqual(resp.status_code, 200)
+      self.assertEqual(resp.json()["choices"][0]["message"]["content"], f"reply-to-msg{i}")
+
+  async def test_batch_flushes_early_at_max_size(self):
+    """A full batch must flush immediately, not wait out the full time window."""
+    from maxtext.eval.runner.server_manager import _build_app  # pylint: disable=import-outside-toplevel
+
+    calls = []
+
+    def fake_generate(prompts, _sampling_params):
+      calls.append(list(prompts))
+      return [_make_mock_output(generated_text="ok") for _ in prompts]
+
+    mock_llm = self._make_llm(fake_generate)
+    app = _build_app(mock_llm, enable_chat_api=True, request_concurrency=2)
+
+    responses = await asyncio.wait_for(
+        asyncio.gather(*[self._post_chat(app, f"m{i}") for i in range(4)]),
+        timeout=2.0,
+    )
+    self.assertTrue(all(r.status_code == 200 for r in responses))
+    self.assertEqual(len(calls), 2)
+    self.assertTrue(all(len(c) == 2 for c in calls))
+
+  async def test_generate_exception_fails_every_request_in_the_batch(self):
+    """One failing batched generate() call must 500 every request in it, not hang any."""
+    from maxtext.eval.runner.server_manager import _build_app  # pylint: disable=import-outside-toplevel
+
+    mock_llm = self._make_llm(ValueError("boom: simulated engine failure"))
+    app = _build_app(mock_llm, enable_chat_api=True)
+
+    responses = await asyncio.wait_for(
+        asyncio.gather(*[self._post_chat(app, f"m{i}") for i in range(3)]),
+        timeout=2.0,
+    )
+    self.assertTrue(all(r.status_code == 500 for r in responses))
+    self.assertTrue(all("boom" in r.json().get("detail", "") for r in responses))
+
+  async def test_chat_endpoint_is_disabled_unless_requested(self):
+    from maxtext.eval.runner.server_manager import _build_app  # pylint: disable=import-outside-toplevel
+
+    mock_llm = self._make_llm(lambda prompts, _: [_make_mock_output() for _ in prompts])
+    with patch("maxtext.eval.runner.server_manager._is_harmony_model") as is_harmony_model:
+      app = _build_app(mock_llm)
+    is_harmony_model.assert_not_called()
+    response = await self._post_chat(app, "m1")
+    self.assertEqual(response.status_code, 404)
 
 
 if __name__ == "__main__":

--- a/tests/unit/eval/test_server_manager.py
+++ b/tests/unit/eval/test_server_manager.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Tests intentionally exercise private concurrency resolution helpers.
+# pylint: disable=protected-access
+
 """Unit tests for server_manager.VllmServerManager."""
 
 import os
@@ -122,6 +125,22 @@ class TestVllmServerManagerConfig(unittest.TestCase):
     mgr = _make_manager(max_num_seqs=None)
     kwargs = _start_capturing_llm_kwargs(mgr)
     self.assertNotIn("max_num_seqs", kwargs)
+
+  def test_concurrency_auto_uses_cpu_and_accelerator_capacity(self):
+    mgr = _make_manager(enable_chat_api=True)
+    self.assertEqual(mgr._resolve_concurrency(cpu_count=192, accelerator_count=8), 32)
+
+  def test_concurrency_auto_honors_max_num_seqs(self):
+    mgr = _make_manager(enable_chat_api=True, max_num_seqs=12)
+    self.assertEqual(mgr._resolve_concurrency(cpu_count=192, accelerator_count=8), 12)
+
+  def test_explicit_concurrency_is_honored(self):
+    mgr = _make_manager(enable_chat_api=True, concurrency=7, max_num_seqs=4)
+    self.assertEqual(mgr._resolve_concurrency(cpu_count=2, accelerator_count=1), 7)
+
+  def test_nonpositive_concurrency_raises(self):
+    with self.assertRaises(ValueError):
+      _make_manager(concurrency=0)
 
   def test_env_applied_to_os_environ_before_llm_init(self):
     mgr = _make_manager(env={"_TEST_EVAL_TOKEN": "abc123"})

--- a/tests/unit/eval/test_simple_evals_runner.py
+++ b/tests/unit/eval/test_simple_evals_runner.py
@@ -1,0 +1,546 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for simple_evals_runner pure helpers.
+
+These tests avoid instantiating real Eval objects (which download datasets) and
+avoid booting a vLLM server; they cover the score mapping and task validation
+logic only.
+"""
+
+from __future__ import annotations
+
+# Tests intentionally construct dataset-free eval objects through private state.
+# pylint: disable=protected-access
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from maxtext.eval.reporting.simple_evals_debug_reporter import (
+    SimpleEvalsDebugCollector,
+    build_debug_report,
+    write_debug_report,
+)
+from maxtext.eval.runner.async_client import _is_retryable_http_status, generate_batch_async
+from maxtext.eval.runner.simple_evals_runner import (
+    SUPPORTED_TASKS,
+    _build_arg_parser,
+    _build_eval,
+    _build_vllm_sampler,
+    _effective_repeats,
+    _map_scores,
+    _validate_tasks,
+)
+from maxtext.eval.simple_evals_template import common as simple_evals_common
+from maxtext.eval.simple_evals_template.aime_eval import extract_answer
+from maxtext.eval.simple_evals_template.drop_eval import DropEval
+from maxtext.eval.simple_evals_template.gsm8k_eval import (
+    _load_gsm8k_examples,
+    extract_answer as extract_gsm8k_answer,
+)
+from maxtext.eval.simple_evals_template.types import EvalResult, SamplerResponse
+
+
+def _make_result(score, metrics=None) -> EvalResult:
+  return EvalResult(
+      score=score,
+      metrics=metrics or {},
+      htmls=[],
+      convos=[],
+      metadata=None,
+  )
+
+
+class TestMapScores(unittest.TestCase):
+  """Tests for _map_scores."""
+
+  def test_score_to_percentage(self):
+    scores = _map_scores("mmlu", _make_result(0.725))
+    self.assertIn("mmlu_accuracy", scores)
+    self.assertAlmostEqual(scores["mmlu_accuracy"], 72.5, places=1)
+
+  def test_zero_score_not_dropped(self):
+    scores = _map_scores("gpqa", _make_result(0.0))
+    self.assertIn("gpqa_accuracy", scores)
+    self.assertAlmostEqual(scores["gpqa_accuracy"], 0.0, places=1)
+
+  def test_none_score_omits_accuracy(self):
+    scores = _map_scores("mmlu", _make_result(None))
+    self.assertNotIn("mmlu_accuracy", scores)
+
+  def test_numeric_metrics_passed_through(self):
+    scores = _map_scores("gpqa", _make_result(0.5, {"chars": 1234.0}))
+    self.assertIn("gpqa_accuracy", scores)
+    self.assertIn("gpqa_chars", scores)
+    self.assertAlmostEqual(scores["gpqa_chars"], 1234.0, places=1)
+
+  def test_non_numeric_metrics_skipped(self):
+    scores = _map_scores("mmlu", _make_result(0.5, {"note": "skip-me"}))
+    self.assertNotIn("mmlu_note", scores)
+
+
+class TestValidateTasks(unittest.TestCase):
+  """Tests for _validate_tasks."""
+
+  def test_supported_tasks_pass(self):
+    _validate_tasks(list(SUPPORTED_TASKS))  # should not raise
+
+  def test_new_tasks_are_registered(self):
+    for task in ("gsm8k", "drop", "mgsm", "mgsm_en", "aime2024", "aime2025"):
+      self.assertIn(task, SUPPORTED_TASKS)
+
+  def test_unsupported_task_raises(self):
+    with self.assertRaises(ValueError):
+      _validate_tasks(["mmlu", "healthbench"])
+
+  def test_empty_list_passes(self):
+    _validate_tasks([])  # should not raise
+
+
+class TestBuildEval(unittest.TestCase):
+  """Tests for _build_eval task guard (does not download datasets)."""
+
+  def test_unsupported_task_raises(self):
+    with self.assertRaises(ValueError):
+      _build_eval("math", num_examples=5, n_repeats=1)
+
+  def test_repeat_defaults_match_task_protocols(self):
+    self.assertEqual(_effective_repeats("gpqa", None, None), 4)
+    self.assertEqual(_effective_repeats("aime2024", None, None), 1)
+    self.assertEqual(_effective_repeats("mmlu", None, 9), 1)
+
+  def test_subsetting_forces_one_repeat(self):
+    self.assertEqual(_effective_repeats("gpqa", 10, 4), 1)
+
+
+class TestDebugInfo(unittest.TestCase):
+  """Tests for debug flag and plain-text diagnostics."""
+
+  def test_debug_flag_defaults_off_and_can_be_enabled(self):
+    parser = _build_arg_parser()
+    required = [
+        "--model_name",
+        "model",
+        "--hf_path",
+        "hf",
+        "--base_output_directory",
+        "/tmp",
+        "--run_name",
+        "run",
+        "--max_model_len",
+        "4096",
+    ]
+    self.assertFalse(parser.parse_args(required).log_debug_info)
+    defaults = parser.parse_args(required)
+    self.assertIsNone(defaults.concurrency)
+    self.assertIsNone(defaults.n_repeats)
+    self.assertAlmostEqual(defaults.temperature, 0.5)
+    self.assertFalse(defaults.continue_on_request_error)
+    self.assertTrue(parser.parse_args(required + ["--log-debug-info"]).log_debug_info)
+
+  def test_report_contains_rates_and_error_sample(self):
+    collector = SimpleEvalsDebugCollector()
+    collector.records = [
+        {
+            "request_id": 1,
+            "task": "mmlu",
+            "status": "success",
+            "attempt_count": 1,
+            "attempt_errors": [],
+            "latency_s": 2.0,
+            "successful_attempt_latency_s": 2.0,
+            "prompt_tokens": 100,
+            "completion_tokens": 32,
+            "finish_reason": "length",
+            "response_text": "Answer: B",
+            "reasoning_text": "private reasoning",
+            "raw_response_text": "<raw harmony output>",
+            "prompt_messages": [{"role": "user", "content": "Question"}],
+        }
+    ]
+    collector.peak_in_flight = 1
+    result = _make_result(0.0)
+    result.metadata = {
+        "example_level_metadata": [
+            {
+                "request_id": 1,
+                "request_status": "success",
+                "score": 0.0,
+                "correct_answer": "A",
+                "extracted_answer": "B",
+            }
+        ]
+    }
+    report = build_debug_report(collector, {"mmlu": result}, {"mmlu": 2.0}, "model", 32, 4096)
+    self.assertIn("output_truncation_rate: 100.00% (1/1)", report)
+    self.assertIn("incorrect_answer_rate: 100.00% (1/1)", report)
+    self.assertIn("-- incorrect answers --", report)
+    self.assertIn("correct_answer='A' extracted_answer='B'", report)
+    self.assertIn("final_output:\nAnswer: B", report)
+    self.assertIn("reasoning (diagnostic-only):\nprivate reasoning", report)
+    self.assertIn("raw_output (diagnostic-only):\n<raw harmony output>", report)
+
+  def test_report_filename_matches_json_stem(self):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      json_path = Path(tmpdir) / "mmlu_model_20260101T000000Z.json"
+      json_path.write_text("{}", encoding="utf-8")
+      debug_path = write_debug_report("report\n", "/local/results", str(json_path))
+      self.assertEqual(Path(debug_path).name, "mmlu_model_20260101T000000Z.debug.txt")
+      self.assertEqual(Path(debug_path).read_text(encoding="utf-8"), "report\n")
+
+
+class TestSamplerConcurrency(unittest.TestCase):
+  """Tests bounded task and HTTP request concurrency."""
+
+  def test_task_worker_pool_uses_resolved_concurrency(self):
+    lock = threading.Lock()
+    active = 0
+    peak = 0
+
+    def work(value):
+      nonlocal active, peak
+      with lock:
+        active += 1
+        peak = max(peak, active)
+      time.sleep(0.02)
+      with lock:
+        active -= 1
+      return value
+
+    simple_evals_common.set_default_num_threads(2)
+    self.assertEqual(simple_evals_common.map_with_progress(work, list(range(8)), pbar=False), list(range(8)))
+    self.assertEqual(peak, 2)
+
+  def test_inflight_requests_are_bounded(self):
+    lock = threading.Lock()
+    active = 0
+    peak = 0
+
+    def create(**_kwargs):
+      nonlocal active, peak
+      with lock:
+        active += 1
+        peak = max(peak, active)
+      time.sleep(0.02)
+      with lock:
+        active -= 1
+      return SimpleNamespace(
+          choices=[SimpleNamespace(message=SimpleNamespace(content="Answer: A"), finish_reason="stop")],
+          usage=SimpleNamespace(prompt_tokens=10, completion_tokens=2, total_tokens=12),
+      )
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    with mock.patch("openai.OpenAI", return_value=client):
+      sampler = _build_vllm_sampler("http://server", "model", 32, 0.5, concurrency=2)
+      with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: sampler([{"role": "user", "content": "q"}]), range(8)))
+    self.assertEqual(len(results), 8)
+    self.assertEqual(peak, 2)
+
+  def test_debug_collection_does_not_change_terminal_error_behavior(self):
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **_: SimpleNamespace(choices=[], usage=None)))
+    )
+    collector = SimpleEvalsDebugCollector()
+    with mock.patch("openai.OpenAI", return_value=client):
+      sampler = _build_vllm_sampler(
+          "http://server",
+          "model",
+          32,
+          0.5,
+          debug_collector=collector,
+          continue_on_request_error=False,
+      )
+      with self.assertRaises(RuntimeError):
+        sampler([{"role": "user", "content": "q"}])
+    self.assertEqual(collector.records[0]["status"], "error")
+
+  def test_analysis_only_truncation_is_success_and_raw_stays_diagnostic(self):
+    captured_kwargs = {}
+
+    def create(**kwargs):
+      captured_kwargs.update(kwargs)
+      return SimpleNamespace(
+          choices=[
+              SimpleNamespace(
+                  message=SimpleNamespace(content=None, reasoning="unfinished reasoning"),
+                  finish_reason="length",
+              )
+          ],
+          usage=SimpleNamespace(prompt_tokens=10, completion_tokens=32, total_tokens=42),
+          model_extra={"diagnostics": {"raw_output": "<raw analysis-only output>"}},
+      )
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    collector = SimpleEvalsDebugCollector()
+    with mock.patch("openai.OpenAI", return_value=client):
+      sampler = _build_vllm_sampler(
+          "http://server",
+          "model",
+          32,
+          0.5,
+          reasoning_effort="high",
+          debug_collector=collector,
+      )
+      response = sampler([{"role": "user", "content": "q"}])
+
+    self.assertEqual(response.response_text, "")
+    self.assertNotIn("<raw analysis-only output>", response.response_text)
+    self.assertEqual(collector.records[0]["status"], "success")
+    self.assertEqual(collector.records[0]["finish_reason"], "length")
+    self.assertEqual(collector.records[0]["reasoning_text"], "unfinished reasoning")
+    self.assertEqual(collector.records[0]["raw_response_text"], "<raw analysis-only output>")
+    self.assertEqual(collector.records[0]["attempt_count"], 1)
+    self.assertEqual(
+        captured_kwargs["extra_body"],
+        {
+            "include_reasoning": True,
+            "include_raw_output": True,
+            "reasoning_effort": "high",
+        },
+    )
+
+  def test_continue_on_request_error_is_explicit(self):
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **_: SimpleNamespace(choices=[], usage=None)))
+    )
+    with mock.patch("openai.OpenAI", return_value=client):
+      sampler = _build_vllm_sampler(
+          "http://server",
+          "model",
+          32,
+          0.5,
+          continue_on_request_error=True,
+      )
+      response = sampler([{"role": "user", "content": "q"}])
+    self.assertEqual(response.response_metadata["status"], "error")
+    self.assertEqual(response.response_text, "")
+
+
+class TestRequestFailureScoring(unittest.TestCase):
+  """Tests that infrastructure failures cannot receive benchmark credit."""
+
+  @staticmethod
+  def _drop_eval() -> DropEval:
+    eval_obj = DropEval.__new__(DropEval)
+    eval_obj.seed = 42
+    eval_obj._train_samples_per_prompt = 1
+    eval_obj.train_samples = [{"context": "TRAIN", "completion": "Answer: yes", "ref_text": "yes"}]
+    eval_obj.test_samples = [{"context": "TEST", "completion": "", "ref_text": "no"}]
+    return eval_obj
+
+  def test_drop_request_failure_always_scores_zero(self):
+    class FailureSampler:
+
+      @staticmethod
+      def _pack_message(content, role):
+        return {"content": content, "role": role}
+
+      @staticmethod
+      def __call__(message_list):
+        return SamplerResponse(
+            response_text="No response (request failed).",
+            actual_queried_message_list=message_list,
+            response_metadata={"status": "error"},
+        )
+
+    with mock.patch.object(simple_evals_common, "map_with_progress", side_effect=lambda fn, xs: list(map(fn, xs))):
+      result = self._drop_eval()(FailureSampler())
+
+    self.assertEqual(result.score, 0.0)
+    self.assertEqual(result.metrics["em_score"], 0.0)
+    self.assertEqual(result.metrics["f1_score"], 0.0)
+    self.assertIsNone(result.metadata["example_level_metadata"][0]["extracted_answer"])
+
+
+class TestDropPromptDeterminism(unittest.TestCase):
+  """Tests that DROP few-shot prompts do not depend on worker scheduling."""
+
+  @staticmethod
+  def _build_eval() -> DropEval:
+    """Build a dataset-free DROP eval for deterministic prompt tests."""
+    eval_obj = DropEval.__new__(DropEval)
+    eval_obj.seed = 42
+    eval_obj._train_samples_per_prompt = 2
+    eval_obj.train_samples = [
+        {"context": f"TRAIN-{index}", "completion": "Answer: yes", "ref_text": "yes"} for index in range(6)
+    ]
+    eval_obj.test_samples = [{"context": f"TEST-{index}", "completion": "", "ref_text": "yes"} for index in range(4)]
+    return eval_obj
+
+  @staticmethod
+  def _captured_prompts(reverse: bool) -> dict[str, tuple[str, ...]]:
+    """Capture test-to-few-shot assignments under a chosen worker order."""
+    prompts = {}
+
+    class CapturingSampler:
+      """Record each prompt while returning a valid model answer."""
+
+      @staticmethod
+      def _pack_message(content, role):
+        return {"content": content, "role": role}
+
+      @staticmethod
+      def __call__(message_list):
+        prompt = message_list[0]["content"]
+        test_id = next(f"TEST-{index}" for index in range(4) if f"TEST-{index}" in prompt)
+        prompts[test_id] = tuple(f"TRAIN-{index}" for index in range(6) if f"TRAIN-{index}" in prompt)
+        return SamplerResponse(
+            response_text="Answer: yes",
+            actual_queried_message_list=message_list,
+            response_metadata={"status": "success"},
+        )
+
+    def scheduled_map(fn, xs):
+      scheduled = reversed(xs) if reverse else xs
+      return [fn(item) for item in scheduled]
+
+    with mock.patch.object(simple_evals_common, "map_with_progress", side_effect=scheduled_map):
+      TestDropPromptDeterminism._build_eval()(CapturingSampler())
+    return prompts
+
+  def test_few_shot_selection_does_not_depend_on_worker_order(self):
+    self.assertEqual(self._captured_prompts(reverse=False), self._captured_prompts(reverse=True))
+
+
+class TestAsyncClientRetries(unittest.TestCase):
+  """Tests async-client HTTP retry classification."""
+
+  def test_only_transient_http_statuses_are_retryable(self):
+    for status in (408, 409, 429, 500, 503):
+      self.assertTrue(_is_retryable_http_status(status))
+    for status in (400, 401, 403, 404, 422):
+      self.assertFalse(_is_retryable_http_status(status))
+
+  def test_permanent_http_error_is_not_retried(self):
+    class FakeResponse:
+      """Minimal aiohttp response context manager."""
+
+      status = 400
+
+      async def __aenter__(self):
+        return self
+
+      async def __aexit__(self, *_args):
+        return None
+
+      @staticmethod
+      async def text():
+        return "invalid request"
+
+    class FakeSession:
+      """Minimal aiohttp session context manager."""
+
+      def __init__(self):
+        self.calls = 0
+
+      async def __aenter__(self):
+        return self
+
+      async def __aexit__(self, *_args):
+        return None
+
+      def post(self, *_args, **_kwargs):
+        self.calls += 1
+        return FakeResponse()
+
+    fake_session = FakeSession()
+    fake_aiohttp = SimpleNamespace(
+        ClientError=RuntimeError,
+        ClientTimeout=lambda **_kwargs: object(),
+        ClientSession=lambda **_kwargs: fake_session,
+    )
+    with (
+        mock.patch.dict(sys.modules, {"aiohttp": fake_aiohttp}),
+        mock.patch("maxtext.eval.runner.async_client.asyncio.sleep", new_callable=mock.AsyncMock) as sleep,
+    ):
+      result = asyncio.run(generate_batch_async(["prompt"], "http://server", "model", max_retries=3))
+
+    self.assertEqual(fake_session.calls, 1)
+    self.assertEqual(result[0].error, "HTTP 400: invalid request")
+    sleep.assert_not_awaited()
+
+
+class TestAimeExtractAnswer(unittest.TestCase):
+  """Tests for aime_eval.extract_answer (pure function, no dataset download)."""
+
+  def test_answer_line(self):
+    self.assertEqual(extract_answer("Steps...\nAnswer: 42"), "42")
+
+  def test_answer_line_case_insensitive_with_dollar(self):
+    self.assertEqual(extract_answer("steps...\nanswer: $007"), "007")
+
+  def test_boxed_without_required_answer_line_is_rejected(self):
+    self.assertIsNone(extract_answer("Steps...\nSo the result is \\boxed{123}."))
+
+  def test_answer_line_preferred_over_boxed(self):
+    self.assertEqual(extract_answer("\\boxed{1} is wrong.\nAnswer: 2"), "2")
+
+  def test_last_integer_without_required_answer_line_is_rejected(self):
+    self.assertIsNone(extract_answer("There are 3 cases, then 4 more, total 7."))
+
+  def test_last_valid_answer_line_wins(self):
+    self.assertEqual(extract_answer("Answer: 41\nCorrection follows.\nAnswer: 42"), "42")
+
+  def test_answer_line_must_be_final(self):
+    self.assertIsNone(extract_answer("Answer: 42\nBut I am still reasoning."))
+
+  def test_no_integer_returns_none(self):
+    self.assertIsNone(extract_answer("I cannot solve this."))
+
+
+class TestGsm8kExtractAnswer(unittest.TestCase):
+  """Tests GSM8K final-answer extraction and dataset loading."""
+
+  def test_final_answer_line(self):
+    self.assertEqual(extract_gsm8k_answer("Reasoning\nAnswer: 1,234"), "1234")
+
+  def test_last_answer_line_wins(self):
+    self.assertEqual(extract_gsm8k_answer("Answer: 10\nCorrection\nAnswer: 12.5"), "12.5")
+
+  def test_unstructured_number_is_rejected(self):
+    self.assertIsNone(extract_gsm8k_answer("The result might be 42."))
+
+  def test_answer_line_must_be_final(self):
+    self.assertIsNone(extract_gsm8k_answer("Answer: 42\nAdditional text"))
+
+  def test_dataset_uses_hub_cache_instead_of_direct_parquet_url(self):
+    rows = [SimpleNamespace(to_dict=lambda: {"question": "q", "answer": "#### 1"}) for _ in range(1319)]
+    dataframe = SimpleNamespace(iterrows=lambda: enumerate(rows))
+    with (
+        mock.patch("huggingface_hub.hf_hub_download", return_value="/cache/gsm8k.parquet") as download,
+        mock.patch("maxtext.eval.native_evals.gsm8k_eval.pandas.read_parquet", return_value=dataframe) as read_parquet,
+    ):
+      examples = _load_gsm8k_examples()
+
+    self.assertEqual(len(examples), 1319)
+    self.assertEqual(examples[0]["answer"], "#### 1")
+    download.assert_called_once_with(
+        repo_id="openai/gsm8k",
+        repo_type="dataset",
+        filename="main/test-00000-of-00001.parquet",
+    )
+    read_parquet.assert_called_once_with("/cache/gsm8k.parquet")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description
This PR is an extension of vLLM Eval Framework. It added simple_evals runner to support gpt-oss model family. 

- Added a dedicated simple_evals runner.
- Supports tasks: MMLU, GPQA, DROP, MGSM, GSM8K, AIME 2024/2025.
- Added OpenAI-compatible chat sampling with bounded concurrency, transient retries, and optional error continuation.
- Added GPT-OSS Harmony rendering, reasoning-effort support, and final/reasoning output separation.
- Added concurrent chat-request batching for TPU throughput.
- Added warmup, automatic concurrency selection, result reporting, and optional diagnostic reports.
- Added unit coverage for task selection, sampling, batching etc. 


# Tests

Added dedicated unit tests.  

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
