### PR TITLE
Revert PR #4636: unconditionally update rollout params before pre-RL evaluation

### DIFF
--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -741,9 +741,13 @@ def _rl_train_impl(argv: Sequence[str], kwargs: dict):
 
   # Run evaluation before training
   if trainer_config.num_test_batches > 0:
-    # `rl_cluster.rollout.update_params()` is intentionally omitted prior to step 0
-    # because `RLCluster` initialization (`create_rl_components`) already syncs the actor model weights
-    # during setup. Skipping this redundant parameter transfer eliminates unnecessary weight resharding.
+    # Explicitly sync actor model weights to the rollout engine before Pre-RL evaluation.
+    # When resuming from an RL checkpoint (step > 0), the trainer restores RL checkpoint
+    # weights into actor_model after RLCluster initializes. Without this explicit sync,
+    # the rollout engine would evaluate using the base HuggingFace/SFT weights instead of
+    # the restored RL checkpoint weights. Calling this unconditionally ensures weight sync
+    # robustness across all initialization and restore workflows.
+    rl_cluster.rollout.update_params(nnx.state(actor_model, nnx.Param))
 
     (corr, total, accuracy, partial_accuracy, format_accuracy, mean_reward), _ = evaluate(
         trainer_config,


### PR DESCRIPTION
# Description

This PR fixes a regression introduced in PR #4636 where `rl_cluster.rollout.update_params` was removed prior to Pre-RL evaluation (step 0).

When running an RL training or evaluation job that resumes from a previously saved RL checkpoint (step > 0), omitting update_params causes Pre-RL evaluation to evaluate using the base HuggingFace/SFT checkpoint weights rather than the restored RL checkpoint weights.

This restores the skipped `rl_cluster.rollout.update_params`  and adds a comment that explains why this is needed.

There is a small difference from what the code looked like before PR #4636. Previously it was `rl_cluster.rollout.update_params(nnx.state(actor_model))`, now it is `rl_cluster.rollout.update_params(nnx.state(actor_model, nnx.Param))`. My JetSki claims that it is required to overcome `RuntimeError: Array has been deleted with shape=uint32[2]` exceptions raised due to  deletion of PRNG keys arrays from the model state.

# Tests

CI tests
A manual run of train_rl.py.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
