### PR TITLE
Add Qwen3-VL-2B E2E test scripts

### DIFF
--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh
@@ -63,8 +63,7 @@ python3 -m maxtext.trainers.pre_train.train \
     ici_fsdp_parallelism=16 \
     weight_dtype=bfloat16 \
     dtype=bfloat16 \
-    opt_type=sgd \
-    optimizer_memory_host_offload=true
+    opt_type=sgd
 
 # Step 3: Run inference on the checkpoint produced by the pre-training run
 python3 -m maxtext.inference.decode \

--- a/tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_multimodal_sft.sh
+++ b/tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_multimodal_sft.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Validates the Qwen3-VL-2B SFT multimodal pipeline using a pre-converted MaxText checkpoint.
+
+# The flow of this script is as follows:
+# 1. Run inference on the pre-converted checkpoint.
+# 2. Run SFT of Qwen3-VL-2B on ChartQA dataset with the converted checkpoint.
+# 3. Run inference on the checkpoint produced by the SFT run.
+
+# Usage:
+# export HF_TOKEN=<your Hugging Face access token>
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_mt.sh $RUN_ID true
+# bash test_qwen3_multimodal_sft.sh $RUN_ID
+
+# Note: You can stop at any step if you just want to run part of the flow.
+
+set -ex
+
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+use_pathways=${2:-false}
+MODEL_NAME='qwen3-vl-2b'
+
+# Non-Googlers please remember to point `BASE_OUTPUT_DIRECTORY` to the GCS paths where you have the scanned and unscanned checkpoints stored
+BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
+MULTIMODAL_UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned_multimodal/${run_id}/0/items
+
+# Non-Googlers please remember to point `DATASET_PATH` to the GCS bucket where you have your training data                                                           
+export DATASET_PATH=gs://maxtext-dataset
+
+# Step 1: Install google-jetstream
+python3 -m pip install google-jetstream@https://github.com/AI-Hypercomputer/JetStream/archive/29329e8e73820993f77cfc8efe34eb2a73f5de98.zip --no-deps
+
+# Step 2: Run inference on the original checkpoint converted from Hugging Face
+python3 -m maxtext.inference.decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${MULTIMODAL_UNSCANNED_CKPT_PATH} \
+    per_device_batch_size=1 \
+    run_name=${run_id} \
+    max_prefill_predict_length=4096 \
+    max_target_length=4200 \
+    steps=1 \
+    async_checkpointing=false \
+    scan_layers=false \
+    use_multimodal=true \
+    tokenizer_type=huggingface \
+    prompt=\'Describe\ image\ \<start_of_image\>\' \
+    image_path=\'tests/assets/test_image.jpg\' \
+    attention=\'dot_product\' \
+    skip_jax_distributed_system=True
+
+# Step 3: Run SFT on the MaxText checkpoint on ChartQA dataset
+python -m maxtext.trainers.post_train.sft.train_sft_native "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/post_train/sft-vision-chartqa.yml \
+    run_name=${run_id} \
+    model_name=${MODEL_NAME} \
+    per_device_batch_size=1 \
+    max_prefill_predict_length=1024 \
+    max_target_length=2048 \
+    steps=5 \
+    scan_layers=false \
+    async_checkpointing=False \
+    float32_qk_product=True \
+    float32_logits=True \
+    dataset_type=hf \
+    hf_path=parquet \
+    hf_train_files=${DATASET_PATH}/hf/chartqa/train-* \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/multimodal/sft \
+    load_parameters_path=${MULTIMODAL_UNSCANNED_CKPT_PATH} \
+    sharding_tolerance=0.05 \
+    checkpoint_storage_use_zarr3=False \
+    checkpoint_storage_use_ocdbt=False \
+    enable_single_controller=${use_pathways} \
+    grain_worker_count=0
+
+# Step 4: Run inference on the checkpoint generated from the previous run
+python3 -m maxtext.inference.decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${BASE_OUTPUT_DIRECTORY}/multimodal/sft/${run_id}/checkpoints/4/items \
+    per_device_batch_size=1 \
+    run_name=${run_id} \
+    max_prefill_predict_length=4096 \
+    max_target_length=4200 \
+    steps=1 \
+    async_checkpointing=false \
+    scan_layers=false \
+    use_multimodal=true \
+    tokenizer_type=huggingface \
+    prompt=\'Describe\ image\ \<start_of_image\>\' \
+    image_path=\'tests/assets/test_image.jpg\' \
+    attention=\'dot_product\' \
+    skip_jax_distributed_system=True

