### PR TITLE
Fix Qwen3/3.5 KV Cache list indexing in vLLM

### DIFF
--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1849,7 +1849,10 @@ class NNXDecoder(nnx.Module):
 
           graphdef, state = nnx.split(layer)
           if kv_caches is not None:
-            if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
+            if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5) and cfg.attention not in (
+                "vllm_rpa",
+                "vllm_batched_rpa",
+            ):
               if (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
                 kv_cache = (
                     kv_caches["key_cache"][lyr],
@@ -1881,7 +1884,10 @@ class NNXDecoder(nnx.Module):
             nnx.update(layer, new_state)
 
           if kv_caches is not None and kv_cache is not None:
-            if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
+            if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5) and cfg.attention not in (
+                "vllm_rpa",
+                "vllm_batched_rpa",
+            ):
               if (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
                 kv_caches["key_cache"][lyr] = kv_cache[0]
                 kv_caches["value_cache"][lyr] = kv_cache[1]


### PR DESCRIPTION
# Description

Fixes a `TypeError` that occurs when running rollouts with Qwen3.5 under vLLM.

### Cause
MaxText's decoder expects `kv_caches` to be a dictionary with `"key_cache"` and `"value_cache"` keys for Qwen3.5 (`DecoderBlockType.QWEN3_5`). However, the vLLM adapter passes `kv_caches` as a list of page state arrays. This causes a `TypeError: list indices must be integers or slices, not str` when trying to index it using string keys.

### Fix
This PR checks if the attention mechanism is vLLM-based (`"vllm_rpa"` or `"vllm_batched_rpa"`) and falls back to integer indexing (treating `kv_caches` as a list) if so, matching the format provided by the vLLM adapter.

### Stack Trace
```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/opt/venv/lib/python3.12/site-packages/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py", line 266, in __call__
[rank0]:     hidden, kv_caches = self.model(
[rank0]:                         ^^^^^^^^^^^
[rank0]:   File "/opt/venv/lib/python3.12/site-packages/maxtext/models/models.py", line 552, in __call__
[rank0]:     logits, hidden_state, kv_caches = self.decoder(
[rank0]:                                        ^^^^^^^^^^^^^
[rank0]:   File "/opt/venv/lib/python3.12/site-packages/maxtext/layers/nnx_decoders.py", line 1854, in __call__
[rank0]:     kv_caches["key_cache"][lyr],
[rank0]:     ~~~~~~~~~^^^^^^^^^^^^^
[rank0]: TypeError: list indices must be integers or slices, not str
```

# Tests

Tested by running DeepSWE training on GKE TPUs. The change resolves the `TypeError` and allows the rollout generation to complete successfully.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
