### PR TITLE
apple envy moe implementation

### DIFF
--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -114,6 +114,7 @@ class DecoderBlockType(enum.Enum):
   LLAMA4 = "llama4"
   OLMO3 = "olmo3"
   DEEPSEEK4 = "deepseek4"
+  ENVY = "envy"
 
 
 class VisionEncoderBlockType(enum.Enum):

--- a/src/maxtext/configs/models/envy-switch-base.yml
+++ b/src/maxtext/configs/models/envy-switch-base.yml
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Model configuration for Envy Switch-Base (30B)
+
+decoder_block: "envy"
+mlp_activations: ["silu", "linear"]
+enable_dropout: false
+logits_via_embedding: true
+tokenizer_type: "huggingface"
+
+base_emb_dim: 1536
+base_num_decoder_layers: 12
+base_num_query_heads: 12
+base_num_kv_heads: 12
+base_mlp_dim: 6144
+base_moe_mlp_dim: 6144
+vocab_size: 32768
+normalization_layer_epsilon: 1e-05
+rope_max_timescale: 500000
+num_experts: 128
+num_experts_per_tok: 1
+use_qk_norm: true
+use_post_ffw_norm: true
+load_balance_loss_weight: 0.01
+interleave_moe_layer_step: 2
+inhomogeneous_layer_cycle_interval: 2

--- a/src/maxtext/configs/models/envy-switch-large.yml
+++ b/src/maxtext/configs/models/envy-switch-large.yml
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Model configuration for Envy Switch-Large (104B)
+
+decoder_block: "envy"
+mlp_activations: ["silu", "linear"]
+enable_dropout: false
+logits_via_embedding: true
+tokenizer_type: "huggingface"
+
+base_emb_dim: 2048
+base_num_decoder_layers: 24
+base_num_query_heads: 16
+base_num_kv_heads: 16
+base_mlp_dim: 8192
+base_moe_mlp_dim: 8192
+vocab_size: 32768
+normalization_layer_epsilon: 1e-05
+rope_max_timescale: 500000
+num_experts: 128
+num_experts_per_tok: 1
+use_qk_norm: true
+use_post_ffw_norm: true
+load_balance_loss_weight: 0.01
+interleave_moe_layer_step: 2
+inhomogeneous_layer_cycle_interval: 2

--- a/src/maxtext/configs/models/envy-switch-xxl.yml
+++ b/src/maxtext/configs/models/envy-switch-xxl.yml
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Model configuration for Envy Switch-XXL (520B)
+
+decoder_block: "envy"
+mlp_activations: ["silu", "linear"]
+enable_dropout: false
+logits_via_embedding: true
+tokenizer_type: "huggingface"
+
+base_emb_dim: 8192
+base_num_decoder_layers: 24
+base_num_query_heads: 64
+base_num_kv_heads: 8
+base_mlp_dim: 20480
+base_moe_mlp_dim: 20480
+vocab_size: 32768
+normalization_layer_epsilon: 1e-05
+rope_max_timescale: 500000
+num_experts: 64
+num_experts_per_tok: 1
+use_qk_norm: true
+use_post_ffw_norm: true
+load_balance_loss_weight: 0.01
+interleave_moe_layer_step: 2
+inhomogeneous_layer_cycle_interval: 2

--- a/src/maxtext/configs/models/envy-test.yml
+++ b/src/maxtext/configs/models/envy-test.yml
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Model configuration for Envy-test
+
+decoder_block: "envy"
+mlp_activations: ["silu", "linear"]
+enable_dropout: false
+logits_via_embedding: true
+tokenizer_type: "huggingface"
+
+base_emb_dim: 8
+base_num_decoder_layers: 4
+base_num_query_heads: 4
+base_num_kv_heads: 2
+base_mlp_dim: 16
+base_moe_mlp_dim: 16
+vocab_size: 32
+normalization_layer_epsilon: 1e-05
+rope_max_timescale: 500000
+num_experts: 8
+num_experts_per_tok: 1
+use_qk_norm: true
+use_post_ffw_norm: true
+interleave_moe_layer_step: 2
+inhomogeneous_layer_cycle_interval: 2
+megablox: false
+sparse_matmul: false

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -281,6 +281,10 @@ ModelName = Literal[
     "olmo3-7b",
     "olmo3-7b-pt",
     "olmo3-32b",
+    "envy-test",
+    "envy-switch-base",
+    "envy-switch-large",
+    "envy-switch-xxl",
 ]
 
 