--- a/tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_multimodal_sft.sh
+++ b/tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_multimodal_sft.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Validates the Qwen3-VL-2B SFT multimodal pipeline using a pre-converted MaxText checkpoint.
+
+# The flow of this script is as follows:
+# 1. Run inference on the pre-converted checkpoint.
+# 2. Run SFT of Qwen3-VL-2B on ChartQA dataset with the converted checkpoint.
+# 3. Run inference on the checkpoint produced by the SFT run.
+
+# Usage:
+# export HF_TOKEN=<your Hugging Face access token>
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_mt.sh $RUN_ID true
+# bash test_qwen3_multimodal_sft.sh $RUN_ID
+
+# Note: You can stop at any step if you just want to run part of the flow.
+
+set -ex
+
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+use_pathways=${2:-false}
+MODEL_NAME='qwen3-vl-2b'
+
+# Non-Googlers please remember to point `BASE_OUTPUT_DIRECTORY` to the GCS paths where you have the scanned and unscanned checkpoints stored
+BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
+MULTIMODAL_UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned_multimodal/${run_id}/0/items
+
+# Step 1: Install google-jetstream
+python3 -m pip install google-jetstream@https://github.com/AI-Hypercomputer/JetStream/archive/29329e8e73820993f77cfc8efe34eb2a73f5de98.zip --no-deps
+
+# Step 2: Run inference on the original checkpoint converted from Hugging Face
+python3 -m maxtext.inference.decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${MULTIMODAL_UNSCANNED_CKPT_PATH} \
+    per_device_batch_size=1 \
+    run_name=${run_id} \
+    max_prefill_predict_length=4096 \
+    max_target_length=4200 \
+    steps=1 \
+    async_checkpointing=false \
+    scan_layers=false \
+    use_multimodal=true \
+    tokenizer_type=huggingface \
+    prompt=\'Describe\ image\ \<start_of_image\>\' \
+    image_path=\'tests/assets/test_image.jpg\' \
+    attention=\'dot_product\' \
+    skip_jax_distributed_system=True
+
+# Step 3: Run SFT on the MaxText checkpoint on ChartQA dataset
+python -m maxtext.trainers.post_train.sft.train_sft_native "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/post_train/sft-vision-chartqa.yml \
+    run_name=${run_id} \
+    model_name=${MODEL_NAME} \
+    per_device_batch_size=1 \
+    max_prefill_predict_length=1024 \
+    max_target_length=2048 \
+    steps=5 \
+    scan_layers=false \
+    async_checkpointing=False \
+    float32_qk_product=True \
+    float32_logits=True \
+    dataset_type=hf \
+    hf_path=parquet \
+    hf_train_files=gs://aireenmei-multipod/dataset/hf/chartqa/train-* \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/multimodal/sft \
+    load_parameters_path=${MULTIMODAL_UNSCANNED_CKPT_PATH} \
+    sharding_tolerance=0.05 \
+    checkpoint_storage_use_zarr3=False \
+    checkpoint_storage_use_ocdbt=False \
+    enable_single_controller=${use_pathways} \
+    grain_worker_count=0
+
+# Step 4: Run inference on the checkpoint generated from the previous run
+python3 -m maxtext.inference.decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${BASE_OUTPUT_DIRECTORY}/multimodal/sft/${run_id}/checkpoints/4/items \
+    per_device_batch_size=1 \
+    run_name=${run_id} \
+    max_prefill_predict_length=4096 \
+    max_target_length=4200 \
+    steps=1 \
+    async_checkpointing=false \
+    scan_layers=false \
+    use_multimodal=true \
+    tokenizer_type=huggingface \
+    prompt=\'Describe\ image\ \<start_of_image\>\' \
+    image_path=\'tests/assets/test_image.jpg\' \
+    attention=\'dot_product\' \
+    skip_jax_distributed_system=True

--- a/tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_hf.sh
+++ b/tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_hf.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Converts a MaxText checkpoint to a Hugging Face model checkpoint.
+
+# Usage:
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_gemma4_to_hf.sh $RUN_ID $CHECKPOINT_PATH $USE_MULTIMODAL $SCAN_LAYERS
+
+set -ex
+
+run_id=$1
+CKPT_PATH=$2
+USE_MULTIMODAL=${3:-false}
+SCAN_LAYERS=${4:-false}
+
+MODEL_NAME='qwen3-vl-2b'
+BASE_OUTPUT_DIRECTORY="gs://runner-maxtext-logs/${MODEL_NAME}"
+
+if [ "${SCAN_LAYERS,,}" = "true" ]; then
+    scan_status="scanned"
+else
+    scan_status="unscanned"
+fi
+
+python3 -m maxtext.checkpoint_conversion.to_huggingface \
+    model_name=${MODEL_NAME} \
+    tokenizer_type="huggingface" \
+    load_parameters_path=${CKPT_PATH} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/to_huggingface/${scan_status}/${run_id} \
+    use_multimodal=${USE_MULTIMODAL} \
+    scan_layers=$SCAN_LAYERS

