### PR TITLE
Extend maxSessionTurns for PR review and assistant

### DIFF
--- a/.github/workflows/gemini_invoke.yml
+++ b/.github/workflows/gemini_invoke.yml
@@ -86,7 +86,7 @@ jobs:
           settings: |-
             {
               "model": {
-                "maxSessionTurns": 25
+                "maxSessionTurns": 100
               },
               "telemetry": {
                 "enabled": false,

--- a/.github/workflows/gemini_review.yml
+++ b/.github/workflows/gemini_review.yml
@@ -36,7 +36,7 @@ defaults:
 jobs:
   review:
     runs-on: 'ubuntu-latest'
-    timeout-minutes: 10
+    timeout-minutes: 30
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -103,7 +103,7 @@ jobs:
           settings: |-
             {
               "model": {
-                "maxSessionTurns": 25
+                "maxSessionTurns": 100
               },
               "telemetry": {
                 "enabled": false,


### PR DESCRIPTION
# Description

We frequently met this [max session turn limitation](https://screenshot.googleplex.com/9BsvkpUFebT5Wtm). Increase the `maxSessionTurns` from 25 to 100, and this is also aligns with Gemini [investigation task](https://github.com/AI-Hypercomputer/maxtext/blob/41248d2ee8dfbfea3b309a1504f2e130bec231e6/.github/workflows/gemini_investigate.yml#L109).


# Tests

Expected checks are all green.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
