### PR TITLE
Fix Qwen3-VL-2B model E2E framework stability issues when running in text-only mode (`use_multimodal=false`).

### DIFF
--- a/src/maxtext/inference/vllm_decode.py
+++ b/src/maxtext/inference/vllm_decode.py
@@ -93,6 +93,7 @@ def decode_with_vllm(config: Config) -> None:
       "additional_config": {
           "maxtext_config": {
               "model_name": config.model_name,
+              "use_multimodal": config.use_multimodal,
               "weight_dtype": config.weight_dtype.name,
               "allow_split_physical_axes": True,
               "debug_sharding": config.debug_sharding,

--- a/src/maxtext/trainers/post_train/sft/train_sft.py
+++ b/src/maxtext/trainers/post_train/sft/train_sft.py
@@ -45,6 +45,7 @@ import optax
 import pathwaysutils
 
 from flax import nnx
+from flax.nnx import tracers
 from flax.linen import partitioning as nn_partitioning
 
 from orbax import checkpoint as ocp
@@ -123,6 +124,17 @@ class MaxTextPeftTrainer(peft_trainer.PeftTrainer):
 
       def loss_wrapper(diff_params, rest, **inputs_kw):
         local_model = nnx.merge(graphdef, diff_params, rest)
+
+        # JAX AD tracing ignores non-differentiable variables (like RngCount ints).
+        # They get instantiated with the base/JIT trace instead of the active
+        # LinearizeTrace, causing flax.errors.TraceContextError when mutated later.
+        # We manually update their trace_state to the current AD trace context.
+
+        for _, v in nnx.iter_graph(local_model):
+          if isinstance(v, nnx.Variable) and hasattr(v, "_trace_state"):
+            if not v._trace_state.is_valid():  # pylint: disable=protected-access
+              object.__setattr__(v, "_trace_state", tracers.TraceState())  # pylint: disable=protected-access
+
         out = loss_fn_ref(local_model, **inputs_kw)
         # Capture updated non-param state (e.g. RNG counters) from local_model.
         _, _, new_rest = nnx.split(local_model, wrt, ...)
@@ -136,6 +148,13 @@ class MaxTextPeftTrainer(peft_trainer.PeftTrainer):
       (out_val, (aux, new_rest)), grads = grad_fn(diff_params, rest, **inputs)
 
       # Propagate updated non-param state (RNG counters, etc.) back to model.
+      # Fix flax.errors.TraceContextError when returning from jax.value_and_grad
+
+      for _, v in nnx.iter_graph(model):
+        if isinstance(v, nnx.Variable) and hasattr(v, "_trace_state"):
+          if not v._trace_state.is_valid():  # pylint: disable=protected-access
+            object.__setattr__(v, "_trace_state", tracers.TraceState())  # pylint: disable=protected-access
+
       nnx.update(model, new_rest)
 
       # Apply optimizer update. grads has the same nnx.State(wrt) structure


### PR DESCRIPTION
This PR addresses two framework bugs encountered during E2E testing when the `Qwen3-VL` model (specifically `qwen3-vl-2b`) is forced to execute entirely on text-only pathways.
  
## 1. Fix TraceContextError in `train_sft` with `scan_layers=false` for Qwen3-VL-2B
  
### Description:

While running SFT training for `qwen3-vl-2b` in text-only mode (`use_multimodal=false`) with `scan_layers=false`, the script crashes with 

```bash
flax.errors. TraceContextError: Cannot mutate RngCount from a different trace level.
```
Full Error Log: https://paste.googleplex.com/5591369333735424
    
### Root Cause:

MaxText uses `jax.value_and_grad` for backpropagation, creating a new AD trace context. JAX drops non-differentiable variables (such as Qwen3's specific integer `RngCount`) from this AD trace. With `scan_layers=false` under Flax NNX architectures, the layer sequentially invokes `nnx.update`. Flax NNX performs a strict safety check, and because these Qwen3-specific integer variables belong to the outer JIT trace, the validation fails and raises a `TraceContextError`.             
  
### Solution:

Iterate over the NNX graph state (`nnx.iter_graph`) just before the update loop and use `object.__setattr__` to manually sync the `_trace_state` of invalid variables with the current JAX trace context (`jax.core.cur_trace()`). This functionally bypasses the NNX safety hook for non-differentiable integers dropped by JAX's AD trace.
  
  
## 2. Fix Qwen3-VL-2B `use_multimodal=false` ignored by backend in `vllm_decode.py`
  
### Description:

 When explicitly executing `vllm_decode.py` on `qwen3-vl-2b` in text-only mode (`use_multimodal=false`), the inference fails deep in JAX array sharding with 
 
```bash
RuntimeError: Array has been deleted with shape=float32[16,64]`.
```
Full Error Log: https://paste.googleplex.com/4582754565095424

### Root Cause:

The command line argument `config.use_multimodal=false` is parsed by `vllm_decode.py` but is not forwarded into the `vllm_args["additional_config"]["maxtext_config"]` payload. Because Qwen3-VL-2B defaults to initializing vision parameters, the downstream vLLM engine assumes default settings and attempts to instantiate vision encoders anyway. It allocates checkpoints and memory incorrectly for a text-only scenario, leading to a catastrophic crash.
  
### Solution:

Explicitly map `"use_multimodal": config.use_multimodal` into the configuration block passed to vLLM so the engine knows to safely skip Qwen3-VL-2B's multimodal nodes during initialization.

# Tests

1. `train_sft.py`

 Log: https://paste.googleplex.com/5502251027267584
 
```bash
 python3 -m maxtext.trainers.post_train.sft.train_sft \
  model_name=qwen3-vl-2b \
  run_name=sft \
  use_multimodal=false \
  scan_layers=false \
  per_device_batch_size=1 \
  steps=5 \
  override_model_config=true \
  base_output_directory=gs://runner-maxtext-logs/qwen3-vl-2b/sft-0805 \
  load_parameters_path=gs://runner-maxtext-logs/qwen3-vl-2b/to_maxtext/no_multi_unscanned/0731/0/items \
  enable_single_controller=true \
  checkpoint_storage_use_zarr3=False \
  checkpoint_storage_use_ocdbt=False
```

2. `vllm_decode.py`

 Log: https://paste.googleplex.com/4975516036759552
 
```bash
python3 -m maxtext.inference.vllm_decode \
  model_name=qwen3-vl-2b \
  load_parameters_path=gs://runner-maxtext-logs/qwen3-vl-2b/to_maxtext/no_multi_unscanned/0731/0/items \
  vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
  hbm_utilization_vllm=0.6 \
  use_chat_template=True \
  scan_layers=false \
  use_multimodal=false \
  override_model_config=True \
  enable_single_controller=True \
  prompt="Suggest some famous landmarks in London."
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).