### PR TITLE
Support MLA TPU Tokamax ring attention

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -3610,8 +3610,13 @@ class MaxTextConfig(
         raise ValueError("TPU ring context parallelism requires use_tokamax_splash=True.")
       if self.use_jax_splash:
         raise ValueError("TPU ring context parallelism requires use_jax_splash=False.")
-      if self.attention_type != "global":
-        raise ValueError("TPU Tokamax ring attention is initially supported only for global causal attention.")
+      if self.attention_type not in ("global", "mla"):
+        raise ValueError("TPU Tokamax ring attention supports only attention_type='global' or 'mla'.")
+      if self.attention_type == "mla":
+        if self.packing:
+          raise ValueError("TPU Tokamax ring attention with MLA does not support packing yet.")
+        if self.use_batch_split_schedule:
+          raise ValueError("TPU Tokamax ring attention with MLA does not support the DeepSeek batch-split schedule.")
       if self.context_parallel_load_balance:
         if context_parallel_size % 2 != 0:
           raise ValueError("TPU Tokamax ring load balancing requires an even context_parallel_size.")

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -534,8 +534,13 @@ class AttentionOp(nnx.Module):
           raise ValueError("TPU Tokamax ring attention requires use_tokamax_splash=True.")
         if self.config.use_jax_splash:
           raise ValueError("TPU Tokamax ring attention requires use_jax_splash=False.")
-        if self.attention_type != AttentionType.GLOBAL:
-          raise ValueError("TPU Tokamax ring attention is initially supported only for global causal attention.")
+        if self.attention_type not in (AttentionType.GLOBAL, AttentionType.MLA):
+          raise ValueError("TPU Tokamax ring attention supports only attention_type='global' or 'mla'.")
+        if self.attention_type == AttentionType.MLA:
+          if self.config.packing:
+            raise ValueError("TPU Tokamax ring attention with MLA does not support packing yet.")
+          if self.config.use_batch_split_schedule:
+            raise ValueError("TPU Tokamax ring attention with MLA does not support the DeepSeek batch-split schedule.")
 
         context_axis = self.config.context_sharding
         axis_names_q = self._logical_to_mesh_axes(self.flash_axis_names_q)

--- a/src/maxtext/models/deepseek.py
+++ b/src/maxtext/models/deepseek.py
@@ -24,7 +24,7 @@ import jax
 from jax.ad_checkpoint import checkpoint_name
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from maxtext.common.common_types import Config
+from maxtext.common.common_types import Config, AttentionType
 from maxtext.common.common_types import HyperConnectionType, MODEL_MODE_PREFILL, DecoderBlockType
 from maxtext.layers import attention_mla
 from maxtext.layers import initializers
@@ -149,7 +149,7 @@ class DeepSeekGenericLayer(nnx.Module):
           max_target_length=self.config.max_target_length,
           max_prefill_predict_length=self.config.max_prefill_predict_length,
           attention_kernel=self.config.attention,
-          attention_type=self.config.attention_type,
+          attention_type=AttentionType(self.config.attention_type),
           inputs_q_shape=self.dummy_inputs_shape,
           inputs_kv_shape=self.dummy_inputs_shape,
           mesh=mesh,

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -2308,6 +2308,219 @@ class MLATest(attention_test_util.MLATestBase):
         f" ici_expert_parallelism={ici_expert_parallelism}.",
     )
 
