### PR TITLE
Fix Tunix state translation to handle Flax NNX rng count structures

### DIFF
--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -94,6 +94,8 @@ def _tpu_inference_compat_patches():
   """
   orig_wsc = jax.lax.with_sharding_constraint
   orig_apply_dtype_cast = tunix_utils._apply_dtype_cast  # pylint: disable=protected-access
+  orig_bulk = tunix_utils._bulk_align_and_unstack  # pylint: disable=protected-access
+  orig_unstack = tunix_utils._unstack_scanned_param  # pylint: disable=protected-access
 
   def _compat_wsc(x, shardings):
     try:
@@ -106,13 +108,30 @@ def _tpu_inference_compat_patches():
       return val
     return orig_apply_dtype_cast(val, tgt_dtype, src_key)
 
+  def _compat_bulk(arr, scan_axis, per_layer, key_path):
+    if hasattr(arr, "shape") and len(arr.shape) <= scan_axis:
+      scan_axis = len(arr.shape) - 1 if len(arr.shape) > 0 else 0
+    return orig_bulk(arr, scan_axis, per_layer, key_path)
+
+  def _compat_unstack(src_val, tgt_val, key_path, scan_axis=None):
+    if scan_axis is not None and hasattr(src_val, "shape") and len(src_val.shape) <= scan_axis:
+      scan_axis = len(src_val.shape) - 1 if len(src_val.shape) > 0 else 0
+    res = orig_unstack(src_val, tgt_val, key_path, scan_axis=scan_axis)
+    if isinstance(res, tuple) and len(res) == 1 and hasattr(src_val, "shape") and src_val.shape == tgt_val.shape:
+      return res * 256
+    return res
+
   jax.lax.with_sharding_constraint = _compat_wsc
   tunix_utils._apply_dtype_cast = _no_bf16_to_f32_cast  # pylint: disable=protected-access
+  tunix_utils._bulk_align_and_unstack = _compat_bulk  # pylint: disable=protected-access
+  tunix_utils._unstack_scanned_param = _compat_unstack  # pylint: disable=protected-access
   try:
     yield
   finally:
     jax.lax.with_sharding_constraint = orig_wsc
     tunix_utils._apply_dtype_cast = orig_apply_dtype_cast  # pylint: disable=protected-access
+    tunix_utils._bulk_align_and_unstack = orig_bulk  # pylint: disable=protected-access
+    tunix_utils._unstack_scanned_param = orig_unstack  # pylint: disable=protected-access
 
 
 os.environ["TOKENIZERS_PARALLELISM"] = "0"


### PR DESCRIPTION
## Description

Fix Tunix state translation (unstacking) crashes in `train_rl.py` caused by Flax NNX 1D arrays and scalar RNG states when syncing weights from MaxText to vLLM rollout engine.

## Root Cause

Tunix’s `transfer_state_directly` logic in `tunix/generate/utils.py` defaults to unstacking layers over `scan_axis=1`.   
This assumption fails critically against Flax NNX's state representations under `scan_layers=True`, resulting in two distinct `IndexError` failure modes depending on the model architecture:

1. **Llama-3.1-70B (1D Array Slicing IndexError)**:                                                                      
       State parameters like `dropout.rngs.params.count` evaluate as 1D arrays (e.g., shape `(80,)`) when stacked over layers.
  Tunix attempts to slice this along `scan_axis=1`, immediately throwing `tuple index out of range` in `_bulk_align_and_unstack` because the requested axis does not exist.

     [DAG Error Log](https://efdb2a1d6c2c435b8b7de77690c286a9-dot-us-central1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_post_training/grid?search=maxtext_e2e_tpu_post_training&tab=logs&task_id=llama3_1_70b.rl-llama3_1_70b.train-rl-llama3_1_70b.run_model.wait_for_workload_completion&dag_run_id=manual__2026-07-29T03%3A04%3A50.305665%2B00%3A00)
  
     **Shortened Error Trace:**
     ```bash
     [2026-07-29, 05:02:29 UTC] {xpk.py:365} INFO - [rank0]:   File "/usr/local/lib/python3.12/site-          packages/tunix/generate/utils.py", line 1697, in intersect_trees
     [2026-07-29, 05:02:29 UTC] {xpk.py:365} INFO - [rank0]:     unstacked_cache[cache_key] = _bulk_align_and_unstack(
     [2026-07-29, 05:02:29 UTC] {xpk.py:365} INFO - [rank0]:                                  ^^^^^^^^^^^^^^^^^^^^^^^^
     [2026-07-29, 05:02:29 UTC] {xpk.py:365} INFO - [rank0]:   File "/usr/local/lib/python3.12/site-     packages/tunix/generate/utils.py", line 1257, in _bulk_align_and_unstack
    [2026-07-29, 05:02:29 UTC] {xpk.py:365} INFO - [rank0]:     + (arr.shape[scan_axis],)
    [2026-07-29, 05:02:29 UTC] {xpk.py:365} INFO - [rank0]:        ~~~~~~~~~^^^^^^^^^^^
    [2026-07-29, 05:02:29 UTC] {xpk.py:365} INFO - [rank0]: IndexError: tuple index out of range
     ```
2. **Gemma3-4B (Scalar Pure-Unstack Indexing limit)**:                                                                  
       Due to Gemma's sliding window attention blocks, `unroll_gemma_scanned_weights` bypasses scalar `dropout` and `rng` fields from being explicitly unrolled. When these scalars (shape `()`) reach Tunix, `_unstack_scanned_param` natively      
  processes them via the "pure unstacking" code path and returns a tuple of length 1 (i.e. `(src_val,)`). 
However, vLLM expects values for all 34 independent layers. The subsequent state loading logic attempts to access `unstacked_cache[cache_key][layer_idx]` (e.g., `layer_idx=33`), resulting in a critical `IndexError` traversing the length-1 tuple.

    [DAG Error Log](https://efdb2a1d6c2c435b8b7de77690c286a9-dot-us-central1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_post_training/grid?search=maxtext_e2e_tpu_post_training&tab=logs&task_id=gemma3-4b.rl-gemma3-4b.train-rl-gemma3-4b.run_model.wait_for_workload_completion&dag_run_id=manual__2026-07-29T03%3A04%3A50.305665%2B00%3A00)

   **Shortened Error Trace:**
   ```bash
   [2026-07-29, 04:14:06 UTC] {xpk.py:365} INFO - [rank0]:   File "/usr/local/lib/python3.12/site-packages/tunix/generate/utils.py", line 1767, in transfer_state_directly
   [2026-07-29, 04:14:06 UTC] {xpk.py:365} INFO - [rank0]:     final_source, final_spec = intersect_trees(full_source_dict,   full_target_spec)
   [2026-07-29, 04:14:06 UTC] {xpk.py:365} INFO - [rank0]:                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   [2026-07-29, 04:14:06 UTC] {xpk.py:365} INFO - [rank0]:   File "/usr/local/lib/python3.12/site-packages/tunix/generate/utils.py", line 1702, in intersect_trees
   [2026-07-29, 04:14:06 UTC] {xpk.py:365} INFO - [rank0]:     sliced_val = unstacked_cache[cache_key][layer_idx]
   [2026-07-29, 04:14:06 UTC] {xpk.py:365} INFO - [rank0]:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
   [2026-07-29, 04:14:06 UTC] {xpk.py:365} INFO - [rank0]: IndexError: tuple index out of range
   ```

## Solution

Expanded the `_tpu_inference_compat_patches` context manager in `train_rl.py` to gracefully handle these NNX state edge cases during `tunix.generate.utils` operations:                                               
    1. **Dynamic `scan_axis` fallback:** Intercepted both `_bulk_align_and_unstack` and `_unstack_scanned_param` to check array dimensions prior to execution. If an array has insufficient dimensions (`len(arr.shape) <= scan_axis`), it safely   assigns `scan_axis=0` to accommodate 1D state arrays smoothly.                                                             
    2. **Broadcasting scalars robustly:** Within `_compat_unstack`, if the unwrapped result yields a length-1 tuple (due to  
  `src_shape == tgt_shape` for fully broadcast/scalar parameters), the tuple is replicated (`res * 256`) to guarantee        
  subsequent `[layer_idx]` lookups succeed uniformly across diverse model depths. 

# Tests

- Evaluated RL-Training on Llama3.1-70b

Log: https://cloudlogging.app.goo.gl/ebVYu3HB79cfkKxQA

```bash
xpk workload create-pathways \
  --cluster=v5p-128-bodaborg-europe-west4-b \
  --workload=llama70-rl-$(date +%m%d%H%M) \
  --tpu-type=v5p-128 \
  --num-slices=1 \
  --priority=very-high \
  --project=cloud-tpu-multipod-dev \
  --zone=europe-west4-b \
  --skip-validation \
  --docker-image=[gcr.io/tpu-prod-env-multipod/llama-rl](http://gcr.io/tpu-prod-env-multipod/maxtext_post_training_nightly:28210168847):latest \
  --command="set -xue; \
    export TPU_MIN_LOG_LEVEL=0; \
    export TF_CPP_MIN_LOG_LEVEL=0; \
    export TPU_STDERR_LOG_LEVEL=0; \
    export JAX_PLATFORMS='proxy,cpu'; \
    export JAX_BACKEND_TARGET='grpc://127.0.0.1:29000'; \
    export ENABLE_PATHWAYS_PERSISTENCE='1'; \
    python3 -m maxtext.trainers.post_train.rl.train_rl \
      base_output_directory='gs://cloud-tpu-multipod-dev-emma-data/llama3.1-70b-0729/rl' \
      load_parameters_path='gs://runner-maxtext-logs/llama3.1-70b/to_maxtext/scanned/post-20260729T003944/0/items' \
      tokenizer_path='meta-llama/Llama-3.1-70B-Instruct'  \
      run_name='rl_test_0630' \
      rl.loss_algo='grpo' \
      scan_layers=true \
      num_batches=5 \
      batch_size=1 \
      num_test_batches=5 \
      model_name=llama3.1-70b \
      enable_single_controller=true \
      checkpoint_storage_use_zarr3=False \
      checkpoint_storage_use_ocdbt=False \
      rollout_tensor_parallelism=4 \
      vllm_hf_overrides='{\"architectures\": [\"MaxTextForCausalLM\"]}' \
      vllm_additional_config='{\"maxtext_config\": {\"model_name\": \"llama3.1-70b\", \"log_config\": \"false\"}}'"
```

- Evaluated end-to-end on Gemma3-4b

Log: https://cloudlogging.app.goo.gl/2YAsHHGbKdfUNerm9

```bash
xpk workload create-pathways \
  --cluster=v5p-128-bodaborg-europe-west4-b \
  --workload=gemma3-rl \
  --tpu-type=v5p-128 \
  --num-slices=1 \
  --priority=very-high \
  --project=cloud-tpu-multipod-dev \
  --zone=europe-west4-b \
  --docker-image=[gcr.io/tpu-prod-env-multipod/gemma3-rl](http://gcr.io/tpu-prod-env-multipod/maxtext_post_training_nightly:28210168847):latest \
  --env GCS_OUTPUT=gs://ml-auto-solutions/output/unowned/rl-f8c-v5p-128-2026-07-29-03-29-13/ \
  --skip-validation \
  --command='set -xue; export TPU_MIN_LOG_LEVEL=0 && export TF_CPP_MIN_LOG_LEVEL=0 && export TPU_STDERR_LOG_LEVEL=0 && export JAX_PLATFORMS=proxy,cpu && export JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 && export ENABLE_PATHWAYS_PERSISTENCE=1 && bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_rl.sh post-20260729T030450 true'
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
