### PR TITLE
Automatically mark all tests as cpu_only  unless explicitly tagged with hardware markers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,7 @@ if is_decoupled():
 
 
 GCP_MARKERS = {"external_serving", "external_training"}
+HARDWARE_MARKERS = {"tpu_only", "gpu_only", "cpu_only"}
 
 
 def _has_tpu_backend_support() -> bool:
@@ -149,6 +150,7 @@ def pytest_collection_modifyitems(config, items):
   - Skip hardware-specific tests when hardware is missing.
   - Deselect tests marked as external_serving/training in decoupled mode.
   - Mark remaining tests with the `decoupled` marker when running decoupled.
+  - Mark tests without explicit hardware markers as `cpu_only`.
   """
 
   changed_tests = get_changed_tests()  # set[(file_path, test_name)]
@@ -196,6 +198,12 @@ def pytest_collection_modifyitems(config, items):
   if decoupled:
     for item in remaining:
       item.add_marker(pytest.mark.decoupled)
+
+  # Auto-mark remaining tests as cpu_only unless explicitly marked with hardware target markers.
+  for item in remaining:
+    cur_test_markers = {m.name for m in item.iter_markers()}
+    if cur_test_markers.isdisjoint(HARDWARE_MARKERS):
+      item.add_marker(pytest.mark.cpu_only)
 
 
 def pytest_configure(config):

--- a/tests/equiv_chunk_test.py
+++ b/tests/equiv_chunk_test.py
@@ -28,11 +28,14 @@ from flax.linen import partitioning as nn_partitioning
 import jax
 import jax.numpy as jnp
 import jax.sharding
+import pytest
 from maxtext.configs import pyconfig
 from maxtext.layers import initializers
 from maxtext.layers import moe
 from maxtext.utils import maxtext_utils
 from tests.utils import test_helpers
+
+pytestmark = [pytest.mark.tpu_only]
 
 
 def build_cfg(n_chunks):

--- a/tests/integration/aot_identical_test.py
+++ b/tests/integration/aot_identical_test.py
@@ -30,6 +30,8 @@ from tests.utils.test_helpers import get_test_config_path
 from maxtext.trainers.pre_train import train_compile
 from maxtext.trainers.pre_train import train
 
+pytestmark = [pytest.mark.integration_test]
+
 
 class AotBaseTest(unittest.TestCase):
   """Base class for AOT identity tests providing shared utilities."""

--- a/tests/integration/check_vma_test.py
+++ b/tests/integration/check_vma_test.py
@@ -30,6 +30,9 @@ from tempfile import gettempdir
 from maxtext.trainers.pre_train.train_compile import main as train_compile_main
 from tests.utils.test_helpers import get_test_config_path
 
+pytestmark = [pytest.mark.integration_test]
+
+
 _BASE_ARGS = (
     None,
     get_test_config_path(),
@@ -58,7 +61,6 @@ _BASE_ARGS = (
 class CheckVmaTest(absltest.TestCase):
   """Tests that megablox MoE compiles under different check_vma / shard_mode settings."""
 
-  @pytest.mark.cpu_only
   def test_check_vma(self):
     """check_vma=True with fsdp and expert parallelism."""
     temp_dir = gettempdir()
@@ -72,7 +74,6 @@ class CheckVmaTest(absltest.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_check_vma_disabled(self):
     """check_vma=False (default) should also compile correctly."""
     temp_dir = gettempdir()
@@ -86,7 +87,6 @@ class CheckVmaTest(absltest.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_check_vma_pure_fsdp(self):
     """check_vma=True with only FSDP parallelism (no expert parallelism)."""
     temp_dir = gettempdir()
@@ -100,7 +100,6 @@ class CheckVmaTest(absltest.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_check_vma_pure_ep(self):
     """check_vma=True with only expert parallelism (no FSDP)."""
     temp_dir = gettempdir()
@@ -114,7 +113,6 @@ class CheckVmaTest(absltest.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_check_vma_error_extra_parallelism(self):
     """check_vma=True must raise ValueError when a non-EP/FSDP ICI axis is enabled."""
     with self.assertRaises(ValueError):
@@ -129,7 +127,6 @@ class CheckVmaTest(absltest.TestCase):
           )
       )
 
-  @pytest.mark.cpu_only
   def test_check_vma_error_tokamax_gmm(self):
     """check_vma=True must raise ValueError when use_tokamax_gmm=True."""
     with self.assertRaises(ValueError):
@@ -144,7 +141,6 @@ class CheckVmaTest(absltest.TestCase):
           )
       )
 
-  @pytest.mark.cpu_only
   def test_explicit_shard_mode(self):
     """shard_mode=explicit should compile correctly without check_vma (check_vma not supported here)."""
     temp_dir = gettempdir()

--- a/tests/integration/checkpoint_conversion_test.py
+++ b/tests/integration/checkpoint_conversion_test.py
@@ -29,13 +29,11 @@ pytestmark = [pytest.mark.integration_test]
 class Qwen3CheckpointConversionTest(unittest.TestCase):
   """Tests HuggingFace to Orbax checkpoint conversion."""
 
-  @pytest.mark.cpu_only
   def test_import_to_maxtext(self):
     # This test validates that to_maxtext can be imported without errors,
     # and ensures its top-level statements are covered by Codecov.
     self.assertIsNotNone(to_maxtext)
 
-  @pytest.mark.cpu_only
   def test_qwen3_30b_a3b_roundtrip_conversion(self):
     model_name = "qwen3-30b-a3b"
     base_num_decoder_layers = 2

--- a/tests/integration/diloco_test.py
+++ b/tests/integration/diloco_test.py
@@ -343,7 +343,6 @@ class DiLoCoTest(unittest.TestCase):
       # synchronization).
       chex.assert_trees_all_equal(diloco_test_state.params, step_three_outer_params)
 
-  @pytest.mark.cpu_only
   @pytest.mark.tpu_backend
   def test_diloco_qwen3_moe_two_slices(self):
     temp_dir = gettempdir()
@@ -369,7 +368,6 @@ class DiLoCoTest(unittest.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   @pytest.mark.tpu_backend
   def test_diloco_two_slices(self):
     temp_dir = gettempdir()

--- a/tests/integration/pipeline_parallelism_test.py
+++ b/tests/integration/pipeline_parallelism_test.py
@@ -41,6 +41,8 @@ from maxtext.trainers.pre_train.train import main as train_main
 from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
 import pytest
 
+pytestmark = [pytest.mark.integration_test, pytest.mark.tpu_only]
+
 
 # Helper to fix pipeline parallelism in test_full_train_fp8 and test_full_train_nanoo_fp8
 def _adapt_parallelism(args, pipeline_stages=4):
@@ -99,7 +101,6 @@ def assert_same_output_and_grad(f1, f2, *inputs):
   )
 
 
-@pytest.mark.integration_test
 class PipelineParallelismTest(unittest.TestCase):
   decoupled = is_decoupled()
   base_output_directory = get_test_base_output_directory()
@@ -275,7 +276,6 @@ class PipelineParallelismTest(unittest.TestCase):
       )
       self.assert_pipeline_matches_sequential_output_and_grad(config)
 
-  @pytest.mark.tpu_only
   def test_circular_minimum_microbatches_same_output_and_grad(self):
     # 4 stages, 8 layers (2 repeats, 1 layer per stage), 4 microbatches
     config = pyconfig.initialize(
@@ -292,7 +292,6 @@ class PipelineParallelismTest(unittest.TestCase):
     )
     self.assert_pipeline_matches_sequential_output_and_grad(config)
 
-  @pytest.mark.tpu_only
   def test_circular_extra_microbatches_same_output_and_grad(self):
     # 4 stages, 8 layers (2 repeats, 1 layer per stage), 8 microbatches
     config = pyconfig.initialize(
@@ -309,7 +308,6 @@ class PipelineParallelismTest(unittest.TestCase):
     )
     self.assert_pipeline_matches_sequential_output_and_grad(config)
 
-  @pytest.mark.tpu_only
   def test_circular_deepseek_megablox_same_output_and_grad(self):
     # 4 stages, 8 layers (2 repeats, 1 layer per stage), 8 microbatches.
     # DeepSeek's MoE block (`moe.RoutedAndSharedMoE`) constructs a `shared_experts`
@@ -346,7 +344,6 @@ class PipelineParallelismTest(unittest.TestCase):
     )
 
   @pytest.mark.scheduled_only
-  @pytest.mark.tpu_only
   def test_deepseek_ragged_a2a_ep_same_output_and_grad(self):
     config = pyconfig.initialize(
         [sys.argv[0], get_test_config_path()],
@@ -380,7 +377,6 @@ class PipelineParallelismTest(unittest.TestCase):
         single_pipeline_stage_class=deepseek.DeepSeekMoELayerToLinen,
     )
 
-  @pytest.mark.tpu_only
   def test_circular_ag_once(self):
     # 2 stages, 8 microbatches, all gather once
     config = pyconfig.initialize(
@@ -398,15 +394,12 @@ class PipelineParallelismTest(unittest.TestCase):
     )
     self.assert_pipeline_matches_sequential_output_and_grad(config)
 
-  @pytest.mark.tpu_only
   def test_circular_pipeline_ag_per_repeat(self):
     self._assert_circular_pipeline_ag_per_repeat_core("nnx_scan")
 
-  @pytest.mark.tpu_only
   def test_circular_pipeline_ag_per_repeat_jax_state_core(self):
     self._assert_circular_pipeline_ag_per_repeat_core("jax_state")
 
-  @pytest.mark.tpu_only
   def test_non_circular_same_output_and_grad(self):
     # 4 stages, 4 layers (no circular repeats, 1 layer per stage), 4 microbatches
     config = pyconfig.initialize(
@@ -422,8 +415,6 @@ class PipelineParallelismTest(unittest.TestCase):
     )
     self.assert_pipeline_matches_sequential_output_and_grad(config)
 
-  @pytest.mark.integration_test
-  @pytest.mark.tpu_only
   def test_full_train_circular(self):
     # Run a full train.py call with 4 stages, 32 layers (2 layers per stage, 4 circular repeats), 8 microbatches
     train_main(
@@ -454,8 +445,6 @@ class PipelineParallelismTest(unittest.TestCase):
         ]
     )
 
-  @pytest.mark.integration_test
-  @pytest.mark.tpu_only
   def test_full_train_circular_pipeline_ag_per_repeat(self):
     # Run a full train.py call with 4 stages, 32 layers (2 layers per stage, 4 circular repeats),
     # 8 microbatches and using pipeline ag per repeat
@@ -487,7 +476,6 @@ class PipelineParallelismTest(unittest.TestCase):
         ]
     )
 
-  @pytest.mark.tpu_only
   def test_delay_activation_forwarding_same_output_and_grad(self):
     # 4 stages, delayed activation forwarding, 8 layers (2 repeats, 1 layer per stage), 8 microbatches
     config = pyconfig.initialize(
@@ -505,8 +493,6 @@ class PipelineParallelismTest(unittest.TestCase):
     )
     self.assert_pipeline_matches_sequential_output_and_grad(config)
 
-  @pytest.mark.integration_test
-  @pytest.mark.tpu_only
   def test_full_train_non_circular(self):
     # Run a full train.py call with 4 stages, 32 layers (8 layers per stage), 8 microbatches
     train_main(
@@ -537,8 +523,6 @@ class PipelineParallelismTest(unittest.TestCase):
         ]
     )
 
-  @pytest.mark.integration_test
-  @pytest.mark.tpu_only
   def test_subset_layers(self):
     # Run a full train.py call with 4 stages, 16 layers - 8 in pipeline, 8 ran outside of pipeline
     train_main(
@@ -572,7 +556,6 @@ class PipelineParallelismTest(unittest.TestCase):
     )
 
   @pytest.mark.skipif(is_decoupled(), reason="Pipeline parallelism not supported in decoupled mode")
-  @pytest.mark.integration_test
   def test_full_train_fp8(self):
     # Run a full train.py call with fp8 quantization, which adds extra
     # variable collections that need to be handled
@@ -605,7 +588,6 @@ class PipelineParallelismTest(unittest.TestCase):
     train_main(args)
 
   @pytest.mark.skipif(is_decoupled(), reason="Pipeline parallelism not supported in decoupled mode")
-  @pytest.mark.integration_test
   def test_full_train_nanoo_fp8(self):
     # Run a full train.py call with NANOO fp8 quantization, which adds extra
     # variable collections that need to be handled

--- a/tests/integration/smoke/train_tokenizer_smoke_test.py
+++ b/tests/integration/smoke/train_tokenizer_smoke_test.py
@@ -16,7 +16,6 @@
 
 import os
 import unittest
-import pytest
 
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.input_pipeline import input_pipeline_utils
@@ -49,12 +48,10 @@ class TrainTokenizerFormatTest(unittest.TestCase):
       if os.path.exists(output_path):
         os.remove(output_path)
 
-  @pytest.mark.cpu_only
   def test_parquet(self):
     path = os.path.join(get_test_dataset_path(), "hf", "c4", "c4-train-00000-of-01637.parquet")
     self._run_format_test(path, "parquet")
 
-  @pytest.mark.cpu_only
   def test_arrayrecord(self):
     dataset_root = get_test_dataset_path()
     if is_decoupled():
@@ -63,7 +60,6 @@ class TrainTokenizerFormatTest(unittest.TestCase):
       path = os.path.join(dataset_root, "array-record", "c4", "en", "3.0.1", "c4-train.array_record-00000-of-01024")
     self._run_format_test(path, "arrayrecord")
 
-  @pytest.mark.cpu_only
   def test_tfrecord(self):
     dataset_root = get_test_dataset_path()
     if is_decoupled():

--- a/tests/post_training/unit/distillation_data_processing_test.py
+++ b/tests/post_training/unit/distillation_data_processing_test.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-pytestmark = [pytest.mark.post_training, pytest.mark.cpu_only]
+pytestmark = [pytest.mark.post_training]
 
 import argparse
 import os

--- a/tests/post_training/unit/distillation_metrics_test.py
+++ b/tests/post_training/unit/distillation_metrics_test.py
@@ -31,7 +31,7 @@ import pytest
 pytest.importorskip("optax")
 pytest.importorskip("tunix")
 
-pytestmark = [pytest.mark.cpu_only, pytest.mark.post_training]
+pytestmark = [pytest.mark.post_training]
 
 import unittest
 from typing import List, Optional

--- a/tests/post_training/unit/distillation_tflops_test.py
+++ b/tests/post_training/unit/distillation_tflops_test.py
@@ -26,7 +26,7 @@ import pytest
 
 pytest.importorskip("tunix")
 
-pytestmark = [pytest.mark.cpu_only, pytest.mark.post_training]
+pytestmark = [pytest.mark.post_training]
 
 import unittest
 from unittest import mock

--- a/tests/post_training/unit/dpo_data_processing_test.py
+++ b/tests/post_training/unit/dpo_data_processing_test.py
@@ -31,7 +31,7 @@ from maxtext.input_pipeline import grain_data_processing
 from maxtext.input_pipeline import input_pipeline_interface
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_CONFIGS_DIR, MAXTEXT_PKG_DIR
 
-pytestmark = [pytest.mark.post_training, pytest.mark.cpu_only]
+pytestmark = [pytest.mark.post_training]
 
 
 class TestDPODataFormatting(unittest.TestCase):

--- a/tests/post_training/unit/dpo_hooks_test.py
+++ b/tests/post_training/unit/dpo_hooks_test.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-pytestmark = [pytest.mark.cpu_only, pytest.mark.external_training, pytest.mark.post_training]
+pytestmark = [pytest.mark.external_training, pytest.mark.post_training]
 
 import jax
 from jax.sharding import Mesh

--- a/tests/post_training/unit/dpo_trainer_correctness_test.py
+++ b/tests/post_training/unit/dpo_trainer_correctness_test.py
@@ -36,7 +36,7 @@ from tests.post_training.integration.dpo_correctness_base import (
 
 # Force this test to run only on CPU to avoid GPU/TPU floating point differences.
 # It will be dynamically bypassed on active accelerator hardware testbeds.
-pytestmark = [pytest.mark.post_training, pytest.mark.cpu_only]
+pytestmark = [pytest.mark.post_training]
 
 
 class DPOTRLCorrectnessTest(DPOCorrectnessTestBase):

--- a/tests/post_training/unit/evaluate_rl_test.py
+++ b/tests/post_training/unit/evaluate_rl_test.py
@@ -53,7 +53,6 @@ class TestScoreResponses(unittest.TestCase):
     self.config = _make_config(eval_mode="pass")
     self.maj_config = _make_config(eval_mode="maj")
 
-  @pytest.mark.cpu_only
   def test_nested_tags(self):
     """Response with nested reasoning tags still extracts the correct answer."""
     is_correct, is_partially_correct, has_correct_format = evaluate_rl.score_responses(
@@ -69,7 +68,6 @@ class TestScoreResponses(unittest.TestCase):
     self.assertTrue(is_partially_correct)
     self.assertTrue(has_correct_format)
 
-  @pytest.mark.cpu_only
   def test_with_extra_ending_tags(self):
     """Answer with extra ending tags such as <end_of_turn>."""
     is_correct, is_partially_correct, has_correct_format = evaluate_rl.score_responses(
@@ -91,7 +89,6 @@ class TestScoreResponses(unittest.TestCase):
     self.assertTrue(is_partially_correct)
     self.assertTrue(has_correct_format)
 
-  @pytest.mark.cpu_only
   def test_with_incomplete_reasoning_tags(self):
     """(1) Incomplete reasoning tags still extracts the correct answer."""
     """(2) Currency symbols works with math_verify."""
@@ -105,7 +102,6 @@ class TestScoreResponses(unittest.TestCase):
     self.assertTrue(is_partially_correct)
     self.assertFalse(has_correct_format)
 
-  @pytest.mark.cpu_only
   def test_for_mcq_value(self):
     """Test for MCQ, where model responds with a math value."""
     is_correct, is_partially_correct, has_correct_format = evaluate_rl.score_responses(
@@ -122,7 +118,6 @@ class TestScoreResponses(unittest.TestCase):
     self.assertTrue(is_partially_correct)
     self.assertFalse(has_correct_format)
 
-  @pytest.mark.cpu_only
   def test_for_mcq_option(self):
     """Test for MCQ, where model responds with an option."""
     is_correct, is_partially_correct, has_correct_format = evaluate_rl.score_responses(
@@ -139,7 +134,6 @@ class TestScoreResponses(unittest.TestCase):
     self.assertTrue(is_partially_correct)
     self.assertFalse(has_correct_format)
 
-  @pytest.mark.cpu_only
   def test_majority_eval_mode(self):
     is_correct, is_partially_correct, has_correct_format = evaluate_rl.score_responses(
         tmvp_config=self.maj_config,
@@ -155,7 +149,6 @@ class TestScoreResponses(unittest.TestCase):
     self.assertTrue(is_partially_correct)
     self.assertTrue(has_correct_format)
 
-  @pytest.mark.cpu_only
   def test_pass_at_1_eval_mode(self):
     """pass@1 returns fraction of correct samples, not a boolean."""
     config = _make_config(eval_mode="pass_at_1")
@@ -175,7 +168,6 @@ class TestScoreResponses(unittest.TestCase):
     self.assertAlmostEqual(is_partially_correct, 0.75)
     self.assertAlmostEqual(has_correct_format, 1.0)
 
-  @pytest.mark.cpu_only
   def test_pass_at_1_all_wrong(self):
     """pass@1 with all wrong samples returns 0.0."""
     config = _make_config(eval_mode="pass_at_1")
@@ -192,7 +184,6 @@ class TestScoreResponses(unittest.TestCase):
     self.assertAlmostEqual(is_partially_correct, 0.0)
     self.assertAlmostEqual(has_correct_format, 1.0)
 
-  @pytest.mark.cpu_only
   def test_pass_at_1_all_correct(self):
     """pass@1 with all correct samples returns 1.0."""
     config = _make_config(eval_mode="pass_at_1")
@@ -228,7 +219,6 @@ class TestComputeRowReward(unittest.TestCase):
 
     return [fn1, fn2]
 
-  @pytest.mark.cpu_only
   def test_single_response_single_fn(self):
     def fn(prompts, completions, answer, question):  # pylint: disable=unused-argument
       return [2.5 for _ in completions]
@@ -244,7 +234,6 @@ class TestComputeRowReward(unittest.TestCase):
     self.assertAlmostEqual(score_sum, 2.5)
     self.assertEqual(count, 1)
 
-  @pytest.mark.cpu_only
   def test_sums_across_reward_fns_for_single_response(self):
     score_sum, count = evaluate_rl._compute_row_reward(
         reward_fns=self._two_fns(),
@@ -258,7 +247,6 @@ class TestComputeRowReward(unittest.TestCase):
     self.assertAlmostEqual(score_sum, 5.0)
     self.assertEqual(count, 1)
 
-  @pytest.mark.cpu_only
   def test_sums_across_passes_for_multiple_responses(self):
     """Multi-pass: helper must aggregate across ALL sampled responses, not just [0]."""
     score_sum, count = evaluate_rl._compute_row_reward(
@@ -274,7 +262,6 @@ class TestComputeRowReward(unittest.TestCase):
     self.assertAlmostEqual(score_sum, 9.0)
     self.assertEqual(count, 3)
 
-  @pytest.mark.cpu_only
   def test_empty_responses_returns_zero_and_zero_count(self):
     """An empty responses list must contribute nothing to the running mean."""
     score_sum, count = evaluate_rl._compute_row_reward(
@@ -288,7 +275,6 @@ class TestComputeRowReward(unittest.TestCase):
     self.assertEqual(score_sum, 0.0)
     self.assertEqual(count, 0)
 
-  @pytest.mark.cpu_only
   def test_exception_in_reward_fn_swallowed_and_returns_zero_count(self):
     """A raising reward_fn must not propagate and must not corrupt the mean denominator."""
 
@@ -306,7 +292,6 @@ class TestComputeRowReward(unittest.TestCase):
     self.assertEqual(score_sum, 0.0)
     self.assertEqual(count, 0)  # zero count so the caller's mean isn't biased
 
-  @pytest.mark.cpu_only
   def test_question_is_forwarded_to_reward_fn(self):
     """Regression: helper must pass `question` through to reward fns.
 
