### PR TITLE
Avoid re-gathering vocab tiling output head in backward

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -703,6 +703,10 @@ num_slices: -1
 # reducing peak memory usage. This is highly recommended for models with large
 # vocabularies (e.g., Gemma). Set to a value greater than 1 to enable.
 num_vocab_tiling: 1
+# If set to true then all gather the output head weight once before the tiled loss so the backward
+# reuses it instead of re-gathering per chunk. Faster when steps are short enough to expose
+# the gathers; holds the gathered head in memory for the backward.
+vocab_tiling_ag_once: false
 
 # Tokenizer
 vocab_size: 32_000 # powers of 2 for sharding

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -587,6 +587,10 @@ class LogitsAndLoss(BaseModel):
       1,
       description="Enables memory-saving optimization by tiling cross-entropy loss computation. >1 to enable.",
   )
+  vocab_tiling_ag_once: bool = Field(
+      False,
+      description="All gather the output head weight once before the tiled loss so the backward reuses it.",
+  )
 
 
 class Attention(BaseModel):

--- a/src/maxtext/utils/vocabulary_tiling.py
+++ b/src/maxtext/utils/vocabulary_tiling.py
@@ -26,6 +26,8 @@ from maxtext.utils.sharding import (
     all_gather_over_fsdp,
     create_sharding,
     get_logical_axis_rules,
+    get_physical_spec_without_axes,
+    FSDP_MESH_AXES,
 )
 from maxtext.common.common_types import ShardMode
 from maxtext.utils import max_utils
@@ -350,14 +352,17 @@ def vocab_tiling_nnx_loss(model, hidden_states, data, config, is_train):
   # custom_vjp + lax.scan boundary, which fails for tied embeddings.
   graphdef, head_params, other_params, rest = nnx.split(model, _is_output_head_param_path, nnx.Param, ...)
 
-  # all gather only the embedding table
-  head_params = all_gather_over_fsdp(
-      head_params,
-      nnx.get_partition_spec(head_params),
-      model.mesh,
-      get_logical_axis_rules(),
-      config.shard_mode,
-  )
+  if config.vocab_tiling_ag_once:
+    # all gather the output head over the embed-sharding axes; doing it before
+    # the custom_vjp lets the backward reuse the gathered table instead of
+    # re-gathering it for every chunk
+    head_physical_spec = get_physical_spec_without_axes(
+        nnx.get_partition_spec(head_params),
+        model.mesh,
+        FSDP_MESH_AXES + ("context", "context_usp_ulysses", "expert"),
+        get_logical_axis_rules(),
+    )
+    head_params = maybe_shard_with_name(head_params, head_physical_spec, shard_mode=config.shard_mode)
 
   def _logits_for_chunk(chunk_head_params, chunk_other_params, chunk_rest, hidden_chunk):
     local_model = nnx.merge(graphdef, chunk_head_params, chunk_other_params, chunk_rest, copy=True)

--- a/src/maxtext/utils/vocabulary_tiling.py
+++ b/src/maxtext/utils/vocabulary_tiling.py
@@ -26,6 +26,8 @@ from maxtext.utils.sharding import (
     all_gather_over_fsdp,
     create_sharding,
     get_logical_axis_rules,
+    get_physical_spec_without_axes,
+    FSDP_MESH_AXES,
 )
 from maxtext.common.common_types import ShardMode
 from maxtext.utils import max_utils
@@ -350,14 +352,16 @@ def vocab_tiling_nnx_loss(model, hidden_states, data, config, is_train):
   # custom_vjp + lax.scan boundary, which fails for tied embeddings.
   graphdef, head_params, other_params, rest = nnx.split(model, _is_output_head_param_path, nnx.Param, ...)
 
