### PR TITLE
[E2E Tests] Fix Llama 3.1 70B OOM and clean up Gemma 3 test configs

### DIFF
--- a/tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh
+++ b/tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh
@@ -23,9 +23,7 @@ MODEL_NAME='gemma3-4b'
 
 # Non-Googlers please remember to point `BASE_OUTPUT_DIRECTORY` to the GCS paths where you have the scanned and unscanned checkpoints stored
 BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
-UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned/${run_id}/0/items
 MULTIMODAL_SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned_multimodal/${run_id}/0/items
-SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned/${run_id}/0/items
 
 # Step 1: Install google-jetstream
 python3 -m pip install google-jetstream@https://github.com/AI-Hypercomputer/JetStream/archive/29329e8e73820993f77cfc8efe34eb2a73f5de98.zip --no-deps

--- a/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_rl.sh
+++ b/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_rl.sh
@@ -56,7 +56,7 @@ python3 -m maxtext.inference.vllm_decode \
     load_parameters_path=${BASE_OUTPUT_DIRECTORY}/rl/${run_id}/checkpoints/actor/5/model_params \
     tokenizer_path='meta-llama/Llama-3.1-70B-Instruct' \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
-    hbm_utilization_vllm=0.85 \
+    hbm_utilization_vllm=0.6 \
     prompt='Suggest some famous landmarks in London.' \
     use_chat_template=True scan_layers=true enable_single_controller=${use_pathways} \
     ici_tensor_parallelism=8

--- a/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_sft.sh
+++ b/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_sft.sh
@@ -52,7 +52,7 @@ python3 -m maxtext.inference.vllm_decode \
     load_parameters_path=${BASE_OUTPUT_DIRECTORY}/sft/${run_id}/checkpoints/5/model_params \
     tokenizer_path='meta-llama/Llama-3.1-70B-Instruct' \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
-    hbm_utilization_vllm=0.85 \
+    hbm_utilization_vllm=0.6 \
     prompt="Suggest some famous landmarks in London." \
     use_chat_template=True scan_layers=true enable_single_controller=${use_pathways} \
     ici_tensor_parallelism=8

--- a/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh
+++ b/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh
@@ -28,4 +28,5 @@ python3 -m maxtext.checkpoint_conversion.to_huggingface \
     load_parameters_path=${CKPT_PATH} \
     base_output_directory=${BASE_OUTPUT_DIRECTORY}/to_huggingface/${scan_status}/${run_id} \
     use_multimodal=${USE_MULTIMODAL} \
-    scan_layers=$SCAN_LAYERS
+    scan_layers=$SCAN_LAYERS \
+    weight_dtype=bfloat16


### PR DESCRIPTION
# Description

This PR updates test configurations to improve end-to-end stability and cleans up unused script variables.

Summary of Changes:
  
 - Llama-3.1-70B (RL & SFT): Reduced ```hbm_utilization_vllm``` in ```vllm_decode``` from ```0.85``` to ```0.6``` to reliably prevent OOM errors.
 - Llama-3.1-70B (HF Conversion): Explicitly set ```weight_dtype=bfloat16``` to prevent OOMKilled during HuggingFace checkpoint conversion.
 - Gemma-3-4B (Multimodal SFT): Cleaned up the script by removing redundant and unused variables (```UNSCANNED_CKPT_PATH``` and ```SCANNED_CKPT_PATH```).

# Tests
1. 
```bash
xpk workload create-pathways \
  --cluster=v5p-128-bodaborg-europe-west4-b \
  --workload=llama-povllm-$(date +%m%d%H%M) \
  --tpu-type=v5p-128 \
  --num-slices=1 \
  --priority=very-high \
  --project=cloud-tpu-multipod-dev \
  --zone=europe-west4-b \
  --skip-validation \
  --docker-image=[gcr.io/tpu-prod-env-multipod/maxtext_post_training_nightly:30411448246](http://gcr.io/tpu-prod-env-multipod/maxtext_post_training_nightly:30411448246) \
  --command="set -xue; \
    export TPU_MIN_LOG_LEVEL=0; \
    export TF_CPP_MIN_LOG_LEVEL=0; \
    export TPU_STDERR_LOG_LEVEL=0; \
    export JAX_PLATFORMS='proxy,cpu'; \
    export JAX_BACKEND_TARGET='grpc://127.0.0.1:29000'; \
    export ENABLE_PATHWAYS_PERSISTENCE='1'; \
    python3 -m maxtext.inference.vllm_decode \
      model_name=llama3.1-70b \
      tokenizer_path='meta-llama/Llama-3.1-70B-Instruct' \
      load_parameters_path='gs://cloud-tpu-multipod-dev-emma-data/llama3.1-70b-0729/rl/rl_test_0630/checkpoints/actor/5/model_params' \
      vllm_hf_overrides='{\"architectures\": [\"MaxTextForCausalLM\"]}' \
      hbm_utilization_vllm=0.6 \
      prompt='Suggest some famous landmarks in London.' \
      scan_layers=True \
      enable_single_controller=true \
      ici_tensor_parallelism=8"
```
Log: https://cloudlogging.app.goo.gl/htEME5fAJ4mjUdjFA

2. 
```bash
xpk workload create \
  --cluster=auto-v5p-8-bodaborg \
  --workload=llamatohf-4 \
  --tpu-type=v5p-8 \
  --num-slices=1 \
  --priority=very-high \
  --project=cloud-tpu-multipod-dev \
  --zone=europe-west4-b \
  --skip-validation \
  --docker-image=[gcr.io/tpu-prod-env-multipod/maxtext_jax_nightly:30502983001](http://gcr.io/tpu-prod-env-multipod/maxtext_jax_nightly:30502983001) \
  --command="set -xue; \
    export LIBTPU_INIT_ARGS=\"--xla_tpu_scoped_vmem_limit_kib=20480\"; \
    export HF_HOME='/dev/shm/hf_cache'; \
    python3 -m maxtext.checkpoint_conversion.to_huggingface \
      model_name=llama3.1-70b \
      tokenizer_type=huggingface \
      load_parameters_path='gs://runner-maxtext-logs/llama3.1-70b/train/pre-20260723T014531/checkpoints/4/items' \
      base_output_directory='gs://runner-maxtext-logs/llama3.1-70b/to_huggingface/unscanned/0730-2' \
      use_multimodal=false \
      scan_layers=false \
      weight_dtype=bfloat16"
```

Log: https://cloudlogging.app.goo.gl/GvhS8f8mNtGcVtD37


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