@@ -330,7 +315,6 @@ class TestComputeRowReward(unittest.TestCase):
     )
     self.assertEqual(received["question"], "What is 2+2?")
 
-  @pytest.mark.cpu_only
   def test_integrates_with_real_check_numbers_reward(self):
     """End-to-end: real `check_numbers` from utils_rl must not raise on the
     eval-time kwargs the helper passes (regression for the original

--- a/tests/post_training/unit/extract_answer_test.py
+++ b/tests/post_training/unit/extract_answer_test.py
@@ -50,44 +50,36 @@ class ExtractAnswerTest(unittest.TestCase):
 
   # ---- boxed extraction ----
 
-  @pytest.mark.cpu_only
   def test_boxed_inside_answer_tags(self):
     got = utils_rl.extract_answer("<reasoning>2+2</reasoning><answer>\\boxed{4}</answer>", self.config)
     self.assertEqual(got, "4")
 
-  @pytest.mark.cpu_only
   def test_boxed_without_answer_tags(self):
     got = utils_rl.extract_answer("the result is \\boxed{42}", self.config)
     self.assertEqual(got, "42")
 
-  @pytest.mark.cpu_only
   def test_boxed_nested_latex(self):
     """Brace-balanced scan keeps the full nested LaTeX content."""
     got = utils_rl.extract_answer("<answer>\\boxed{\\frac{1}{2}}</answer>", self.config)
     self.assertEqual(got, "\\frac{1}{2}")
 
-  @pytest.mark.cpu_only
   def test_multiple_boxed_returns_last(self):
     got = utils_rl.extract_answer("first \\boxed{1} then \\boxed{99}", self.config)
     self.assertEqual(got, "99")
 
-  @pytest.mark.cpu_only
   def test_boxed_strips_whitespace(self):
     got = utils_rl.extract_answer("<answer>\\boxed{ 7 }</answer>", self.config)
     self.assertEqual(got, "7")
 
-  @pytest.mark.cpu_only
   def test_boxed_negative(self):
     got = utils_rl.extract_answer("answer: \\boxed{-3}", self.config)
     self.assertEqual(got, "-3")
 
-  @pytest.mark.cpu_only
   def test_answer_tag_scopes_over_reasoning_boxed(self):
     """A boxed value in <reasoning> must not win over the one in <answer>."""
     resp = "<reasoning>maybe \\boxed{1}</reasoning><answer>\\boxed{8}</answer>"
     self.assertEqual(utils_rl.extract_answer(resp, self.config), "8")
 
-  @pytest.mark.cpu_only
   def test_scoping_follows_configured_solution_tokens(self):
     """Scoping uses solution_start/end_token, not a hardcoded <answer> tag."""
     config = SimpleNamespace(
@@ -101,20 +93,17 @@ class ExtractAnswerTest(unittest.TestCase):
 
   # ---- legacy fallback (no boxed) ----
 
-  @pytest.mark.cpu_only
   def test_legacy_plain_answer_in_tags(self):
     """A plain-text answer inside <answer> tags (no boxed) still extracts."""
     got = utils_rl.extract_answer("<reasoning>work</reasoning><answer>42</answer>", self.config)
     self.assertEqual(got, "42")
 
-  @pytest.mark.cpu_only
   def test_legacy_last_answer_wins(self):
     got = utils_rl.extract_answer("<answer>1</answer> ... <answer>5</answer>", self.config)
     self.assertEqual(got, "5")
 
   # ---- no answer ----
 
-  @pytest.mark.cpu_only
   def test_no_answer_returns_fallback_constant(self):
     got = utils_rl.extract_answer("I have no idea", self.config)
     self.assertEqual(got, utils_rl.FALLBACK_ANSWER)

--- a/tests/post_training/unit/hooks_test.py
+++ b/tests/post_training/unit/hooks_test.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock
 import pytest
 
 pytest.importorskip("tunix")
-pytestmark = [pytest.mark.cpu_only, pytest.mark.external_training, pytest.mark.post_training]
+pytestmark = [pytest.mark.external_training, pytest.mark.post_training]
 
 import jax
 from jax.sharding import Mesh

--- a/tests/post_training/unit/load_custom_callable_test.py
+++ b/tests/post_training/unit/load_custom_callable_test.py
@@ -60,7 +60,6 @@ def _write_user_file(tmpdir):
 class LoadCustomCallableTest(unittest.TestCase):
   """Verify load_custom_callable loads a function from a user .py file."""
 
-  @pytest.mark.cpu_only
   def test_loads_function_from_user_file(self):
     """Returns a callable that behaves like the function in the user file."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -81,7 +80,6 @@ class LoadCustomCallableTest(unittest.TestCase):
       self.assertEqual(result["question"], "2+2?")
       self.assertEqual(result["answer"], "4")
 