@@ -3512,6 +3516,12 @@ class MaxTextConfig(
         )
       if self.num_experts_per_tok > 1:
         raise ValueError("Only top-1 routing is supported for Llama4 for now!")
+      if self.base_num_decoder_layers % self.interleave_moe_layer_step != 0:
+        raise ValueError(
+            f"The number of decoder layers ({self.base_num_decoder_layers}) must be divisible by interleave moe layer step "
+            f"({self.interleave_moe_layer_step})"
+        )
+    if self.decoder_block == DecoderBlockType.ENVY:
       if self.base_num_decoder_layers % self.interleave_moe_layer_step != 0:
         raise ValueError(
             f"The number of decoder layers ({self.base_num_decoder_layers}) must be divisible by interleave moe layer step "

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -44,6 +44,7 @@ from maxtext.models import (
     deepseek4,
     deepseek_batchsplit,
     deepseek_batchsplit_fp8,
+    envy,
     gemma,
     gemma2,
     gemma3,
@@ -493,6 +494,8 @@ class Decoder(nn.Module):
         return [llama4.Llama4ScannableBlockToLinen] if self.config.scan_layers else [llama4.Llama4DecoderLayerToLinen]
       case DecoderBlockType.OLMO3:
         return [olmo3.Olmo3ScannableBlockToLinen] if self.config.scan_layers else [olmo3.Olmo3DecoderLayerToLinen]
+      case DecoderBlockType.ENVY:
+        return [envy.EnvyScannableBlockToLinen] if self.config.scan_layers else [envy.EnvyDecoderLayerToLinen]
 
       case _:
         # Default case to handle any unknown decoder block types.
@@ -528,6 +531,7 @@ class Decoder(nn.Module):
         DecoderBlockType.DEEPSEEK: [deepseek.DeepSeekDenseLayer, deepseek.DeepSeekMoELayer],
         DecoderBlockType.LLAMA4: get_scannable(llama4.Llama4DecoderLayer, llama4.Llama4ScannableBlock),
         DecoderBlockType.OLMO3: get_scannable(olmo3.Olmo3DecoderLayer, olmo3.Olmo3ScannableBlock),
+        DecoderBlockType.ENVY: get_scannable(envy.EnvyDecoderLayer, envy.EnvyScannableBlock),
     }
 
     if cfg.decoder_block not in layer_map:
@@ -1078,6 +1082,11 @@ class Decoder(nn.Module):
                 "nope_layer_interval": self.config.nope_layer_interval,
                 "interleave_moe_layer_step": self.config.interleave_moe_layer_step,
             }
+          if cfg.decoder_block == DecoderBlockType.ENVY:
+            layer_kwargs = {
+                "interleave_moe_layer_step": self.config.interleave_moe_layer_step,
+            }
+
           # Update broadcast_args and in_axes_tuple for vLLM RPA
           in_axes_tuple = (nn.broadcast,) * len(broadcast_args)
           current_broadcast_args = list(broadcast_args)
@@ -1203,6 +1212,11 @@ class Decoder(nn.Module):
                   "is_nope_layer": llama4.determine_is_nope_layer(lyr, self.config.nope_layer_interval),
                   "is_moe_layer": llama4.determine_is_moe_layer(lyr, self.config.interleave_moe_layer_step),
               }
+            if cfg.decoder_block == DecoderBlockType.ENVY:
+              layer_kwargs = {
+                  "is_moe_layer": (lyr + 1) % self.config.interleave_moe_layer_step == 0,
+              }
+
             if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5, DecoderBlockType.DEEPSEEK4):
               layer_kwargs = {"layer_idx": lyr}
             if cfg.decoder_block == DecoderBlockType.DEEPSEEK4:

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -48,6 +48,7 @@ from maxtext.models import (
     deepseek4,
     deepseek_batchsplit,
     deepseek_batchsplit_fp8,
+    envy,
     gemma,
     gemma2,
     gemma3,
@@ -684,6 +685,10 @@ class NNXDecoder(nnx.Module):
           "nope_layer_interval": self.config.nope_layer_interval,
           "interleave_moe_layer_step": self.config.interleave_moe_layer_step,
       }
