### PR TITLE
Enable 3D Mrope for Qwen3 in multimodal training

### DIFF
--- a/src/maxtext/input_pipeline/hf_data_processing.py
+++ b/src/maxtext/input_pipeline/hf_data_processing.py
@@ -166,6 +166,17 @@ def vision_sft_preprocessing_pipeline(
   operations.append(input_pipeline_utils.ExtractImagesAndMasks())
   operations.append(grain.Batch(batch_size=batch_size, drop_remainder=True))
   operations.append(input_pipeline_utils.FoldImagesIntoBatch(model_name=config.model_name))
+  if config.use_mrope:
+    operations.append(
+        input_pipeline_utils.ComputeQwen3OmniPositions(
+            data_column="inputs",
+            spatial_merge_size=config.spatial_merge_size_for_vit,
+            position_id_per_seconds=config.position_id_per_seconds,
+            use_audio_in_video=getattr(config, "use_audio_in_video", False),
+            config=config,
+            keep_aux_fields=False,  # drop aux to match train shape
+        )
+    )
   operations.append(input_pipeline_utils.ShiftData(ignored_ids=[pad_id], axis=1))
   dummy_index_sampler = grain.IndexSampler(
       num_records=len(dataset),

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -909,6 +909,10 @@ class ExtractImagesAndMasks(grain.MapTransform):
     output["images"] = preprocessed_image.pixel_values  # pyrefly: ignore[unsupported-operation]
     if preprocessed_image.pixel_mask is not None:
       output["image_masks"] = preprocessed_image.pixel_mask
+    # Qwen MRoPE needs per-image (t, h, w) grids to build 3D positions.
+    pixel_grid_thw = getattr(preprocessed_image, "pixel_grid_thw", None)
+    if pixel_grid_thw is not None:
+      output["image_grid_thw"] = pixel_grid_thw
 
     return output
 
@@ -1022,6 +1026,8 @@ class ComputeQwen3OmniPositions(grain.MapTransform):
       spatial_merge_size: int = 2,
       position_id_per_seconds: int = 25,
       use_audio_in_video: bool = False,
+      config=None,
+      keep_aux_fields: bool = False,
   ):
     """Initialize the Qwen3-Omni position computation transform.
 
@@ -1030,11 +1036,17 @@ class ComputeQwen3OmniPositions(grain.MapTransform):
       spatial_merge_size: Number of patches merged spatially (e.g., 2 for 2x2→1).
       position_id_per_seconds: Temporal granularity (tokens per second, typically 25).
       use_audio_in_video: If True, audio tokens are interleaved with video tokens.
+      config: Optional model config for model-specific special token IDs.
+      keep_aux_fields: If True, keep auxiliary (aux) fields — mrope deltas / grid
+        metadata — on the element for inference. Training should leave this False
+        so the batch matches get_shaped_batch.
     """
     self.data_column = data_column
     self.spatial_merge_size = spatial_merge_size
     self.position_id_per_seconds = position_id_per_seconds
     self.use_audio_in_video = use_audio_in_video
+    self.config = config
+    self.keep_aux_fields = keep_aux_fields
 
   def map(self, element: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
     """Compute 3D position IDs for the batch element.
@@ -1043,13 +1055,13 @@ class ComputeQwen3OmniPositions(grain.MapTransform):
       element: Dictionary containing:
         - {data_column}: Token IDs with shape (batch, seq_len)
         - {data_column}_segmentation: Attention mask (1=real, 0=padding)
-        - image_grid_thw: Optional (num_images, 3) array
+        - image_grid_thw: Optional (num_images, 3) or (batch, num_images, 3) array
         - video_grid_thw: Optional (num_videos, 3) array
         - audio_lengths: Optional (num_audios,) array
         - second_per_grids: Optional (num_videos,) array
 
     Returns:
-      element with {data_column}_position updated to shape (3, batch, seq_len)
+      element with {data_column}_position updated to shape (batch, seq_len, 3)
       for 3D positions (always 3D, even for text-only sequences).
     """
 
@@ -1062,6 +1074,14 @@ class ComputeQwen3OmniPositions(grain.MapTransform):
     video_grid_thw = element.get("video_grid_thw")
     audio_lengths = element.get("audio_lengths")
     second_per_grids = element.get("second_per_grids")
+
+    # grain.Batch stacks per-example (N, 3) grids to (B, N, 3). get_rope_index
+    # resets image_idx per sequence against a shared (N, 3) table, which is
+    # correct when training force-resizes all images to the same grid.
+    if image_grid_thw is not None and image_grid_thw.ndim == 3:
+      image_grid_thw = image_grid_thw[0]
+    if video_grid_thw is not None and video_grid_thw.ndim == 3:
+      video_grid_thw = video_grid_thw[0]
 
     # Call the standalone get_rope_index function from multimodal_utils
     from maxtext.multimodal import processor_qwen3_omni  # pylint: disable=import-outside-toplevel
@@ -1077,11 +1097,20 @@ class ComputeQwen3OmniPositions(grain.MapTransform):
         second_per_grids=second_per_grids,
         spatial_merge_size=self.spatial_merge_size,
         position_id_per_seconds=self.position_id_per_seconds,
+        config=self.config,
     )
 
     # Update element with 3D positions
-    # Shape: (3, batch, seq_len) for multimodal, or (batch, seq_len) for text-only
-    element[f"{self.data_column}_position"] = position_ids
-    element[f"{self.data_column}_mrope_deltas"] = mrope_position_deltas
+    # Shape: (batch, seq_len, 3) for multimodal, or (batch, seq_len) for text-only
+    element[f"{self.data_column}_position"] = position_ids.astype(np.int32)
+    if self.keep_aux_fields:
+      element[f"{self.data_column}_mrope_deltas"] = mrope_position_deltas
+    else:
+      # Drop metadata that is not part of the training shaped batch.
+      element.pop(f"{self.data_column}_mrope_deltas", None)
+      element.pop("image_grid_thw", None)
+      element.pop("video_grid_thw", None)
+      element.pop("audio_lengths", None)
+      element.pop("second_per_grids", None)
 
     return element

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -903,6 +903,10 @@ class ExtractImagesAndMasks(grain.MapTransform):
     output["images"] = preprocessed_image.pixel_values  # pyrefly: ignore[unsupported-operation]
     if preprocessed_image.pixel_mask is not None:
       output["image_masks"] = preprocessed_image.pixel_mask
+    # Qwen MRoPE needs per-image (t, h, w) grids to build 3D positions.
+    pixel_grid_thw = getattr(preprocessed_image, "pixel_grid_thw", None)
+    if pixel_grid_thw is not None:
+      output["image_grid_thw"] = pixel_grid_thw
 
     return output
 
@@ -1016,6 +1020,8 @@ class ComputeQwen3OmniPositions(grain.MapTransform):
       spatial_merge_size: int = 2,
       position_id_per_seconds: int = 25,
       use_audio_in_video: bool = False,
+      config=None,
+      keep_aux_fields: bool = False,
   ):
     """Initialize the Qwen3-Omni position computation transform.
 
@@ -1024,11 +1030,16 @@ class ComputeQwen3OmniPositions(grain.MapTransform):
       spatial_merge_size: Number of patches merged spatially (e.g., 2 for 2x2→1).
       position_id_per_seconds: Temporal granularity (tokens per second, typically 25).
       use_audio_in_video: If True, audio tokens are interleaved with video tokens.
+      config: Optional model config for model-specific special token IDs.
+      keep_aux_fields: If True, keep mrope deltas / grid metadata on the element.
+        Training should leave this False so the batch matches get_shaped_batch.
     """
     self.data_column = data_column
     self.spatial_merge_size = spatial_merge_size
     self.position_id_per_seconds = position_id_per_seconds
     self.use_audio_in_video = use_audio_in_video