-  @pytest.mark.cpu_only
   def test_loads_any_named_function(self):
     """function_name argument selects which symbol to return."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -89,7 +87,6 @@ class LoadCustomCallableTest(unittest.TestCase):
       fn = load_custom_callable(user_file, "another_helper")
       self.assertEqual(fn(5), 10)  # pylint: disable=not-callable
 
-  @pytest.mark.cpu_only
   def test_raises_when_file_does_not_exist(self):
     """Nonexistent path -> ValueError, not a cryptic ImportError."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -97,7 +94,6 @@ class LoadCustomCallableTest(unittest.TestCase):
       with self.assertRaises(ValueError):
         load_custom_callable(bogus, "process_data")
 
-  @pytest.mark.cpu_only
   def test_raises_when_function_not_defined(self):
     """File exists but doesn't define the named function -> ValueError."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -105,7 +101,6 @@ class LoadCustomCallableTest(unittest.TestCase):
       with self.assertRaises(ValueError):
         load_custom_callable(user_file, "no_such_function")
 
-  @pytest.mark.cpu_only
   def test_does_not_pollute_sys_path(self):
     """Loading the file must not append its directory to sys.path."""
     sys_path_before = list(sys.path)
@@ -114,7 +109,6 @@ class LoadCustomCallableTest(unittest.TestCase):
       load_custom_callable(user_file, "process_data")
     self.assertEqual(sys.path, sys_path_before)
 
-  @pytest.mark.cpu_only
   def test_does_not_pollute_sys_modules_globally(self):
     """The loaded module gets a unique synthetic name; it should not shadow
     other modules with a generic name like 'user_processor'."""

--- a/tests/post_training/unit/rl_hooks_test.py
+++ b/tests/post_training/unit/rl_hooks_test.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 import pytest
 
-pytestmark = [pytest.mark.cpu_only, pytest.mark.post_training]
+pytestmark = [pytest.mark.post_training]
 
 from maxtext.trainers.post_train.rl import hooks as rl_hooks
 from maxtext.trainers.post_train.rl import utils_rl

--- a/tests/post_training/unit/rl_lr_schedule_test.py
+++ b/tests/post_training/unit/rl_lr_schedule_test.py
@@ -108,7 +108,6 @@ def _effective_lr_at_step(opt, step):
 class RLLearningRateScheduleTest(unittest.TestCase):
   """Schedule-shape guards for utils_rl.get_optimizer built on a real config."""
 
-  @pytest.mark.cpu_only
   def test_default_rl_config_warms_up_within_run(self):
     """REGRESSION GUARD (FAILS on PR #4029, passes once fixed).
 
@@ -143,7 +142,6 @@ class RLLearningRateScheduleTest(unittest.TestCase):
         ),
     )
 
-  @pytest.mark.cpu_only
   def test_explicit_schedule_steps_decouples_from_run_length(self):
     """FEATURE GUARD (passes before and after the fix).
 
@@ -173,7 +171,6 @@ class RLLearningRateScheduleTest(unittest.TestCase):
     self.assertLessEqual(_effective_lr_at_step(opt, 20), 0.4 * peak)
     self.assertGreaterEqual(_effective_lr_at_step(opt, int(0.1 * schedule_len) + 5), 0.9 * peak)
 
-  @pytest.mark.cpu_only
   def test_validator_overwrites_minus_one_sentinel(self):
     """ROOT-CAUSE characterization (effective-value assertion).
 

--- a/tests/post_training/unit/rl_utils_test.py
+++ b/tests/post_training/unit/rl_utils_test.py
@@ -46,7 +46,6 @@ def _make_config():
 class TestProcessAnswer(unittest.TestCase):
   """Tests for utils_rl.process_answer."""
 
-  @pytest.mark.cpu_only
   def test_for_mcq(self):
     self.assertEqual(len(utils_rl.process_answer("(A) 1\n(B) 2\n(C) 3\n", "B", "MCQ")), 2)
     self.assertEqual(len(utils_rl.process_answer("A. 1\nB. 2\n(C) 3\n", "B", "MCQ")), 2)
@@ -59,34 +58,29 @@ class TestProcessAnswer(unittest.TestCase):
 class TestNormalizeFinalAnswer(unittest.TestCase):
   """Tests for utils_rl.normalize_final_answer."""
 
-  @pytest.mark.cpu_only
   def test_comma_boxed_and_currency(self):
     # Comma-separated numbers, \\boxed{}, and leading $ are all normalized to plain integers
     self.assertEqual(utils_rl.normalize_final_answer("1,000"), "1000")
     self.assertEqual(utils_rl.normalize_final_answer("$1,000"), "1000")
     self.assertEqual(utils_rl.normalize_final_answer("\\boxed{1,000}"), "1000")
 
-  @pytest.mark.cpu_only
   def test_equation_splitting_and_unit_removal(self):
     # Expressions with '=' are split on '='; trailing unit words are stripped
     self.assertEqual(utils_rl.normalize_final_answer("x = 10"), "10")
     self.assertEqual(utils_rl.normalize_final_answer("total = 100 meters"), "100")
     self.assertEqual(utils_rl.normalize_final_answer("42 mph"), "42")
 
-  @pytest.mark.cpu_only
   def test_latex_wrappers(self):
     # \\text{}, \\textbf{}, and \\overline{} wrappers are removed, leaving inner content
     self.assertEqual(utils_rl.normalize_final_answer("\\text{hello}"), "hello")
     self.assertEqual(utils_rl.normalize_final_answer("\\textbf{42}"), "42")
     self.assertEqual(utils_rl.normalize_final_answer("\\overline{AB}"), "AB")
 
-  @pytest.mark.cpu_only
   def test_dollar_math_extraction(self):
     # Content inside $...$ is extracted
     self.assertEqual(utils_rl.normalize_final_answer("The answer is $\\frac{1}{2}$"), "\\frac{1}{2}")
     self.assertEqual(utils_rl.normalize_final_answer("The answer is 3 $\\frac{1}{2}$"), "3\\frac{1}{2}")
 
-  @pytest.mark.cpu_only
   def test_shorthand_frac_and_sqrt(self):
     # Shorthand \\fracab and \\sqrta are expanded to their full LaTeX forms
     self.assertEqual(utils_rl.normalize_final_answer("\\fracab"), "\\frac{a}{b}")
@@ -107,27 +101,22 @@ class TestMatchFormatApproximatelyScores(unittest.TestCase):
   def _score(self, completion):
     return utils_rl.match_format_approximately(None, completion, self.config)
 
-  @pytest.mark.cpu_only
   def test_score_all_tags_present_exactly_once(self):
     # All four tags present exactly once -> 4 * 0.5 = 2.0
     self.assertEqual(self._score(["<reasoning>think</reasoning><answer>42</answer>"])[0], 2.0)
 
-  @pytest.mark.cpu_only
   def test_score_no_tags_present(self):
     # No tags at all -> 4 * -0.5 = -2.0
     self.assertEqual(self._score(["The answer is 42."])[0], -2.0)
 
-  @pytest.mark.cpu_only
   def test_score_only_answer_tags_present(self):
     # Only <answer>...</answer> present -> 2 * 0.5 + 2 * -0.5 = 0.0
     self.assertEqual(self._score(["<answer>42</answer>"])[0], 0.0)
 
-  @pytest.mark.cpu_only
   def test_score_duplicate_reasoning_start_tag(self):
     # Duplicate <reasoning> tag -> 3 * 0.5 + 1 * -0.5 = 1.0
     self.assertEqual(self._score(["<reasoning><reasoning>think</reasoning><answer>42</answer>"])[0], 1.0)
 
