### PR TITLE
Add images in SFT loss_func for multimodal post training

### DIFF
--- a/src/maxtext/trainers/post_train/sft/train_sft.py
+++ b/src/maxtext/trainers/post_train/sft/train_sft.py
@@ -210,6 +210,9 @@ def use_maxtext_loss_function(trainer, mt_config):
       targets,
       targets_position,
       targets_segmentation,
+      images=None,
+      image_masks=None,
+      **kwargs,
   ):
     data = {
         "inputs": inputs,
@@ -219,6 +222,10 @@ def use_maxtext_loss_function(trainer, mt_config):
         "targets_position": targets_position,
         "targets_segmentation": targets_segmentation,
     }
+    if images is not None:
+      data["images"] = images
+    if image_masks is not None:
+      data["image_masks"] = image_masks
     return loss_fn(model, mt_config, data, dropout_rng=None, params=None, is_train=True)
 
   trainer = trainer.with_loss_fn(loss_func, has_aux=True)


### PR DESCRIPTION
# Description

MaxText's post-training wrapper function (use_maxtext_loss_function in train_sft.py) has a hardcoded function signature accepting only text keyword arguments (inputs, targets, etc.), but Tunix's batch iterator unpacks all batch dictionary keys—including images and image_masks—into the loss function during multimodal training.

I was working on post-train Gemma3-4B on Robotic dataset, previously converted from HF LeRobot to Parquet format.

# Tests

Tested by post-training Gemma3-4B with the following command:

```
python3 -m maxtext.trainers.post_train.sft.train_sft \
    src/maxtext/configs/post_train/sft-vision-chartqa.yml \
    run_name=${RUN_NAME} \
    model_name="gemma3-4b" \
    tokenizer_path="google/gemma-3-4b-it" \
    tokenizer_type="huggingface" \
    sharding_tolerance=0.05 \
    load_parameters_path=${MAXTEXT_CKPT_PATH} \
    base_output_directory=${BASE_OUTPUT_DIRECTORY} \
    dataset_type="hf" \
    hf_path="parquet" \
    hf_train_files="lerobot/train-*.parquet" \
    hf_eval_files="lerobot/eval-*.parquet" \
    train_split="train" \
    hf_eval_split="eval" \
    train_data_columns="['prompt','completion']" \
    eval_data_columns="['prompt','completion']" \
    train_image_column="image" \
    eval_image_column="image" \
    max_num_images_per_example=4 \
    use_sft=true \
    use_multimodal=true \
    sft_train_on_completion_only=true \
    packing=false \
    freeze_vision_encoder_params=true \
    learning_rate=2e-6 \
    per_device_batch_size=1 \
    max_prefill_predict_length=1024 \
    max_target_length=2048 \
    steps=75 \
    eval_interval=5 \
    eval_steps=5 \
    target_eval_loss=-1.0 \
    dtype="bfloat16" \
    weight_dtype="bfloat16" \
    async_checkpointing=false \
    attention="dot_product"
 ```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