+    self.config = config
+    self.keep_aux_fields = keep_aux_fields
 
   def map(self, element: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
     """Compute 3D position IDs for the batch element.
@@ -1037,13 +1048,13 @@ class ComputeQwen3OmniPositions(grain.MapTransform):
       element: Dictionary containing:
         - {data_column}: Token IDs with shape (batch, seq_len)
         - {data_column}_segmentation: Attention mask (1=real, 0=padding)
-        - image_grid_thw: Optional (num_images, 3) array
+        - image_grid_thw: Optional (num_images, 3) or (batch, num_images, 3) array
         - video_grid_thw: Optional (num_videos, 3) array
         - audio_lengths: Optional (num_audios,) array
         - second_per_grids: Optional (num_videos,) array
 
     Returns:
-      element with {data_column}_position updated to shape (3, batch, seq_len)
+      element with {data_column}_position updated to shape (batch, seq_len, 3)
       for 3D positions (always 3D, even for text-only sequences).
     """
 
@@ -1056,6 +1067,14 @@ class ComputeQwen3OmniPositions(grain.MapTransform):
     video_grid_thw = element.get("video_grid_thw")
     audio_lengths = element.get("audio_lengths")
     second_per_grids = element.get("second_per_grids")
+
+    # grain.Batch stacks per-example (N, 3) grids to (B, N, 3). get_rope_index
+    # resets image_idx per sequence against a shared (N, 3) table, which is
+    # correct when training force-resizes all images to the same grid.
+    if image_grid_thw is not None and image_grid_thw.ndim == 3:
+      image_grid_thw = image_grid_thw[0]
+    if video_grid_thw is not None and video_grid_thw.ndim == 3:
+      video_grid_thw = video_grid_thw[0]
 
     # Call the standalone get_rope_index function from multimodal_utils
     from maxtext.multimodal import processor_qwen3_omni  # pylint: disable=import-outside-toplevel
@@ -1071,11 +1090,20 @@ class ComputeQwen3OmniPositions(grain.MapTransform):
         second_per_grids=second_per_grids,
         spatial_merge_size=self.spatial_merge_size,
         position_id_per_seconds=self.position_id_per_seconds,
+        config=self.config,
     )
 
     # Update element with 3D positions
-    # Shape: (3, batch, seq_len) for multimodal, or (batch, seq_len) for text-only
-    element[f"{self.data_column}_position"] = position_ids
-    element[f"{self.data_column}_mrope_deltas"] = mrope_position_deltas
+    # Shape: (batch, seq_len, 3) for multimodal, or (batch, seq_len) for text-only
+    element[f"{self.data_column}_position"] = position_ids.astype(np.int32)
+    if self.keep_aux_fields:
+      element[f"{self.data_column}_mrope_deltas"] = mrope_position_deltas
+    else:
+      # Drop metadata that is not part of the training shaped batch.
+      element.pop(f"{self.data_column}_mrope_deltas", None)
+      element.pop("image_grid_thw", None)
+      element.pop("video_grid_thw", None)
+      element.pop("audio_lengths", None)
+      element.pop("second_per_grids", None)
 
     return element

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -1822,16 +1822,16 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
     interleaved [THTHWHTHW...], preserving frequency continuity.
 
     Args:
