### PR TITLE
Mhc optimization: Rewrites einsums for better xla fusion

### DIFF
--- a/src/maxtext/layers/mhc.py
+++ b/src/maxtext/layers/mhc.py
@@ -67,13 +67,10 @@ def sinkhorn(t, iters=20):
   t = jax.nn.softmax(t, axis=-1) + eps
   t = t / (jnp.sum(t, axis=-2, keepdims=True) + eps)
 
-  def body_fun(i, val):
-    val = val / (jnp.sum(val, axis=-1, keepdims=True) + eps)
-    val = val / (jnp.sum(val, axis=-2, keepdims=True) + eps)
-    return val
+  for _ in range(iters - 1):
+    t = t / (jnp.sum(t, axis=-1, keepdims=True) + eps)
+    t = t / (jnp.sum(t, axis=-2, keepdims=True) + eps)
 
-  # Use lax.fori_loop for an efficient, JIT-friendly loop
-  t = jax.lax.fori_loop(0, iters - 1, body_fun, t)
   return t.astype(initial_dtype)
 
 
@@ -249,8 +246,9 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
     # x shape: [batch, seq, expansion_rate, emb]
     b, s, k, d = x.shape
 
-    # 1. Flatten the tensor, and RMS normalization
-    norm_x = self.mhc_norm(jnp.reshape(x, (b, s, k * d)))
+    with jax.named_scope("mhc_norm"):
+      # 1. Flatten the tensor, and RMS normalization
+      norm_x = self.mhc_norm(jnp.reshape(x, (b, s, k * d)))
 
     # Fused Projections
     pre_alpha = jnp.asarray(self.pre_alpha[...], self.dtype)
@@ -274,7 +272,10 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
         1.0,
         eps=1e-6,
     )
-    layer_input = jnp.einsum("bskd,bsk -> bsd", x, pre_mapping, precision=self.matmul_precision)
+    # Moving away from einsum seems to allow XLA to perform better fusions
+    # https://github.com/AI-Hypercomputer/maxtext/pull/4664#discussion_r3677899970
+    # bskd, bsk -> bsd
+    layer_input = jnp.sum(x * jnp.expand_dims(pre_mapping, axis=3), axis=2)
 
     # 3. Pre-norm
     layer_input = norm_fn(layer_input)
@@ -299,16 +300,16 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
         self.post_beta[...],
         2.0,
     )
-    post_out = jnp.einsum(
-        "bsd,bsk -> bskd",
-        layer_out,
-        post_mapping,
-        precision=self.matmul_precision,
-    )
+    # Moving away from einsum seems to allow XLA to perform better fusions
+    # bsd,bsk -> bskd
+    post_out = jnp.expand_dims(layer_out, axis=2) * jnp.expand_dims(post_mapping, axis=3)
 
     # 6. Residual mapping, res_out shape as [batch, seq, expansion_rate, emb]
     res_mapping = self.res_mapping(h_res)
-    res_out = jnp.einsum("bskd,bskm -> bsmd", x, res_mapping, precision=self.matmul_precision)
+
+    # Moving away from einsum seems to allow XLA to perform better fusions
+    # bskd,bskm -> bsmd
+    res_out = jnp.sum(jnp.expand_dims(x, axis=3) * jnp.expand_dims(res_mapping, axis=4), axis=2)
     return res_out + post_out, metadata
 
 


### PR DESCRIPTION
# Description

XLA optimizations does not seem to gel well with einsum for cases where dimensions are being expanded. Leading to a ~10- 15% performance drop in the current implementation. This change implements expanded einsums with jnp.expand_dims leading to better XLA fusion.

Before (110us): 
<img width="1906" height="1102" alt="image" src="https://github.com/user-attachments/assets/b4246e62-250d-461e-aec6-710ef1ca2b20" />
After (97us):
<img width="1768" height="606" alt="image" src="https://github.com/user-attachments/assets/4e81c0c0-b7c9-4762-9386-31aec77f5239" />

# Tests

All existing tests passing.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