-  # all gather only the embedding table
-  head_params = all_gather_over_fsdp(
-      head_params,
+  # all gather the output head over fsdp and context; doing it before the
+  # custom_vjp lets the backward reuse the gathered table instead of
+  # re-gathering it for every chunk
+  head_physical_spec = get_physical_spec_without_axes(
       nnx.get_partition_spec(head_params),
       model.mesh,
+      FSDP_MESH_AXES + ("context",),
       get_logical_axis_rules(),
-      config.shard_mode,
   )
+  head_params = maybe_shard_with_name(head_params, head_physical_spec, shard_mode=config.shard_mode)
 
   def _logits_for_chunk(chunk_head_params, chunk_other_params, chunk_rest, hidden_chunk):
     local_model = nnx.merge(graphdef, chunk_head_params, chunk_other_params, chunk_rest, copy=True)

--- a/tests/unit/tiling_test.py
+++ b/tests/unit/tiling_test.py
@@ -668,11 +668,13 @@ class VocabTilingNNXTest(unittest.TestCase):
       num_vocab_tiling=4,
       logits_via_embedding=False,
       z_loss_multiplier=1e-4,
+      ici_context_parallelism=1,
+      vocab_tiling_ag_once=False,
   ):
     """Build a pyconfig + matching NNX `Transformer` for the test."""
     cfg = pyconfig.initialize(
         self.base_config,
-        run_name=f"vt_nnx_n{num_vocab_tiling}_emb{logits_via_embedding}_z{z_loss_multiplier}",
+        run_name=f"vt_nnx_n{num_vocab_tiling}_emb{logits_via_embedding}_z{z_loss_multiplier}_cp{ici_context_parallelism}",
         enable_checkpointing=False,
         enable_dropout=False,
         max_target_length=self.seq_len,
@@ -683,6 +685,8 @@ class VocabTilingNNXTest(unittest.TestCase):
         matmul_precision="high",
         num_vocab_tiling=num_vocab_tiling,
         z_loss_multiplier=z_loss_multiplier,
+        ici_context_parallelism=ici_context_parallelism,
+        vocab_tiling_ag_once=vocab_tiling_ag_once,
         pure_nnx=True,
         enable_nnx=True,
         pure_nnx_decoder=True,
@@ -761,9 +765,14 @@ class VocabTilingNNXTest(unittest.TestCase):
     """grad wrapped in jit — see `_vg`."""
     return jax.jit(jax.grad(fn, argnums=argnums))
 
-  def _run_parity(self, *, logits_via_embedding):
+  def _run_parity(self, *, logits_via_embedding, ici_context_parallelism=1, vocab_tiling_ag_once=False):
     """Compare full-vocab xent loss/grads against the tiled custom_vjp path."""
-    cfg, model = self._build_cfg_and_model(num_vocab_tiling=4, logits_via_embedding=logits_via_embedding)
+    cfg, model = self._build_cfg_and_model(
+        num_vocab_tiling=4,
+        logits_via_embedding=logits_via_embedding,
+        ici_context_parallelism=ici_context_parallelism,
+        vocab_tiling_ag_once=vocab_tiling_ag_once,
+    )
     hidden_states, labels, segmentation = self._make_inputs(cfg)
     graphdef, params, rest = self._split_and_axes(cfg, model)
 
@@ -790,6 +799,11 @@ class VocabTilingNNXTest(unittest.TestCase):
   def test_nnx_vocab_tiling_tied_embedding(self):
     """custom_vjp parity when logits share the input embedding table."""
     self._run_parity(logits_via_embedding=True)
+
+  @pytest.mark.tpu_only
+  def test_nnx_vocab_tiling_gradient_context_parallelism(self):
+    """custom_vjp parity when the mesh shards the context axis."""
+    self._run_parity(logits_via_embedding=False, ici_context_parallelism=4, vocab_tiling_ag_once=True)
 
   # ---------- Coverage expansion ----------
 

--- a/tests/unit/tiling_test.py
+++ b/tests/unit/tiling_test.py
@@ -668,11 +668,12 @@ class VocabTilingNNXTest(unittest.TestCase):
       num_vocab_tiling=4,
       logits_via_embedding=False,
       z_loss_multiplier=1e-4,
+      ici_context_parallelism=1,
   ):
     """Build a pyconfig + matching NNX `Transformer` for the test."""
     cfg = pyconfig.initialize(
         self.base_config,
-        run_name=f"vt_nnx_n{num_vocab_tiling}_emb{logits_via_embedding}_z{z_loss_multiplier}",
+        run_name=f"vt_nnx_n{num_vocab_tiling}_emb{logits_via_embedding}_z{z_loss_multiplier}_cp{ici_context_parallelism}",
         enable_checkpointing=False,
         enable_dropout=False,
         max_target_length=self.seq_len,
@@ -683,6 +684,7 @@ class VocabTilingNNXTest(unittest.TestCase):
         matmul_precision="high",
         num_vocab_tiling=num_vocab_tiling,
         z_loss_multiplier=z_loss_multiplier,
+        ici_context_parallelism=ici_context_parallelism,
         pure_nnx=True,
         enable_nnx=True,
         pure_nnx_decoder=True,
@@ -761,9 +763,13 @@ class VocabTilingNNXTest(unittest.TestCase):
     """grad wrapped in jit — see `_vg`."""
     return jax.jit(jax.grad(fn, argnums=argnums))
 
-  def _run_parity(self, *, logits_via_embedding):
+  def _run_parity(self, *, logits_via_embedding, ici_context_parallelism=1):
     """Compare full-vocab xent loss/grads against the tiled custom_vjp path."""
-    cfg, model = self._build_cfg_and_model(num_vocab_tiling=4, logits_via_embedding=logits_via_embedding)
+    cfg, model = self._build_cfg_and_model(
+        num_vocab_tiling=4,
+        logits_via_embedding=logits_via_embedding,
+        ici_context_parallelism=ici_context_parallelism,
+    )
     hidden_states, labels, segmentation = self._make_inputs(cfg)
     graphdef, params, rest = self._split_and_axes(cfg, model)
 
@@ -790,6 +796,11 @@ class VocabTilingNNXTest(unittest.TestCase):
   def test_nnx_vocab_tiling_tied_embedding(self):
     """custom_vjp parity when logits share the input embedding table."""
     self._run_parity(logits_via_embedding=True)
+
+  @pytest.mark.tpu_only
+  def test_nnx_vocab_tiling_gradient_context_parallelism(self):
+    """custom_vjp parity when the mesh shards the context axis."""
+    self._run_parity(logits_via_embedding=False, ici_context_parallelism=4)
 
   # ---------- Coverage expansion ----------
 


### PR DESCRIPTION
# Description

Vocab tiling currently re-gathers the sharded output head for every backward chunk. This PR adds `vocab_tiling_ag_once` (default false) to gather the head once up front and reuse it in the backward, at the cost of keeping the gathered head in memory. Practitioners should use it when steps are short and memory is free, at long context it might not be needed since the gathers hide under the step anyway.


# Tests

- `python3 -m pytest tests/unit/tiling_test.py`: passed
- Flag on vs off on the same inputs and mesh: loss identical, max grad difference 2.4e-7


On v5p-128, Llama3.1-8B, synthetic data, num_vocab_tiling=16

| Config | Context | MFU off | MFU on | Peak HBM off | Peak HBM on |
|---|---|---|---|---|---|
| Llama3.1-8B, ring CP=16 | 64K | 60.1% | 60.9% | 50.2 GB | 54.6 GB |
| Llama3.1-8B, ring CP=16 | 256K | 59.2% | 59.0% | 49.2 GB | 54.7 GB |
| Llama3.1-8B (head_dim=256), ring CP=64 | 256K | 37.6% | 38.6% | 8.8 GB | 11.8 GB |
| Llama3.1-8B (head_dim=256), ring CP=64 | 1M | 43.0% | 43.0% | 26.2 GB | 31.9 GB |


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).