### PR TITLE
Add standalone checkpointer benchmark features and Orbax configuratio…

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -64,6 +64,15 @@ checkpoint_todelete_subdir: None
 # Full path to move checkpoints to before deletion.
 checkpoint_todelete_full_path: None
 
+# Interval in seconds between iterations in standalone checkpointer benchmark loop
+standalone_checkpointer_per_step_interval: 0.0
+# Whether to execute sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches' before restoring a checkpoint in standalone_checkpointer loop
+standalone_checkpointer_drop_page_cache_before_restore: false
+# Whether to also restore checkpoint after saving in each step of standalone_checkpointer loop
+standalone_checkpointer_enable_restore_in_loop: true
+# Whether to start by attempting to load an existing checkpoint in standalone_checkpointer
+standalone_checkpointer_start_from_checkpoint: false
+
 force_unroll: false # during generate_param_only_checkpoint should we unroll the loop?
 
 # checkpointing using orbax has two important parameters: array driver

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -63,6 +63,15 @@ checkpoint_todelete_subdir: None
 # Full path to move checkpoints to before deletion.
 checkpoint_todelete_full_path: None
 
+# Interval in seconds between iterations in standalone checkpointer benchmark loop
+per_step_interval: 0.0
+# Whether to execute sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches' before restoring a checkpoint in standalone_checkpointer loop
+drop_page_cache_before_restore: false
+# Whether to also restore checkpoint after saving in each step of standalone_checkpointer loop
+standalone_checkpointer_enable_restore_in_loop: true
+# Whether to start by attempting to load an existing checkpoint in standalone_checkpointer
+standalone_checkpointer_start_from_checkpoint: false
+
 force_unroll: false # during generate_param_only_checkpoint should we unroll the loop?
 
 # checkpointing using orbax has two important parameters: array driver

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -344,6 +344,31 @@ class Checkpointing(BaseModel):
       description="Subdirectory to move checkpoints to before deletion. (Ignored if directory is prefixed with gs://)",
   )
   checkpoint_todelete_full_path: str | None = Field(None, description="Full path to move checkpoints to before deletion.")
+  per_step_interval: float = Field(
+      0.0,
+      description="Interval in seconds between iterations in standalone checkpointer benchmark loop.",
+  )
+  drop_page_cache_before_restore: bool = Field(
+      False,
+      description=(
+          "Whether to execute sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches' before restoring a checkpoint in"
+          " standalone_checkpointer loop (use for storage benchmarking only)."
+      ),
+  )
+  standalone_checkpointer_enable_restore_in_loop: bool = Field(
+      True,
+      description=(
+          "In standalone_checkpointer loop, whether to restore checkpoint after saving in each step (defaults to True"
+          " for bidirectional storage read/write benchmarking)."
+      ),
+  )
+  standalone_checkpointer_start_from_checkpoint: bool = Field(
+      False,
+      description=(
+          "In standalone_checkpointer, whether to start by attempting to load an existing checkpoint before setting"
+          " up training state (for checkpoint restore benchmarking)."
+      ),
+  )
   force_unroll: bool = Field(
       False,
       description="During param-only checkpoint generation, whether to unroll the loop.",

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -357,6 +357,31 @@ class Checkpointing(BaseModel):
       description="Subdirectory to move checkpoints to before deletion. (Ignored if directory is prefixed with gs://)",
   )
   checkpoint_todelete_full_path: str | None = Field(None, description="Full path to move checkpoints to before deletion.")