-  @pytest.mark.cpu_only
   def test_score_multiple_completions(self):
     # Multiple completions at once -> one score per entry
     multi_completions = [
@@ -164,7 +153,6 @@ class TestCheckNumbers(unittest.TestCase):
   # Scenario 1: regex extraction succeeds / fails
   # ---------------------------------------------------------------
 
-  @pytest.mark.cpu_only
   def test_extraction_succeeds_full_format(self):
     """Full <reasoning>…</reasoning><answer>…</answer> format allows extraction."""
     scores = self._check(
@@ -173,7 +161,6 @@ class TestCheckNumbers(unittest.TestCase):
     )
     self.assertEqual(scores[0], self.config.reward_exact_answer)
 
-  @pytest.mark.cpu_only
   def test_extraction_fails_no_tags(self):
     """Plain-text completion without any tags yields score 0 (cannot extract)."""
     scores = self._check(
@@ -182,7 +169,6 @@ class TestCheckNumbers(unittest.TestCase):
     )
     self.assertEqual(scores[0], self.config.penalty_incorrect_format)
 
-  @pytest.mark.cpu_only
   def test_extraction_fails_answer_tags_only(self):
     """<answer> tag alone (no <reasoning> block) is matched by the regex as a fallback, score 1.5."""
     scores = self._check(
@@ -191,7 +177,6 @@ class TestCheckNumbers(unittest.TestCase):
     )
     self.assertEqual(scores[0], self.config.reward_exact_answer)
 
-  @pytest.mark.cpu_only
   def test_extraction_fails_reasoning_tags_only(self):
     """<reasoning> block with no <answer> tag cannot be extracted, score 0."""
     scores = self._check(
@@ -200,7 +185,6 @@ class TestCheckNumbers(unittest.TestCase):
     )
     self.assertEqual(scores[0], self.config.penalty_incorrect_format)
 
-  @pytest.mark.cpu_only
   def test_extraction_batch_mixed(self):
     """Batch with one extractable and one non-extractable completion."""
     scores = self._check(
@@ -213,7 +197,6 @@ class TestCheckNumbers(unittest.TestCase):
     self.assertEqual(scores[0], self.config.reward_exact_answer)
     self.assertEqual(scores[1], self.config.penalty_incorrect_format)
 
-  @pytest.mark.cpu_only
   def test_extraction_for_mcq(self):
     """Batch with two multiple-choice questions and one single-answer question."""
     scores = self._check(
@@ -232,7 +215,6 @@ class TestCheckNumbers(unittest.TestCase):
   # Scenario 2: extraction succeeds, value matches/mismatches the answer
   # ---------------------------------------------------------------
 
-  @pytest.mark.cpu_only
   def test_extracted_matches_integer_answer(self):
     """Extracted integer equal to reference answer earns 1.5."""
     scores = self._check(
@@ -241,7 +223,6 @@ class TestCheckNumbers(unittest.TestCase):
     )
     self.assertEqual(scores[0], self.config.reward_exact_answer)
 
-  @pytest.mark.cpu_only
   def test_extracted_does_not_match_answer(self):
     """Extracted number that differs from the reference answer earns 0.0."""
     scores = self._check(
@@ -250,7 +231,6 @@ class TestCheckNumbers(unittest.TestCase):
     )
     self.assertEqual(scores[0], self.config.penalty_incorrect_answer)
 
-  @pytest.mark.cpu_only
   def test_extracted_matches_comma_formatted_number(self):
     """Comma-formatted guess (e.g. '1,000') normalizes to match integer answer '1000'."""
     scores = self._check(
@@ -259,7 +239,6 @@ class TestCheckNumbers(unittest.TestCase):
     )
     self.assertEqual(scores[0], self.config.reward_exact_answer)
 
-  @pytest.mark.cpu_only
   def test_extracted_matches_with_currency_prefix(self):
     """Leading '$' in extracted answer is normalized away before comparison."""
     scores = self._check(
@@ -268,7 +247,6 @@ class TestCheckNumbers(unittest.TestCase):
     )
     self.assertEqual(scores[0], self.config.reward_exact_answer)
 
-  @pytest.mark.cpu_only
   def test_extracted_non_numeric_no_match(self):
     """Non-numeric extraction that cannot be float-converted and does not math-verify returns 0."""
     scores = self._check(
@@ -281,14 +259,12 @@ class TestCheckNumbers(unittest.TestCase):
 class TestExtractHashAnswer(unittest.TestCase):
   """Tests for utils_rl.extract_hash_answer."""
 
-  @pytest.mark.cpu_only
   def test_with_hash(self):
     """Test extraction when #### is present."""
     self.assertEqual(utils_rl.extract_hash_answer("The answer is #### 42"), "42")
     self.assertEqual(utils_rl.extract_hash_answer("Some reasoning ####   123.45  "), "123.45")
     self.assertEqual(utils_rl.extract_hash_answer("####"), "")
 
-  @pytest.mark.cpu_only
   def test_without_hash(self):
     """Test extraction when #### is not present."""
     self.assertIsNone(utils_rl.extract_hash_answer("The answer is 42"))
@@ -309,7 +285,6 @@ class TestGetOptimizer(unittest.TestCase):
         train_steps=100,
     )
 
-  @pytest.mark.cpu_only
   def test_returns_optimizer_without_clipping(self):
     """get_optimizer returns an optax optimizer when gradient clipping is disabled."""
     import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
@@ -321,7 +296,6 @@ class TestGetOptimizer(unittest.TestCase):
     state = opt.init(params)
     self.assertIn("learning_rate", state.hyperparams)
 
-  @pytest.mark.cpu_only
   def test_returns_optimizer_with_clipping(self):
     """get_optimizer includes gradient clipping when threshold > 0."""
     import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
@@ -344,7 +318,6 @@ class TestFormatMaxTextMessages(unittest.TestCase):
         "TEMPLATE": "system: {system_prompt}\nquestion: {question}",
     }
 
-  @pytest.mark.cpu_only
   def test_format_with_template(self):
     """Test formatting when a template is provided."""
     messages = ["What is 2+2?"]
@@ -358,7 +331,6 @@ class TestFormatMaxTextMessages(unittest.TestCase):
     )
     self.assertEqual(formatted[0]["content"], expected_content)
 
-  @pytest.mark.cpu_only
   def test_format_without_template(self):
     """Test formatting when template_config is None (the fix)."""
     messages = ["What is 2+2?"]

--- a/tests/post_training/unit/sft_data_processing_test.py
+++ b/tests/post_training/unit/sft_data_processing_test.py
@@ -15,7 +15,7 @@
 """Data processing tests for SFT."""
 import pytest
 
-pytestmark = [pytest.mark.post_training, pytest.mark.cpu_only]
+pytestmark = [pytest.mark.post_training]
 
 import subprocess
 import unittest

--- a/tests/post_training/unit/sft_hooks_test.py
+++ b/tests/post_training/unit/sft_hooks_test.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 pytest.importorskip("tunix")
-pytestmark = [pytest.mark.cpu_only, pytest.mark.external_training, pytest.mark.post_training]
+pytestmark = [pytest.mark.external_training, pytest.mark.post_training]
 
 import jax
 from jax.sharding import Mesh

--- a/tests/post_training/unit/train_dpo_test.py
+++ b/tests/post_training/unit/train_dpo_test.py
@@ -26,7 +26,6 @@ pytestmark = [pytest.mark.post_training]
 class TrainDPOTest(unittest.TestCase):
   """Tests for train_dpo.py."""
 
-  @pytest.mark.cpu_only
   def test_validate_config_valid(self):
     config = SimpleNamespace(
         optimizer_memory_host_offload=False,
@@ -35,7 +34,6 @@ class TrainDPOTest(unittest.TestCase):
     # Should not raise any exception
     train_dpo.validate_config(config)
 
-  @pytest.mark.cpu_only
   def test_validate_config_invalid_offload(self):
     config = SimpleNamespace(
         optimizer_memory_host_offload=True,
@@ -44,7 +42,6 @@ class TrainDPOTest(unittest.TestCase):
     with self.assertRaisesRegex(ValueError, "optimizer_memory_host_offload=True is not supported"):
       train_dpo.validate_config(config)
 
-  @pytest.mark.cpu_only
   def test_validate_config_invalid_vocab_tiling(self):
     config = SimpleNamespace(
         optimizer_memory_host_offload=False,

--- a/tests/post_training/unit/train_rl_test.py
+++ b/tests/post_training/unit/train_rl_test.py
@@ -42,7 +42,6 @@ def _get_mock_devices(devices_per_slice, num_slices=1):
 class TrainRLTest(unittest.TestCase):
   """Tests for train_rl.py."""
 
-  @pytest.mark.cpu_only
   def test_rl_config_includes_decoder_engram_defaults(self):
     """RL models must expose Engram fields consumed by the shared decoder."""
     config = types.RLConfig(model_name="gemma4-26b")
@@ -50,7 +49,6 @@ class TrainRLTest(unittest.TestCase):
     self.assertEqual(config.engram_layers, [])
     self.assertEqual(config.engram_max_ngram_size, 3)
 
-  @pytest.mark.cpu_only
   def test_setup_configs_and_devices_pathways_split(self):
     """Test setup_configs_and_devices with multiple VMs and Pathways."""
     mock_devices = _get_mock_devices(8)
@@ -83,7 +81,6 @@ class TrainRLTest(unittest.TestCase):
       self.assertEqual(trainer_devices, mock_devices[:4])
       self.assertEqual(sampler_devices, mock_devices[4:])
 
-  @pytest.mark.cpu_only
   def test_setup_configs_and_devices_pathways_fractional_split(self):
     """Test setup_configs_and_devices with multiple VMs and custom fractions."""
     mock_devices = _get_mock_devices(8)
@@ -113,7 +110,6 @@ class TrainRLTest(unittest.TestCase):
       self.assertEqual(trainer_devices, mock_devices[:2])
       self.assertEqual(sampler_devices, mock_devices[2:])
 
-  @pytest.mark.cpu_only
   def test_setup_configs_and_devices_multislice_not_enough_slices(self):
     """Test setup_configs_and_devices raises ValueError when not enough slices."""
     mock_devices = _get_mock_devices(num_slices=2, devices_per_slice=4)
@@ -138,7 +134,6 @@ class TrainRLTest(unittest.TestCase):
       with self.assertRaisesRegex(ValueError, "Not enough slices for trainer and samplers"):
         model_creation_utils.setup_configs_and_devices(["dummy", "dummy"], config_class=types.RLConfig)
 
-  @pytest.mark.cpu_only
   def test_setup_configs_and_devices_multislice_invalid_tp(self):
     """Test setup_configs_and_devices raises ValueError for invalid TP."""
     mock_devices = _get_mock_devices(num_slices=4, devices_per_slice=8)
@@ -165,7 +160,6 @@ class TrainRLTest(unittest.TestCase):
       with self.assertRaisesRegex(ValueError, "must be divisible by tensor parallelism"):
         model_creation_utils.setup_configs_and_devices(["dummy", "dummy"], config_class=types.RLConfig)
 
-  @pytest.mark.cpu_only
   def test_setup_configs_and_devices_multislice_invalid_tp_fsdp(self):
     """Test setup_configs_and_devices raises ValueError for inconsistent TP and FSDP."""
     mock_devices = _get_mock_devices(num_slices=4, devices_per_slice=8)
@@ -192,7 +186,6 @@ class TrainRLTest(unittest.TestCase):
       with self.assertRaisesRegex(ValueError, "must equal devices_per_slice"):
         model_creation_utils.setup_configs_and_devices(["dummy", "dummy"], config_class=types.RLConfig)
 
-  @pytest.mark.cpu_only
   def test_get_rollout_kwargs_no_dp(self):
     """Test case 1: sampler_config.rollout_data_parallelism=-1 -> verify result is calculated."""
     # num_sampler_devices=16, tp=2, ep=4 -> dp should be 16 // (2 * 4) = 2
@@ -211,7 +204,6 @@ class TrainRLTest(unittest.TestCase):
         expected_result,
     )
 
-  @pytest.mark.cpu_only
   def test_get_rollout_kwargs_auto_tp(self):
     """Test case 2: dp=2, tp=-1, num_sampler_devices=4."""
     sampler_config = SimpleNamespace(
@@ -229,7 +221,6 @@ class TrainRLTest(unittest.TestCase):
         expected_result,
     )
 
-  @pytest.mark.cpu_only
   def test_get_rollout_kwargs_fixed_tp_dp(self):
     """Test case 3: dp=2, tp=2, num_sampler_devices=4."""
     sampler_config = SimpleNamespace(
@@ -247,7 +238,6 @@ class TrainRLTest(unittest.TestCase):
         expected_result,
     )
 
-  @pytest.mark.cpu_only
   def test_get_rollout_kwargs_auto_ep(self):
     """Test case 4: ep=-1 -> verify result is calculated."""
     # num_sampler_devices=8, tp=2, dp=2 -> ep should be 8 // (2 * 2) = 2
@@ -266,7 +256,6 @@ class TrainRLTest(unittest.TestCase):
         expected_result,
     )
 
-  @pytest.mark.cpu_only
   def test_get_rollout_kwargs_errors(self):
     """Test various error cases for get_rollout_kwargs_for_parallelism."""
     # More than one -1
@@ -314,7 +303,6 @@ class TrainRLTest(unittest.TestCase):
     with self.assertRaisesRegex(ValueError, r"!= len\(sampler_devices\)"):
       train_rl.get_rollout_kwargs_for_parallelism(sampler_config, 8)
 
-  @pytest.mark.cpu_only
   def test_prompt_filtering(self):
     """Test that prompts longer than max_prefill_predict_length are filtered out."""
     # Setup mocks
@@ -412,7 +400,6 @@ class TrainRLTest(unittest.TestCase):
       self.assertEqual(len(test_batch["prompts"]), 1)
       self.assertEqual(test_batch["prompts"][0], "short")
 
-  @pytest.mark.cpu_only
   @mock.patch("datasets.load_dataset")
   def test_prepare_datasets_with_split(self, mock_load):
     mock_ds = mock.MagicMock()
@@ -465,7 +452,6 @@ class TrainRLTest(unittest.TestCase):
     total_test_examples = sum(len(batch["question"]) for batch in test_batches)
     assert total_test_examples == 1
 
-  @pytest.mark.cpu_only
   @mock.patch("datasets.load_dataset")
   def test_prepare_datasets_without_split(self, mock_load):
     mock_ds = mock.MagicMock()
@@ -514,7 +500,6 @@ class TrainRLTest(unittest.TestCase):
     mock_load.assert_has_calls(expected_calls, any_order=True)
     assert mock_load.call_count == len(expected_calls)
 
-  @pytest.mark.cpu_only
   def test_build_reward_fns_defaults_when_no_custom(self):
     """With neither knob set, the built-in 3-fn stack is returned."""
     trainer_config = SimpleNamespace(reward_functions_path="", reward_functions="")
@@ -528,7 +513,6 @@ class TrainRLTest(unittest.TestCase):
         ],
     )
 
