### PR TITLE
Add Pathways health check to run_pathways_tests.yml

### DIFF
--- a/.github/workflows/run_pathways_tests.yml
+++ b/.github/workflows/run_pathways_tests.yml
@@ -104,6 +104,19 @@ jobs:
           python3 -m pip freeze
       - name: Copy test assets files
         run : gcloud storage cp gs://maxtext-test-assets/* tests/assets
+      - name: Wait for Pathways Proxy Readiness
+        shell: bash
+        run: |
+          echo "Waiting for Pathways Proxy at localhost:29000..."
+          for i in {1..30}; do
+            if python3 -c "import socket; socket.create_connection(('localhost', 29000), timeout=1)" 2>/dev/null; then
+              echo "Pathways Proxy port is open and listening!"
+              sleep 2  # Allow gRPC server to complete internal handshakes
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: Pathways Proxy failed to start within 60s" && exit 1
       - name: Run Tests
         env:
           TOTAL_WORKERS: ${{ inputs.total_workers }}
@@ -141,7 +154,7 @@ jobs:
           - "29001:29001"
           - "29002:29002"
         options:
-          --entrypoint=[/usr/pathways/run/cloud_pathways_server_sanitized, --server_port=29001, --node_type=resource_manager, --enforce_kernel_ipv6_support=false, --instance_count=1, --instance_type=tpuv6e:2x2, --gcs_scratch_location=gs://cloud-pathways-staging/tmp]
+          --entrypoint=[/usr/pathways/run/cloud_pathways_server_sanitized, --server_port=29001, --node_type=resource_manager, --enforce_kernel_ipv6_support=false, --instance_count=1, --instance_type=tpuv6e:2x2, --gcs_scratch_location=gs://cloud-pathways-staging/maxtext-ci/${{ github.run_id }}_${{ github.run_attempt }}_${{ inputs.worker_group }}]
         env:
           TPU_SKIP_MDS_QUERY: true
 
@@ -153,7 +166,7 @@ jobs:
           - "8471:8471"
           - "8080:8080"
         options:
-          --entrypoint=[/usr/pathways/run/cloud_pathways_server_sanitized, --server_port=29005, --resource_manager_address=localhost:29001, --enforce_kernel_ipv6_support=false, --gcs_scratch_location=gs://cloud-pathways-staging/tmp]
+          --entrypoint=[/usr/pathways/run/cloud_pathways_server_sanitized, --server_port=29005, --resource_manager_address=localhost:29001, --enforce_kernel_ipv6_support=false, --gcs_scratch_location=gs://cloud-pathways-staging/maxtext-ci/${{ github.run_id }}_${{ github.run_attempt }}_${{ inputs.worker_group }}]
           --tpu=4
 
       proxy:
@@ -164,4 +177,4 @@ jobs:
           IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS: true
           XLA_FLAGS: "--xla_dump_to=/tmp/aot_test_dump --xla_dump_hlo_as_text --xla_dump_hlo_module_re=jit_train_step"
         options:
-          --entrypoint=[/usr/pathways/run/cloud_proxy_server_sanitized, --server_port=29000, --resource_manager_address=localhost:29001, --enforce_kernel_ipv6_support=false, --gcs_scratch_location=gs://cloud-pathways-staging/tmp, --xla_tpu_scoped_vmem_limit_kib=65536, --xla_tpu_spmd_rng_bit_generator_unsafe=true]
+          --entrypoint=[/usr/pathways/run/cloud_proxy_server_sanitized, --server_port=29000, --resource_manager_address=localhost:29001, --enforce_kernel_ipv6_support=false, --gcs_scratch_location=gs://cloud-pathways-staging/maxtext-ci/${{ github.run_id }}_${{ github.run_attempt }}_${{ inputs.worker_group }}, --xla_tpu_scoped_vmem_limit_kib=65536, --xla_tpu_spmd_rng_bit_generator_unsafe=true]


### PR DESCRIPTION
# Description

This PR introduces two main stability improvements for the CI pipeline:

1. **Adds a readiness probe for the Pathways Proxy**: A bash loop has been added to try connecting to `localhost:29000` using a Python socket connection up to 30 times with a 2-second delay between attempts. If it succeeds, it waits an extra 2 seconds for gRPC internal handshakes and exits successfully. If it fails after 60 seconds, it errors out. This will prevent race conditions where tests might start executing before the proxy is fully ready to accept connections.

2. **Isolates the GCS scratch directories per CI run to prevent collisions**: The static `--gcs_scratch_location=gs://cloud-pathways-staging/tmp` argument has been updated to a dynamic path: `--gcs_scratch_location=gs://cloud-pathways-staging/maxtext-ci/${{ github.run_id }}_${{ github.run_attempt }}_${{ inputs.worker_group }}`. Using a shared directory often causes painful state collisions when multiple tests or pull requests run concurrently. By scoping the scratch directory to the exact run_id, run_attempt, and worker_group, runs are now perfectly isolated.

# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