-      freqs: Shape (3, batch, seq_len, head_dim // 2)
-        Dimension 0: temporal frequencies
-        Dimension 1: height frequencies
-        Dimension 2: width frequencies
+      freqs: Shape (batch, seq_len, 3, head_dim // 2)
+        Dimension -2 index 0: temporal frequencies
+        Dimension -2 index 1: height frequencies
+        Dimension -2 index 2: width frequencies
 
     Returns:
       freqs_t: Shape (batch, seq_len, head_dim // 2) with interleaved pattern
     """
-    # Start with temporal frequencies (dimension 0)
-    freqs_t = freqs[0]  # (batch, seq_len, head_dim // 2)
+    # Start with temporal frequencies
+    freqs_t = freqs[..., 0, :]  # (batch, seq_len, head_dim // 2)
 
     # Create interleaved pattern
     # For each spatial dimension (H, W), place frequencies at positions:
@@ -1842,7 +1842,7 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
       # Use slice syntax to match PyTorch behavior
       idx = slice(offset, section_size, 3)
       # Replace those positions with the corresponding spatial frequencies
-      freqs_t = freqs_t.at[..., idx].set(freqs[dim_idx, ..., idx])
+      freqs_t = freqs_t.at[..., idx].set(freqs[..., dim_idx, idx])
 
     return freqs_t
 
@@ -1857,8 +1857,8 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
       inputs: Input tensor of shape [batch, sequence, heads, head_dim].
       position: Position IDs with shape:
         - [batch, sequence] for text-only (2D)
-        - [3, batch, sequence] for multimodal with vision (3D)
-          where dim 0 = temporal, dim 1 = height, dim 2 = width
+        - [batch, sequence, 3] for multimodal with vision (3D)
+          where the last dim is (temporal, height, width)
 
     Returns:
       Tensor of shape [batch, sequence, heads, head_dim] with RoPE applied.
@@ -1872,15 +1872,15 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
 
     # Handle both 2D (text-only) and 3D (multimodal) position IDs
     if position.ndim == 2:
-      # Text-only: expand (batch, seq) -> (3, batch, seq) with same positions
-      position = jnp.broadcast_to(position[jnp.newaxis, ...], (3,) + position.shape)
-    elif position.ndim != 3 or position.shape[0] != 3:
-      raise ValueError(f"Position IDs must be 2D (batch, seq) or 3D (3, batch, seq), got shape {position.shape}")
+      # Text-only: expand (batch, seq) -> (batch, seq, 3) with same positions
+      position = jnp.broadcast_to(position[..., jnp.newaxis], position.shape + (3,))
+    elif position.ndim != 3 or position.shape[-1] != 3:
+      raise ValueError(f"Position IDs must be 2D (batch, seq) or 3D (batch, seq, 3), got shape {position.shape}")
 
-    # Compute frequencies: (3, batch, seq, 1) @ (head_dim // 2, 1) -> (3, batch, seq, head_dim // 2)
+    # Compute frequencies: (batch, seq, 3, 1) * (1, 1, 1, head_dim//2) -> (batch, seq, 3, head_dim//2)
     inv_freq_expanded = (1.0 / self.timescale)[jnp.newaxis, jnp.newaxis, jnp.newaxis, :]  # (1, 1, 1, head_dim//2)
-    position_expanded = position[..., jnp.newaxis]  # (3, batch, seq, 1)
-    freqs = position_expanded * inv_freq_expanded  # (3, batch, seq, head_dim//2)
+    position_expanded = position[..., jnp.newaxis]  # (batch, seq, 3, 1)
+    freqs = position_expanded * inv_freq_expanded  # (batch, seq, 3, head_dim//2)
 
     # Apply interleaved MRoPE pattern for 3D positions
     freqs = self._apply_interleaved_mrope(freqs)  # (batch, seq, head_dim//2)

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -1841,16 +1841,16 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
     interleaved [THTHWHTHW...], preserving frequency continuity.
 
     Args:
-      freqs: Shape (3, batch, seq_len, rotary_dim // 2)
-        Dimension 0: temporal frequencies
-        Dimension 1: height frequencies
-        Dimension 2: width frequencies
+      freqs: Shape (batch, seq_len, 3, head_dim // 2)
+        Dimension -2 index 0: temporal frequencies
+        Dimension -2 index 1: height frequencies
+        Dimension -2 index 2: width frequencies
 
     Returns:
       freqs_t: Shape (batch, seq_len, rotary_dim // 2) with interleaved pattern
     """
-    # Start with temporal frequencies (dimension 0)
-    freqs_t = freqs[0]  # (batch, seq_len, rotary_dim // 2)
+    # Start with temporal frequencies
+    freqs_t = freqs[..., 0, :]  # (batch, seq_len, head_dim // 2)
 
     # Create interleaved pattern
     # For each spatial dimension (H, W), place frequencies at positions:
@@ -1861,7 +1861,7 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
       # Use slice syntax to match PyTorch behavior
       idx = slice(offset, section_size, 3)
       # Replace those positions with the corresponding spatial frequencies
-      freqs_t = freqs_t.at[..., idx].set(freqs[dim_idx, ..., idx])
+      freqs_t = freqs_t.at[..., idx].set(freqs[..., dim_idx, idx])
 
     return freqs_t
 
@@ -1878,8 +1878,8 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
         returned unchanged.
       position: Position IDs with shape:
         - [batch, sequence] for text-only (2D)
-        - [3, batch, sequence] for multimodal with vision (3D)
-          where dim 0 = temporal, dim 1 = height, dim 2 = width
+        - [batch, sequence, 3] for multimodal with vision (3D)
+          where the last dim is (temporal, height, width)
 
     Returns:
       Tensor of shape [batch, sequence, heads, head_dim] with RoPE applied.
@@ -1891,15 +1891,15 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
 
     # Handle both 2D (text-only) and 3D (multimodal) position IDs
     if position.ndim == 2:
-      # Text-only: expand (batch, seq) -> (3, batch, seq) with same positions
-      position = jnp.broadcast_to(position[jnp.newaxis, ...], (3,) + position.shape)
-    elif position.ndim != 3 or position.shape[0] != 3:
-      raise ValueError(f"Position IDs must be 2D (batch, seq) or 3D (3, batch, seq), got shape {position.shape}")
+      # Text-only: expand (batch, seq) -> (batch, seq, 3) with same positions
+      position = jnp.broadcast_to(position[..., jnp.newaxis], position.shape + (3,))
+    elif position.ndim != 3 or position.shape[-1] != 3:
+      raise ValueError(f"Position IDs must be 2D (batch, seq) or 3D (batch, seq, 3), got shape {position.shape}")
 
-    # Compute frequencies over the rotated prefix only.
-    inv_freq_expanded = (1.0 / self.timescale)[jnp.newaxis, jnp.newaxis, jnp.newaxis, :]
-    position_expanded = position[..., jnp.newaxis]  # (3, batch, seq, 1)
-    freqs = position_expanded * inv_freq_expanded  # (3, batch, seq, rotary_dim // 2)
+    # Compute frequencies: (batch, seq, 3, 1) * (1, 1, 1, head_dim//2) -> (batch, seq, 3, head_dim//2)
+    inv_freq_expanded = (1.0 / self.timescale)[jnp.newaxis, jnp.newaxis, jnp.newaxis, :]  # (1, 1, 1, head_dim//2)
+    position_expanded = position[..., jnp.newaxis]  # (batch, seq, 3, 1)
+    freqs = position_expanded * inv_freq_expanded  # (batch, seq, 3, head_dim//2)
 
     # Apply interleaved MRoPE pattern for 3D positions
     freqs = self._apply_interleaved_mrope(freqs)  # (batch, seq, rotary_dim // 2)

--- a/src/maxtext/multimodal/processor_qwen3_omni.py
+++ b/src/maxtext/multimodal/processor_qwen3_omni.py
@@ -1043,7 +1043,7 @@ def get_rope_index(
 
   Returns:
     A tuple of:
-      - position_ids: 3D position IDs. Shape: (3, batch, seq_len).
+      - position_ids: 3D position IDs. Shape: (batch, seq_len, 3)
       - mrope_position_deltas: Position offset for each sequence. Shape: (batch, 1).
 
   Raises:
@@ -1062,10 +1062,10 @@ def get_rope_index(
     position_ids = np.where(attention_mask == 0, 1.0, position_ids)
 
     # Expand to 3D (same value in all dimensions for text-only)
-    position_ids = np.broadcast_to(position_ids[np.newaxis, :, :], (3, batch_size, seq_len))
+    position_ids = np.stack([position_ids, position_ids, position_ids], axis=-1)
 
     # Calculate deltas for each sequence
-    max_position_ids = np.max(position_ids, axis=(0, 2), keepdims=True).transpose(1, 0, 2)  # (batch, 1, 1)
+    max_position_ids = np.max(position_ids, axis=(1, 2), keepdims=True)  # (batch, 1, 1)
     mrope_position_deltas = max_position_ids.squeeze(-1) + 1 - np.sum(attention_mask, axis=-1, keepdims=True)
 
     return position_ids, mrope_position_deltas
@@ -1075,6 +1075,7 @@ def get_rope_index(
     attention_mask = np.ones_like(input_ids)
 
   attention_mask_bool = attention_mask == 1
+  # Internally still build (3, batch, seq) then transpose to (batch, seq, 3).
   position_ids = np.zeros((3, batch_size, seq_len), dtype=jnp.float32)
   mrope_position_deltas = []
 
@@ -1281,6 +1282,7 @@ def get_rope_index(
     mrope_position_deltas.append(llm_positions.max().item() + 1 - len(valid_input_ids))
 
   mrope_position_deltas = np.array(mrope_position_deltas).reshape(batch_size, 1)
+  position_ids = np.transpose(position_ids, (1, 2, 0))  # (3, batch, seq) -> (batch, seq, 3)
 
   return position_ids, mrope_position_deltas
 

--- a/src/maxtext/multimodal/processor_qwen3_omni.py
+++ b/src/maxtext/multimodal/processor_qwen3_omni.py
@@ -1043,7 +1043,7 @@ def get_rope_index(
 
   Returns:
     A tuple of:
-      - position_ids: 3D position IDs. Shape: (3, batch, seq_len).
+      - position_ids: 3D position IDs. Shape: (batch, seq_len, 3)
       - mrope_position_deltas: Position offset for each sequence. Shape: (batch, 1).
 
   Raises:
@@ -1062,10 +1062,10 @@ def get_rope_index(
     position_ids = np.where(attention_mask == 0, 1.0, position_ids)
 
     # Expand to 3D (same value in all dimensions for text-only)
-    position_ids = np.broadcast_to(position_ids[np.newaxis, :, :], (3, batch_size, seq_len))
+    position_ids = np.stack([position_ids, position_ids, position_ids], axis=-1)
 
     # Calculate deltas for each sequence
-    max_position_ids = np.max(position_ids, axis=(0, 2), keepdims=True).transpose(1, 0, 2)  # (batch, 1, 1)
+    max_position_ids = np.max(position_ids, axis=(1, 2), keepdims=True)  # (batch, 1, 1)
     mrope_position_deltas = max_position_ids.squeeze(-1) + 1 - np.sum(attention_mask, axis=-1, keepdims=True)
 
     return position_ids, mrope_position_deltas
@@ -1075,6 +1075,7 @@ def get_rope_index(
     attention_mask = np.ones_like(input_ids)
 
   attention_mask_bool = attention_mask == 1
+  # Internally still build (3, batch, seq) then transpose to (batch, seq, 3).
   position_ids = np.zeros((3, batch_size, seq_len), dtype=jnp.float32)
   mrope_position_deltas = []
 
@@ -1275,6 +1276,7 @@ def get_rope_index(
     mrope_position_deltas.append(llm_positions.max().item() + 1 - len(valid_input_ids))
 
   mrope_position_deltas = np.array(mrope_position_deltas).reshape(batch_size, 1)
+  position_ids = np.transpose(position_ids, (1, 2, 0))  # (3, batch, seq) -> (batch, seq, 3)
 
   return position_ids, mrope_position_deltas
 

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -156,7 +156,9 @@ def get_shaped_batch(config, batch_sharding=None):
     batch_shape = (config.global_batch_size_to_load, config.max_target_length)
   shaped_batch = {}
   shaped_batch["inputs"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32, sharding=batch_sharding)
-  shaped_batch["inputs_position"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32, sharding=batch_sharding)
+  # MRoPE uses (batch, seq, 3); same batch/seq axes as 1D positions so batch_sharding applies as-is.
+  position_shape = batch_shape + (3,) if getattr(config, "use_mrope", False) else batch_shape
+  shaped_batch["inputs_position"] = jax.ShapeDtypeStruct(position_shape, jnp.int32, sharding=batch_sharding)
   shaped_batch["inputs_segmentation"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32, sharding=batch_sharding)
   shaped_batch["targets"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32, sharding=batch_sharding)
   shaped_batch["targets_position"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32, sharding=batch_sharding)

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -156,7 +156,9 @@ def get_shaped_batch(config, batch_sharding=None):
     batch_shape = (config.global_batch_size_to_load, config.max_target_length)
   shaped_batch = {}
   shaped_batch["inputs"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32, sharding=batch_sharding)
-  shaped_batch["inputs_position"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32, sharding=batch_sharding)
+  # MRoPE uses (batch, seq, 3); same batch/seq axes as 1D positions so batch_sharding applies as-is.
+  position_shape = batch_shape + (3,) if config.use_mrope and config.use_multimodal else batch_shape
+  shaped_batch["inputs_position"] = jax.ShapeDtypeStruct(position_shape, jnp.int32, sharding=batch_sharding)
   shaped_batch["inputs_segmentation"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32, sharding=batch_sharding)
   shaped_batch["targets"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32, sharding=batch_sharding)
   shaped_batch["targets_position"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32, sharding=batch_sharding)

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -1153,7 +1153,15 @@ class TestGetFunctionalEvalWithSignature(unittest.TestCase):
 class TestGetShapedBatch(unittest.TestCase):
   """Tests for get_shaped_batch."""
 
-  def _make_cfg(self, *, enable_diloco=False, use_multimodal=False, use_audio=False, model_name="llama3.1-8b"):
+  def _make_cfg(
+      self,
+      *,
+      enable_diloco=False,
+      use_multimodal=False,
+      use_audio=False,
+      use_mrope=False,
+      model_name="llama3.1-8b",
+  ):
     """Build a minimal config mock for get_shaped_batch tests."""
     cfg = MagicMock()
     cfg.enable_diloco = enable_diloco
@@ -1161,6 +1169,7 @@ class TestGetShapedBatch(unittest.TestCase):
     cfg.max_target_length = 16
     cfg.use_multimodal = use_multimodal
     cfg.use_audio = use_audio
+    cfg.use_mrope = use_mrope
     cfg.model_name = model_name
     if enable_diloco:
       cfg.num_diloco_replicas = 2
@@ -1215,6 +1224,12 @@ class TestGetShapedBatch(unittest.TestCase):
       batch = maxtext_utils.get_shaped_batch(self._make_cfg(use_multimodal=True, model_name=model_name))
       self.assertIn("images", batch)
       self.assertNotIn("image_masks", batch, msg=f"{model_name} should omit image_masks")
+
+  def test_mrope_inputs_position_shape(self):
+    """use_mrope shaped batches use (B, S, 3) positions."""
+    batch = maxtext_utils.get_shaped_batch(self._make_cfg(use_mrope=True))
+    self.assertEqual(batch["inputs_position"].shape, (4, 16, 3))
+    self.assertEqual(batch["targets_position"].shape, (4, 16))
 
   def test_all_values_are_shape_dtype_struct(self):
     batch = maxtext_utils.get_shaped_batch(self._make_cfg())

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -1151,7 +1151,15 @@ class TestGetFunctionalEvalWithSignature(unittest.TestCase):
 class TestGetShapedBatch(unittest.TestCase):
   """Tests for get_shaped_batch."""
 
-  def _make_cfg(self, *, enable_diloco=False, use_multimodal=False, use_audio=False, model_name="llama3.1-8b"):
+  def _make_cfg(
+      self,
+      *,
+      enable_diloco=False,
+      use_multimodal=False,
+      use_audio=False,
+      use_mrope=False,
+      model_name="llama3.1-8b",
+  ):
     """Build a minimal config mock for get_shaped_batch tests."""
     cfg = MagicMock()
     cfg.enable_diloco = enable_diloco
@@ -1159,6 +1167,7 @@ class TestGetShapedBatch(unittest.TestCase):
     cfg.max_target_length = 16
     cfg.use_multimodal = use_multimodal
     cfg.use_audio = use_audio
+    cfg.use_mrope = use_mrope
     cfg.model_name = model_name
     if enable_diloco:
       cfg.num_diloco_replicas = 2
@@ -1213,6 +1222,22 @@ class TestGetShapedBatch(unittest.TestCase):
       batch = maxtext_utils.get_shaped_batch(self._make_cfg(use_multimodal=True, model_name=model_name))
       self.assertIn("images", batch)
       self.assertNotIn("image_masks", batch, msg=f"{model_name} should omit image_masks")
+
+  def test_mrope_inputs_position_shape(self):
+    """inputs_position is (B, S, 3) only for multimodal + MRoPE; else (B, S)."""
+    cases = (
+        # text-only + MRoPE → still (B, S)
+        ({"use_mrope": True, "use_multimodal": False}, (4, 16)),
+        # multimodal SFT + MRoPE → (B, S, 3)
+        ({"use_mrope": True, "use_multimodal": True, "model_name": "qwen3-vl-2b"}, (4, 16, 3)),
+        # multimodal SFT without MRoPE → (B, S)
+        ({"use_mrope": False, "use_multimodal": True, "model_name": "qwen3-vl-2b"}, (4, 16)),
+    )
+    for cfg_kwargs, expected_inputs_position_shape in cases:
+      with self.subTest(**cfg_kwargs):
+        batch = maxtext_utils.get_shaped_batch(self._make_cfg(**cfg_kwargs))
+        self.assertEqual(batch["inputs_position"].shape, expected_inputs_position_shape)
+        self.assertEqual(batch["targets_position"].shape, (4, 16))
 
   def test_all_values_are_shape_dtype_struct(self):
     batch = maxtext_utils.get_shaped_batch(self._make_cfg())

--- a/tests/unit/multimodal_rope_check.py
+++ b/tests/unit/multimodal_rope_check.py
@@ -36,13 +36,14 @@ from maxtext.layers.embeddings import Qwen3OmniMoeThinkerTextRotaryEmbedding as 
 
 
 # Qwen3-Omni special token IDs
-VISION_START = processor_qwen3_omni.QWEN3_OMNI_VISION_START_TOKEN
-VISION_END = processor_qwen3_omni.QWEN3_OMNI_VISION_END_TOKEN
-AUDIO_START = processor_qwen3_omni.QWEN3_OMNI_AUDIO_START_TOKEN
-AUDIO_END = processor_qwen3_omni.QWEN3_OMNI_AUDIO_END_TOKEN
-IMAGE_TOKEN = processor_qwen3_omni.QWEN3_OMNI_IMAGE_TOKEN
-VIDEO_TOKEN = processor_qwen3_omni.QWEN3_OMNI_VIDEO_TOKEN
-AUDIO_TOKEN = processor_qwen3_omni.QWEN3_OMNI_AUDIO_TOKEN
+special_tokens = processor_qwen3_omni.QwenTokens()
+VISION_START = special_tokens.vision_start
+VISION_END = special_tokens.vision_end
+AUDIO_START = special_tokens.audio_start
+AUDIO_END = special_tokens.audio_end
+IMAGE_TOKEN = special_tokens.image_pad
+VIDEO_TOKEN = special_tokens.video_pad
+AUDIO_TOKEN = special_tokens.audio_pad
 
 
 def create_pytorch_config(head_dim=128, mrope_section=(24, 20, 20), rope_max_timescale=1_000_000):
@@ -60,9 +61,15 @@ def create_pytorch_config(head_dim=128, mrope_section=(24, 20, 20), rope_max_tim
       self.hidden_size = head_dim
       self.num_attention_heads = 1
       self.max_position_embeddings = 65536
+      self.rope_parameters = {
+          "rope_type": "default",
+          "rope_theta": float(rope_max_timescale),
+          "mrope_section": list(mrope_section),
+      }
+      # Legacy aliases kept for older code paths / get_rope_index
       self.rope_theta = rope_max_timescale
       self.mrope_section = mrope_section
-      self.rope_scaling = {"mrope_section": list(mrope_section)}
+      self.rope_scaling = self.rope_parameters
       self.attention_scaling = 1.0
       self.partial_rotary_factor = 1.0
 
@@ -168,7 +175,7 @@ def assert_mrope_matches_pytorch(
 
   Args:
     query_states: Query tensor. Shape: (batch, seq_len, num_heads, head_dim)
-    position_ids: 3D position IDs. Shape: (3, batch, seq_len)
+    position_ids: 3D position IDs. Shape: (batch, seq_len, 3)
     err_msg: Error message for assertion failure
     mrope_section: Dimensions for temporal, height, width
     rope_max_timescale: Max timescale for RoPE
@@ -176,7 +183,7 @@ def assert_mrope_matches_pytorch(
     rtol: Relative tolerance for comparison
     atol: Absolute tolerance for comparison
   """
-  # JAX version
+  # JAX version — MaxText uses (batch, seq, 3)
   rngs = nnx.Rngs(0)
   jax_mrope = JaxMRoPE(
       min_timescale=1,
@@ -192,12 +199,12 @@ def assert_mrope_matches_pytorch(
   jax_position_ids = jnp.array(position_ids)
   jax_output = jax_mrope(jax_query, jax_position_ids)
 
-  # PyTorch version
+  # PyTorch version still expects HF layout (3, batch, seq)
   torch_config = create_pytorch_config(head_dim, mrope_section, rope_max_timescale)
   torch_mrope = PyTorchMRoPE(torch_config)
 
   torch_query = torch.from_numpy(np.array(query_states)).float()
-  torch_position_ids = torch.from_numpy(np.array(position_ids))
+  torch_position_ids = torch.from_numpy(np.transpose(np.array(position_ids), (2, 0, 1)))
 
   # PyTorch expects (batch, num_heads, seq_len, head_dim)
   # We have (batch, seq_len, num_heads, head_dim), so transpose
@@ -289,8 +296,8 @@ class GetRopeIndexComparisonTest(unittest.TestCase):
         second_per_grids=torch_second_per_grids,
     )
 
-    # Convert to numpy for comparison
-    torch_position_ids_np = torch_position_ids.cpu().numpy()
+    # Convert to numpy for comparison. PyTorch uses HF (3, B, S); MaxText uses (B, S, 3).
+    torch_position_ids_np = np.transpose(torch_position_ids.cpu().numpy(), (1, 2, 0))
     torch_deltas_np = torch_deltas.cpu().numpy()
 
     return jax_position_ids_np, torch_position_ids_np, jax_deltas_np, torch_deltas_np
@@ -532,9 +539,9 @@ class MRoPEComparisonTest(unittest.TestCase):
     # Query states
     query_states = np.random.randn(batch, seq_len, num_heads, head_dim).astype(np.float32)
 
-    # 1D position IDs (text-only): same value in all 3 dimensions
+    # 1D position IDs (text-only): same value in all 3 dimensions -> (B, S, 3)
     position_ids_1d = np.arange(seq_len).reshape(1, seq_len)
-    position_ids_3d = np.broadcast_to(position_ids_1d[np.newaxis, :, :], (3, batch, seq_len))
+    position_ids_3d = np.stack([position_ids_1d, position_ids_1d, position_ids_1d], axis=-1)
 
     assert_mrope_matches_pytorch(query_states, position_ids_3d, err_msg="MRoPE text-only output doesn't match PyTorch")
 
@@ -545,12 +552,19 @@ class MRoPEComparisonTest(unittest.TestCase):
     # Query states
     query_states = np.random.randn(batch, seq_len, num_heads, head_dim).astype(np.float32)
 
-    # 3D position IDs for vision: temporal=0, height=[0,0,1,1,...], width=[0,1,0,1,...]
+    # 3D position IDs for vision as (B, S, 3): temporal / height / width
     position_ids_3d = np.array(
         [
-            [[0, 0, 0, 0, 25, 25, 25, 25]],  # temporal
-            [[0, 0, 1, 1, 0, 0, 1, 1]],  # height
-            [[0, 1, 0, 1, 0, 1, 0, 1]],  # width
+            [  # t   h  w
+                [0, 0, 0],
+                [0, 0, 1],
+                [0, 1, 0],
+                [0, 1, 1],
+                [25, 0, 0],
+                [25, 0, 1],
+                [25, 1, 0],
+                [25, 1, 1],
+            ]
         ],
         dtype=np.float32,
     )
@@ -564,12 +578,21 @@ class MRoPEComparisonTest(unittest.TestCase):
     # Query states
     query_states = np.random.randn(batch, seq_len, num_heads, head_dim).astype(np.float32)
 
-    # Mixed: text tokens [0,1], vision tokens (4 tokens), text tokens [5,6,7]
+    # Mixed: text tokens [0,1], vision tokens (4 tokens), text tokens — (B, S, 3)
     position_ids_3d = np.array(
         [
-            [[0, 1, 2, 2, 2, 2, 6, 7, 8, 9]],  # temporal
-            [[0, 1, 2, 2, 3, 3, 6, 7, 8, 9]],  # height (vision different)
-            [[0, 1, 2, 3, 2, 3, 6, 7, 8, 9]],  # width (vision different)
+            [  # t  h  w
+                [0, 0, 0],
+                [1, 1, 1],
+                [2, 2, 2],
+                [2, 2, 3],
+                [2, 3, 2],
+                [2, 3, 3],
+                [6, 6, 6],
+                [7, 7, 7],
+                [8, 8, 8],
+                [9, 9, 9],
+            ]
         ],
         dtype=np.float32,
     )
@@ -585,12 +608,16 @@ class MRoPEComparisonTest(unittest.TestCase):
     # Query states
     query_states = np.random.randn(batch, seq_len, num_heads, head_dim).astype(np.float32)
 
-    # 3D position IDs
+    # 3D position IDs as (B, S, 3)
     position_ids_3d = np.array(
         [
-            [[0, 0, 25, 25, 50]],  # temporal
-            [[0, 1, 0, 1, 0]],  # height
-            [[0, 0, 1, 1, 2]],  # width
+            [  # t   h  w
+                [0, 0, 0],
+                [0, 1, 0],
+                [25, 0, 1],
+                [25, 1, 1],
+                [50, 0, 2],
+            ]
         ],
         dtype=np.float32,
     )
@@ -613,7 +640,7 @@ class MRoPEComparisonTest(unittest.TestCase):
     query_states = np.random.randn(batch, seq_len, num_heads, head_dim).astype(np.float32)
 
     # Different position IDs for each sequence in batch
-    position_ids_3d = np.random.randint(0, 100, size=(3, batch, seq_len)).astype(np.float32)
+    position_ids_3d = np.random.randint(0, 100, size=(batch, seq_len, 3)).astype(np.float32)
 
     # Batch test may have slightly larger numerical differences due to accumulation
     assert_mrope_matches_pytorch(
@@ -628,7 +655,11 @@ class ComputeQwen3OmniPositionsTest(unittest.TestCase):
     """Test that the Grain transform wrapper correctly calls get_rope_index."""
     # Test with image to verify multimodal handling
     spatial_merge_size = 2
-    transform = ComputeQwen3OmniPositions(data_column="inputs", spatial_merge_size=spatial_merge_size)
+    transform = ComputeQwen3OmniPositions(
+        data_column="inputs",
+        spatial_merge_size=spatial_merge_size,
+        keep_aux_fields=True,
+    )
 
     element = {
         "inputs": np.array(
@@ -640,9 +671,10 @@ class ComputeQwen3OmniPositionsTest(unittest.TestCase):
 
     result = transform.map(element)
 
-    # Verify transform adds position fields
+    # Verify transform adds position fields as (B, S, 3)
     self.assertIn("inputs_position", result)
     self.assertIn("inputs_mrope_deltas", result)
+    self.assertEqual(result["inputs_position"].shape, (1, 7, 3))
 
     # Verify it matches direct get_rope_index call
     expected_pos, expected_deltas = processor_qwen3_omni.get_rope_index(
@@ -659,6 +691,25 @@ class ComputeQwen3OmniPositionsTest(unittest.TestCase):
 
     np.testing.assert_array_equal(result["inputs_position"], expected_pos)
     np.testing.assert_array_equal(result["inputs_mrope_deltas"], expected_deltas)
+
+  def test_training_drops_aux_fields(self):
+    """Training path stores (B, S, 3) and drops aux fields."""
+    transform = ComputeQwen3OmniPositions(
+        data_column="inputs",
+        spatial_merge_size=2,
+        keep_aux_fields=False,
+    )
+    element = {
+        "inputs": np.array(
+            [[VISION_START, IMAGE_TOKEN, IMAGE_TOKEN, IMAGE_TOKEN, IMAGE_TOKEN, VISION_END, 100]], dtype=np.int32
+        ),
+        "inputs_segmentation": np.array([[1, 1, 1, 1, 1, 1, 1]], dtype=np.int32),
+        "image_grid_thw": np.array([[1, 2, 2]], dtype=np.int32),
+    }
+    result = transform.map(element)
+    self.assertEqual(result["inputs_position"].shape, (1, 7, 3))
+    self.assertNotIn("inputs_mrope_deltas", result)
+    self.assertNotIn("image_grid_thw", result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/qwen35_partial_mrope_test.py
+++ b/tests/unit/qwen35_partial_mrope_test.py
@@ -35,14 +35,14 @@ _ROPE_THETA = 10_000_000
 def _reference_partial_mrope(inputs: np.ndarray, positions: np.ndarray) -> np.ndarray:
   """Independent NumPy implementation of the Qwen3.5 partial-MRoPE rule."""
   if positions.ndim == 2:
-    positions = np.broadcast_to(positions[np.newaxis, ...], (3,) + positions.shape)
+    positions = np.broadcast_to(positions[..., np.newaxis], positions.shape + (3,))
 
   inv_freq = 1.0 / (_ROPE_THETA ** (np.arange(0, _ROTARY_DIM, 2, dtype=np.float32) / _ROTARY_DIM))
   freqs = positions[..., np.newaxis].astype(np.float32) * inv_freq
-  interleaved = np.array(freqs[0], copy=True)
+  interleaved = np.array(freqs[..., 0, :], copy=True)
   for dim, offset in enumerate((1, 2), start=1):
     idx = slice(offset, _MROPE_SECTION[dim] * 3, 3)
-    interleaved[..., idx] = freqs[dim, ..., idx]
+    interleaved[..., idx] = freqs[..., dim, idx]
 
   angles = np.concatenate([interleaved, interleaved], axis=-1)
   cos = np.cos(angles)[:, :, np.newaxis, :]
@@ -60,7 +60,7 @@ class Qwen35PartialMropeTest(unittest.TestCase):
   def test_matches_reference_and_preserves_unrotated_suffix(self):
     inputs = np.linspace(-1.0, 1.0, num=2 * 4 * 3 * _HEAD_DIM, dtype=np.float32).reshape((2, 4, 3, _HEAD_DIM))
     text_positions = np.broadcast_to(np.arange(4, dtype=np.int32), (2, 4))
-    multimodal_positions = np.stack([text_positions, text_positions + 3, text_positions + 7], axis=0)
+    multimodal_positions = np.stack([text_positions, text_positions + 3, text_positions + 7], axis=-1)
     embedding = Qwen3OmniMoeThinkerTextRotaryEmbedding(
         min_timescale=1,
         max_timescale=_ROPE_THETA,


### PR DESCRIPTION
Note: this PR has 2 commits, but the first commit is raised in a separate PR #4705. 
 
# Description

Currently even if `use_mrope: True` in yml, qwen3* model still silently use 1D rope for vision sft training since the dataloader only produce 1D `input_position` tensor.
This PR uses the existing `ComputeQwen3OmniPositions` for inference and use it in the training dataloader as well.

The current rope expects position indices of shape `(3, B, S)`. This does not play well with maxtext codebase where data is generally expected to be leading with shape `(B, S)`. I adapt to use the shape `(B, S, 3)` throughout.

# Tests
- The `multimodal_rope_check.py` test was not running before, due to missing import of the special tokens. 
- Also fix the HF's transformers MockConfig to work with `transformers > 5`
- Update the test data to match the new shape BS3.
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