-  @pytest.mark.cpu_only
   def test_build_reward_fns_custom_replaces_builtins(self):
     """When both knobs are set, the stack is the user-provided functions only."""
     trainer_config = SimpleNamespace(
@@ -548,7 +532,6 @@ class TrainRLTest(unittest.TestCase):
         ]
     )
 
-  @pytest.mark.cpu_only
   def test_build_reward_fns_partial_config_falls_back(self):
     """If only one of the two knobs is set, the built-in stack is used."""
     trainer_config = SimpleNamespace(reward_functions_path="/tmp/my_rewards.py", reward_functions="")
@@ -559,7 +542,6 @@ class TrainRLTest(unittest.TestCase):
 class TokenizerChatTemplateTest(unittest.TestCase):
   """Unit tests for configure_tokenizer_chat_template."""
 
-  @pytest.mark.cpu_only
   def test_chat_template_populated_from_config_string(self):
     """Test that chat_template is set from config.chat_template when tokenizer lacks one."""
     mock_tokenizer = mock.MagicMock()
@@ -572,7 +554,6 @@ class TokenizerChatTemplateTest(unittest.TestCase):
     train_rl.configure_tokenizer_chat_template(mock_tokenizer, trainer_config)
     self.assertEqual(mock_tokenizer.chat_template, "{{ messages[0].content }}")
 
-  @pytest.mark.cpu_only
   @mock.patch("maxtext.input_pipeline.instruction_data_processing.load_chat_template_from_file")
   def test_chat_template_populated_from_config_file(self, mock_load):
     """Test that chat_template is loaded from chat_template_path when tokenizer lacks one."""
@@ -591,7 +572,6 @@ class TokenizerChatTemplateTest(unittest.TestCase):
         "{% for message in messages %}{{ message.content }}{% endfor %}",
     )
 
-  @pytest.mark.cpu_only
   def test_chat_template_raises_value_error_when_empty(self):
     """Test that ValueError is raised when tokenizer lacks chat_template and both config options are empty."""
     mock_tokenizer = mock.MagicMock()
@@ -604,7 +584,6 @@ class TokenizerChatTemplateTest(unittest.TestCase):
     with self.assertRaisesRegex(ValueError, "Tokenizer 'dummy-base-model' has no chat_template"):
       train_rl.configure_tokenizer_chat_template(mock_tokenizer, trainer_config)
 
-  @pytest.mark.cpu_only
   def test_chat_template_unchanged_when_already_exists(self):
     """Test that an existing chat_template on the tokenizer is preserved (backward compatibility)."""
     mock_tokenizer = mock.MagicMock()
@@ -617,7 +596,6 @@ class TokenizerChatTemplateTest(unittest.TestCase):
     train_rl.configure_tokenizer_chat_template(mock_tokenizer, trainer_config)
     self.assertEqual(mock_tokenizer.chat_template, "{{ existing_template }}")
 
-  @pytest.mark.cpu_only
   def test_apply_chat_template_works_after_configuration(self):
     """Verifies apply_chat_template succeeds and produces the expected format after our code path runs."""
 

--- a/tests/post_training/unit/train_sft_test.py
+++ b/tests/post_training/unit/train_sft_test.py
@@ -27,7 +27,6 @@ pytestmark = [pytest.mark.post_training]
 class TrainSFTTest(unittest.TestCase):
   """Tests for train_sft.py."""
 
