### PR TITLE
PR permission test, from TPU Raiden team intern, clarify that maxtext…

### DIFF
--- a/src/maxtext/training_engine/maxtext_engine.py
+++ b/src/maxtext/training_engine/maxtext_engine.py
@@ -329,13 +329,16 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     return self._metrics_recorder.get_metrics(clear_cache=clear_cache)
 
   def prepare_weight_sync(self, **kwargs: Any) -> Any:
-    """Stages weights for transfer and returns access coordinates.
-
+    """Returns weight synchronization metadata.
+  
+    Weight synchronization is not implemented yet. This placeholder returns an
+    empty dictionary until a transfer backend is integrated.
+  
     Args:
-      **kwargs: Weight staging parameters.
-
+      **kwargs: Reserved for future weight-staging configuration.
+  
     Returns:
-      Synchronization endpoints or coordinates for rollout actors.
+      An empty dictionary.
     """
     return {}
 


### PR DESCRIPTION
… weight sync is not implemented

## Summary

Clarify that `MaxTextTrainingEngine.prepare_weight_sync()` is currently a placeholder and returns no synchronization metadata.

The previous docstring stated that the method stages weights for transfer, although the implementation only returns an empty dictionary.

## Testing

Documentation-only change; no runtime behavior changed.


