### PR TITLE
docs: fix broken and redirected documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,5 +29,5 @@ This project follows
 
 All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult
-[GitHub Help](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more
+[GitHub Help](https://docs.github.com/en/pull-requests/reference/pull-requests) for more
 information on using pull requests.

--- a/docs/guides/monitoring_and_debugging/use_vertex_ai_tensorboard.md
+++ b/docs/guides/monitoring_and_debugging/use_vertex_ai_tensorboard.md
@@ -22,14 +22,14 @@ MaxText supports automatic upload of logs collected in a directory to a Tensorbo
 
 ## What is Vertex AI Tensorboard and Vertex AI Experiment
 
-Vertex AI Tensorboard is a fully managed and enterprise-ready version of open-source Tensorboard. To learn more about Vertex AI Tensorboard, visit [this](https://docs.cloud.google.com/vertex-ai/docs/experiments/tensorboard-introduction). Vertex AI Experiment is a tool that helps to track and analyze an experiment run on Vertex AI Tensorboard. To learn more about Vertex AI Experiments, visit [this](https://docs.cloud.google.com/vertex-ai/docs/experiments/intro-vertex-ai-experiments).
+Vertex AI Tensorboard is a fully managed and enterprise-ready version of open-source Tensorboard. To learn more about Vertex AI Tensorboard, visit [this](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/experiments/tensorboard-introduction). Vertex AI Experiment is a tool that helps to track and analyze an experiment run on Vertex AI Tensorboard. To learn more about Vertex AI Experiments, visit [this](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/experiments/intro-vertex-ai-experiments).
 
 You can use a single Vertex AI Tensorboard instance to track and compare metrics from multiple Vertex AI Experiments. While you can view metrics from multiple Vertex AI Experiments within a single Tensorboard instance, the underlying log data for each experiment remains separate.
 
 ## Prerequisites
 
-- Enable [Vertex AI API](https://docs.cloud.google.com/vertex-ai/docs/start/cloud-environment#set_up_a_project) in your Google Cloud console.
-- Assign [Vertex AI User IAM role](https://docs.cloud.google.com/vertex-ai/docs/general/access-control#aiplatform.user) to the service account used by the TPU VMs. This is required to create and access the Vertex AI Tensorboard in Google Cloud console. If you are using XPK for MaxText, the necessary Vertex AI User IAM role will be automatically assigned to your node pools by XPK – no need to assign it manually.
+- Enable [Vertex AI API](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/start/cloud-environment#set_up_a_project) in your Google Cloud console.
+- Assign [Vertex AI User IAM role](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/access-control#aiplatform.user) to the service account used by the TPU VMs. This is required to create and access the Vertex AI Tensorboard in Google Cloud console. If you are using XPK for MaxText, the necessary Vertex AI User IAM role will be automatically assigned to your node pools by XPK – no need to assign it manually.
 
 ## Upload logs to Vertex AI Tensorboard
 
@@ -47,7 +47,7 @@ The above configuration will upload logs in `config.tensorboard_dir` to Vertex T
 
 **Scenario 2: Running MaxText on GCE**
 
-Set `use_vertex_tensorboard=True` to upload logs in `config.tensorboard_dir` to a Tensorboard instance in Vertex AI. You can manually create a Tensorboard instance named `<config.vertex_tensorboard_project>-tb-instance` and an Experiment named `config.run_name` in Vertex AI on Google Cloud console. Otherwise, MaxText will create those resources for you when `use_vertex_tensorboard=True`. Note that Vertex AI is available in only [these](https://docs.cloud.google.com/vertex-ai/docs/general/locations#available-regions) regions.
+Set `use_vertex_tensorboard=True` to upload logs in `config.tensorboard_dir` to a Tensorboard instance in Vertex AI. You can manually create a Tensorboard instance named `<config.vertex_tensorboard_project>-tb-instance` and an Experiment named `config.run_name` in Vertex AI on Google Cloud console. Otherwise, MaxText will create those resources for you when `use_vertex_tensorboard=True`. Note that Vertex AI is available in only [these](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/locations#available-regions) regions.
 
 **Scenario 2.1: Configuration to upload logs to Vertex AI Tensorboard**
 

--- a/docs/run_maxtext/run_maxtext_single_host_gpu.md
+++ b/docs/run_maxtext/run_maxtext_single_host_gpu.md
@@ -56,9 +56,14 @@ https://docs.docker.com/engine/install/debian/
 
 https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 
-If you get the NVML Error: Please follow these instructions.
+If you get an NVML error, try the following:
 
-https://stackoverflow.com/questions/72932940/failed-to-initialize-nvml-unknown-error-in-docker-after-few-hours
+1. Edit `/etc/nvidia-container-runtime/config.toml` (e.g., `sudo vim /etc/nvidia-container-runtime/config.toml`), change `no-cgroups = false`, and save.
+2. Restart the Docker daemon: `sudo systemctl restart docker`.
+3. Test by running:
+   ```bash
+   sudo docker run --rm --runtime=nvidia --gpus all ubuntu nvidia-smi
+   ```
 
 ## Build MaxText Docker image
 

--- a/docs/run_maxtext/run_maxtext_via_cluster_toolkit.md
+++ b/docs/run_maxtext/run_maxtext_via_cluster_toolkit.md
@@ -52,7 +52,7 @@ Before you begin, ensure you have the necessary client tools installed and permi
   ```bash
   gcloud components install kubectl gke-gcloud-auth-plugin
   ```
-- **gcluster CLI:** Follow the official [Cluster Toolkit CLI Installation Guide](https://cloud.google.com/cluster-toolkit/docs/install-cli) (or download the binary from the [releases page](https://github.com/GoogleCloudPlatform/cluster-toolkit/releases)) and ensure `gcluster` is in your `$PATH`.
+- **gcluster CLI:** Follow the official [Cluster Toolkit CLI Installation Guide](https://docs.cloud.google.com/cluster-toolkit/docs/setup/configure-environment) (or download the binary from the [releases page](https://github.com/GoogleCloudPlatform/cluster-toolkit/releases)) and ensure `gcluster` is in your `$PATH`.
 - **Docker Credentials:** Configure Docker authentication for your target Artifact Registry region:
   ```bash
   gcloud auth configure-docker <region>-docker.pkg.dev --quiet
@@ -173,7 +173,7 @@ Ahead-of-Time (AOT) compilation can significantly reduce the startup time of you
 
 ### Step 1: Generate the AOT artifact
 
-Note that running `train_compile.py` locally requires a Python environment with MaxText and JAX installed. Follow the [MaxText Getting Started Guide](https://github.com/AI-Hypercomputer/maxtext#getting-started) to set up your local environment before running compilation.
+Note that running `train_compile.py` locally requires a Python environment with MaxText and JAX installed. Follow the [MaxText Getting Started Guide](../getting_started.md) to set up your local environment before running compilation.
 
 Run `train_compile.py` locally to create the compiled artifact for the target TPU topology:
 


### PR DESCRIPTION
- Update Cluster Toolkit CLI installation guide link to docs.cloud.google.com/cluster-toolkit/docs/setup/configure-environment
- Replace broken StackOverflow link for NVML Docker error with inline troubleshooting steps
- Update Getting Started link in run_maxtext_via_cluster_toolkit.md to relative doc link
- Update permanently redirected Vertex AI documentation links to new Gemini Enterprise Agent Platform URLs
- Update GitHub Pull Requests reference link in CONTRIBUTING.md

FIXES: b/542079379

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
