### PR TITLE
fix: apply loss cotangent to hidden-state grad in vocab tiling

### DIFF
--- a/src/maxtext/utils/vocabulary_tiling.py
+++ b/src/maxtext/utils/vocabulary_tiling.py
@@ -253,6 +253,9 @@ def vocab_tiling_linen_loss(
     grad_params = jax.tree_util.tree_map(lambda g: g * loss_cotangent, grad_params)
     # Cast cotangents back to each primal's dtype; custom_vjp requires dtype match.
     grad_params = jax.tree_util.tree_map(lambda x, y: y.astype(x.dtype), gathered_params, grad_params)
+    # _bwd_scan_body seeds vjp_fn(1.0), so the scan yields d(total_loss)/d(hidden).
+    # The incoming cotangent must be applied here too, exactly as for grad_params
+    grad_reshaped_hidden_states = grad_reshaped_hidden_states * loss_cotangent
     # Give back sharding constraint
     grad_reshaped_hidden_states = _reshape(grad_reshaped_hidden_states, (batch_size, seq_len, emb_dim), hidden_spec)
     return (
@@ -464,7 +467,8 @@ def vocab_tiling_nnx_loss(model, hidden_states, data, config, is_train):
     )
     grad_reshaped_hidden_states = _maybe_shard_with_name(grad_reshaped_hidden_states, reshaped_hidden_spec)
     grad_head = jax.tree_util.tree_map(lambda g: g * loss_cotangent, grad_head)
-    grad_head = jax.tree_util.tree_map(lambda x, y: y.astype(x.dtype), chunk_head_params, grad_head)
+    grad_head = jax.tree_util.tree_map(lambda x, y: y.astype(x.dtype), chunk_head_params, grad_head)    
+    grad_reshaped_hidden_states = grad_reshaped_hidden_states * loss_cotangent
     grad_reshaped_hidden_states = _reshape(grad_reshaped_hidden_states, (batch_size, seq_len, emb_dim), hidden_spec)
 
     # Return explicit zeros for other_params and rest, not None. With None, JAX builds

--- a/tests/unit/tiling_test.py
+++ b/tests/unit/tiling_test.py
@@ -967,3 +967,35 @@ class VocabTilingNNXTest(unittest.TestCase):
           loss, base_loss, rtol=self.rtol, atol=self.atol
       ), f"num_vocab_tiling={n}: loss diverges from n=2 baseline ({loss} vs {base_loss})"
       self._assert_pytrees_close(base_grads, grads, f"num_vocab_tiling={n}: grads diverge from n=2 baseline.")
+
+  @pytest.mark.tpu_only
+  def test_nnx_vocab_tiling_grad_applies_loss_cotangent(self):
+    """A non-unit incoming cotangent must reach the hidden_states gradient, not only the
+    head params. The shared loss closures return the unnormalized total_loss, so every
+    other test seeds the cotangent at exactly 1.0 and cannot observe a missing multiply."""
+    cfg, model = self._build_cfg_and_model(num_vocab_tiling=4)
+    hidden_states, labels, segmentation = self._make_inputs(cfg)
+    graphdef, params, rest = self._split_and_axes(cfg, model)
+    data = {"targets": labels, "targets_segmentation": segmentation}
+    # train.py divides xent_sum by total_weights, which is what makes the cotangent != 1.0.
+    scale = 1.0 / jnp.sum(segmentation != 0)
+
+    def _ref(p, h):
+      local_model = nnx.merge(graphdef, p, rest, copy=True)
+      logits = local_model.logits_from_hidden_states_for_vocab_tiling(h, True, "train")
+      one_hot = jax.nn.one_hot(labels, cfg.vocab_size)
+      xent_ref, _ = max_utils.cross_entropy_with_logits(logits, one_hot, z_loss=cfg.z_loss_multiplier)
+      return jnp.sum(xent_ref * (segmentation != 0)) * scale
+
+    def _tile(p, h):
+      local_model = nnx.merge(graphdef, p, rest, copy=True)
+      total_loss, _ = vocab_tiling_nnx_loss(local_model, h, data, cfg, is_train=True)
+      return total_loss * scale
+
+    with nn_partitioning.axis_rules(cfg.logical_axis_rules):
+      ref_grad_h = self._g(_ref, argnums=1)(params, hidden_states)
+      tile_grad_h = self._g(_tile, argnums=1)(params, hidden_states)
+
+    assert jnp.allclose(
+        ref_grad_h, tile_grad_h, rtol=self.rtol, atol=self.atol
+    ), "grad_hidden_states ignored the incoming loss cotangent"