+    if config.decoder_block == DecoderBlockType.ENVY:
+      layer_kwargs = {
+          "interleave_moe_layer_step": self.config.interleave_moe_layer_step,
+      }
 
     if num_layers > 0:
       self.layers = self._create_scanned_layers(
@@ -727,6 +732,11 @@ class NNXDecoder(nnx.Module):
             "is_nope_layer": llama4.determine_is_nope_layer(lyr, self.config.nope_layer_interval),
             "is_moe_layer": llama4.determine_is_moe_layer(lyr, self.config.interleave_moe_layer_step),
         }
+      elif config.decoder_block == DecoderBlockType.ENVY:
+        layer_kwargs = {
+            "is_moe_layer": (lyr + 1) % self.config.interleave_moe_layer_step == 0,
+        }
+
       elif config.decoder_block in {
           DecoderBlockType.QWEN3_NEXT,
           DecoderBlockType.QWEN3_5,
@@ -1044,6 +1054,7 @@ class NNXDecoder(nnx.Module):
         DecoderBlockType.QWEN3_5: get_scannable(qwen3_5.Qwen3_5DecoderLayer, qwen3_5.Qwen3_5ScannableBlock),
         DecoderBlockType.LLAMA4: get_scannable(llama4.Llama4DecoderLayer, llama4.Llama4ScannableBlock),
         DecoderBlockType.OLMO3: get_scannable(olmo3.Olmo3DecoderLayer, olmo3.Olmo3ScannableBlock),
+        DecoderBlockType.ENVY: get_scannable(envy.EnvyDecoderLayer, envy.EnvyScannableBlock),
     }
 
     if cfg.decoder_block not in layer_map:
@@ -1203,6 +1214,7 @@ class NNXDecoder(nnx.Module):
         DecoderBlockType.SIMPLE_MLP,
         DecoderBlockType.LLAMA4,
         DecoderBlockType.OLMO3,
