### PR TITLE
Small fix for Qwen3-VL to run vision sft.

### DIFF
--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -166,7 +166,10 @@ def get_shaped_batch(config, batch_sharding=None):
         config.model_name, batch_size=config.micro_batch_size_to_train_on
     )
     shaped_batch["images"] = jax.ShapeDtypeStruct(image_shape, jnp.int32, sharding=batch_sharding)
-    shaped_batch["image_masks"] = jax.ShapeDtypeStruct(image_shape[:2], jnp.int32, sharding=batch_sharding)
+    # Image masks are only used by Llama4 (shape (B*N, num_tiles)) for empty tiles.
+    # Other multimodal models (Gemma, Qwen, ...) leave masks unset.
+    if "llama4" in config.model_name:
+      shaped_batch["image_masks"] = jax.ShapeDtypeStruct(image_shape[:2], jnp.int32, sharding=batch_sharding)
   if config.use_audio:
     audio_shape = mm_processor.get_dummy_audio_shape_for_init(config)
     shaped_batch["audios"] = jax.ShapeDtypeStruct(audio_shape, jnp.float32, sharding=batch_sharding)

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -1154,13 +1154,15 @@ class TestGetFunctionalEvalWithSignature(unittest.TestCase):
 class TestGetShapedBatch(unittest.TestCase):
   """Tests for get_shaped_batch."""
 
-  def _make_cfg(self, *, enable_diloco=False, use_multimodal=False, use_audio=False):
+  def _make_cfg(self, *, enable_diloco=False, use_multimodal=False, use_audio=False, model_name="llama3.1-8b"):
+    """Build a minimal config mock for get_shaped_batch tests."""
     cfg = MagicMock()
     cfg.enable_diloco = enable_diloco
     cfg.global_batch_size_to_load = 4
     cfg.max_target_length = 16
     cfg.use_multimodal = use_multimodal
     cfg.use_audio = use_audio
+    cfg.model_name = model_name
     if enable_diloco:
       cfg.num_diloco_replicas = 2
     return cfg
@@ -1200,6 +1202,20 @@ class TestGetShapedBatch(unittest.TestCase):
   def test_no_audio_key_without_audio(self):
     batch = maxtext_utils.get_shaped_batch(self._make_cfg(use_audio=False))
     self.assertNotIn("audios", batch)
+
+  def test_llama4_includes_image_masks(self):
+    """Llama4 uses tile masks shaped as image_shape[:2] = (B*N, num_tiles)."""
+    batch = maxtext_utils.get_shaped_batch(self._make_cfg(use_multimodal=True, model_name="llama4-17b-16e"))
+    self.assertIn("images", batch)
+    self.assertIn("image_masks", batch)
+    self.assertEqual(batch["image_masks"].shape, batch["images"].shape[:2])
+
+  def test_qwen_and_gemma_omit_image_masks(self):
+    """Non-tiled VLMs must not treat image_shape[:2] (e.g. channels) as masks."""
+    for model_name in ("qwen3-vl-2b", "gemma3-4b", "gemma4-e2b"):
+      batch = maxtext_utils.get_shaped_batch(self._make_cfg(use_multimodal=True, model_name=model_name))
+      self.assertIn("images", batch)
+      self.assertNotIn("image_masks", batch, msg=f"{model_name} should omit image_masks")
 
   def test_all_values_are_shape_dtype_struct(self):
     batch = maxtext_utils.get_shaped_batch(self._make_cfg())


### PR DESCRIPTION
# Description

Minor fix to get Qwen3-VL-2B running with vision sft.

Currently if run `python  -m maxtext.trainers.post_train.sft.train_sft_native src/maxtext/configs/post_train/sft-vision-chartqa.yml model_name=qwen3-vl-2b` we get error:
```
  File "/lustre1/tier2/users/phuc.lekhac/maxtext/src/maxtext/trainers/pre_train/train.py", line 189, in loss_fn
    logits = model(
             ^^^^^^
  File "/lustre1/tier2/users/phuc.lekhac/maxtext/src/maxtext/models/models.py", line 552, in __call__
    logits, hidden_state, kv_caches = self.decoder(
                                      ^^^^^^^^^^^^^
  File "/lustre1/tier2/users/phuc.lekhac/maxtext/src/maxtext/layers/nnx_decoders.py", line 1540, in __call__
    y = self._apply_embedding(
        ^^^^^^^^^^^^^^^^^^^^^^
  File "/lustre1/tier2/users/phuc.lekhac/maxtext/src/maxtext/layers/nnx_decoders.py", line 1312, in _apply_embedding
    y = mm_utils.merge_mm_embeddings(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lustre1/tier2/users/phuc.lekhac/maxtext/src/maxtext/multimodal/utils.py", line 172, in merge_mm_embeddings
    raise ValueError(
ValueError: token_masks must contain either one value per multimodal token or one value per tile. Got 3 mask values for 576 embeddings.
```

When lowering/compile, the image mask is always passed down:
`shaped_batch["image_masks"] = ShapeDtypeStruct(image_shape[:2], ...)`

Currently, this `image_mask` is only supposed to be used with llama4-tiling with input `(B*N, tiles, C, H, W)`, so I gated it with the llama4 model name.
Gemma 4 return image_shape `(B, N, H, W, C)` and accidentally run, but semantic it's still wrong.
Qwen3 return image_shape `(B, C, T, H, W)` with C=3 thus fail with that error.

# Tests

Added a small test to make sure that gate 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
