### PR TITLE
fix(ci): enable docker --init and add 500ms trap handlers for TPU runner lock release on cancellation

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -285,7 +285,7 @@ jobs:
       pytest_addopts: '--ignore=tests/post_training'
       xla_python_client_mem_fraction: 0.75
       tf_force_gpu_allow_growth: false
-      container_resource_option: "--privileged"
+      container_resource_option: "--init --privileged"
       is_scheduled_run: ${{ github.event_name == 'schedule' }}
       maxtext_sha: ${{ needs.gate_test_run.outputs.maxtext_sha }}
       total_workers: ${{ needs.gate_test_run.outputs.total_workers || '2' }}
@@ -308,7 +308,7 @@ jobs:
       pytest_addopts: '--ignore=tests/post_training --ignore=tests/integration/hlo_diff_test.py'
       xla_python_client_mem_fraction: 0.75
       tf_force_gpu_allow_growth: false
-      container_resource_option: "--privileged"
+      container_resource_option: "--init --privileged"
       is_scheduled_run: ${{ github.event_name == 'schedule' }}
       maxtext_sha: ${{ needs.gate_test_run.outputs.maxtext_sha }}
 

--- a/.github/workflows/run_pathways_tests.yml
+++ b/.github/workflows/run_pathways_tests.yml
@@ -105,6 +105,7 @@ jobs:
       - name: Copy test assets files
         run : gcloud storage cp gs://maxtext-test-assets/* tests/assets
       - name: Run Tests
+        shell: bash
         env:
           TOTAL_WORKERS: ${{ inputs.total_workers }}
           WORKER_GROUP: ${{ inputs.worker_group }}
@@ -113,6 +114,17 @@ jobs:
           PYTEST_ADDOPTS: ${{ inputs.pytest_addopts }}
           PYTHONPATH: "${{ github.workspace }}/src"
         run: |
+          # Cleanly release TPU device locks upon SIGTERM / PR cancellation
+          cleanup_tpu_locks() {
+            echo "Received cancellation signal; cleaning up /dev/accel* locks and /tmp/libtpu_lockfile..."
+            kill -9 "${PYTEST_PID:-}" 2>/dev/null || true
+            rm -f /tmp/libtpu_lockfile
+            fuser -k -9 /dev/accel* 2>/dev/null || true
+            sleep 0.5
+            exit 143
+          }
+          trap cleanup_tpu_locks TERM INT
+
           if [ "${TOTAL_WORKERS}" -gt 1 ]; then
             .venv/bin/python3 -m pip install --quiet pytest-split
             SPLIT_ARGS="--splits ${TOTAL_WORKERS} --group ${WORKER_GROUP}"
@@ -133,7 +145,9 @@ jobs:
           export MAXTEXT_TEST_ASSETS_ROOT=$(pwd)/tests/assets
           export MAXTEXT_PKG_DIR=$(pwd)/src/maxtext
           # TODO(b/454659463): Enable test_default_hlo_match after volume mount is supported.
-          .venv/bin/python3 -m pytest ${PYTEST_ADDOPTS} -v -m "${FINAL_PYTEST_MARKER}" -k "not AotHloIdenticalTest and not CompileThenLoad" --durations=0 ${SPLIT_ARGS}
+          .venv/bin/python3 -m pytest ${PYTEST_ADDOPTS} -v -m "${FINAL_PYTEST_MARKER}" -k "not AotHloIdenticalTest and not CompileThenLoad" --durations=0 ${SPLIT_ARGS} &
+          PYTEST_PID=$!
+          wait $PYTEST_PID
     services:
       resource_manager:
         image: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest # zizmor: ignore[unpinned-images]

--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -152,6 +152,17 @@ jobs:
       - name: Run Tests
         shell: bash
         run: |
+          # Cleanly release TPU device locks upon SIGTERM / PR cancellation
+          cleanup_tpu_locks() {
+            echo "Received cancellation signal; cleaning up /dev/accel* locks and /tmp/libtpu_lockfile..."
+            kill -9 "${PYTEST_PID:-}" 2>/dev/null || true
+            rm -f /tmp/libtpu_lockfile
+            fuser -k -9 /dev/accel* 2>/dev/null || true
+            sleep 0.5
+            exit 143
+          }
+          trap cleanup_tpu_locks TERM INT
+
           # Determine environment and entry directory
           if [ "${INPUTS_MAXTEXT_INSTALLED}" == "true" ]; then
             # Move to the directory where code is baked into the image. See the Dockerfile.
@@ -227,7 +238,9 @@ jobs:
               --junitxml=test-results-${INPUTS_FLAVOR}-${INPUTS_WORKER_GROUP}.xml \
               $PYTEST_COV_ARGS \
               $SPLIT_ARGS \
-              ${INPUTS_PYTEST_EXTRA_ARGS}
+              ${INPUTS_PYTEST_EXTRA_ARGS} &
+            PYTEST_PID=$!
+            wait $PYTEST_PID
           fi
 
         env:

--- a/.github/workflows/run_tests_coordinator.yml
+++ b/.github/workflows/run_tests_coordinator.yml
@@ -213,8 +213,8 @@ jobs:
 
       container_resource_option: >-
         ${{ contains(inputs.flavor, 'gpu')
-            && '--shm-size 2g --runtime=nvidia --gpus all --privileged'
-            || '--privileged' }}
+            && '--init --shm-size 2g --runtime=nvidia --gpus all --privileged'
+            || '--init --privileged' }}
 
       # Metadata
       base_image: ${{ inputs.base_image }}


### PR DESCRIPTION
# Description

This PR fixes 10-minute runner lockouts and TPU device driver (`/dev/accel*`) resource leaks in GitHub Actions when pull request workflows are cancelled or updated.

### Why this change is being made & problem being solved
When GitHub Actions cancels a CI job (due to a PR branch push or manual cancellation), it sends `SIGTERM` to the container. Without `--init`, Docker PID 1 is a shell/command that does not forward `SIGTERM` to child Python/Pytest processes. Consequently, orphaned `libtpu.so` processes fail to release `/dev/accel*` TPU device driver locks or delete `/tmp/libtpu_lockfile`, leaving self-hosted TPU runners locked and unusable for 10 minutes until timeout.

### Specific implementation details
1. Enabled Docker `--init` in `container_resource_option` across `.github/workflows/ci_pipeline.yml` and `.github/workflows/run_tests_coordinator.yml` so that `tini` runs as PID 1 and reliably forwards termination signals to child processes.
2. Added a 500ms Bash signal handler (`trap cleanup_tpu_locks SIGTERM SIGINT`) at the top of test execution scripts in `.github/workflows/run_tests_against_package.yml` and `.github/workflows/run_pathways_tests.yml` to cleanly delete `/tmp/libtpu_lockfile` and release TPU `/dev/accel*` handles before container shutdown.

# Tests

- Verified YAML syntax and schema formatting across all 4 modified workflows:
  ```bash
  pre-commit run --files .github/workflows/ci_pipeline.yml .github/workflows/run_tests_coordinator.yml .github/workflows/run_tests_against_package.yml .github/workflows/run_pathways_tests.yml
  ```
- Tested Bash trap handler compatibility and signal propagation semantics for Docker `--init`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
