### PR TITLE
Warn when running on the Linen code path

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1087,11 +1087,29 @@ class HardwareAndMesh(BaseModel):
       description="Customized mesh and logical rules for evaluation.",
   )
   allow_split_physical_axes: bool = Field(False, description="Allow splitting physical axes for device mesh creation.")
-  enable_nnx: bool = Field(True, description="Whether to use NNX for model definition.")
+  enable_nnx: bool = Field(
+      True,
+      description=(
+          "Whether to use NNX for model definition. Setting this to False selects the Linen path, "
+          "which will be deprecated in the near future."
+      ),
+  )
   optimize_mesh_for_tpu_v6e: bool = Field(False, description="Apply transformations to the mesh for TPU v6e.")
   shardy: bool = Field(True, description="Whether to use shardy XLA backend.")
-  pure_nnx_decoder: bool = Field(True, description="Whether to enable pure NNX decoder.")
-  pure_nnx: bool = Field(True, description="Whether to enable pure NNX mode.")
+  pure_nnx_decoder: bool = Field(
+      True,
+      description=(
+          "Whether to enable pure NNX decoder. Setting this to False selects the Linen decoder, "
+          "which will be deprecated in the near future."
+      ),
+  )
+  pure_nnx: bool = Field(
+      True,
+      description=(
+          "Whether to enable pure NNX mode. Setting this to False selects the Linen path, "
+          "which will be deprecated in the near future."
+      ),
+  )
   remove_size_one_mesh_axis_from_type: bool = Field(
       True,
       description="Whether to remove size one mesh axis from type through jax.config.",
@@ -2889,6 +2907,24 @@ class MaxTextConfig(
             "pure_nnx_decoder=True. The bridged Linen decoder (pure_nnx_decoder=False) is invisible to Qwix, "
             "so quantization (and weight sparsity) would silently have no effect. Set pure_nnx_decoder=True."
         )
+
+    # TODO: Remove this block once the Linen code path and the enable_nnx, pure_nnx and pure_nnx_decoder flags are deleted.
+    linen_flags = [
+        name
+        for name, value in (
+            ("enable_nnx", self.enable_nnx),
+            ("pure_nnx", self.pure_nnx),
+            ("pure_nnx_decoder", self.pure_nnx_decoder),
+        )
+        if not value
+    ]
+    if linen_flags:
+      logger.warning("=" * 80)
+      logger.warning("MAXTEXT DEPRECATION NOTICE: you are running on the Linen code path.")
+      logger.warning("Selected by: %s", ", ".join(f"{name}=False" for name in linen_flags))
+      logger.warning("Linen will be deprecated in the near future and removed after that.")
+      logger.warning("Plan to migrate to NNX: leave enable_nnx, pure_nnx and pure_nnx_decoder at their default of True.")
+      logger.warning("=" * 80)
 
     # Validate distillation schedule parameters
     if self.distill_alpha_end is not None and not 0.0 <= self.distill_alpha_end <= 1.0:


### PR DESCRIPTION
# Description

Logs a deprecation banner during config validation when a run selects the Linen code path, and notes the upcoming deprecation in the relevant field descriptions.

## What it looks like

```
W0728 23:10:04 types.py:2922] ================================================================================
W0728 23:10:04 types.py:2923] MAXTEXT DEPRECATION NOTICE: you are running on the Linen code path.
W0728 23:10:04 types.py:2924] Selected by: pure_nnx_decoder=False
W0728 23:10:04 types.py:2925] Linen will be deprecated in the near future and removed after that.
W0728 23:10:04 types.py:2926] Plan to migrate to NNX: leave enable_nnx, pure_nnx and pure_nnx_decoder at their default of True.
W0728 23:10:04 types.py:2927] ================================================================================
```

## Testing
| case | banner | `Selected by:` | Log |
|---|---|---|---|
| defaults (NNX) | no | — | [log](https://paste.googleplex.com/4766416183099392) |
| `enable_nnx=false` | yes | `enable_nnx=False` | [log](https://paste.googleplex.com/6124486050054144#l=11)  |
| `pure_nnx=false` | yes | `pure_nnx=False` | [log](https://paste.googleplex.com/6392178434768896#l=11)  |
| `pure_nnx_decoder=false` | yes | `pure_nnx_decoder=False` | [log](https://paste.googleplex.com/4695292522921984#l=11)  |
| all three off | yes | all three | [log](https://paste.googleplex.com/6641137287823360#l=11)  |

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