--- a/tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_mt.sh
+++ b/tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_mt.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Converts Qwen3-VL-2B HuggingFace checkpoint to MaxText format and validates logit correctness.
+
+# The flow of this script is as follows:
+# 1. Install PyTorch (CPU) required for checkpoint conversion.
+# 2. Convert the HuggingFace checkpoint to MaxText format in both unscanned and scanned formats.
+# 3. Run a forward pass logits check to verify the converted checkpoint matches the original HF model.
+
+# Usage:
+# export HF_TOKEN=<your Hugging Face access token>
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_mt.sh $RUN_ID
+
+set -ex
+
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+MODEL_NAME='qwen3-vl-2b'
+HF_GOLDEN_MODEL=Qwen/Qwen3-VL-2B-Instruct
+
+# To convert the multimodal model, make sure the use_multimodal is set to be true
+
+BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}/to_maxtext
+
+# Step 1: Install torch
+python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+python3 -m pip install decord
+
+# Step 2: Convert to scanned multimodal checkpoint (for multimodal training)
+python3 -m maxtext.checkpoint_conversion.to_maxtext \
+    model_name=${MODEL_NAME} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/unscanned_multimodal/${run_id} \
+    use_multimodal=true \
+    scan_layers=false \
+    hardware=cpu \
+    skip_jax_distributed_system=True \
+    checkpoint_storage_use_zarr3=False \
+    checkpoint_storage_use_ocdbt=False \
+    --lazy_load_tensors=False \
+    --eager_load_method='safetensors'
+
+MULTIMODAL_UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/unscanned_multimodal/${run_id}/0/items
+echo "Multimodal Unscanned checkpoint path: ${MULTIMODAL_UNSCANNED_CKPT_PATH}"
+
+# Step 3: Test whether the forward pass logits match the original HF model
+# to get higher precision (eg. float32) run on CPU with `JAX_PLATFORMS=cpu`
+TEST_PROMPT='Describe this image'
+TEST_IMAGE='tests/assets/test_image.jpg'
+export GOLDEN_LOGITS_PATH=/tmp/golden_qwen3_vl_2b_vision.jsonl
+
+python3 -m tests.assets.logits_generation.generate_hf_golden_logits \
+    --model-id=${HF_GOLDEN_MODEL} \
+    --output-path=${GOLDEN_LOGITS_PATH} \
+    --prompts="${TEST_PROMPT}" \
+    --image-paths=${TEST_IMAGE} \
+    --hf-model-path=${HF_GOLDEN_MODEL} \
+    --apply-chat-template \
+    --output-format=json
+
+echo "=== Running MaxText Multimodal Forward Pass Logit Checker ==="
+python3 -m tests.utils.forward_pass_logit_checker \
+    tokenizer_path=${HF_GOLDEN_MODEL} \
+    load_parameters_path=${MULTIMODAL_UNSCANNED_CKPT_PATH} \
+    model_name=${MODEL_NAME} \
+    use_multimodal=true \
+    scan_layers=false \
+    dtype=float32 \
+    matmul_precision=highest \
+    per_device_batch_size=1 \
+    attention=dot_product \
+    prompt="${TEST_PROMPT}" \
+    image_path=${TEST_IMAGE} \
+    --max_kl_div=0.1 \
+    --golden_logits_path=${GOLDEN_LOGITS_PATH} \
+    override_model_config=true


### PR DESCRIPTION

# Description

This PR introduces end-to-end (E2E) testing and validation pipelines for the Qwen3-VL-2B model in MaxText and adjusts the config of Qwen3-30b E2E script.

**Note on `scan_layers=false`**:
Qwen3-VL-2B requires `scan_layers=false` due to its Deepstack visual embedding injection design. Because the visual tokens are interwoven deeply across specific layers, the transformer blocks are not computationally identical and therefore cannot be wrapped inside a homogeneous `jax.lax.scan` loop.

# Tests (Testing on v6e-8 TPU VM)

Multimodal SFT: 
```bash
export RUN_ID=$(date +%Y-%m-%d-%H-%M)
bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_mt.sh $RUN_ID
bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_multimodal_sft.sh $RUN_ID
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