+  @parameterized.named_parameters(
+      {"testcase_name": "no_load_balance", "context_parallel_load_balance": False},
+      {"testcase_name": "load_balance", "context_parallel_load_balance": True},
+  )
+  @pytest.mark.tpu_only
+  def test_tpu_flash_attention_ring_context_parallel(self, context_parallel_load_balance):
+    """Test equivalence between dot_product and flash attention + ring context parallelism"""
+
+    config_arguments = {
+        "per_device_batch_size": 1.0,
+        "run_name": "test",
+        "enable_checkpointing": False,
+        "max_target_length": 512,
+        "sa_block_q": 128,
+        "sa_block_kv": 128,
+        "sa_block_kv_compute": 128,
+        "sa_block_q_dkv": 128,
+        "sa_block_kv_dkv": 128,
+        "sa_block_kv_dkv_compute": 128,
+        "attention_type": AttentionType.MLA.value,
+        "q_lora_rank": 4,
+        "kv_lora_rank": 4,
+        "qk_nope_head_dim": 128,
+        "qk_rope_head_dim": 64,
+        "v_head_dim": 128,
+        "dtype": "float32",
+    }
+
+    cfg, mla = self.init_mla(config_arguments, rope_type="default")
+    lnx, decoder_segment_ids, decoder_positions = self.get_data(cfg, cfg.dtype)
+    mla_generic_output, _ = mla(
+        lnx,
+        lnx,
+        decoder_segment_ids=decoder_segment_ids,
+        inputs_positions=decoder_positions,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    generic_state = nnx.state(mla)
+
+    cfg_cp = pyconfig.initialize(
+        [sys.argv[0], get_test_config_path()],
+        **config_arguments,
+        attention="flash",
+        rope_type=cfg.rope_type,
+        context_parallel_strategy="ring",
+        context_parallel_load_balance=context_parallel_load_balance,
+        ici_context_parallelism=2,
+        use_tokamax_splash=True,
+        use_jax_splash=False,
+        packing=False,
+    )
+    devices_array_cp = maxtext_utils.create_device_mesh(cfg_cp)
+    mesh_cp = Mesh(devices_array_cp, cfg_cp.mesh_axes)
+    with nn_partitioning.axis_rules(cfg_cp.logical_axis_rules):
+      attention_as_mla_flash_cp = MLA(
+          config=cfg_cp,
+          num_query_heads=cfg_cp.num_query_heads,
+          num_kv_heads=cfg_cp.num_kv_heads,
+          head_dim=cfg_cp.head_dim,
+          inputs_q_shape=lnx.shape,
+          inputs_kv_shape=lnx.shape,
+          max_target_length=cfg_cp.max_target_length,
+          max_prefill_predict_length=cfg_cp.max_prefill_predict_length,
+          mesh=mesh_cp,
+          attention_kernel="flash",
+          dtype=cfg_cp.dtype,
+          dropout_rate=cfg_cp.dropout_rate,
+          attention_type=AttentionType(cfg_cp.attention_type),
+          q_lora_rank=cfg_cp.q_lora_rank,
+          kv_lora_rank=cfg_cp.kv_lora_rank,
+          qk_nope_head_dim=cfg_cp.qk_nope_head_dim,
+          qk_rope_head_dim=cfg_cp.qk_rope_head_dim,
+          v_head_dim=cfg_cp.v_head_dim,
+          model_mode=MODEL_MODE_PREFILL,
+          rngs=self.nnx_rng,
+      )
+    nnx.update(attention_as_mla_flash_cp, generic_state)
+
+    mla_generic_flash_cp_output = attention_test_util.forward_with_context_expert_parallelism(
+        cfg_cp,
+        mesh_cp,
+        attention_as_mla_flash_cp,
+        lnx,
+        decoder_segment_ids,
+        decoder_positions,
+    )
+
+    mla_generic_output = jax.device_get(mla_generic_output)
+    mla_generic_flash_cp_output = jax.device_get(mla_generic_flash_cp_output)
+
+    self.assertTrue(
+        jax.numpy.allclose(mla_generic_output, mla_generic_flash_cp_output, rtol=1e-02, atol=1e-02, equal_nan=False),
+        msg="MLA logits from generic dot product and flash attention + ring context parallelism are not close. "
+        f"context_parallel_load_balance={context_parallel_load_balance}.",
+    )
+
+  @parameterized.named_parameters(
+      {"testcase_name": "no_load_balance", "context_parallel_load_balance": False},
+      {"testcase_name": "load_balance", "context_parallel_load_balance": True},
+  )
+  @pytest.mark.tpu_only
+  def test_tpu_flash_attention_ring_context_parallel_grad(self, context_parallel_load_balance):
+    """Test gradient equivalence between dot_product and flash attention + ring context parallelism"""
+
+    config_arguments = {
+        "per_device_batch_size": 1.0,
+        "run_name": "test",
+        "enable_checkpointing": False,
+        "max_target_length": 512,
+        "sa_block_q": 128,
+        "sa_block_kv": 128,
+        "sa_block_kv_compute": 128,
+        "sa_block_q_dkv": 128,
+        "sa_block_kv_dkv": 128,
+        "sa_block_kv_dkv_compute": 128,
+        "attention_type": AttentionType.MLA.value,
+        "q_lora_rank": 4,
+        "kv_lora_rank": 4,
+        "qk_nope_head_dim": 128,
+        "qk_rope_head_dim": 64,
+        "v_head_dim": 128,
+        "dtype": "float32",
+    }
+
+    cfg, mla = self.init_mla(config_arguments, rope_type="default")
+    lnx, decoder_segment_ids, decoder_positions = self.get_data(cfg, cfg.dtype)
+
+    cfg_cp = pyconfig.initialize(
+        [sys.argv[0], get_test_config_path()],
+        **config_arguments,
+        attention="flash",
+        rope_type=cfg.rope_type,
+        context_parallel_strategy="ring",
+        context_parallel_load_balance=context_parallel_load_balance,
+        ici_context_parallelism=2,
+        use_tokamax_splash=True,
+        use_jax_splash=False,
+        packing=False,
+    )
+    devices_array_cp = maxtext_utils.create_device_mesh(cfg_cp)
+    mesh_cp = Mesh(devices_array_cp, cfg_cp.mesh_axes)
+    with nn_partitioning.axis_rules(cfg_cp.logical_axis_rules):
+      attention_as_mla_flash_cp = MLA(
+          config=cfg_cp,
+          num_query_heads=cfg_cp.num_query_heads,
+          num_kv_heads=cfg_cp.num_kv_heads,
+          head_dim=cfg_cp.head_dim,
+          inputs_q_shape=lnx.shape,
+          inputs_kv_shape=lnx.shape,
+          max_target_length=cfg_cp.max_target_length,
+          max_prefill_predict_length=cfg_cp.max_prefill_predict_length,
+          mesh=mesh_cp,
+          attention_kernel="flash",
+          dtype=cfg_cp.dtype,
+          dropout_rate=cfg_cp.dropout_rate,
+          attention_type=AttentionType(cfg_cp.attention_type),
+          q_lora_rank=cfg_cp.q_lora_rank,
+          kv_lora_rank=cfg_cp.kv_lora_rank,
+          qk_nope_head_dim=cfg_cp.qk_nope_head_dim,
+          qk_rope_head_dim=cfg_cp.qk_rope_head_dim,
+          v_head_dim=cfg_cp.v_head_dim,
+          model_mode=MODEL_MODE_PREFILL,
+          rngs=self.nnx_rng,
+      )
+    nnx.update(attention_as_mla_flash_cp, nnx.state(mla))
+    generic_graphdef, generic_state = nnx.split(mla)
+    ring_graphdef, ring_state = nnx.split(attention_as_mla_flash_cp)
+
+    def generic_loss(lnx):
+      mla_merged = nnx.merge(generic_graphdef, generic_state)
+      output, _ = mla_merged(
+          lnx,
+          lnx,
+          decoder_segment_ids=decoder_segment_ids,
+          inputs_positions=decoder_positions,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.mean(output.astype(jnp.float32) ** 2)
+
+    def ring_loss(lnx):
+      if context_parallel_load_balance:
+        context_parallel_size = cfg_cp.ici_context_parallelism
+        lnx = max_utils.reorder_sequence(lnx, cp_size=context_parallel_size)
+        ring_decoder_segment_ids = max_utils.reorder_sequence(decoder_segment_ids, cp_size=context_parallel_size)
+        ring_decoder_positions = max_utils.reorder_sequence(decoder_positions, cp_size=context_parallel_size)
+      else:
+        ring_decoder_segment_ids = decoder_segment_ids
+        ring_decoder_positions = decoder_positions
+      ring_merged = nnx.merge(ring_graphdef, ring_state)
+      output, _ = ring_merged(
+          lnx,
+          lnx,
+          decoder_segment_ids=ring_decoder_segment_ids,
+          inputs_positions=ring_decoder_positions,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.mean(output.astype(jnp.float32) ** 2)
+
+    generic_grad = jax.grad(generic_loss)(lnx)
+    with jax.set_mesh(mesh_cp), nn_partitioning.axis_rules(cfg_cp.logical_axis_rules):
+      ring_grad = jax.grad(ring_loss)(lnx)
+    generic_grad = jax.device_get(generic_grad)
+    ring_grad = jax.device_get(ring_grad)
+
+    self.assertTrue(
+        jax.numpy.allclose(generic_grad, ring_grad, rtol=1e-02, atol=1e-06, equal_nan=False),
+        msg="MLA input gradients from generic dot product and flash attention + ring context parallelism are not close. "
+        f"context_parallel_load_balance={context_parallel_load_balance}.",
+    )
+
   def get_indexer_test_data(self, batch_size, q_len, kv_len, num_heads, head_dim):
     """Helper to generate random data for indexer tests."""
     key_q, key_k, key_is = jax.random.split(self.rng, 3)

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -145,6 +145,29 @@ class ConfigTest(absltest.TestCase):
 
     self.assertTrue(config.context_parallel_load_balance)
 
+  def test_tpu_tokamax_ring_config_validation_accepts_mla(self):
+    argv = [
+        "",
+        _BASE_CONFIG_PATH,
+        "run_name=test",
+        "attention=flash",
+        "attention_type=mla",
+        "use_tokamax_splash=True",
+        "use_jax_splash=False",
+        "context_parallel_strategy=ring",
+        "context_parallel_load_balance=False",
+        "ici_context_parallelism=2",
+        "hardware=tpu",
+        "packing=False",
+        "dataset_type=synthetic",
+        "skip_jax_distributed_system=True",
+    ]
+    mock_devices = [unittest.mock.MagicMock(slice_index=0) for _ in range(8)]
+    with unittest.mock.patch("jax.devices", return_value=mock_devices):
+      config = pyconfig.initialize(argv)
+
+    self.assertEqual(config.attention_type, "mla")
+
   def test_tpu_tokamax_ring_config_validation_accepts_packing(self):
     argv = [
         "",
@@ -213,7 +236,12 @@ class ConfigTest(absltest.TestCase):
         (["attention=dot_product"], ["attention=flash"], "attention=flash"),
         (["use_tokamax_splash=False"], ["use_tokamax_splash=True"], "use_tokamax_splash"),
         (["use_jax_splash=True"], ["use_jax_splash=False"], "use_jax_splash"),
-        (["attention_type=full"], [], "global causal"),
+        (["attention_type=full"], [], "attention_type"),
+        (["attention_type=local_sliding", "sliding_window_size=128"], [], "attention_type"),
+        (["attention_type=chunk", "chunk_attn_window_size=128"], [], "attention_type"),
+        (["attention_type=compressed"], [], "attention_type"),
+        (["attention_type=mla", "packing=True"], ["packing=False"], "packing"),
+        (["attention_type=mla", "use_batch_split_schedule=True"], [], "batch-split"),
         (
             [
                 "context_parallel_load_balance=True",


### PR DESCRIPTION
# Description

This PR extends support for TPU Ring attention CP (`context_parallel_strategy=ring`) to MLA architectures (such as DeepSeek-V2 / DeepSeek-V3 / DeepSeek-R1). This allows training MLA models at extended sequence lengths (e.g., `1M` tokens) by overlapping attention computation and collective comm across the context parallel mesh on TPU. Inherits load-balancing support from ring attention MHA.

FIXES: b/528396231

# Tests

1. PR Unit & Integration Tests: All unit and integration test passed verifying correctness, forward/backward pass execution, and numerical parity with `context_parallel_strategy=ring`.
2. E2E training: Tested synthetic pre-training on `deepseek3-671b` (modified with 12 decoder layers, 16 experts) at 256K seq len (`ici_context_parallelism=16`, `ici_fsdp_parallelism=8`) and 1M seq len (`ici_context_parallelism=128`) on TPU v5p-256, and on `deepseek2-16b` at 256K and 1M on TPU v5p-128 (see repro command below).

### Performance comparison
`deepseek2-16b`, TPU v5p-128:

| Seq len | all_gather | ring |
|---|---|---|
| 256K | 31.1% ([Xprof](http://xprof.corp.google.com/trace_viewer/htn-2308424751465145358)) | 31.8% ([Xprof](http://xprof.corp.google.com/trace_viewer/htn-14200900718499892882)) |
| 1M | - | 32.3% ([Xprof](http://xprof.corp.google.com/trace_viewer/htn-13045309889153651256)) |

`deepseek3-671b` (12 layers, 16 experts), TPU v5p-256:

| Seq len | all_gather | ring |
|---|---|---|
| 256K | - | 33.6% ([Xprof](http://xprof.corp.google.com/trace_viewer/htn-9302126885154977424)) |
| 1M | - | 29.1% ([Xprof](http://xprof.corp.google.com/trace_viewer/htn-13273187974083079988)) |

### Example run command

`deepseek3-671b` (12L/16E) at 256K on v5p-256:

```bash
export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=65472 --xla_tpu_use_enhanced_launch_barrier=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --xla_enable_async_collective_permute=true --xla_tpu_enable_sparse_core_collective_offload_all_reduce=true --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=true --xla_tpu_enable_sparse_core_collective_offload_3d_all_gather=true"

python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
  run_name=<name> base_output_directory=<gcs path> \
  model_name=deepseek3-671b override_model_config=true base_num_decoder_layers=12 num_experts=16 \
  dataset_type=synthetic enable_checkpointing=false \
  attention=flash use_tokamax_splash=true use_jax_splash=false \
  context_parallel_strategy=ring context_parallel_load_balance=true packing=false \
  dq_reduction_steps=3 remat_policy=full \
  sa_block_q=2048 sa_block_kv=2048 sa_block_q_dkv=2048 sa_block_kv_dkv=2048 \
  ici_tensor_parallelism=1 ici_expert_parallelism=1 ici_context_parallelism=16 ici_fsdp_parallelism=8 \
  per_device_batch_size=0.125 max_target_length=262144 steps=10 \
  profiler=xplane profiler_steps=3 skip_first_n_steps_for_profiler=3 upload_all_profiler_results=true 
```


- 1M on v5p-256: `max_target_length=1048576 ici_context_parallelism=128 ici_fsdp_parallelism=1 per_device_batch_size=0.015625`
- `deepseek2-16b` on v5p-128: `model_name=deepseek2-16b` (drop `override_model_config`, `base_num_decoder_layers`, `num_experts`); 256K: `ici_context_parallelism=16 ici_fsdp_parallelism=4`; 1M: `max_target_length=1048576 ici_context_parallelism=64 ici_fsdp_parallelism=1 per_device_batch_size=0.03125`

## Checklist 

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).