### PR TITLE
Add indexer_cutoff_threshold field to Config and remat policy

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -357,6 +357,7 @@ remat_policy: 'full'
 # If "custom" remat_policy is chosen, you can select tensors from the following list to offload on host memory, rematerialize or save on device memory.
 # Pick one of these options for following tensors: ['remat','device','offload']
 decoder_layer_input: 'device' # this tensor cannot be rematerialized - it serves as periodic checkpoints that act as the remat start points
+indexer_cutoff_threshold: 'remat' # Remat policy for indexer cutoff threshold (can be set to 'remat', 'offload', or 'device')
 context: 'remat' # From https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/jax/attention.py#L581-L583
 mlpwi: 'remat'
 mlpwi_0: 'remat'

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1241,6 +1241,9 @@ class RematAndOffload(BaseModel):
   decoder_layer_input: RematLocation = Field(
       RematLocation.DEVICE, description="Remat policy for the decoder layer's input."
   )
+  indexer_cutoff_threshold: RematLocation = Field(
+      RematLocation.REMAT, description="Remat policy for the indexer cutoff threshold (shape: [batch, seq_len])."
+  )
   context: RematLocation = Field(RematLocation.REMAT, description="Remat policy for the attention context.")
   mlpwi: RematLocation = Field(
       RematLocation.REMAT,
@@ -3228,6 +3231,7 @@ class MaxTextConfig(
     if self.remat_policy == "custom":
       tensors = [
           "decoder_layer_input",
+          "indexer_cutoff_threshold",
           "context",
           "mlpwi",
           "moe_mlpwi_0",
@@ -3471,6 +3475,11 @@ class MaxTextConfig(
             "when indexer loss is enabled (`indexer_loss_scaling_factor > 0.0`); otherwise the indexer "
             "short-circuits to select all tokens and no indexer loss is produced."
         )
+    if not self.use_indexer and self.indexer_cutoff_threshold != RematLocation.REMAT:
+      raise ValueError(
+          f"Setting `indexer_cutoff_threshold='{self.indexer_cutoff_threshold}'` is only valid when "
+          "`use_indexer=True` (DeepSeek Sparse Attention / MLA Indexer)."
+      )
     if self.attention_type == AttentionType.CHUNK.value and (
         not isinstance(self.chunk_attn_window_size, int) or self.chunk_attn_window_size <= 0
     ):
@@ -4167,6 +4176,7 @@ class RLConfig(
     if self.remat_policy == "custom":
       tensors = [
           "decoder_layer_input",
+          "indexer_cutoff_threshold",
           "context",
           "mlpwi",
           "moe_mlpwi_0",

--- a/src/maxtext/layers/attention_mla.py
+++ b/src/maxtext/layers/attention_mla.py
@@ -231,7 +231,9 @@ class Indexer(nnx.Module):
     Returns:
         mask: [b, t, s] - `0.0` for top-k selected elements, `DEFAULT_MASK_VALUE` elsewhere.
     """
-    cutoff_threshold = topk_values[..., -1:]
+    indexer_cutoff_threshold = topk_values[..., -1]
+    indexer_cutoff_threshold = checkpoint_name(indexer_cutoff_threshold, "indexer_cutoff_threshold")
+    indexer_cutoff_threshold = indexer_cutoff_threshold[..., None]
 
     val_true = jnp.array(0.0, dtype=self.dtype)
     val_false = jnp.array(DEFAULT_MASK_VALUE, dtype=self.dtype)
@@ -239,8 +241,8 @@ class Indexer(nnx.Module):
     if self.config.indexer_mask_exact_topk:
       # Prune ties by keeping only the first k unmasked tokens along sequence dimension
       k = topk_values.shape[-1]
-      is_strictly_greater = indexer_score > cutoff_threshold
-      is_equal = indexer_score == cutoff_threshold
+      is_strictly_greater = indexer_score > indexer_cutoff_threshold
+      is_equal = indexer_score == indexer_cutoff_threshold
 
       # Use cumsum to rank both strictly greater and equal tokens (XLA fuses these scans)
       sg_rank = jnp.cumsum(is_strictly_greater.astype(jnp.int32), axis=-1)
@@ -258,7 +260,7 @@ class Indexer(nnx.Module):
       return jnp.where(selected, val_true, val_false)
     else:
       # Raw threshold cutoff masking (optional: enables speedups, but may unmask > k tokens under indexer scores ties)
-      raw_mask = indexer_score >= cutoff_threshold
+      raw_mask = indexer_score >= indexer_cutoff_threshold
       return jnp.where(raw_mask, val_true, val_false)
 
   def __call__(

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -334,6 +334,47 @@ class ConfigTest(absltest.TestCase):
     with self.assertRaises(pydantic.ValidationError):
       pyconfig.initialize(argv)
 
+  def test_indexer_cutoff_threshold_remat_policy(self):
+    """Tests custom remat policy and validation for indexer_cutoff_threshold."""
+    # 1. Verify custom remat policy puts indexer_cutoff_threshold on device
+    argv_device = [
+        "",
+        _BASE_CONFIG_PATH,
+        "run_name=test",
+        "use_indexer=true",
+        "q_lora_rank=1536",
+        "attention=dot_product",
+        "remat_policy=custom",
+        "indexer_cutoff_threshold=device",
+    ]
+    config_device = pyconfig.initialize(argv_device)
+    self.assertIn("indexer_cutoff_threshold", config_device.tensors_on_device)
+
+    # 2. Verify custom remat policy puts indexer_cutoff_threshold on offload
+    argv_offload = [
+        "",
+        _BASE_CONFIG_PATH,
+        "run_name=test",
+        "use_indexer=true",
+        "q_lora_rank=1536",
+        "attention=dot_product",
+        "remat_policy=custom",
+        "indexer_cutoff_threshold=offload",
+    ]
+    config_offload = pyconfig.initialize(argv_offload)
+    self.assertIn("indexer_cutoff_threshold", config_offload.tensors_to_offload)
+
+    # 3. Verify validation error when use_indexer=False and indexer_cutoff_threshold != 'remat'
+    argv_invalid = [
+        "",
+        _BASE_CONFIG_PATH,
+        "run_name=test",
+        "use_indexer=false",
+        "indexer_cutoff_threshold=device",
+    ]
+    with self.assertRaises(ValueError):
+      pyconfig.initialize(argv_invalid)
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
# Description
    
This PR introduces **`indexer_cutoff_threshold`** as a configurable checkpointed tensor in MaxText's custom rematerialization policy  (`remat_policy: 'custom'`), enabling micro-checkpointing of the Indexer top-$k$ cutoff score to eliminate backward-pass Indexer recomputation.

FIXES: b/539999685

### Context & Problem Solved
* **The Recompute Overhead:** In DeepSeek V3.2, generating the sparse attention mask requires comparing relevance scores against the $k$-th highest score (`topk_values[..., -1]`). Without checkpointing this threshold, XLA is forced during the backward pass to recompute the entire Indexer top-$k$ search/sort, which happened to be one of the slowest part of the computation in long context (sorting [b,s,t], which grows sequence square).
* **Why Micro-Checkpointing is Optimal:** The cutoff threshold (`[batch, seq_len]`) contains only $1,024$ bfloat16 elements for 128K/CP=128 (**~2 KB  per layer**, or **~122 KB total across 61 layers**). Storing indexer_cutoff_threshold=device` in TPU HBM eliminates Indexer backward recomputation while consuming less than 0.5 MB of HBM across the entire model.
* **Works across all Top-K and Masking modes:** Whether using exact top-$k$ (`indexer_use_approx_top_k=false`) or approximate top-$k$  (`true`), and whether using exact rank-pruned masking (`indexer_mask_exact_topk=true`) or raw threshold masking (`false`), the mask  generation relies on the checkpointed `indexer_cutoff_threshold` tensor.
    
### Implementation Details
* **`base.yml` & `types.py`:** Added `indexer_cutoff_threshold` as a `RematLocation` field to `Config` and included it in the  `remat_policy: 'custom'` tensor lists.
* **Checkpointing in `attention_mla.py`:** In `generate_mask`, we slice `topk_values[..., -1]` as a 2D tensor (`[batch, seq_len]`)  before calling `checkpoint_name(..., "indexer_cutoff_threshold")` and restore the trailing dimension (`[..., None]`) afterward. 

# Tests

Added `test_indexer_cutoff_threshold_remat_policy`. 

Tested on a gf_4x8x8_untwisted TPU slice 128K (deepseek3.2-671b) CP 128 with:

    --maxtext_flag="remat_policy=custom" \
    --maxtext_flag="indexer_cutoff_threshold=device|offload"

 [baseline](https://xprof.corp.google.com/overview_page/zjiahao-7879250017129803544): 42s
 [device](https://xprof.corp.google.com/overview_page/zjiahao-182806723994268044): 31s
[offload](https://xprof.corp.google.com/overview_page/zjiahao-3642303396813996391): 31s

Memory difference is unnoticeable, in this case ~122 KB per chip.

   # Checklist 

  Before submitting this PR, please make sure (put X in square brackets):

  [✓] I have performed a self-review of my code. For an optional AI review, add the gemini-review label.
  [✓] I have necessary comments in my code, particularly in hard-to-understand areas.
  [✓] I have run end-to-end tests and provided workload links above if applicable.
  [✓] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in our documentation https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files.
  