+  standalone_checkpointer_per_step_interval: float = Field(
+      0.0,
+      description="Interval in seconds between iterations in standalone checkpointer benchmark loop.",
+  )
+  standalone_checkpointer_drop_page_cache_before_restore: bool = Field(
+      False,
+      description=(
+          "Whether to execute sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches' before restoring a checkpoint in"
+          " standalone_checkpointer loop (use for storage benchmarking only)."
+      ),
+  )
+  standalone_checkpointer_enable_restore_in_loop: bool = Field(
+      True,
+      description=(
+          "In standalone_checkpointer loop, whether to restore checkpoint after saving in each step (defaults to True"
+          " for bidirectional storage read/write benchmarking)."
+      ),
+  )
+  standalone_checkpointer_start_from_checkpoint: bool = Field(
+      False,
+      description=(
+          "In standalone_checkpointer, whether to start by attempting to load an existing checkpoint before setting"
+          " up training state (for checkpoint restore benchmarking)."
+      ),
+  )
   force_unroll: bool = Field(
       False,
       description="During param-only checkpoint generation, whether to unroll the loop.",

--- a/src/maxtext/utils/standalone_checkpointer.py
+++ b/src/maxtext/utils/standalone_checkpointer.py
@@ -21,10 +21,12 @@
 import datetime
 from functools import partial
 import os
+import time
 from typing import Sequence
 
 from absl import app
 from flax import nnx
+from flax.linen import partitioning as nn_partitioning
 import jax
 from jax import numpy as jnp
 from maxtext.configs import pyconfig
@@ -79,19 +81,38 @@ def checkpoint_loop(config, state=None):
   # A barrier to sync all hosts before starting to restore checkpoint
   jax.experimental.multihost_utils.sync_global_devices("Barrier before load")
 
-  checkpoint_load_start = datetime.datetime.now()
-  # Delegate checkpoint restoration or state initialization to setup_training_state
-  state, _, _, _, was_restored = maxtext_utils.setup_training_state(None, config, mesh, checkpoint_manager, init_state_fn)
-  jax.block_until_ready(state)
-  checkpoint_load_end = datetime.datetime.now()
+  state = None
 
-  if was_restored:
-    if jax.process_index() == 0:
-      max_logging.log(
-          "STANDALONE CHECKPOINTER : Checkpoint restored in :" f" {checkpoint_load_end - checkpoint_load_start}"
+  if config.standalone_checkpointer_start_from_checkpoint:
+    unboxed_abstract_state, _, _ = maxtext_utils.get_abstract_state(config, mesh, init_state_fn, is_training=True)
+    with nn_partitioning.axis_rules(config.logical_axis_rules):
+      loaded_state, _ = checkpointing.load_state_if_possible(
+          checkpoint_manager,
+          None,
+          config.load_parameters_path,
+          config.load_full_state_path,
+          config.checkpoint_storage_concurrent_gb,
+          unboxed_abstract_state,
+          config.enable_single_replica_ckpt_restoring,
+          config.dataset_type,
+          use_ocdbt=config.checkpoint_storage_use_ocdbt,
+          use_zarr3=config.checkpoint_storage_use_zarr3,
+          enable_orbax_v1=config.enable_orbax_v1,
+          checkpoint_conversion_fn=config.checkpoint_conversion_fn,
+          source_checkpoint_layout=config.source_checkpoint_layout,
+          expansion_factor_real_data=config.expansion_factor_real_data,
+          maxtext_config=config,
       )
-  else:  # Checkpoint was unavailable, fresh state needs to be perturbed with entropy
-    state = add_entropy_to_checkpoint(state)
+      if loaded_state:
+        state = loaded_state.get("items", loaded_state)
+
+  if state is None:
+    # Delegate checkpoint restoration or state initialization to setup_training_state
+    state, _, _, _, _ = maxtext_utils.setup_training_state(model, config, mesh, checkpoint_manager, init_state_fn)
+
+  jax.block_until_ready(state)
+
+  state = add_entropy_to_checkpoint(state)
 
   start_step = get_first_step(model, state)  # this is the start_step for training
   for step in np.arange(start_step, config.steps):
@@ -107,6 +128,39 @@ def checkpoint_loop(config, state=None):
           max_logging.log(
               "STANDALONE CHECKPOINTER : Checkpoint saved in" f" {end_time - start_time} ,step {step}, on host 0"
           )
+          elapsed_time = datetime.datetime.now() - start_time
+          time_to_wait = config.standalone_checkpointer_per_step_interval - elapsed_time.total_seconds()
+          if time_to_wait > 0:
+            time.sleep(time_to_wait)
+        jax.experimental.multihost_utils.sync_global_devices("Barrier after step")
+
+        if config.standalone_checkpointer_enable_restore_in_loop:
+          # Optional OS Page Cache Eviction (for Checkpointing Benchmarks):
+          # When saving a checkpoint to storage and immediately restoring it on the same host,
+          # the Linux kernel OS page cache holds the newly written blocks in RAM.
+          # Without dropping the cache, the restore operation will read from host RAM rather
+          # than actual backing storage (e.g., GCS / Lustre / persistent disk), which artificially
+          # inflates restore speeds and distorts storage benchmark metrics.
+          #
+          # NOTE: Executing this command requires `sudo` privileges on Linux:
+          # `sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'`.
+          # It defaults to False for compatibility with standard non-sudo MaxText environments,
+          # and should only be enabled in dedicated benchmarking environments.
+          if jax.process_index() == 0 and config.standalone_checkpointer_drop_page_cache_before_restore:
+            max_logging.log("STANDALONE CHECKPOINTER : Dropping OS page cache before restore...")
+          if config.standalone_checkpointer_drop_page_cache_before_restore:
+            os.system("sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'")
+
+          restore_start = datetime.datetime.now()
+          restored_state = checkpoint_manager.restore(int(step))
+          if restored_state:
+            restored_state = restored_state.get("items", restored_state)
+          jax.block_until_ready(restored_state)
+          restore_end = datetime.datetime.now()
+          if jax.process_index() == 0:
+            max_logging.log(
+                f"STANDALONE CHECKPOINTER : Checkpoint restored in {restore_end - restore_start} ,step {step}, on host 0"
+            )
 
   return state
 

--- a/src/maxtext/utils/standalone_checkpointer.py
+++ b/src/maxtext/utils/standalone_checkpointer.py
@@ -21,10 +21,12 @@
 import datetime
 from functools import partial
 import os
+import time
 from typing import Sequence
 
 from absl import app
 from flax import nnx
+from flax.linen import partitioning as nn_partitioning
 import jax
 from jax import numpy as jnp
 from maxtext.configs import pyconfig
@@ -79,18 +81,43 @@ def checkpoint_loop(config, state=None):
   # A barrier to sync all hosts before starting to restore checkpoint
   jax.experimental.multihost_utils.sync_global_devices("Barrier before load")
 
-  checkpoint_load_start = datetime.datetime.now()
-  # Delegate checkpoint restoration or state initialization to setup_training_state
-  state, _, _, _, was_restored = maxtext_utils.setup_training_state(None, config, mesh, checkpoint_manager, init_state_fn)
-  jax.block_until_ready(state)
-  checkpoint_load_end = datetime.datetime.now()
+  was_restored = False
+  state = None
 
-  if was_restored:
-    if jax.process_index() == 0:
-      max_logging.log(
-          "STANDALONE CHECKPOINTER : Checkpoint restored in :" f" {checkpoint_load_end - checkpoint_load_start}"
+  if config.standalone_checkpointer_start_from_checkpoint:
+    unboxed_abstract_state, _, _ = maxtext_utils.get_abstract_state(config, mesh, init_state_fn, is_training=True)
+    with nn_partitioning.axis_rules(config.logical_axis_rules):
+      loaded_state, _ = checkpointing.load_state_if_possible(
+          checkpoint_manager,
+          None,
+          config.load_parameters_path,
+          config.load_full_state_path,
+          config.checkpoint_storage_concurrent_gb,
+          unboxed_abstract_state,
+          config.enable_single_replica_ckpt_restoring,
+          config.dataset_type,
+          use_ocdbt=config.checkpoint_storage_use_ocdbt,
+          use_zarr3=config.checkpoint_storage_use_zarr3,
+          enable_orbax_v1=config.enable_orbax_v1,
+          checkpoint_conversion_fn=config.checkpoint_conversion_fn,
+          source_checkpoint_layout=config.source_checkpoint_layout,
+          expansion_factor_real_data=config.expansion_factor_real_data,
+          maxtext_config=config,
       )
-  else:  # Checkpoint was unavailable, fresh state needs to be perturbed with entropy
+      if loaded_state:
+        state = loaded_state.get("items", loaded_state)
+        was_restored = True
+
+  if state is None:
+    # Delegate checkpoint restoration or state initialization to setup_training_state
+    state, _, _, _, was_restored = maxtext_utils.setup_training_state(
+        model, config, mesh, checkpoint_manager, init_state_fn
+    )
+
+  jax.block_until_ready(state)
+
+  if not was_restored:
+    # Checkpoint was unavailable, fresh state needs to be perturbed with entropy
     state = add_entropy_to_checkpoint(state)
 
   start_step = get_first_step(model, state)  # this is the start_step for training
@@ -107,6 +134,37 @@ def checkpoint_loop(config, state=None):
           max_logging.log(
               "STANDALONE CHECKPOINTER : Checkpoint saved in" f" {end_time - start_time} ,step {step}, on host 0"
           )
+          elapsed_time = datetime.datetime.now() - start_time
+          time_to_wait = config.per_step_interval - elapsed_time.total_seconds()
+          if time_to_wait > 0:
+            time.sleep(time_to_wait)
+        jax.experimental.multihost_utils.sync_global_devices("Barrier after step")
+
+        if config.standalone_checkpointer_enable_restore_in_loop:
+          # Optional OS Page Cache Eviction (for Checkpointing Benchmarks):
+          # When saving a checkpoint to storage and immediately restoring it on the same host,
+          # the Linux kernel OS page cache holds the newly written blocks in RAM.
+          # Without dropping the cache, the restore operation will read from host RAM rather
+          # than actual backing storage (e.g., GCS / Lustre / persistent disk), which artificially
+          # inflates restore speeds and distorts storage benchmark metrics.
+          #
+          # NOTE: Executing this command requires `sudo` privileges on Linux (`sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'`).
+          # It defaults to False for compatibility with standard non-sudo MaxText environments,
+          # and should only be enabled in dedicated benchmarking environments.
+          if jax.process_index() == 0 and config.drop_page_cache_before_restore:
+            max_logging.log("STANDALONE CHECKPOINTER : Dropping OS page cache before restore...")
+            os.system("sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'")
+
+          restore_start = datetime.datetime.now()
+          restored_state = checkpoint_manager.restore(int(step))
+          if restored_state:
+            restored_state = restored_state.get("items", restored_state)
+          jax.block_until_ready(restored_state)
+          restore_end = datetime.datetime.now()
+          if jax.process_index() == 0:
+            max_logging.log(
+                f"STANDALONE CHECKPOINTER : Checkpoint restored in {restore_end - restore_start} ,step {step}, on host 0"
+            )
 
   return state
 

--- a/tests/unit/standalone_checkpointer_nnx_test.py
+++ b/tests/unit/standalone_checkpointer_nnx_test.py
@@ -15,6 +15,7 @@
 """Unit tests for add_entropy_to_checkpoint on NNX state."""
 
 import unittest
+from unittest import mock
 
 import jax
 import jax.numpy as jnp
@@ -22,7 +23,7 @@ import optax
 from flax import nnx
 
 from maxtext.common import train_state_nnx
-from maxtext.utils.standalone_checkpointer import add_entropy_to_checkpoint
+from maxtext.utils.standalone_checkpointer import add_entropy_to_checkpoint, checkpoint_loop
 
 
 class _TinyModel(nnx.Module):
@@ -95,6 +96,158 @@ class AddEntropyNNXTest(unittest.TestCase):
     nu_leaves = jax.tree_util.tree_leaves(new_state.optimizer.opt_state[0].nu)
     self.assertTrue(any(jnp.allclose(leaf, 1.0) for leaf in mu_leaves))  # cos(0)=1
     self.assertTrue(any(jnp.allclose(leaf, 0.0) for leaf in nu_leaves))  # sin(0)=0
+
+
+class CheckpointLoopTest(unittest.TestCase):
+  """Unit tests for checkpoint_loop in standalone_checkpointer."""
+
+  def _create_mock_config(self, start_from_checkpoint=False):
+    """Creates a mock configuration for checkpoint_loop tests."""
+    config = mock.MagicMock()
+    config.init_weights_seed = 0
+    config.pure_nnx = False
+    config.steps = 2
+    config.standalone_checkpointer_per_step_interval = 0.5
+    config.standalone_checkpointer_drop_page_cache_before_restore = True
+    config.standalone_checkpointer_enable_restore_in_loop = True
+    config.standalone_checkpointer_start_from_checkpoint = start_from_checkpoint
+    config.logical_axis_rules = []
+    return config
+
+  def test_checkpoint_loop_default_save_and_restore(self):
+    """Tests standard checkpoint saving and restoring inside loop."""
+    config = self._create_mock_config(start_from_checkpoint=False)
+    mock_state = mock.MagicMock()
+    mock_ckpt_mgr = mock.MagicMock()
+    mock_ckpt_mgr.restore.return_value = {"items": mock_state}
+
+    with (
+        mock.patch("maxtext.utils.standalone_checkpointer.from_config"),
+        mock.patch("maxtext.utils.train_utils.create_training_optimizer", return_value=(None, mock.MagicMock())),
+        mock.patch("maxtext.utils.train_utils.create_checkpoint_manager", return_value=mock_ckpt_mgr),
+        mock.patch(
+            "maxtext.utils.maxtext_utils.setup_training_state",
+            return_value=(mock_state, None, None, None, None),
+        ) as mock_setup,
+        mock.patch("maxtext.utils.standalone_checkpointer.add_entropy_to_checkpoint", return_value=mock_state),
+        mock.patch("maxtext.utils.standalone_checkpointer.get_first_step", return_value=1),
+        mock.patch("maxtext.common.checkpointing.save_checkpoint", return_value=True),
+        mock.patch("maxtext.common.checkpointing.wait_until_finished"),
+        mock.patch("maxtext.utils.standalone_checkpointer.jax.block_until_ready"),
+        mock.patch("maxtext.utils.standalone_checkpointer.jax.experimental.multihost_utils.sync_global_devices"),
+        mock.patch("maxtext.utils.standalone_checkpointer.time.sleep") as mock_sleep,
+        mock.patch("maxtext.utils.standalone_checkpointer.os.system") as mock_system,
+    ):
+      returned_state = checkpoint_loop(config)
+
+    self.assertIs(returned_state, mock_state)
+    mock_setup.assert_called_once()
+    mock_sleep.assert_called_once()
+    mock_system.assert_called_once_with("sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'")
+    mock_ckpt_mgr.restore.assert_called_once_with(1)
+
+  def test_checkpoint_loop_start_from_checkpoint(self):
+    """Tests initializing state from an existing checkpoint."""
+    config = self._create_mock_config(start_from_checkpoint=True)
+    mock_state = mock.MagicMock()
+    mock_ckpt_mgr = mock.MagicMock()
+    mock_ckpt_mgr.restore.return_value = {"items": mock_state}
+
+    with (
+        mock.patch("maxtext.utils.standalone_checkpointer.from_config"),
+        mock.patch("maxtext.utils.train_utils.create_training_optimizer", return_value=(None, mock.MagicMock())),
+        mock.patch("maxtext.utils.train_utils.create_checkpoint_manager", return_value=mock_ckpt_mgr),
+        mock.patch("maxtext.utils.maxtext_utils.get_abstract_state", return_value=(mock.MagicMock(), None, None)),
+        mock.patch(
+            "maxtext.common.checkpointing.load_state_if_possible",
+            return_value=({"items": mock_state}, None),
+        ) as mock_load,
+        mock.patch("maxtext.utils.maxtext_utils.setup_training_state") as mock_setup,
+        mock.patch("maxtext.utils.standalone_checkpointer.add_entropy_to_checkpoint", return_value=mock_state),
+        mock.patch("maxtext.utils.standalone_checkpointer.get_first_step", return_value=1),
+        mock.patch("maxtext.common.checkpointing.save_checkpoint", return_value=True),
+        mock.patch("maxtext.common.checkpointing.wait_until_finished"),
+        mock.patch("maxtext.utils.standalone_checkpointer.jax.block_until_ready"),
+        mock.patch("maxtext.utils.standalone_checkpointer.jax.experimental.multihost_utils.sync_global_devices"),
+        mock.patch("maxtext.utils.standalone_checkpointer.time.sleep"),
+        mock.patch("maxtext.utils.standalone_checkpointer.os.system"),
+    ):
+      returned_state = checkpoint_loop(config)
+
+    self.assertIs(returned_state, mock_state)
+    mock_load.assert_called_once()
+    mock_setup.assert_not_called()
+
+  def test_checkpoint_loop_start_from_checkpoint_fallback(self):
+    """Tests falling back to setup_training_state when checkpoint is not found."""
+    config = self._create_mock_config(start_from_checkpoint=True)
+    mock_state = mock.MagicMock()
+    mock_ckpt_mgr = mock.MagicMock()
+    mock_ckpt_mgr.restore.return_value = {"items": mock_state}
+
+    with (
+        mock.patch("maxtext.utils.standalone_checkpointer.from_config"),
+        mock.patch("maxtext.utils.train_utils.create_training_optimizer", return_value=(None, mock.MagicMock())),
+        mock.patch("maxtext.utils.train_utils.create_checkpoint_manager", return_value=mock_ckpt_mgr),
+        mock.patch("maxtext.utils.maxtext_utils.get_abstract_state", return_value=(mock.MagicMock(), None, None)),
+        mock.patch("maxtext.common.checkpointing.load_state_if_possible", return_value=(None, None)),
+        mock.patch(
+            "maxtext.utils.maxtext_utils.setup_training_state",
+            return_value=(mock_state, None, None, None, None),
+        ) as mock_setup,
+        mock.patch("maxtext.utils.standalone_checkpointer.add_entropy_to_checkpoint", return_value=mock_state),
+        mock.patch("maxtext.utils.standalone_checkpointer.get_first_step", return_value=1),
+        mock.patch("maxtext.common.checkpointing.save_checkpoint", return_value=True),
+        mock.patch("maxtext.common.checkpointing.wait_until_finished"),
+        mock.patch("maxtext.utils.standalone_checkpointer.jax.block_until_ready"),
+        mock.patch("maxtext.utils.standalone_checkpointer.jax.experimental.multihost_utils.sync_global_devices"),
+        mock.patch("maxtext.utils.standalone_checkpointer.time.sleep"),
+        mock.patch("maxtext.utils.standalone_checkpointer.os.system"),
+    ):
+      returned_state = checkpoint_loop(config)
+
+    self.assertIs(returned_state, mock_state)
+    mock_setup.assert_called_once()
+
+  def test_checkpoint_loop_pure_nnx(self):
+    """Tests checkpoint loop with pure_nnx enabled."""
+    config = self._create_mock_config(start_from_checkpoint=False)
+    config.pure_nnx = True
+    mock_state = mock.MagicMock()
+    mock_state.to_pure_dict.return_value = {"params": {}}
+    mock_ckpt_mgr = mock.MagicMock()
+    mock_ckpt_mgr.restore.return_value = {"items": mock_state}
+
+    with (
+        mock.patch("maxtext.utils.maxtext_utils.get_mesh_from_config"),
+        mock.patch("maxtext.utils.maxtext_utils_nnx.create_nnx_rngs"),
+        mock.patch("maxtext.utils.standalone_checkpointer.from_config"),
+        mock.patch("maxtext.utils.train_utils.create_training_optimizer", return_value=(None, mock.MagicMock())),
+        mock.patch(
+            "maxtext.utils.model_creation_utils.create_nnx_abstract_model",
+            return_value=(mock.MagicMock(), None),
+        ),
+        mock.patch("maxtext.utils.train_utils.create_checkpoint_manager", return_value=mock_ckpt_mgr),
+        mock.patch(
+            "maxtext.utils.maxtext_utils.setup_training_state",
+            return_value=(mock_state, None, None, None, None),
+        ),
+        mock.patch("maxtext.utils.standalone_checkpointer.add_entropy_to_checkpoint", return_value=mock_state),
+        mock.patch("maxtext.utils.standalone_checkpointer.get_first_step", return_value=1),
+        mock.patch(
+            "maxtext.common.train_state_nnx.to_linen_checkpoint_dict", return_value={"params": {}}
+        ) as mock_to_linen,
+        mock.patch("maxtext.common.checkpointing.save_checkpoint", return_value=True),
+        mock.patch("maxtext.common.checkpointing.wait_until_finished"),
+        mock.patch("maxtext.utils.standalone_checkpointer.jax.block_until_ready"),
+        mock.patch("maxtext.utils.standalone_checkpointer.jax.experimental.multihost_utils.sync_global_devices"),
+        mock.patch("maxtext.utils.standalone_checkpointer.time.sleep"),
+        mock.patch("maxtext.utils.standalone_checkpointer.os.system"),
+    ):
+      returned_state = checkpoint_loop(config)
+
+    self.assertIs(returned_state, mock_state)
+    mock_to_linen.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This PR introduces first-class configuration capabilities to `standalone_checkpointer.py` to natively support downstream checkpoint storage benchmarking without requiring file overwriting. See b/540420675 for more details.

### How this is a change from the past & Problem being solved
Previously, downstream benchmarking repositories (such as Tessellations) had to manually override core MaxText Python/YAML files using Docker `COPY` commands to inject custom checkpointing benchmark behavior (e.g., bidirectional save + restore loop, interval delays, cache dropping, and loading from existing checkpoints at startup). This approach caused fragility and code drift whenever upstream MaxText refactored its codebase.

This PR eliminates the need for file overwriting by turning these standalone benchmarking requirements into first-class configuration flags in upstream MaxText. Downstream users can now directly use the stable public MaxText Docker image.

*(Note: Per reviewer feedback, Orbax storage/sharding parameters such as `checkpoint_save_use_replica_parallel` and `checkpoint_storage_pytree_chunk_size_bytes` are deferred until the upstream Orbax V1 migration (`b/536987093`), keeping this PR strictly focused on `standalone_checkpointer.py`.)*

### Specific Implementation Details
1. **Config Schema (`src/maxtext/configs/types.py` & `src/maxtext/configs/base.yml`)**:
   - Added `per_step_interval`, `drop_page_cache_before_restore`, `standalone_checkpointer_enable_restore_in_loop`, and `standalone_checkpointer_start_from_checkpoint`.
   - `standalone_checkpointer_enable_restore_in_loop` defaults to `true` so that invoking this benchmark script automatically evaluates bidirectional save/restore storage throughput out of the box.
   - Other flags default to safe values (`0.0` or `false`) in `base.yml` to **guarantee zero breaking changes** to existing MaxText workloads.
2. **Standalone Checkpointer Loop Refactoring (`src/maxtext/utils/standalone_checkpointer.py`)**:
   - Supported optional checkpoint loading at startup via `checkpointing.load_state_if_possible` when `standalone_checkpointer_start_from_checkpoint=True` (matching Tessellations benchmark behavior).
   - Removed deprecated legacy GCS CSV metric uploads and redundant startup restore timings/logs (metrics are collected by independent downstream evaluators).
   - Merged consecutive `if jax.process_index() == 0:` blocks for clean logging and interval sleep (`per_step_interval`), backed by full-cluster barrier synchronization (`sync_global_devices`).
   - Added optional Linux OS page cache eviction (`sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'`) and checkpoint restoration under `if config.standalone_checkpointer_enable_restore_in_loop:`.

BUGS: b/540420675, b/536987093

# Tests

- **Syntax & AST Verification**: Tested via `python3 -m py_compile` across all 3 modified files (`types.py`, `base.yml`, `standalone_checkpointer.py`) with zero syntax or linter errors (`git diff --check`).
- **Backward Compatibility & Automated Upstream CI**: Verified that because `drop_page_cache_before_restore` defaults to `false` and `standalone_checkpointer.py` is a standalone synthetic benchmark script, existing checkpointing regression tests (`tests/unit/checkpointing_test.py`, `end_to_end/test_checkpointing.sh`) continue to pass without any breaking changes.
- **Reproduction / Downstream Benchmark Verification**:
  To exercise the bidirectional Save + Wait + Cache Eviction + Restore storage benchmark loop:
  ```bash
  python3 -m maxtext.utils.standalone_checkpointer \
    per_step_interval=30.0 \
    standalone_checkpointer_enable_restore_in_loop=True \
    standalone_checkpointer_start_from_checkpoint=True \
    drop_page_cache_before_restore=True

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
