### PR TITLE
Copy the merged model in the SFT train step

### DIFF
--- a/src/maxtext/trainers/post_train/sft/train_sft.py
+++ b/src/maxtext/trainers/post_train/sft/train_sft.py
@@ -122,7 +122,10 @@ class MaxTextPeftTrainer(peft_trainer.PeftTrainer):
       _, diff_params, rest = nnx.split(model, wrt, ...)
 
       def loss_wrapper(diff_params, rest, **inputs_kw):
-        local_model = nnx.merge(graphdef, diff_params, rest)
+        # copy=True keeps the merge from handing back the variables the graphdef was built
+        # from, which belong to the outer trace. Writing to those raises TraceContextError, as
+        # the unscanned decoder does when it updates each layer.
+        local_model = nnx.merge(graphdef, diff_params, rest, copy=True)
         out = loss_fn_ref(local_model, **inputs_kw)
         # Capture updated non-param state (e.g. RNG counters) from local_model.
         _, _, new_rest = nnx.split(local_model, wrt, ...)

--- a/tests/post_training/unit/train_sft_test.py
+++ b/tests/post_training/unit/train_sft_test.py
@@ -19,9 +19,93 @@ from unittest import mock
 from types import SimpleNamespace
 import pytest
 
+from flax import nnx
+import jax
+import jax.numpy as jnp
+import optax
+
 from maxtext.trainers.post_train.sft import train_sft
 
 pytestmark = [pytest.mark.post_training]
+
+
+class _StatefulModel(nnx.Module):
+  """Model that advances an RNG during the forward pass.
+
+  The unscanned decoder writes back to each layer with `nnx.update`, which mutates the same
+  variables. The scanned decoder carries its state through the scan and never writes to the
+  module, which is why only unscanned hits this.
+  """
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(2, 2, rngs=rngs)
+    self.rngs = rngs
+
+  def __call__(self, x):
+    self.rngs.default()
+    return self.linear(x)
+
+
+class TrainStepTraceLevelTest(unittest.TestCase):
+  """The train step must not hand the loss function variables owned by an outer trace.
+
+  `create_train_step_fn` captures the graphdef outside the transform and merges inside
+  `jax.value_and_grad`. Without `copy=True` the merge returns the original variables, and
+  writing to them raises `TraceContextError`.
+  """
+
+  def _train_step_over(self, model):
+    """Builds the real train step over the trainer attributes it reads.
+
+    Args:
+      model: Model the step trains.
+
+    Returns:
+      The train step function.
+    """
+    trainer = SimpleNamespace(
+        model=model,
+        loss_fn=lambda m, x: (jnp.sum(m(x) ** 2), {"aux": 1}),
+        _has_aux=True,
+        gen_model_input_fn=lambda inputs: inputs,
+        _lora_enabled=False,
+    )
+    return train_sft.MaxTextPeftTrainer.create_train_step_fn(trainer)
+
+  def _build(self):
+    model = _StatefulModel(nnx.Rngs(0))
+    return model, nnx.Optimizer(model, optax.sgd(1e-2), wrt=nnx.Param)
+
+  @pytest.mark.cpu_only
+  def test_a_model_that_writes_to_its_own_state_trains(self):
+    model, optimizer = self._build()
+    before = jnp.asarray(model.linear.kernel[...])
+
+    # The step returns (loss, aux) or (loss, aux, grad_norm), depending on the Tunix version.
+    out = self._train_step_over(model)(model, optimizer, {"x": jnp.ones((1, 2))})
+
+    self.assertTrue(jnp.isfinite(out[0]))
+    self.assertFalse(jnp.array_equal(before, model.linear.kernel[...]), "weights did not move")
+
+  @pytest.mark.cpu_only
+  def test_the_same_model_trains_under_jit(self):
+    """Tunix runs the step under `nnx.jit`, where the trace levels stack up."""
+    model, optimizer = self._build()
+
+    out = nnx.jit(self._train_step_over(model))(model, optimizer, {"x": jnp.ones((1, 2))})
+
+    self.assertTrue(jnp.isfinite(out[0]))
+
+  @pytest.mark.cpu_only
+  def test_rng_state_updates_reach_the_caller_model(self):
+    """RNG counters advance inside the traced loss and have to come back out."""
+    model, optimizer = self._build()
+    before = jax.tree.leaves(nnx.state(model, nnx.RngCount))
+
+    self._train_step_over(model)(model, optimizer, {"x": jnp.ones((1, 2))})
+
+    after = jax.tree.leaves(nnx.state(model, nnx.RngCount))
+    self.assertNotEqual([int(c) for c in before], [int(c) for c in after])
 
 
 class TrainSFTTest(unittest.TestCase):


### PR DESCRIPTION
The SFT train step captures the graphdef outside the transform, then rebuilds the model inside jax.value_and_grad with nnx.merge. Without copy=True that merge returns the same Variable objects the graphdef was built from, which belong to the outer trace.

The scanned decoder carries its layer state through the scan and never writes to the module, so nothing noticed. The unscanned decoder runs each layer as a pure function and writes the result back with nnx.update, and that write fails:

  flax.errors.TraceContextError: Cannot mutate RngCount from a different trace
  level

So SFT could not run at all with scan_layers=False, which the RL scripts ship and vLLM requires. Pre-training's train step already merges with copy=True for the same reason.

The regression tests drive the real train step over a model that advances an RNG during the forward pass, bare and under nnx.jit, and check the advanced counters reach the caller's model. All three fail without the copy.

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

You can also provide a comma-separated list. If you don't want to close a bug but
simply to reference it, use BUGS, e.g.: 
BUGS: b/123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