+        DecoderBlockType.ENVY,
     }:
       return functools.partial(
           RMSNorm,

--- a/src/maxtext/models/envy.py
+++ b/src/maxtext/models/envy.py
@@ -1,0 +1,339 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Envy MoE decoder layer definition."""
+# pylint: disable=arguments-differ, disable=no-name-in-module, missing-function-docstring
+
+from flax import linen as nn
+from flax import nnx
+import jax
+from jax.ad_checkpoint import checkpoint_name
+import jax.numpy as jnp
+from jax.sharding import Mesh
+from maxtext.common.common_types import Config, MODEL_MODE_PREFILL
+from maxtext.layers import initializers
+from maxtext.layers import nnx_wrappers
+from maxtext.layers import quantizations
+from maxtext.layers.attentions import Attention
+from maxtext.layers.linears import Dropout
+from maxtext.layers.linears import MlpBlock
+from maxtext.layers import moe
+from maxtext.layers.normalizations import RMSNorm
+from maxtext.layers.quantizations import AqtQuantization as Quant
+from maxtext.utils import max_utils
+
+
+class EnvyDecoderLayer(nnx.Module):
+  """Transformer decoder layer for Envy."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: str,
+      rngs: nnx.Rngs,
+      quant: None | Quant = None,
+      is_moe_layer: bool = False,
+  ):
+    """Initializes the Envy decoder layer.
+
+    Args:
+      config: The main model configuration object.
+      mesh: The device mesh used for sharding parameters and activations.
+      model_mode: One of MODEL_MODE_TRAIN, MODEL_MODE_PREFILL, or MODEL_MODE_AUTOREGRESSIVE.
+      rngs: An `nnx.Rngs` object to provide random numbers.
+      quant: An optional configuration for quantization. Defaults to None.
+      is_moe_layer: If True, this layer will use a MoE block. Defaults to False as Dense.
+    """
+    self.config = config
+    self.mesh = mesh
+    self.quant = quant
+    self.rngs = rngs
+    self.is_moe_layer = is_moe_layer
+
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
+
+    self.pre_self_attention_layer_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=rngs,
+    )
+
+    query_pre_attn_scalar = config.head_dim**-0.5
+    self.self_attention = Attention(
+        config=config,
+        num_query_heads=config.num_query_heads,
+        num_kv_heads=config.num_kv_heads,
+        head_dim=config.head_dim,
+        max_target_length=config.max_target_length,
+        max_prefill_predict_length=config.max_prefill_predict_length,
+        attention_kernel=config.attention,
+        inputs_q_shape=dummy_inputs_shape,
+        inputs_kv_shape=dummy_inputs_shape,
+        mesh=mesh,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        dropout_rate=config.dropout_rate,
+        float32_qk_product=config.float32_qk_product,
+        float32_logits=config.float32_logits,
+        quant=self.quant,
+        kv_quant=quantizations.configure_kv_quant(config),
+        prefill_cache_axis_order=tuple(map(int, config.prefill_cache_axis_order.split(","))),
+        ar_cache_axis_order=tuple(map(int, config.ar_cache_axis_order.split(","))),
+        compute_axis_order=tuple(map(int, config.compute_axis_order.split(","))),
+        reshape_q=config.reshape_q,
+        use_ragged_attention=config.use_ragged_attention,
+        ragged_block_size=config.ragged_block_size,
+        use_qk_norm=config.use_qk_norm,
+        query_pre_attn_scalar=query_pre_attn_scalar,
+        model_mode=model_mode,
+        rngs=rngs,
+    )
+
+    self.post_self_attention_layer_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=self.rngs,
+    )
+
+    if self.is_moe_layer:
+      self.MoeBlock_0 = moe.RoutedMoE(
+          config=config,
+          num_experts=config.num_experts,
+          num_experts_per_tok=config.num_experts_per_tok,
+          mesh=mesh,
+          kernel_init=initializers.nd_dense_init(config.dense_init_scale, "fan_in", "truncated_normal"),
+          kernel_axes=("embed", None),
+          intermediate_dim=config.base_moe_mlp_dim,
+          dtype=config.dtype,
+          weight_dtype=config.weight_dtype,
+          quant=self.quant,
+          rngs=self.rngs,
+      )
+    else:
+      self.mlp = MlpBlock(
+          mesh=self.mesh,
+          in_features=config.emb_dim,
+          intermediate_dim=config.mlp_dim,
+          activations=config.mlp_activations,
+          intermediate_dropout_rate=config.dropout_rate,
+          dtype=config.dtype,
+          weight_dtype=config.weight_dtype,
+          config=config,
+          quant=self.quant,
+          model_mode=model_mode,
+          rngs=self.rngs,
+      )
+
+    if config.use_post_ffw_norm:
+      self.post_ffw_norm = RMSNorm(
+          num_features=config.emb_dim,
+          dtype=config.dtype,
+          weight_dtype=config.weight_dtype,
+          kernel_axes=("norm",),
+          epsilon=config.normalization_layer_epsilon,
+          rngs=self.rngs,
+      )
+
+    self.dropout = Dropout(rate=config.dropout_rate, broadcast_dims=(-2,), rngs=self.rngs)
+    if model_mode == MODEL_MODE_PREFILL:
+      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
+    else:
+      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
+  @property
+  def moe_block(self):
+    return getattr(self, "MoeBlock_0", None)
+
+  def __call__(
+      self,
+      inputs,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      previous_chunk=None,
+      slot: None | int = None,
+      kv_cache=None,
+      attention_metadata=None,
+  ):
+    cfg = self.config
+
+    # Unpack inputs if it's a tuple (e.g. from a scanned sequential block
+    # returning (hidden_states, stacked_kv_cache, layer_idx))
+    is_scan_carry = False
+    if isinstance(inputs, tuple) and len(inputs) == 3:
+      hidden_states, stacked_kv_cache, layer_idx = inputs
+      kv_cache = stacked_kv_cache[layer_idx]
+      inputs = hidden_states
+      is_scan_carry = True
+    elif isinstance(inputs, tuple):
+      inputs = inputs[0]
+    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
+
+    lnx = self.pre_self_attention_layer_norm(inputs)
+    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+
+    # Self-attention block
+    attention_lnx, kv_cache = self.self_attention(
+        lnx,
+        lnx,
+        decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        deterministic=deterministic,
+        model_mode=model_mode,
+        slot=slot,
+        previous_chunk=previous_chunk,
+        kv_cache=kv_cache,
+        attention_metadata=attention_metadata,
+    )
+    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
+    intermediate_inputs = inputs + attention_lnx
+
+    # Fully Connected / MLP block
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+
+    load_balance_loss = None
+    if self.is_moe_layer:
+      mlp_lnx, load_balance_loss, _ = self.moe_block(hidden_states)
+    else:
+      mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
+    if self.config.use_post_ffw_norm:
+      mlp_lnx = self.post_ffw_norm(mlp_lnx)
+    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+
+    layer_output = mlp_lnx + intermediate_inputs
+    layer_output = self.dropout(layer_output, deterministic=deterministic)
+    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+
+    if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
+      self.sow(nnx.Intermediate, "moe_lb_loss", load_balance_loss)
+
+    if cfg.record_internal_nn_metrics:
+      self.sow(nnx.Intermediate, "activation_mean", jnp.mean(layer_output))
+      self.sow(nnx.Intermediate, "activation_stdev", jnp.std(layer_output))
+      self.sow(
+          nnx.Intermediate,
+          "activation_fraction_zero",
+          jnp.sum(layer_output == 0) / jnp.size(layer_output),
+      )
+
+    if is_scan_carry:
+
+      def update_cache(cache, val):
+        if jnp.size(val) > 0:
+          return cache.at[layer_idx].set(val)
+        return cache
+
+      stacked_kv_cache = jax.tree_util.tree_map(update_cache, stacked_kv_cache, kv_cache)
+      return (layer_output, stacked_kv_cache, layer_idx + 1), None
+    elif cfg.scan_layers:
+      return layer_output, None
+    else:
+      return layer_output, kv_cache
+
+
+EnvyDecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    EnvyDecoderLayer,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)
+
+
+class EnvyScannableBlock(nnx.Module):
+  """A repeatable block of inhomogeneous layers for Envy."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: str,
+      rngs: nnx.Rngs,
+      quant: None | Quant = None,
+      interleave_moe_layer_step: int = 2,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.quant = quant
+    self.rngs = rngs
+    self.interleave_moe_layer_step = interleave_moe_layer_step
+
+    for layer_id in range(self.config.inhomogeneous_layer_cycle_interval):
+      moe_layer = (layer_id + 1) % self.interleave_moe_layer_step == 0
+      layer_name = f"layers_{layer_id}"
+      layer = EnvyDecoderLayer(
+          config=self.config,
+          mesh=self.mesh,
+          model_mode=self.model_mode,
+          rngs=self.rngs,
+          quant=self.quant,
+          is_moe_layer=moe_layer,
+      )
+      setattr(self, layer_name, layer)
+
+  def __call__(
+      self,
+      inputs,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      previous_chunk=None,
+      slot: None | int = None,
+      kv_cache=None,
+      attention_metadata=None,
+  ):
+    cfg = self.config
+
+    if model_mode == MODEL_MODE_PREFILL:
+      activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
+    else:
+      activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    inputs = nn.with_logical_constraint(inputs, activation_axis_names)
+
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
+    y = inputs
+    for layer_id in range(cfg.inhomogeneous_layer_cycle_interval):
+      y = getattr(self, f"layers_{layer_id}")(
+          y,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          previous_chunk=previous_chunk,
+          slot=slot,
+          kv_cache=kv_cache,
+          attention_metadata=attention_metadata,
+      )
+      if cfg.scan_layers:
+        y = y[0]
+    if cfg.scan_layers:
+      return y, None
+    else:
+      return y
+
+
+EnvyScannableBlockToLinen = nnx_wrappers.to_linen_class(
+    EnvyScannableBlock,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)

--- a/tests/unit/envy_test.py
+++ b/tests/unit/envy_test.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Envy MoE."""
+
+import sys
+import unittest
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh
+from maxtext.configs import pyconfig
+from maxtext.common.common_types import MODEL_MODE_TRAIN
+from maxtext.layers import quantizations
+from maxtext.models import models
+from maxtext.utils import maxtext_utils
+from tests.utils.test_helpers import get_test_config_path
+import numpy as np
+
+
+class EnvyTest(unittest.TestCase):
+  """Compile and verification tests for Envy MoE."""
+
+  def setUp(self):
+    super().setUp()
+    self.cfg = pyconfig.initialize(
+        [sys.argv[0], get_test_config_path()],
+        run_name="test",
+        enable_checkpointing=False,
+        model_name="envy-test",
+        dtype="float32",
+        per_device_batch_size=1.0 / jax.device_count(),
+    )
+    self.rng = jax.random.PRNGKey(123)
+
+    devices_array = maxtext_utils.create_device_mesh(self.cfg, devices=[jax.devices()[0]])
+    mesh = Mesh(devices_array, self.cfg.mesh_axes)
+    quant = quantizations.configure_quantization(self.cfg)
+    self.model = models.transformer_as_linen(config=self.cfg, mesh=mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
+    self.example_batch = {
+        "inputs": jnp.array([[5, 12, 18, 3, 22]], dtype=jnp.int32),
+        "inputs_position": jnp.array([[0, 1, 2, 3, 4]], dtype=jnp.int32),
+        "inputs_segmentation": jnp.array([[1, 1, 1, 1, 1]], dtype=jnp.int32),
+        "targets": jnp.array([[12, 18, 3, 22, 1]], dtype=jnp.int32),
+        "targets_position": jnp.array([[0, 1, 2, 3, 4]], dtype=jnp.int32),
+        "targets_segmentation": jnp.array([[1, 1, 1, 1, 0]], dtype=jnp.int32),
+    }
+
+  def test_model_initialization_and_forward(self):
+    """Verifies that the Envy model initializes and computes a training forward pass without error."""
+    model_vars = self.model.init(
+        {"params": self.rng, "aqt": self.rng},
+        self.example_batch["inputs"],
+        self.example_batch["inputs_position"],
+        enable_dropout=False,
+    )
+
+    logits, _ = self.model.apply(
+        model_vars,
+        self.example_batch["inputs"],
+        self.example_batch["inputs_position"],
+        decoder_segment_ids=self.example_batch["inputs_segmentation"],
+        enable_dropout=False,
+        rngs={"dropout": self.rng, "aqt": self.rng},
+        mutable="intermediates",
+    )
+
+    self.assertEqual(logits.shape, (1, 5, self.cfg.vocab_size))
+    # Make sure logits are not all zeros or NaNs
+    self.assertFalse(np.isnan(logits).any())
+    self.assertFalse((logits == 0).all())
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -1229,3 +1229,32 @@ class TrainCompile(parameterized.TestCase):
             "pure_nnx_decoder=true",
         )
     )
