### PR TITLE
Fix Qwen3.5 GDN Kernel ImportError on MaxText

### DIFF
--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -658,8 +658,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       # vLLM PAGED STATE PATH: use tpu_inference fused conv + ragged delta-rule.
       # =========================================================================
       try:
-        from tpu_inference.layers.common.gdn_attention import GdnAttentionConfig, run_jax_gdn_attention  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
-        from tpu_inference.layers.common.ragged_gated_delta_rule_wrapper import RaggedGatedDeltaRuleImpl  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
+        from tpu_inference.layers.common.gdn_attention import run_jax_gdn_attention  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
         from tpu_inference.layers.common.sharding import ShardingAxisName  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
         from tpu_inference.layers.common.utils import reorder_concatenated_tensor_for_sharding  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
         from tpu_inference.utils import get_mesh_shape_product  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
@@ -703,9 +702,6 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
 
       conv_state_paged, recurrent_state_paged = kv_cache
 
-      # Use REF impl (pure JAX) to avoid Mosaic kernel compilation issues.
-      gdn_config = GdnAttentionConfig(ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.REF)
-
       (new_conv_state_paged, new_recurrent_state_paged), gdn_output = run_jax_gdn_attention(
           mixed_qkv,
           b_flat,
@@ -726,7 +722,6 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
           self.head_v_dim,
           cfg.gdn_conv_kernel_dim,
           mesh=self.mesh,
-          config=gdn_config,
       )
 
       # Reshape GDN output and apply gated norm + out projection.


### PR DESCRIPTION
# Description

Fixes an `ImportError` on `GdnAttentionConfig` and `RaggedGatedDeltaRuleImpl` when initializing Qwen3.5 with vLLM paged state.

### Cause
In recent versions of `tpu-inference` (which vLLM depends on), the GDN attention API was fused/simplified, and the configuration class `GdnAttentionConfig` (along with `RaggedGatedDeltaRuleImpl`) was removed. MaxText still attempted to import these classes and instantiate `gdn_config`, leading to import crashes when running Qwen3.5.

### Fix
This PR removes the imports of `GdnAttentionConfig` and `RaggedGatedDeltaRuleImpl`, removes the `gdn_config` instantiation, and updates the `run_jax_gdn_attention` call to omit the `config` parameter, aligning with the new API in `tpu-inference`.

# Tests

Tested by running DeepSWE training (which uses vLLM paged state initialization) on GKE TPUs and verifying that it compiles and starts training without ImportError.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
