### PR TITLE
test(unit): remove skipped test markers for sharding tests

### DIFF
--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -483,7 +483,6 @@ class TestAssertParamsSufficientlySharded(unittest.TestCase):
     with self.assertRaises(AssertionError):
       assert_params_sufficiently_sharded(params, self.mesh, tolerance=0.1)
 
-  @pytest.mark.skip(reason="This test is skipped due to a sharding issue. b/542212958")
   def test_mixed_sharding_fails(self):
     """Tests that a mix of sharded and unsharded parameters fails when the unsharded
 
@@ -536,7 +535,6 @@ class TestAssertParamsSufficientlySharded(unittest.TestCase):
     with self.assertRaises(AssertionError):
       assert_params_sufficiently_sharded(params, mesh, tolerance=0.05)
 
-  @pytest.mark.skip(reason="This test is skipped due to a sharding issue. b/542212958")
   def test_multi_axis_mixed_sharding_fails(self):
     """Tests that a mix of sharded (correctly) and unsharded tensors on a complex mesh fails."""
     devices = np.array(jax.devices()).reshape((jax.device_count(), 1, 1, 1, 1))


### PR DESCRIPTION
# Description

This PR re-enables `test_mixed_sharding_fails` and `test_multi_axis_mixed_sharding_fails` in `tests/unit/maxtext_utils_test.py`, which were previously skipped in commit 3b08232df30b927ddfb78c6127efd4acd98af8f4 (PR #4714).

With commit 29a0ad60b5347f67d3fb8e616233a0c672818b98 fixing the scope of PartitionSpec defaulting strictly to LoRA parameters in `sharding.py`, standard unannotated arrays raise an `AssertionError` as expected. Thus, removing the `@pytest.mark.skip` decorators allows the tests to pass without modifying `src/maxtext/utils/sharding.py`.

BUGS: b/542212958

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Ran the test suite locally with 8 virtual XLA devices:
```bash
pytest tests/unit/maxtext_utils_test.py
```
Results: 98 passed, 13 skipped (7/7 passed in `TestAssertParamsSufficientlySharded`).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