+
+  @parameterized.named_parameters(
+      {"testcase_name": "scanned", "scan_layers": "true"},
+  )
+  @pytest.mark.cpu_only
+  def test_envy(self, scan_layers):
+    # test deepseek4 compile (Linen-only: DeepSeek NNX decoder rewrite is a follow-up PR).
+    compiled_trainstep_file = f"/tmp/test_envy_{scan_layers}.pickle"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-256",
+            "use_iota_embed=true",
+            "compile_topology_num_slices=1",
+            "model_name=envy-switch-base",
+            "per_device_batch_size=1",
+            "max_target_length=8192",
+            f"scan_layers={scan_layers}",
+            "attention=dot_product",
+            "dtype=bfloat16",
+            "weight_dtype=bfloat16",
+            "enable_nnx=True",
+            "pure_nnx=True",
+            "pure_nnx_decoder=True",
+            "override_model_config=True",
+        )
+    )


### PR DESCRIPTION
# Description

Implements Apple Envy MoE model as described [here](https://github.com/apple/axlearn/blob/cbdcde5e745ba29ef84eb82e11f2aaa7af24dca1/axlearn/experiments/text/gpt/envy.py)
# Tests

# Envy MoE Parameter Equivalence Report

This report compares the parameter structures of Apple's Envy Switch-Base model between **AXLearn** and **MaxText** to verify architectural correctness.

## 1. Parameter Shape Mapping

Here is the direct mapping of parameter tensors for the **12-layer Switch-Base model** (6 repeat blocks of Alternating Dense and Sparse MoE layers):

| Component / Layer | AXLearn Parameter (Shape) | MaxText Parameter (Shape) | Equivalence Note |
| :--- | :--- | :--- | :--- |
| **Token Embedding / Logits** | `decoder/emb/token_emb/weight` `[32768, 1536]` | `token_embedder/embedding` `(32768, 1536)` | **Exactly Shared & Identical** (`logits_via_embedding: true`) |
| **Final Decoder Norm** | `decoder/output_norm/scale` `[1536]` | `decoder_norm/scale` `(1536,)` | **Exactly Identical** |
| **Self-Attention Norm** | `self_attention/norm/scale` `(6, 1536)` | `pre_self_attention_layer_norm/scale` `(1536, 6)` | **Exactly Identical** (Transposed layers axis) |
| **Self-Attention QKV Proj**| `self_attention/attention/i_proj/i_proj/qkv_proj/weight` `(6, 1536, 36, 128)` | Q, K, V are stored as 3 separate parameters:<br>- `query/kernel` `(1536, 6, 12, 128)`<br>- `key/kernel` `(1536, 6, 12, 128)`<br>- `value/kernel` `(1536, 6, 12, 128)` | **Exactly Identical**.<br>AXLearn groups QKV along the projection axis:<br>$12 + 12 + 12 = 36$ heads total. |
| **Self-Attention QK Norm** | `attention/scale_query/norm/scale` `(6, 128)` <br> `attention/scale_key/norm/scale` `(6, 128)` | `query_norm/scale` `(128, 6)` <br> `key_norm/scale` `(128, 6)` | **Exactly Identical** (Transposed layers axis) |
| **Self-Attention Output Proj**| `self_attention/attention/o_proj/weight` `(6, 1536, 12, 128)` | `out/kernel` `(12, 6, 128, 1536)` | **Exactly Identical** |
| **Dense FFN Norm** | `feed_forward/prenorm/scale` `(6, 1536)` | `post_self_attention_layer_norm/scale` `(1536, 6)` | **Exactly Identical** (Transposed layers axis) |
| **Dense FFN Post-Norm** | `feed_forward/postnorm/scale` `(6, 1536)` | `post_ffw_norm/scale` `(1536, 6)` | **Exactly Identical** (`use_post_ffw_norm: true`) |
| **Dense FFN Projections** | `feed_forward/linear1_0/weight` `(6, 1536, 6144)` <br> `feed_forward/linear1_1/weight` `(6, 1536, 6144)` <br> `feed_forward/linear2/weight` `(6, 6144, 1536)` | `wi_0/kernel` `(1536, 6, 6144)` <br> `wi_1/kernel` `(1536, 6, 6144)` <br> `wo/kernel` `(6144, 6, 1536)` | **Exactly Identical** |
| **Sparse MoE Norm** | `feed_forward/prenorm/scale` `(6, 1536)` | `post_self_attention_layer_norm/scale` `(1536, 6)` | **Exactly Identical** (Transposed layers axis) |
| **Sparse MoE Post-Norm** | `feed_forward/postnorm/scale` `(6, 1536)` | `post_ffw_norm/scale` `(1536, 6)` | **Exactly Identical** (`use_post_ffw_norm: true`) |
| **Sparse MoE Gate** | `feed_forward/gate_weight` `(6, 1536, 128)` | `MoeBlock_0/gate/kernel` `(1536, 6, 128)` | **Exactly Identical** |
| **Sparse MoE Experts Proj**| `feed_forward/wi_0_weight` `(6, 128, 1536, 6144)` <br> `feed_forward/wi_1_weight` `(6, 128, 1536, 6144)` <br> `feed_forward/wo_weight` `(6, 128, 6144, 1536)` | `MoeBlock_0/wi_0` `(128, 6, 1536, 6144)` <br> `MoeBlock_0/wi_1` `(128, 6, 1536, 6144)` <br> `MoeBlock_0/wo` `(128, 6, 6144, 1536)` | **Exactly Identical** |

---

## 2. Parameter Counts Analysis

- **AXLearn Parameter Count**: `22,077,958,656` (22.07B)
- **MaxText Parameter Count**: `22,077,958,656` (22.07B)
- **Difference**: **`0` parameters (100% exact match)**

### Key Configurations Enabled:
1. **`logits_via_embedding: true`**: Shares the token embedding parameters with the output logits projection.
2. **`use_post_ffw_norm: true`**: Activates the post-FFN normalization layer (`post_ffw_norm` in MaxText, mapping to `postnorm` in AXLearn's `hybridnorm` FFN structure).

Ran test:

```
python -m pytest tests/unit/envy_test.py
=========================================================== test session starts ===========================================================
platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0
rootdir: /mnt/disks/external_disk/maxtext
configfile: pytest.ini
plugins: anyio-4.13.0, typeguard-2.13.3, jaxtyping-0.3.9, xdist-3.8.0, hypothesis-6.151.9, mock-3.15.1
collected 1 item                                                                                                                          

tests/unit/envy_test.py .                                                                                                           [100%]

============================================================ warnings summary =============================================================
maxtext_venv/lib/python3.12/site-packages/flax/nnx/variablelib.py:324
  /mnt/disks/external_disk/maxtext/maxtext_venv/lib/python3.12/site-packages/flax/nnx/variablelib.py:324: DeprecationWarning: jax.core.Effect is deprecated. Use jax.extend.core.Effect.
    class VariableEffect(jax.core.Effect): ...

tests/unit/envy_test.py::EnvyTest::test_model_initialization_and_forward
  /mnt/disks/external_disk/maxtext/maxtext_venv/lib/python3.12/site-packages/flax/core/tracers.py:30: DeprecationWarning: jax.core.get_opaque_trace_state is deprecated. Use jax.extend.core.get_opaque_trace_state.
    return jax.core.get_opaque_trace_state(convention="flax")

tests/unit/envy_test.py: 90 warnings
  /mnt/disks/external_disk/maxtext/src/maxtext/layers/nnx_scan.py:84: DeprecationWarning: '.value' access is now deprecated. For Variable[Array] instances use:
  
    variable[...]
  
  For other Variable types use:
  
    variable.get_value()
  
    is_leaf=lambda x: hasattr(x, "replace") and hasattr(x, "value"),

tests/unit/envy_test.py: 90 warnings
  /mnt/disks/external_disk/maxtext/src/maxtext/layers/nnx_scan.py:56: DeprecationWarning: '.value' access is now deprecated. For Variable[Array] instances use:
  
    variable[...]
  
  For other Variable types use:
  
    variable.get_value()
  
    if hasattr(leaf, "replace") and hasattr(leaf, "value"):

tests/unit/envy_test.py: 90 warnings
  /mnt/disks/external_disk/maxtext/src/maxtext/layers/nnx_scan.py:65: DeprecationWarning: 'sharding_names' is deprecated, use 'out_sharding' instead.
    value = getattr(leaf, key, None)

tests/unit/envy_test.py::EnvyTest::test_model_initialization_and_forward
tests/unit/envy_test.py::EnvyTest::test_model_initialization_and_forward
  /mnt/disks/external_disk/maxtext/maxtext_venv/lib/python3.12/site-packages/qwix/_src/qconfig.py:178: DeprecationWarning: The 'm.iter_modules()' method is deprecated; use the 'nnx.iter_modules(m)' function instead.
    for _, node in model.iter_modules():

tests/unit/envy_test.py::EnvyTest::test_model_initialization_and_forward
tests/unit/envy_test.py::EnvyTest::test_model_initialization_and_forward
  /mnt/disks/external_disk/maxtext/maxtext_venv/lib/python3.12/site-packages/flax/nnx/statelib.py:378: DeprecationWarning: `flax.nnx.State` will be deprecated and be replaced by the built-in Python dict. Please use the equivalent `nnx.split_state` instead.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 1 passed, 276 warnings in 14.50s =====================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