-  @pytest.mark.cpu_only
   def test_validate_config_valid(self):
     config = SimpleNamespace(
         optimizer_memory_host_offload=False,
@@ -35,7 +34,6 @@ class TrainSFTTest(unittest.TestCase):
     # Should not raise any exception
     train_sft.validate_config(config)
 
-  @pytest.mark.cpu_only
   def test_validate_config_invalid_offload(self):
     config = SimpleNamespace(
         optimizer_memory_host_offload=True,
@@ -43,7 +41,6 @@ class TrainSFTTest(unittest.TestCase):
     with self.assertRaisesRegex(ValueError, "optimizer_memory_host_offload=True is not supported"):
       train_sft.validate_config(config)
 
-  @pytest.mark.cpu_only
   def test_train_model_caching_moe(self):
     """Test that NNX graph caching is disabled for MoE models (num_experts > 1)."""
     mt_config = SimpleNamespace(
@@ -64,7 +61,6 @@ class TrainSFTTest(unittest.TestCase):
         cache_nnx_graph=False,
     )
 
-  @pytest.mark.cpu_only
   def test_train_model_caching_dense(self):
     """Test that NNX graph caching is enabled for dense models (num_experts <= 1)."""
     mt_config = SimpleNamespace(

--- a/tests/post_training/unit/tunix_adapter_test.py
+++ b/tests/post_training/unit/tunix_adapter_test.py
@@ -70,7 +70,6 @@ class TunixAdapterSegmentIdsTest(unittest.TestCase):
 
     self.base = _CallableStubBase()
 
-  @pytest.mark.cpu_only
   def test_synthesizes_segment_ids_when_pad_id_set_and_seg_ids_none(self):
     """pad_id is set + caller passes decoder_segment_ids=None -> adapter
     synthesizes segment_ids = (input_tokens != pad_id)."""
@@ -91,7 +90,6 @@ class TunixAdapterSegmentIdsTest(unittest.TestCase):
     np.testing.assert_array_equal(np.asarray(seg), np.asarray(expected))
     self.assertEqual(seg.dtype, jnp.int32)
 
-  @pytest.mark.cpu_only
   def test_does_not_synthesize_when_pad_id_is_none(self):
     """pad_id omitted -> adapter forwards decoder_segment_ids=None unchanged
     (backward-compatibility for callers that don't set pad_id)."""
@@ -104,7 +102,6 @@ class TunixAdapterSegmentIdsTest(unittest.TestCase):
 
     self.assertIsNone(self.base.captured["decoder_segment_ids"])
 
-  @pytest.mark.cpu_only
   def test_passes_through_explicit_segment_ids_unchanged(self):
     """Caller-provided decoder_segment_ids should pass through verbatim
     regardless of pad_id."""
@@ -118,7 +115,6 @@ class TunixAdapterSegmentIdsTest(unittest.TestCase):
 
     np.testing.assert_array_equal(np.asarray(self.base.captured["decoder_segment_ids"]), np.asarray(explicit_seg))
 
-  @pytest.mark.cpu_only
   def test_returns_logits_and_none_tuple(self):
     """Adapter's __call__ contract: return (logits, None) to match Tunix's
     expected interface."""

--- a/tests/post_training/unit/vllm_rollout_unroll_test.py
+++ b/tests/post_training/unit/vllm_rollout_unroll_test.py
@@ -16,7 +16,6 @@
 
 import unittest
 import numpy as np
-import pytest
 
 from maxtext.integration.vllm.maxtext_vllm_rollout import unroll_gemma_scanned_weights
 
@@ -34,14 +33,12 @@ class MockWeights:
 class GemmaScannedWeightsUnrollTest(unittest.TestCase):
   """Verify the correctness of the unroll_gemma_scanned_weights utility."""
 
-  @pytest.mark.cpu_only
   def test_bypasses_non_pytree_weights(self):
     """If the weights object doesn't have `to_pure_dict`, it should be returned unchanged."""
     raw_weights = {"dummy": np.ones(5)}
     result = unroll_gemma_scanned_weights(raw_weights)
     self.assertIs(result, raw_weights)
 
-  @pytest.mark.cpu_only
   def test_bypasses_non_scanned_checkpoints(self):
     """If the checkpoint is not scanned (no 'layers_0' inside 'decoder/layers/'), return unchanged."""
     pure_dict = {
@@ -56,7 +53,6 @@ class GemmaScannedWeightsUnrollTest(unittest.TestCase):
     result = unroll_gemma_scanned_weights(weights)
     self.assertIs(result, weights)
 
-  @pytest.mark.cpu_only
   def test_correctly_unrolls_gemma_scanned_weights(self):
     """Verify that scanned layers are properly interleaved and mapped, and remainder layers are appended."""
     # Pattern length = 2 (layers_0 and layers_1)
@@ -131,7 +127,6 @@ class GemmaScannedWeightsUnrollTest(unittest.TestCase):
     np.testing.assert_array_equal(decoder_dict["layers_0"]["attn"]["wq"], np.array([[9], [9]]))
     np.testing.assert_array_equal(decoder_dict["layers_2"]["attn"]["wq"], np.array([[9], [9]]))
 
-  @pytest.mark.cpu_only
   def test_correctly_unrolls_gemma3_gemma4_scanned_blocks(self):
     """Verify that scanned layers under scanned_blocks are properly interleaved and mapped."""
     arr0 = np.zeros((2, 3, 1))

--- a/tests/unit/compile_cache_test.py
+++ b/tests/unit/compile_cache_test.py
@@ -34,7 +34,6 @@ To debug:
 import os
 import tempfile
 import shutil
-import pytest
 import subprocess
 import sys
 
@@ -44,7 +43,6 @@ from tests.utils.test_helpers import (
 )
 
 
-@pytest.mark.cpu_only
 def test_train_step_cache_hit():
   temp_dir = tempfile.mkdtemp()
   _base_output_directory = get_test_base_output_directory()

--- a/tests/unit/dequantize_pack_quantized_int4_test.py
+++ b/tests/unit/dequantize_pack_quantized_int4_test.py
@@ -25,7 +25,6 @@ Not run in GitHub runners (depends on torch + compressed_tensors).
 """
 
 import unittest
-import pytest
 import torch
 
 from compressed_tensors.compressors.quantized_compressors.pack_quantized import (
@@ -54,7 +53,6 @@ def _quantize_per_group(w_fp32: torch.Tensor, group_size: int = INT4_GROUP_SIZE)
   return w_int.reshape(out_features, in_features), scale.squeeze(-1)
 
 
-@pytest.mark.cpu_only
 class DequantizePackQuantizedInt4Test(unittest.TestCase):
 
   def setUp(self):

--- a/tests/unit/estimator_test.py
+++ b/tests/unit/estimator_test.py
@@ -17,7 +17,6 @@ These tests verify the proper functioning of MaxText estimator.
 """
 
 import unittest
-import pytest
 from unittest.mock import MagicMock, patch
 import os
 
@@ -47,7 +46,6 @@ class TestRematEstimator(unittest.TestCase):
     self.tensor_names = ["context", "mlpwo"]
     self.base_argv = (None, os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"))
 
-  @pytest.mark.cpu_only
   def test_policy_to_dict_conversion(self):
     """Verify the Action enum correctly maps to MaxText string flags."""
     policy = RematPolicy(self.tensor_names, initial_level=Action.REMAT)
@@ -57,7 +55,6 @@ class TestRematEstimator(unittest.TestCase):
     policy.tensors["context"] = Action.DEVICE
     self.assertEqual(policy.to_dict["context"], "device")
 
-  @pytest.mark.cpu_only
   def test_next_policy_logic(self):
     """
     Verify that next_policy moves through actions incrementally
@@ -76,19 +73,16 @@ class TestRematEstimator(unittest.TestCase):
     same_p = next_p.previous_policy()
     self.assertEqual(same_p.tensors["mlpwo"], Action.REMAT)
 
-  @pytest.mark.cpu_only
   def test_policy_terminal_state(self):
     """Verify next_policy returns None when no more upgrades are possible."""
     policy = RematPolicy(self.tensor_names, initial_level=Action.DEVICE)
     self.assertIsNone(policy.next_policy())
 
-  @pytest.mark.cpu_only
   def test_previous_policy_terminal_state(self):
     """Verify previous_policy returns None when no more downgrades are possible."""
     policy = RematPolicy(self.tensor_names, initial_level=Action.REMAT)
     self.assertIsNone(policy.previous_policy())
 
-  @pytest.mark.cpu_only
   def test_find_pdb_scalar(self):
     """Verify pdb_scalar ignores data/fsdp axes and multiplies parallelism axes."""
     mock_config = MagicMock()
@@ -101,7 +95,6 @@ class TestRematEstimator(unittest.TestCase):
     # Only "tensor" is left -> scalar should be 4.0
     self.assertEqual(scalar, 4.0)
 
-  @pytest.mark.cpu_only
   @patch("maxtext.utils.estimator.is_oom")
   def test_largest_batch_size_binary_search(self, mock_is_oom):
     """
@@ -119,7 +112,6 @@ class TestRematEstimator(unittest.TestCase):
     result = largest_batch_size(self.base_argv, policy, min_pdb=1.0, max_pdb=8.0, pdb_scalar=1.0)
     self.assertEqual(result, 4.0)
 
-  @pytest.mark.cpu_only
   @patch("maxtext.utils.estimator.is_oom")
   def test_largest_batch_size_min_equals_max_no_oom(self, mock_is_oom):
     """When min_pdb == max_pdb and it does NOT OOM, return that batch size."""
@@ -128,7 +120,6 @@ class TestRematEstimator(unittest.TestCase):
     result = largest_batch_size(self.base_argv, policy, min_pdb=4.0, max_pdb=4.0, pdb_scalar=1.0)
     self.assertEqual(result, 4.0)
 
-  @pytest.mark.cpu_only
   @patch("maxtext.utils.estimator.is_oom")
   def test_largest_batch_size_min_equals_max_oom(self, mock_is_oom):
     """When min_pdb == max_pdb and it DOES OOM, return below min."""
@@ -137,21 +128,18 @@ class TestRematEstimator(unittest.TestCase):
     result = largest_batch_size(self.base_argv, policy, min_pdb=4.0, max_pdb=4.0, pdb_scalar=1.0)
     self.assertEqual(result, 3.0)
 
-  @pytest.mark.cpu_only
   def test_largest_batch_size_zero_scalar(self):
     """Verify ValueError is raised when pdb_scalar is zero."""
     policy = RematPolicy(self.tensor_names)
     with self.assertRaises(ValueError):
       largest_batch_size(self.base_argv, policy, min_pdb=1.0, max_pdb=8.0, pdb_scalar=0.0)
 
-  @pytest.mark.cpu_only
   def test_largest_batch_size_invalid_range(self):
     """Verify ValueError when max_pdb < min_pdb."""
     policy = RematPolicy(self.tensor_names)
     with self.assertRaises(ValueError):
       largest_batch_size(self.base_argv, policy, min_pdb=8.0, max_pdb=4.0, pdb_scalar=1.0)
 
-  @pytest.mark.cpu_only
   @patch("maxtext.utils.estimator.is_oom")
   def test_largest_batch_size_default_min_pdb(self, mock_is_oom):
     """Verify min_pdb defaults to 1/pdb_scalar when None."""
@@ -161,7 +149,6 @@ class TestRematEstimator(unittest.TestCase):
     # min_pdb defaults to 1/4 = 0.25; since no OOM at max, result should be 8.0
     self.assertEqual(result, 8.0)
 
-  @pytest.mark.cpu_only
   def test_build_argv_default_layer_input(self):
     """Ensure decoder_layer_input=device is added if not present."""
     policy = RematPolicy(["context"], initial_level=Action.REMAT)
@@ -171,7 +158,6 @@ class TestRematEstimator(unittest.TestCase):
     self.assertIn("per_device_batch_size=2", argv)
     self.assertIn("context=remat", argv)
 
-  @pytest.mark.cpu_only
   def test_build_argv_with_existing_layer_input(self):
     """Ensure decoder_layer_input is NOT added when already present."""
     base = self.base_argv[1:] + ("decoder_layer_input=offload",)
@@ -183,7 +169,6 @@ class TestRematEstimator(unittest.TestCase):
     self.assertEqual(count, 1)
     self.assertIn("decoder_layer_input=offload", argv)
 
-  @pytest.mark.cpu_only
   def test_build_argv_with_dict_policy(self):
     """Ensure build_argv works with a dict policy (as stored in Mode 2 results)."""
     policy_dict = {"context": "remat", "mlpwo": "offload"}
@@ -194,7 +179,6 @@ class TestRematEstimator(unittest.TestCase):
     self.assertIn("mlpwo=offload", argv)
     self.assertIn("per_device_batch_size=4", argv)
 
-  @pytest.mark.cpu_only
   def test_priority_list_generation(self):
     """Test that generate_priority_list pulls the correct key from config."""
     mock_config = MagicMock()
@@ -214,7 +198,6 @@ class TestRematEstimator(unittest.TestCase):
     self.assertIn("mlpwi_0", plist)
     self.assertIn("mlpwi_1", plist)
 
-  @pytest.mark.cpu_only
   def test_get_parameter_value_found(self):
     """Verify get_parameter_value finds a matching prefix."""
     config = ("foo=bar", "per_device_batch_size=4", "baz=qux")
@@ -222,7 +205,6 @@ class TestRematEstimator(unittest.TestCase):
     self.assertTrue(found)
     self.assertEqual(value, "4")
 
-  @pytest.mark.cpu_only
   def test_get_parameter_value_not_found(self):
     """Verify get_parameter_value returns (False, None) when not found."""
     config = ("foo=bar", "baz=qux")
@@ -230,7 +212,6 @@ class TestRematEstimator(unittest.TestCase):
     self.assertFalse(found)
     self.assertIsNone(value)
 
-  @pytest.mark.cpu_only
   def test_find_batch_size_provided(self):
     """Verify find_batch_size returns the batch size when present."""
     argv = ("base.yml", "per_device_batch_size=2.5", "model_name=llama")
@@ -238,7 +219,6 @@ class TestRematEstimator(unittest.TestCase):
     self.assertTrue(provided)
     self.assertEqual(pdb, 2.5)
 
-  @pytest.mark.cpu_only
   def test_find_batch_size_not_provided(self):
     """Verify find_batch_size returns (False, None) when not present."""
     argv = ("base.yml", "model_name=llama")
@@ -246,7 +226,6 @@ class TestRematEstimator(unittest.TestCase):
     self.assertFalse(provided)
     self.assertIsNone(pdb)
 
-  @pytest.mark.cpu_only
   def test_find_remat_policy_tensor_names(self):
     """Verify tensor names are detected from argv."""
     argv = ("base.yml", "context=offload", "mlpwo=remat", "model_name=llama")
@@ -255,14 +234,12 @@ class TestRematEstimator(unittest.TestCase):
     self.assertIn("mlpwo", result)
     self.assertNotIn("query_proj", result)
 
-  @pytest.mark.cpu_only
   def test_find_remat_policy_tensor_names_none(self):
     """Verify empty list when no tensor names in argv."""
     argv = ("base.yml", "model_name=llama")
     result = find_remat_policy_tensor_names(argv)
     self.assertEqual(result, [])
 
-  @pytest.mark.cpu_only
   def test_generate_remat_config_from_policy(self):
     """Verify generate_remat_config works with a RematPolicy object."""
     policy = RematPolicy(["context", "mlpwo"], initial_level=Action.REMAT)
@@ -271,7 +248,6 @@ class TestRematEstimator(unittest.TestCase):
     self.assertIn("context=remat", config)
     self.assertIn("mlpwo=remat", config)
 
-  @pytest.mark.cpu_only
   def test_generate_remat_config_from_dict(self):
     """Verify generate_remat_config works with a dict."""
     policy_dict = {"context": "offload", "mlpwo": "device"}
@@ -280,13 +256,11 @@ class TestRematEstimator(unittest.TestCase):
     self.assertIn("context=offload", config)
     self.assertIn("mlpwo=device", config)
 
-  @pytest.mark.cpu_only
   def test_generate_pdb_config(self):
     """Verify generate_pdb_config returns the expected tuple."""
     result = generate_pdb_config(4.0)
     self.assertEqual(result, ("per_device_batch_size=4.0",))
 
-  @pytest.mark.cpu_only
   @patch("maxtext.utils.estimator.is_oom")
   def test_search_policy_only_finds_fitting_policy(self, mock_is_oom):
     """Verify search_policy_only returns the first non-OOM policy."""
@@ -315,7 +289,6 @@ class TestRematEstimator(unittest.TestCase):
     # Result should be a RematPolicy that fits
     self.assertIsInstance(result, RematPolicy)
 
-  @pytest.mark.cpu_only
   @patch("maxtext.utils.estimator.is_oom")
   def test_search_policy_only_raises_on_impossible_batch(self, mock_is_oom):
     """Verify search_policy_only raises ValueError when full remat OOMs."""
@@ -324,7 +297,6 @@ class TestRematEstimator(unittest.TestCase):
     with self.assertRaises(ValueError):
       search_policy_only(self.tensor_names, self.base_argv, pdb=999.0)
 
-  @pytest.mark.cpu_only
   @patch("maxtext.utils.estimator.is_oom")
   def test_search_returns_pareto_frontier(self, mock_is_oom):
     """Verify search returns a list of (pdb, dict) tuples."""
@@ -350,7 +322,6 @@ class TestRematEstimator(unittest.TestCase):
       # pdb should be > 0 (valid)
       self.assertGreater(pdb, 0)
 
-  @pytest.mark.cpu_only
   def test_next_previous_policy_full_traversal(self):
     """Verify we can traverse from full remat to full device and back."""
     names = ["a", "b"]

--- a/tests/unit/flop_calculation_test.py
+++ b/tests/unit/flop_calculation_test.py
@@ -16,7 +16,6 @@
 
 from typing import Any
 import unittest
-import pytest
 from unittest.mock import MagicMock
 from absl.testing import parameterized
 
@@ -26,7 +25,6 @@ from maxtext.utils.maxtext_utils import calculate_tflops_training_per_device
 from tests.utils.test_helpers import get_test_config_path
 
 
-@pytest.mark.cpu_only
 class FlopCalculation(parameterized.TestCase):
   """Tests for verifying FLOP calculation in MaxText"""
 

--- a/tests/unit/gcloud_stub_test.py
+++ b/tests/unit/gcloud_stub_test.py
@@ -23,13 +23,10 @@ import os
 import unittest
 from unittest import mock
 
-import pytest
-
 from maxtext.common import gcloud_stub
 from maxtext.utils import gcs_utils
 
 
-@pytest.mark.cpu_only
 class GCloudStubTest(unittest.TestCase):
   # pylint: disable=protected-access
 

--- a/tests/unit/gcs_utils_test.py
+++ b/tests/unit/gcs_utils_test.py
@@ -18,13 +18,11 @@ import unittest
 from unittest import mock
 import os
 import tempfile
-import pytest
 
 # Module to be tested
 from maxtext.utils import gcs_utils
 
 
-@pytest.mark.cpu_only
 class GcsUtilsTest(unittest.TestCase):
   """Unit tests for GCS utility functions."""
 

--- a/tests/unit/gemma4_layers_test.py
+++ b/tests/unit/gemma4_layers_test.py
@@ -46,7 +46,6 @@ except ImportError:
   HAS_TORCH = False
 
 pytestmark = [
-    pytest.mark.cpu_only,
     pytest.mark.scheduled_only,
     pytest.mark.skipif(not HAS_TORCH, reason="Torch or transformers not available"),
 ]

--- a/tests/unit/grain_data_processing_test.py
+++ b/tests/unit/grain_data_processing_test.py
@@ -181,7 +181,6 @@ class _GrainArrayRecordSetup:
     return pyconfig.initialize([sys.argv[0], get_test_config_path()], **kwargs)
 
 
-@pytest.mark.cpu_only
 class GrainArrayRecordProcessingTest(
     _GrainArrayRecordSetup, GrainDeterminismMixin, GrainBaseProcessingTest, unittest.TestCase
 ):
@@ -202,7 +201,6 @@ class GrainArrayRecordProcessingTest(
     super().test_batch_determinism()
 
 
-@pytest.mark.cpu_only
 class GrainArrayRecordProcessingWithMultiSourceBlendingTest(
     _GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase
 ):
@@ -213,7 +211,6 @@ class GrainArrayRecordProcessingWithMultiSourceBlendingTest(
     self.config = self._make_config(grain_train_files=train_files_weighted)
 
 
-@pytest.mark.cpu_only
 class GrainArrayRecordProcessingWithMixtureConfigTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
 
   def setUp(self):
@@ -273,7 +270,6 @@ class GrainArrayRecordAutoTuneTest(_GrainArrayRecordSetup, GrainBaseProcessingTe
     self.config = self._make_config(grain_ram_budget_mb=512, grain_worker_count=-1)  # Enable auto-tuning
 
 
-@pytest.mark.cpu_only
 class GrainArrayRecordTiktokenTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with tiktoken tokenizer."""
 
@@ -285,7 +281,6 @@ class GrainArrayRecordTiktokenTest(_GrainArrayRecordSetup, GrainBaseProcessingTe
     )
 
 
-@pytest.mark.cpu_only
 class GrainArrayRecordHFTokenizerTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with HuggingFace tokenizer."""
 
@@ -297,7 +292,6 @@ class GrainArrayRecordHFTokenizerTest(_GrainArrayRecordSetup, GrainBaseProcessin
     )
 
 
-@pytest.mark.cpu_only
 class GrainArrayRecordBestFitPackingTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with best_fit packing strategy."""
 
@@ -387,7 +381,6 @@ class _GrainParquetSetup:
     return pyconfig.initialize([sys.argv[0], get_test_config_path()], **kwargs)
 
 
-@pytest.mark.cpu_only
 class GrainParquetProcessingTest(_GrainParquetSetup, GrainDeterminismMixin, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with Parquet format.
 
@@ -526,7 +519,6 @@ class _GrainTFRecordSetup:
     return pyconfig.initialize([sys.argv[0], get_test_config_path()], **kwargs)
 
 
-@pytest.mark.cpu_only
 class GrainTFRecordProcessingTest(_GrainTFRecordSetup, GrainDeterminismMixin, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with TFRecord format.
 
@@ -541,7 +533,6 @@ class GrainTFRecordProcessingTest(_GrainTFRecordSetup, GrainDeterminismMixin, Gr
     super().setUpClass()
 
 
-@pytest.mark.cpu_only
 class GrainTFRecordPreTokenizedProcessingTest(_GrainTFRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with a pre-tokenized TFRecord dataset (tokenize_train_data=False).
 
@@ -561,7 +552,6 @@ class GrainTFRecordPreTokenizedProcessingTest(_GrainTFRecordSetup, GrainBaseProc
     )
 
 
-@pytest.mark.cpu_only
 class GrainFewerFilesThanHostsTest(_GrainTFRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Tests data loading when file count < dataloading_host_count.
 

--- a/tests/unit/hf_data_processing_test.py
+++ b/tests/unit/hf_data_processing_test.py
@@ -19,7 +19,6 @@ import unittest
 import os.path
 
 import jax
-import pytest
 from jax.sharding import Mesh
 from jax.experimental import mesh_utils
 
@@ -31,7 +30,6 @@ from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from tests.utils.test_helpers import get_test_config_path, get_test_base_output_directory
 
 
-@pytest.mark.cpu_only
 class HfDataProcessingTest(unittest.TestCase):
 
   def setUp(self):

--- a/tests/unit/input_pipeline_utils_test.py
+++ b/tests/unit/input_pipeline_utils_test.py
@@ -14,13 +14,11 @@
 
 """Unit tests for input_pipeline_utils."""
 
-import pytest
 import unittest
 
 from maxtext.input_pipeline.input_pipeline_utils import compute_file_sharding
 
 
-@pytest.mark.cpu_only
 class ComputeFileShardingNormalCaseTest(unittest.TestCase):
   """file_count >= host_count: disjoint file subsets, no row sharding."""
 

--- a/tests/unit/kernels_test.py
+++ b/tests/unit/kernels_test.py
@@ -109,7 +109,6 @@ class RaggedAttentionTest(unittest.TestCase):
     )
 
 
-@pytest.mark.cpu_only
 class RaggedAttentionCpuTest(unittest.TestCase):
   """Tests for ragged attention kernel on CPU (interpret mode)."""
 

--- a/tests/unit/managed_mldiagnostics_test.py
+++ b/tests/unit/managed_mldiagnostics_test.py
@@ -18,10 +18,8 @@ import unittest
 from unittest import mock
 
 from maxtext.common.managed_mldiagnostics import ManagedMLDiagnostics, mldiag
-import pytest
 
 
-@pytest.mark.cpu_only
 class ManagedMLDiagnosticsTest(unittest.TestCase):
   # pylint: disable=protected-access
 

--- a/tests/unit/marker_propagation_test.py
+++ b/tests/unit/marker_propagation_test.py
@@ -16,10 +16,40 @@
 
 import functools
 import unittest
+from unittest import mock
 
 from absl.testing import parameterized
 import jax
-import pytest
+
+from tests.conftest import pytest_collection_modifyitems
+
+
+class FakeMarker:
+  """Fake pytest marker for testing."""
+
+  def __init__(self, name):
+    self.name = name
+
+
+class FakeItem:
+  """Fake pytest item for testing."""
+
+  def __init__(self, name, marker_names):
+    self.nodeid = f"test_file.py::{name}"
+    self.name = name
+    self._markers = [FakeMarker(m) for m in marker_names]
+    self.added_markers = []
+
+  def iter_markers(self):
+    return iter(self._markers + self.added_markers)
+
+  def add_marker(self, marker):
+    if hasattr(marker, "name"):
+      self.added_markers.append(marker)
+    elif hasattr(marker, "mark"):
+      self.added_markers.append(marker.mark)
+    else:
+      self.added_markers.append(marker)
 
 
 def dummy_decorator(func):
@@ -35,7 +65,6 @@ def dummy_decorator(func):
 class MarkerPropagationTest(parameterized.TestCase):
   """Validates that pytest markers propagate correctly through decorator stacks."""
 
-  @pytest.mark.cpu_only
   @parameterized.named_parameters(
       {"testcase_name": "default", "unused": None},
   )
@@ -46,7 +75,6 @@ class MarkerPropagationTest(parameterized.TestCase):
     assert not has_tpu, "cpu_only parameterized test accidentally executed on TPU hardware"
     assert not has_gpu, "cpu_only parameterized test accidentally executed on GPU hardware"
 
-  @pytest.mark.cpu_only
   @dummy_decorator
   def test_standard_decorator_cpu_only_marker_propagation(self):
     """Verifies cpu_only marker above standard decorators propagates correctly."""
@@ -54,6 +82,34 @@ class MarkerPropagationTest(parameterized.TestCase):
     has_gpu = any(d.platform == "gpu" for d in jax.devices())
     assert not has_tpu, "cpu_only standard decorated test accidentally executed on TPU hardware"
     assert not has_gpu, "cpu_only standard decorated test accidentally executed on GPU hardware"
+
+  def test_auto_apply_cpu_only_marker(self):
+    """Verifies cpu_only is auto-applied to tests without explicit hardware markers."""
+    item_no_markers = FakeItem("test_no_markers", [])
+    item_other_marker = FakeItem("test_other_marker", ["scheduled_only", "integration_test"])
+    item_tpu = FakeItem("test_tpu", ["tpu_only"])
+    item_gpu = FakeItem("test_gpu", ["gpu_only"])
+    item_tpu_backend = FakeItem("test_tpu_backend", ["tpu_backend"])
+    item_cpu = FakeItem("test_cpu", ["cpu_only"])
+
+    items = [item_no_markers, item_other_marker, item_tpu, item_gpu, item_tpu_backend, item_cpu]
+    mock_config = mock.MagicMock()
+
+    with (
+        mock.patch("tests.conftest.get_changed_tests", return_value=set()),
+        mock.patch("tests.conftest._has_tpu_backend_support", return_value=True),
+    ):
+      pytest_collection_modifyitems(mock_config, items)
+
+    def get_added_names(item):
+      return [m.name if hasattr(m, "name") else str(m) for m in item.added_markers]
+
+    self.assertIn("cpu_only", get_added_names(item_no_markers))
+    self.assertIn("cpu_only", get_added_names(item_other_marker))
+    self.assertIn("cpu_only", get_added_names(item_tpu_backend))
+    self.assertNotIn("cpu_only", get_added_names(item_tpu))
+    self.assertNotIn("cpu_only", get_added_names(item_gpu))
+    self.assertNotIn("cpu_only", get_added_names(item_cpu))
 
 
 if __name__ == "__main__":

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -1150,7 +1150,6 @@ class TestGetFunctionalEvalWithSignature(unittest.TestCase):
     self.assertEqual(len(in_shardings), 3)
 
 
-@pytest.mark.cpu_only
 class TestGetShapedBatch(unittest.TestCase):
   """Tests for get_shaped_batch."""
 
@@ -1761,7 +1760,6 @@ class TestKVCacheScanHelpers(unittest.TestCase):
       maxtext_utils.update_kv_caches_after_scan(kv_caches_tuple, returned_kv_cache, scan_length=1, block_len=2)
 
 
-@pytest.mark.cpu_only
 class TestGetSaveAndOffloadNames(unittest.TestCase):
   """Tests for maxtext_utils.get_save_and_offload_names (pure config logic, no device needed)."""
 

--- a/tests/unit/newly_added_detection_test.py
+++ b/tests/unit/newly_added_detection_test.py
@@ -16,14 +16,10 @@
 
 import textwrap
 
-import pytest
-
 from tests.utils.newly_added_detection import _build_diff_commands
 from tests.utils.newly_added_detection import _is_test_file
 from tests.utils.newly_added_detection import parse_changed_line_map
 from tests.utils.newly_added_detection import touched_test_names
-
-pytestmark = pytest.mark.cpu_only
 
 
 # --- _is_test_file -----------------------------------------------------------

--- a/tests/unit/nnx_scan_test.py
+++ b/tests/unit/nnx_scan_test.py
@@ -21,7 +21,6 @@ from flax import nnx
 import jax
 import jax.numpy as jnp
 import numpy as np
-import pytest
 
 from maxtext.layers import nnx_scan
 
@@ -35,7 +34,6 @@ class _LinearLayer(nnx.Module):
     return inputs @ self.kernel.value
 
 
-@pytest.mark.cpu_only
 class TestCreateScannedLayers(unittest.TestCase):
   """Tests for nnx_scan.create_scanned_layers."""
 
@@ -64,7 +62,6 @@ class TestCreateScannedLayers(unittest.TestCase):
     self.assertIsNone(layers)
 
 
-@pytest.mark.cpu_only
 class TestApplyScannedLayers(unittest.TestCase):
   """Tests for nnx_scan.apply_scanned_layers."""
 

--- a/tests/unit/quantizations_test.py
+++ b/tests/unit/quantizations_test.py
@@ -150,7 +150,6 @@ class QuantizationTest(unittest.TestCase):
       quant = _configure_quantization(quant_str="int8", mode_str=quant_mode, replicate_scale=True)
       self.assertEqual(quant.replicate_scale, True)
 
-  @pytest.mark.cpu_only
   def test_configure_quantization_is_int8(self):
     for quant_mode in ["train", "serve", "convert"]:
       quant = _configure_quantization(quant_str="int8", mode_str=quant_mode)

--- a/tests/unit/sharding_compare_test.py
+++ b/tests/unit/sharding_compare_test.py
@@ -112,7 +112,6 @@ def compare_sharding_jsons(json1: dict, model1_name: str, json2: dict, model2_na
 
 
 # Requires JAX TPU support to generate the simulated TPU topology.
-@pytest.mark.cpu_only
 @pytest.mark.tpu_backend
 @pytest.mark.parametrize("model_name, topology, num_slice, custom_mesh_and_rule, overrides", TEST_CASES)
 def test_sharding_dump_for_model(
@@ -274,7 +273,6 @@ def abstract_state_and_shardings(request):
   )
 
 
-@pytest.mark.cpu_only
 @pytest.mark.tpu_backend
 class TestGetAbstractState:
   """Test class for get_abstract_state function and sharding comparison."""

--- a/tests/unit/tfds_data_processing_test.py
+++ b/tests/unit/tfds_data_processing_test.py
@@ -33,7 +33,6 @@ from maxtext.input_pipeline import input_pipeline_interface
 from tests.utils.test_helpers import get_test_config_path, get_test_base_output_directory
 
 
-@pytest.mark.cpu_only
 class TfdsDataProcessingTest(unittest.TestCase):
 
   def setUp(self):

--- a/tests/unit/tokenizer_test.py
+++ b/tests/unit/tokenizer_test.py
@@ -21,7 +21,6 @@ from maxtext.trainers.tokenizer import train_tokenizer
 from maxtext.common.gcloud_stub import is_decoupled
 
 import unittest
-import pytest
 import subprocess
 import os
 
@@ -60,12 +59,10 @@ class TrainTokenizerTest(unittest.TestCase):
   def tearDownClass(cls):
     os.remove(cls.tokenizer_path)
 
-  @pytest.mark.tpu_only
   def test_tokenize(self):
     text = "This is a test"
     self.assertTrue(np.array_equal(self.source_tokenizer.encode(text), self.test_tokenizer.encode(text)))
 
-  @pytest.mark.tpu_only
   def test_detokenize(self):
     tokens = [66, 12, 10, 702]
     self.assertEqual(np.asarray(self.source_tokenizer.decode(tokens)), np.asarray(self.test_tokenizer.decode(tokens)))
@@ -86,13 +83,11 @@ class TikTokenTest(unittest.TestCase):
     )
     cls.dataset = train_tokenizer.build_grain_iterator(grain_train_files, "parquet")
 
-  @pytest.mark.tpu_only
   def test_tokenize(self):
     text = "This is a test"
     tokens = [2028, 374, 264, 1296]
     self.assertTrue(np.array_equal(self.source_tokenizer.encode(text), tokens))
 
-  @pytest.mark.tpu_only
   def test_detokenize(self):
     tokens = [2028, 374, 264, 1296]
     text = "This is a test"
@@ -118,7 +113,6 @@ class HFTokenizerTest(unittest.TestCase):
         os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "tokenizer.gemma"), "sentencepiece", add_bos=False, add_eos=False
     )
 
-  @pytest.mark.tpu_only
   def test_tokenize(self):
     text = "This is a test"
     self.assertTrue(np.array_equal(self.hf_tokenizer.encode(text), self.sp_tokenizer.encode(text)))

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -46,7 +46,6 @@ except Exception:  # pylint: disable=broad-exception-caught
 class TrainCompile(parameterized.TestCase):
   """Tests for the Ahead of Time Compilation functionality, train_compile.py"""
 
-  @pytest.mark.cpu_only
   def test_save_compiled_v4(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_v4.pickle")
@@ -63,7 +62,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_save_compiled_v5e(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_v5e.pickle")
@@ -82,7 +80,6 @@ class TrainCompile(parameterized.TestCase):
 
   # TODO (b/366200617) : This tests fails in AOT, but config works fine on real hardware
   @pytest.mark.skip(reason="Issue w/ kernels_test. Error: The TPU is already in use by process...")
-  @pytest.mark.cpu_only
   def test_minimal_offloaded_v5e(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_v5e_offload.pickle")
@@ -105,7 +102,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_save_flash(self):
     compiled_trainstep_file = "/tmp/test_save_flash"
     train_compile_main(
@@ -121,7 +117,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_save_compiled_v5p_two_slices(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_v5p_two_slices.pickle")
@@ -138,7 +133,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_save_compiled_v6e(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_v6e.pickle")
@@ -155,7 +149,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_save_compiled_tpu7x(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_tpu7x.pickle")
@@ -173,7 +166,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_save_compiled_tpu7x_two_slices(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_tpu7x_two_slices.pickle")
@@ -193,7 +185,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_remat_save_dot_except_mlpwi(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_remat_save_dot_except_mlpwi.pickle")
@@ -216,7 +207,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_remat_save_dot_except_mlp(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_remat_save_dot_except_mlp.pickle")
@@ -239,7 +229,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_remat_save_qkv_proj(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_remat_save_qkv_proj.pickle")
@@ -262,7 +251,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_remat_full(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_remat_full.pickle")
@@ -285,7 +273,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_custom_64x4_mesh(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_custom_64x4_mesh.pickle")
@@ -327,7 +314,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_custom_32x8_mesh(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_custom_32x8_mesh.pickle")
@@ -352,7 +338,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_dropping_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_dropping_bf16.pickle")
@@ -375,7 +360,6 @@ class TrainCompile(parameterized.TestCase):
     )
 
   @pytest.mark.skip(reason="b/400476456 Tests are currently flaking / failing due to JAX 0.5.1 upgrade")
-  @pytest.mark.cpu_only
   def test_moe_dropping_int8(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_dropping_int8.pickle")
@@ -399,7 +383,6 @@ class TrainCompile(parameterized.TestCase):
     )
 
   # TODO(b/388572320): Add int8 quantization test once this bug is fixed.
-  @pytest.mark.cpu_only
   def test_moe_megablox_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_megablox_bf16.pickle")
@@ -421,7 +404,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_megablox_ring_ep_random(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_megablox_ring_ep_random.pickle")
@@ -446,7 +428,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_ragged_dot_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_ragged_dot_bf16.pickle")
@@ -468,7 +449,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_dense_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_dense_bf16.pickle")
@@ -491,7 +471,6 @@ class TrainCompile(parameterized.TestCase):
     )
 
   @pytest.mark.skip(reason="b/400476456 Tests are currently flaking / failing due to JAX 0.5.1 upgrade")
-  @pytest.mark.cpu_only
   def test_moe_dense_int8(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_dense_int8.pickle")
@@ -514,7 +493,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_pp_bf16(self):
     cfg = pyconfig.initialize([None, get_test_config_path()])
     if getattr(cfg, "pure_nnx_decoder", False):
@@ -542,7 +520,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_deepseek_scanned_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_deepseek_scanned_bf16.pickle")
@@ -566,7 +543,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_emb_chunking(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_emb_chunking.pickle")
@@ -595,7 +571,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_emb_chunking_with_mlp_bias(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_emb_chunking_bias.pickle")
@@ -625,7 +600,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_deepseek_unscanned_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_deepseek_unscanned_bf16.pickle")
@@ -649,7 +623,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_deepseek_with_device_limit(self):
     compiled_trainstep_file = "/tmp/test_moe_deepseek_with_device_limit.pickle"
     train_compile_main(
@@ -673,7 +646,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_deepseek_pipeline_subset(self):
     cfg = pyconfig.initialize([None, get_test_config_path()])
     if getattr(cfg, "pure_nnx_decoder", False):
@@ -700,7 +672,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_pipeline_subset(self):
     cfg = pyconfig.initialize([None, get_test_config_path()])
     if getattr(cfg, "pure_nnx_decoder", False):
@@ -724,7 +695,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_llama4_17b_16e(self):
     compiled_trainstep_file = "/tmp/test_moe_llama4_17b_16e.pickle"
     train_compile_main(
@@ -745,7 +715,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_gpt_oss_20b_sparse_matmul(self):
     compiled_trainstep_file = "/tmp/test_moe_gpt_oss_20b_sparse_matmul.pickle"
     train_compile_main(
@@ -767,7 +736,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_moe_gpt_oss_20b_dense_matmul(self):
     compiled_trainstep_file = "/tmp/test_moe_gpt_oss_20b_dense_matmul.pickle"
     train_compile_main(
@@ -789,7 +757,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_gpt3_6b(self):
     compiled_trainstep_file = "/tmp/test_gpt3_6b"
     train_compile_main(
@@ -804,7 +771,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_qwen3_qk_norm(self):
     """AOT test for non-llama qk norm models"""
     compiled_trainstep_file = "/tmp/test_qwen3_qk_norm"
@@ -820,7 +786,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_qwen3_next(self):
     """AOT test for qwen3-next and GatedDeltaNet implementation"""
     compiled_trainstep_file = "/tmp/test_qwen3_next"
@@ -837,7 +802,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_deepseek32(self):
     # test deepseek3.2 with sparse attention
     compiled_trainstep_file = "/tmp/test_deepseek32.pickle"
@@ -891,7 +855,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_indexer_dense_warmup(self):
     # test deepseek3.2 with sparse attention
     compiled_trainstep_file = "/tmp/test_indexer_dense_warmup.pickle"
@@ -918,7 +881,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_indexer_sparse_training(self):
     # test deepseek3.2 with sparse attention
     compiled_trainstep_file = "/tmp/test_indexer_sparse_training.pickle"
@@ -944,7 +906,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_olmo3_7b(self):
     """AOT test for Olmo3 7B implementation"""
     compiled_trainstep_file = "/tmp/test_olmo3_7b"
@@ -962,7 +923,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_mhc_integration(self):
     """AOT test for Manifold-constrained Hyper Connection implementation"""
     compiled_trainstep_file = "/tmp/test_mhc_integration"
@@ -986,7 +946,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_engram_integration(self):
     """AOT test for Engram implementation"""
     compiled_trainstep_file = "/tmp/test_engram_integration"
@@ -1009,7 +968,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_circular_pipeline_ag_per_repeat_ep_ds(self):
     cfg = pyconfig.initialize([None, get_test_config_path()])
     if getattr(cfg, "pure_nnx_decoder", False):
@@ -1043,7 +1001,6 @@ class TrainCompile(parameterized.TestCase):
       {"testcase_name": "dot_product", "attention": "dot_product"},
       {"testcase_name": "tokamax_splash", "attention": "flash"},
   )
-  @pytest.mark.cpu_only
   def test_qk_clip(self, attention):
     """AOT test for AdamW optimizer with QK clip for DeepSeek3 Tiny model"""
     compiled_trainstep_file = "/tmp/test_qk_clip.pickle"
@@ -1076,7 +1033,6 @@ class TrainCompile(parameterized.TestCase):
       {"testcase_name": "consistent_rms_scaling", "muon_consistent_rms": 0.2},
       {"testcase_name": "width_scaling", "muon_consistent_rms": None},
   )
-  @pytest.mark.cpu_only
   def test_muon(self, muon_consistent_rms):
     """AOT test for Muon optimizer for DeepSeek3 Tiny model"""
     compiled_trainstep_file = "/tmp/test_muon.pickle"
@@ -1107,7 +1063,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_vocab_tiling_bf16(self):
     """test vocab_tiling when weight_dtype=bfloat16"""
     compiled_trainstep_file = "/tmp/test_vocab_tiling_bf16.pickle"
@@ -1126,7 +1081,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_qwen3_5(self):
     """AOT test for qwen3-5"""
     compiled_trainstep_file = "/tmp/test_qwen3_5"
@@ -1147,7 +1101,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_serialization_and_deserialization_formats(self):
     """Tests that our custom binary save/load functions work securely and legacy fallback triggers warning."""
 
@@ -1185,7 +1138,6 @@ class TrainCompile(parameterized.TestCase):
       assert loaded_legacy.startswith(b"\x80")
       assert loaded_legacy != serialized
 
-  @pytest.mark.cpu_only
   def test_zero1_optimizer_sharding(self):
     """AOT test for Zero-1 optimizer sharding (shard_optimizer_over_data)"""
     temp_dir = gettempdir()
@@ -1206,7 +1158,6 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
-  @pytest.mark.cpu_only
   def test_vocab_tiling_bf16_nnx(self):
     """AOT compile vocab tiling on the NNX path (vocab_tiling_nnx_loss + custom_vjp).
 

--- a/tests/unit/train_state_nnx_checkpoint_test.py
+++ b/tests/unit/train_state_nnx_checkpoint_test.py
@@ -30,7 +30,6 @@ from maxtext.common import checkpointing
 from maxtext.common import train_state_nnx
 import optax
 import orbax.checkpoint as ocp
-import pytest
 
 
 class MockModel(nnx.Module):
@@ -94,7 +93,6 @@ class TestEmergencyReplicatorCheckpointManager(unittest.TestCase):
     self.assertIs(kwargs["global_mesh"], mesh)
 
 
-@pytest.mark.cpu_only
 class TestTrainStateNNXCheckpoint(unittest.TestCase):
   """Class to test NNX checkpoint."""
 
@@ -333,7 +331,6 @@ class TestTrainStateNNXCheckpoint(unittest.TestCase):
       shutil.rmtree(temp_dir)
 
 
-@pytest.mark.cpu_only
 class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
   """Verify maybe_save_checkpoint's fallback step matches the last completed step.
 


### PR DESCRIPTION
# Description

This PR updates Pytest collection behavior in `tests/conftest.py` so that all collected tests are marked as `cpu_only` by default unless they explicitly specify a hardware marker (tpu_only, gpu_only, or tpu_backend).
Because `cpu_only` is now applied automatically to tests targeting CPU execution, explicit `@pytest.mark.cpu_only` decorators and module-level `pytestmark` entries have been removed across the test suite.

Fixes: [b/540415491](b/540415491)

# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