### PR DESCRIPTION
# Description

Both vocab tiling backward rules apply the incoming loss cotangent to the parameter
gradients but not to the hidden-state gradient, so the cotangent returned for
`hidden_states` is off by a factor of `1/loss_cotangent`. This PR adds the missing
multiply in `vocab_tiling_linen_loss` and `vocab_tiling_nnx_loss`, plus a regression
test for the NNX path.

## The problem

`_bwd_scan_body` calls `vjp_fn(1.0)` in both paths, so the scan produces an unweighted
`d(total_loss)/d(hidden)`. A `custom_vjp` backward has to return
`cotangent * d(output)/d(input)` for every input. The params get that:

```python
grad_head = jax.tree_util.tree_map(lambda g: g * loss_cotangent, grad_head)
```

but `grad_reshaped_hidden_states` goes to the return statement unscaled.

In `train.py`, `loss = xent_sum / (total_weights + EPS)`, so `loss_cotangent` is
`1/total_weights`. Because `hidden_states` is the decoder output, every gradient
reaching the transformer body is inflated by `total_weights`, which is 65,528 at a
batch of 8 and sequence length 8192. The output head is scaled correctly, so the
head-to-body gradient ratio is wrong by that same factor, and `clip_by_global_norm`
then hands nearly the entire update budget to the body.

Observed on a Qwen3-VL-4B pretraining run with vocab tiling enabled: a raw gradient
norm around 2e6 where the correctly scaled value is around 30, and a loss that spikes
far above `ln(vocab_size)` within the first steps and then descends slowly from a few
hundred.

This is not model specific. The path is gated only on `config.num_vocab_tiling > 1`,
so it affects any configuration that turns vocab tiling on.

## Why the existing tests pass

Every test in `VocabTilingNNXTest` and `LossAndGradientCorrectnessTest` differentiates
the unnormalized `total_loss` returned by `_tiled_loss_fn`, so `jax.grad` seeds the
cotangent at exactly 1.0 and `g * 1.0 == g`. The missing multiply is algebraically
invisible. `test_nnx_vocab_tiling_grad_over_hidden_states` targets this exact cotangent
and still passes for that reason. The harness never composes vocab tiling with a
downstream scalar normalization, which is what `train.py` does.

## Implementation

One line in each backward rule, placed beside the existing parameter scaling. No extra
dtype handling is required: both return statements already apply
`.astype(reshaped_hidden_states.dtype)`, which covers the fp32 promotion introduced by
the scalar multiply.

## Shortcomings and follow-ups

The regression test covers the NNX path only. The Linen change is the same one-line fix
verified by inspection, and the Linen tests share the cotangent-of-1.0 blind spot, so a
matching test there is a reasonable follow-up.

# Tests

Added `test_nnx_vocab_tiling_grad_applies_loss_cotangent` to `VocabTilingNNXTest` in
`tests/unit/tiling_test.py`. It scales the loss by `1/total_weights` to match `train.py`
and compares the `hidden_states` gradient against the full-vocab reference.

```
pytest tests/unit/tiling_test.py -k test_nnx_vocab_tiling_grad_applies_loss_cotangent
```

I could not execute it: every test in `VocabTilingNNXTest` is marked
`@pytest.mark.tpu_only` and I only have GPU hardware. Removing the marker locally
reproduces the failure, which appears as a `jnp.allclose` mismatch scaled by
`batch_size * seq_len`. A maintainer with TPU access should confirm red before and
green after.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).