### PR TITLE
DSV4 MTP Support

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -3808,9 +3808,6 @@ class MaxTextConfig(
       if val != 0 and val < 4:
         raise ValueError(f"compress_ratio must be 0 (disabled) or >= 4, got {val}")
 
-    if self.decoder_block == DecoderBlockType.DEEPSEEK4 and self.mtp_num_layers > 0:
-      raise ValueError("DeepSeek4 decoder block currently does not support MTP layers.")
-
     if self.num_kv_shared_layers > 0:
       if self.fused_qkv:
         raise ValueError("`num_kv_shared_layers > 0` is not compatible with `fused_qkv`.")

--- a/src/maxtext/layers/multi_token_prediction.py
+++ b/src/maxtext/layers/multi_token_prediction.py
@@ -98,6 +98,14 @@ class MultiTokenPredictionLayer(nnx.Module):
         kernel_axes=("norm",),
         rngs=rngs,
     )
+    self.final_norm = RMSNorm(
+        num_features=cfg.emb_dim,
+        epsilon=cfg.normalization_layer_epsilon,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        kernel_axes=("norm",),
+        rngs=rngs,
+    )
     self.projection_layer = DenseGeneral(
         in_features_shape=2 * cfg.emb_dim,
         out_features_shape=cfg.emb_dim,
@@ -108,12 +116,31 @@ class MultiTokenPredictionLayer(nnx.Module):
         rngs=rngs,
     )
     # Use MODEL_MODE_TRAIN for initialization; runtime model_mode is passed dynamically.
-    self.transformer_layer = transformer_layer_module(
-        config=cfg,
-        mesh=mesh,
-        model_mode=MODEL_MODE_TRAIN,
-        rngs=rngs,
-    )
+    if cfg.decoder_block in (DecoderBlockType.DEEPSEEK4, DecoderBlockType.DEEPSEEK4.value):
+      from maxtext.models import deepseek4  # pylint: disable=import-outside-toplevel
+      from maxtext.layers import mhc  # pylint: disable=import-outside-toplevel
+
+      self.transformer_layer = deepseek4.DeepSeek4DecoderLayer(
+          config=cfg,
+          mesh=mesh,
+          model_mode=MODEL_MODE_TRAIN,
+          rngs=rngs,
+          layer_idx=0,
+          compress_ratio=0,  # bypass compression, use sliding window
+          is_hash_routing=False,  # not a prefix layer
+      )
+      self.hc_head = mhc.DeepSeek4HyperHead(
+          config=cfg,
+          mesh=mesh,
+          rngs=rngs,
+      )
+    else:
+      self.transformer_layer = transformer_layer_module(
+          config=cfg,
+          mesh=mesh,
+          model_mode=MODEL_MODE_TRAIN,
+          rngs=rngs,
+      )
 
   @property
   def embedding_norm(self):
@@ -130,6 +157,14 @@ class MultiTokenPredictionLayer(nnx.Module):
   @hidden_state_norm.setter
   def hidden_state_norm(self, module):
     setattr(self, f"mtp_{self.layer_number}_hidden_state_norm", module)
+
+  @property
+  def final_norm(self):
+    return getattr(self, f"mtp_{self.layer_number}_final_norm")
+
+  @final_norm.setter
+  def final_norm(self, module):
+    setattr(self, f"mtp_{self.layer_number}_final_norm", module)
 
   @property
   def projection_layer(self):
@@ -187,6 +222,14 @@ class MultiTokenPredictionLayer(nnx.Module):
       hidden_state_pspec = jax.sharding.NamedSharding(self.mesh, jax.typeof(hidden_state_norm).sharding.spec)
       embedding_norm = jax.reshard(embedding_norm, hidden_state_pspec)
 
+    if (
+        self.config.decoder_block in (DecoderBlockType.DEEPSEEK4, DecoderBlockType.DEEPSEEK4.value)
+        and self.config.mhc_expansion_rate > 1
+    ):
+      # e: (batch, seq, dim), x: (batch, seq, hc, dim)
+      # We need to broadcast e to (batch, seq, hc, dim) before concatenation
+      mhc = self.config.mhc_expansion_rate
+      embedding_norm = jnp.expand_dims(embedding_norm, axis=2).repeat(mhc, axis=2)
     concatenated_features = jnp.concatenate([embedding_norm, hidden_state_norm], axis=-1)
     projected_features = self.projection_layer(concatenated_features)
 
@@ -319,7 +362,17 @@ class MultiTokenPredictionBlock(nnx.Module):
           model_mode=self.decoder.model_mode,
       )
 
-      mtp_logits = self.decoder.apply_output_head(shared_embedding, mtp_hidden_state, deterministic, model_mode)
+      mtp_hidden_state_to_head = mtp_hidden_state
+      if cfg.mhc_expansion_rate > 1 and cfg.decoder_block == DecoderBlockType.DEEPSEEK4:
+        mtp_hidden_state_to_head = mtp_layer.hc_head(mtp_hidden_state)
+      mtp_logits = self.decoder.apply_output_head(
+          shared_embedding,
+          mtp_hidden_state_to_head,
+          deterministic,
+          model_mode,
+          reduce_mhc=False,
+          decoder_norm=mtp_layer.final_norm,
+      )
 
       logits_logical_axes = (
           "activation_embed_and_logits_batch",

--- a/src/maxtext/layers/multi_token_prediction.py
+++ b/src/maxtext/layers/multi_token_prediction.py
@@ -108,12 +108,30 @@ class MultiTokenPredictionLayer(nnx.Module):
         rngs=rngs,
     )
     # Use MODEL_MODE_TRAIN for initialization; runtime model_mode is passed dynamically.
-    self.transformer_layer = transformer_layer_module(
-        config=cfg,
-        mesh=mesh,
-        model_mode=MODEL_MODE_TRAIN,
-        rngs=rngs,
-    )
+    if cfg.decoder_block == DecoderBlockType.DEEPSEEK4:
+      from maxtext.models import deepseek4  # pylint: disable=import-outside-toplevel
+      from maxtext.layers import mhc  # pylint: disable=import-outside-toplevel
+
+      self.transformer_layer = deepseek4.DeepSeek4LayerToLinen(
+          config=cfg,
+          mesh=mesh,
+          model_mode=MODEL_MODE_TRAIN,
+          rngs=rngs,
+          compress_ratio=0,  # bypass compression, use sliding window
+          is_hash_routing=False,  # not a prefix layer
+      )
+      self.hc_head = mhc.DeepSeek4HyperHead(
+          config=cfg,
+          mesh=mesh,
+          rngs=rngs,
+      )
+    else:
+      self.transformer_layer = transformer_layer_module(
+          config=cfg,
+          mesh=mesh,
+          model_mode=MODEL_MODE_TRAIN,
+          rngs=rngs,
+      )
 
   @property
   def embedding_norm(self):
@@ -187,6 +205,11 @@ class MultiTokenPredictionLayer(nnx.Module):
       hidden_state_pspec = jax.sharding.NamedSharding(self.mesh, jax.typeof(hidden_state_norm).sharding.spec)
       embedding_norm = jax.reshard(embedding_norm, hidden_state_pspec)
 
+    if self.config.decoder_block == DecoderBlockType.DEEPSEEK4 and self.config.mhc_expansion_rate > 1:
+      # e: (batch, seq, dim), x: (batch, seq, hc, dim)
+      # We need to broadcast e to (batch, seq, hc, dim) before concatenation
+      mhc = self.config.mhc_expansion_rate
+      embedding_norm = jnp.expand_dims(embedding_norm, axis=2).repeat(mhc, axis=2)
     concatenated_features = jnp.concatenate([embedding_norm, hidden_state_norm], axis=-1)
     projected_features = self.projection_layer(concatenated_features)
 
@@ -319,7 +342,12 @@ class MultiTokenPredictionBlock(nnx.Module):
           model_mode=self.decoder.model_mode,
       )
 
-      mtp_logits = self.decoder.apply_output_head(shared_embedding, mtp_hidden_state, deterministic, model_mode)
+      mtp_hidden_state_to_head = mtp_hidden_state
+      if cfg.mhc_expansion_rate > 1 and cfg.decoder_block == DecoderBlockType.DEEPSEEK4:
+        mtp_hidden_state_to_head = mtp_layer.hc_head(mtp_hidden_state)
+      mtp_logits = self.decoder.apply_output_head(
+          shared_embedding, mtp_hidden_state_to_head, deterministic, model_mode, reduce_mhc=False
+      )
 
       logits_logical_axes = (
           "activation_embed_and_logits_batch",

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1386,10 +1386,17 @@ class NNXDecoder(nnx.Module):
 
     return y
 
-  def apply_output_head(self, shared_embedding, y, deterministic, model_mode):
+  def apply_output_head(self, shared_embedding, y, deterministic, model_mode, reduce_mhc=True, decoder_norm=None):
     """Applies final normalization and projects hidden states to logits."""
 
     cfg = self.config
+    if reduce_mhc and cfg.mhc_expansion_rate > 1 and y.ndim >= 4:
+      if cfg.decoder_block in (DecoderBlockType.DEEPSEEK4, DecoderBlockType.DEEPSEEK4.value):
+        y = self.hc_head(y)
+      else:
+        _, mhc_reduce_fn = mhc.get_functions(cfg.mhc_expansion_rate)
+        y = mhc_reduce_fn(y)
+
     if cfg.shard_mode == ShardMode.EXPLICIT:
       norm_out_sharding = create_sharding(
           self.mesh,
@@ -1398,7 +1405,8 @@ class NNXDecoder(nnx.Module):
     else:
       norm_out_sharding = None
 
-    y = self.decoder_norm(y, out_sharding=norm_out_sharding)
+    norm_to_apply = self.decoder_norm if decoder_norm is None else decoder_norm
+    y = norm_to_apply(y, out_sharding=norm_out_sharding)
     y = self.dropout(y, deterministic=deterministic)  # NNX call
 
     if model_mode in {MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE}:
@@ -1581,9 +1589,8 @@ class NNXDecoder(nnx.Module):
         multimodal_input=multimodal_input,
     )
 
-    mhc_reduce = None
     if hasattr(cfg, "mhc_expansion_rate"):
-      mhc_expand, mhc_reduce = mhc.get_functions(cfg.mhc_expansion_rate)
+      mhc_expand, _ = mhc.get_functions(cfg.mhc_expansion_rate)
       if cfg.mhc_expansion_rate > 1:
         # (batch, length, emb_dim) --> (batch, length, mhc_expansion_rate, emb_dim)
         y = mhc_expand(y)
@@ -1949,14 +1956,10 @@ class NNXDecoder(nnx.Module):
     assert isinstance(y, jax.Array)
 
     # After the final transformer layer, `y` holds the raw, un-normalized hidden state.
-    if getattr(cfg, "mhc_expansion_rate", 1) > 1:
-      if cfg.decoder_block == DecoderBlockType.DEEPSEEK4:
-        hidden_state = self.hc_head(y)
-      else:
-        # (batch, length, mhc_expansion_rate, emb_dim) --> (batch, length, emb_dim)
-        hidden_state = mhc_reduce(y)
-    else:
-      hidden_state = y
+    # Note: `y` is kept in its raw un-reduced 4D representation for MHC models (e.g. DeepSeek-V4)
+    # so that downstream consumers (like MTP blocks or intermediate state logging) receive the full state.
+    # Dimensionality reduction is deferred to `apply_output_head`.
+    hidden_state = y
 
     # When invoking from vLLM with RPA attention, logit computation is deferred to a later stage.
     if cfg.attention in ("vllm_rpa", "vllm_batched_rpa"):

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1386,10 +1386,18 @@ class NNXDecoder(nnx.Module):
 
     return y
 
-  def apply_output_head(self, shared_embedding, y, deterministic, model_mode):
+  def apply_output_head(self, shared_embedding, y, deterministic, model_mode, reduce_mhc=True):
     """Applies final normalization and projects hidden states to logits."""
 
     cfg = self.config
+    if reduce_mhc and cfg.mhc_expansion_rate > 1 and y.ndim >= 4:
+      if cfg.decoder_block == DecoderBlockType.DEEPSEEK4:
+        y = self.hc_head(y)
+      else:
+
+        _, mhc_reduce_fn = mhc.get_functions(cfg.mhc_expansion_rate)
+        y = mhc_reduce_fn(y)
+
     if cfg.shard_mode == ShardMode.EXPLICIT:
       norm_out_sharding = create_sharding(
           self.mesh,
@@ -1581,9 +1589,8 @@ class NNXDecoder(nnx.Module):
         multimodal_input=multimodal_input,
     )
 
-    mhc_reduce = None
     if hasattr(cfg, "mhc_expansion_rate"):
-      mhc_expand, mhc_reduce = mhc.get_functions(cfg.mhc_expansion_rate)
+      mhc_expand, _ = mhc.get_functions(cfg.mhc_expansion_rate)
       if cfg.mhc_expansion_rate > 1:
         # (batch, length, emb_dim) --> (batch, length, mhc_expansion_rate, emb_dim)
         y = mhc_expand(y)
@@ -1949,14 +1956,7 @@ class NNXDecoder(nnx.Module):
     assert isinstance(y, jax.Array)
 
     # After the final transformer layer, `y` holds the raw, un-normalized hidden state.
-    if getattr(cfg, "mhc_expansion_rate", 1) > 1:
-      if cfg.decoder_block == DecoderBlockType.DEEPSEEK4:
-        hidden_state = self.hc_head(y)
-      else:
-        # (batch, length, mhc_expansion_rate, emb_dim) --> (batch, length, emb_dim)
-        hidden_state = mhc_reduce(y)
-    else:
-      hidden_state = y
+    hidden_state = y
 
     # When invoking from vLLM with RPA attention, logit computation is deferred to a later stage.
     if cfg.attention in ("vllm_rpa", "vllm_batched_rpa"):

--- a/tests/unit/deepseek4_mtp_test.py
+++ b/tests/unit/deepseek4_mtp_test.py
@@ -1,0 +1,106 @@
+"""Unit tests for DeepSeek V4 MTP execution logic."""
+
+import unittest
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import Mesh
+
+from maxtext.configs import pyconfig
+from maxtext.layers import multi_token_prediction
+from maxtext.models import deepseek4
+from maxtext.common.common_types import MODEL_MODE_TRAIN
+
+
+class DeepSeek4MTPTest(unittest.TestCase):
+  """Unit tests for DeepSeek4 MTP layer and block execution."""
+
+  def setUp(self):
+    os.environ["LIBTPU_INIT_ARGS"] = ""
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
+  def test_mtp_initialization(self):
+    config = pyconfig.initialize(
+        ["", "src/maxtext/configs/base.yml", "model_name=deepseek4-tiny", "skip_jax_distributed_system=True"]
+    )
+    mesh = Mesh(jax.devices(), ("data",))
+
+    layer = multi_token_prediction.MultiTokenPredictionLayer(
+        config=config,
+        mesh=mesh,
+        layer_number=1,
+        transformer_layer_module=deepseek4.DeepSeek4DecoderLayer,
+        rngs=nnx.Rngs(0),
+    )
+
+    self.assertIsInstance(layer.transformer_layer, deepseek4.DeepSeek4DecoderLayer)
+    self.assertEqual(layer.transformer_layer.config.mhc_expansion_rate, config.mhc_expansion_rate)
+
+  def test_mtp_forward_execution(self):
+    config = pyconfig.initialize(
+        [
+            "",
+            "src/maxtext/configs/base.yml",
+            "model_name=deepseek4-tiny",
+            "mtp_num_layers=1",
+            "skip_jax_distributed_system=True",
+        ]
+    )
+    mesh = Mesh(jax.devices(), ("data",))
+    rngs = nnx.Rngs(0)
+
+    class MockDecoder(nnx.Module):
+      """Mock decoder for test forward execution."""
+
+      def __init__(self, config):
+        self.config = config
+        self.model_mode = MODEL_MODE_TRAIN
+
+      def _apply_embedding(self, _shared_embedding, input_ids, _position_ids, _deterministic, model_mode):
+        batch_size, seq_len = input_ids.shape
+        return jnp.zeros((batch_size, seq_len, self.config.base_emb_dim), dtype=self.config.dtype)
+
+      def apply_output_head(
+          self, _shared_embedding, hidden_state, _deterministic, model_mode, reduce_mhc=True, decoder_norm=None
+      ):
+        batch_size, seq_len = hidden_state.shape[:2]
+        return jnp.zeros((batch_size, seq_len, self.config.vocab_size), dtype=self.config.dtype)
+
+    decoder_mock = MockDecoder(config)
+
+    mtp_block = multi_token_prediction.MultiTokenPredictionBlock(
+        config=config,
+        mesh=mesh,
+        transformer_layer_module=deepseek4.DeepSeek4DecoderLayer,
+        decoder=decoder_mock,
+        rngs=rngs,
+    )
+
+    batch_size = 2
+    seq_len = 8
+    main_hidden_state = jnp.zeros(
+        (batch_size, seq_len, config.mhc_expansion_rate, config.emb_dim),
+        dtype=config.dtype,
+    )
+    input_ids = jnp.zeros((batch_size, seq_len), dtype=jnp.int32)
+
+    with jax.set_mesh(mesh):
+      mtp_block(
+          shared_embedding=None,
+          main_hidden_state=main_hidden_state,
+          input_ids=input_ids,
+          target_ids=input_ids,
+          target_mask=jnp.ones((batch_size, seq_len), dtype=jnp.int32),
+          position_ids=jnp.arange(seq_len)[None, :].repeat(batch_size, axis=0),
+          decoder_segment_ids=None,
+          model_mode=MODEL_MODE_TRAIN,
+          deterministic=True,
+      )
+
+    self.assertTrue(hasattr(mtp_block, "losses"))
+    self.assertEqual(len(mtp_block.losses.value), 1)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/deepseek4_mtp_test.py
+++ b/tests/unit/deepseek4_mtp_test.py
@@ -1,0 +1,42 @@
+"""Unit tests for DeepSeek V4 MTP execution logic."""
+
+import unittest
+import jax
+from maxtext.configs import pyconfig
+from maxtext.layers import multi_token_prediction
+from maxtext.models import deepseek4
+from jax.sharding import Mesh
+import os
+from flax import nnx
+
+
+class DeepSeek4MTPTest(unittest.TestCase):
+
+  def setUp(self):
+    os.environ["LIBTPU_INIT_ARGS"] = ""
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
+  def test_mtp_initialization(self):
+    config = pyconfig.initialize(
+        ["", "src/maxtext/configs/base.yml", "base_config=deepseek4-tiny", "skip_jax_distributed_system=True"]
+    )
+    mesh = Mesh(jax.devices(), ("data",))
+
+    layer = multi_token_prediction.MultiTokenPredictionLayer(
+        config=config,
+        mesh=mesh,
+        layer_number=1,
+        transformer_layer_module=deepseek4.DeepSeek4LayerToLinen,
+        rngs=nnx.Rngs(0),
+    )
+
+    self.assertIsInstance(layer.transformer_layer, deepseek4.DeepSeek4LayerToLinen)
+    self.assertEqual(layer.transformer_layer.kwargs.get("compress_ratio", 0), 0)
+    self.assertEqual(layer.transformer_layer.kwargs.get("is_hash_routing", False), False)
+
+    # Test that we pass the unabridged config unmodified, so it keeps its HC logic
+    self.assertEqual(layer.transformer_layer.kwargs["config"].mhc_expansion_rate, config.mhc_expansion_rate)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/flop_calculation_test.py
+++ b/tests/unit/flop_calculation_test.py
@@ -432,17 +432,6 @@ class FlopCalculation(parameterized.TestCase):
     self.assertFlopsAlmostEqual(calculated_total, golden_total_flops)
     self.assertFlopsAlmostEqual(calculated_weight, golden_weight_flops)
 
-  def test_deepseek4_mtp_validation(self):
-    """Test that DeepSeek-V4 with MTP layers raises a ValueError"""
-    with self.assertRaises(ValueError):
-      self._initialize_model_config(
-          "deepseek4-284b",
-          max_target_length=4096,
-          per_device_batch_size=4,
-          attention="dot_product",
-          mtp_num_layers=1,
-      )
-
   def test_custom_engram_flops(self):
     """Test model with Engram Flops calculation"""
     cfg = self._initialize_model_config(

--- a/tests/unit/multi_token_prediction_test.py
+++ b/tests/unit/multi_token_prediction_test.py
@@ -137,9 +137,11 @@ class _MockDecoderForMTP:
     batch_size, seq_len = input_ids.shape
     return jnp.zeros((batch_size, seq_len, self.config.base_emb_dim), dtype=self.config.dtype)
 
-  def apply_output_head(self, _shared_embedding, hidden_state, _deterministic, model_mode):
+  def apply_output_head(self, _shared_embedding, hidden_state, _deterministic, model_mode, reduce_mhc=False):
     """Returns a zero tensor with the correct logit shape."""
-    batch_size, seq_len, _ = hidden_state.shape
+    # Use [:2] instead of exactly unpacking 3 items to gracefully handle 4D tensors
+    # (e.g. DeepSeek-V4 MTP [batch, seq_len, mhc_expansion_rate, dim]) without throwing a ValueError.
+    batch_size, seq_len = hidden_state.shape[:2]
     return jnp.zeros((batch_size, seq_len, self.config.vocab_size), dtype=self.config.dtype)
 
 

--- a/tests/unit/multi_token_prediction_test.py
+++ b/tests/unit/multi_token_prediction_test.py
@@ -137,9 +137,13 @@ class _MockDecoderForMTP:
     batch_size, seq_len = input_ids.shape
     return jnp.zeros((batch_size, seq_len, self.config.base_emb_dim), dtype=self.config.dtype)
 
-  def apply_output_head(self, _shared_embedding, hidden_state, _deterministic, model_mode):
+  def apply_output_head(
+      self, _shared_embedding, hidden_state, _deterministic, model_mode, reduce_mhc=False, decoder_norm=None
+  ):
     """Returns a zero tensor with the correct logit shape."""
-    batch_size, seq_len, _ = hidden_state.shape
+    # Use [:2] instead of exactly unpacking 3 items to gracefully handle 4D tensors
+    # (e.g. DeepSeek-V4 MTP [batch, seq_len, mhc_expansion_rate, dim]) without throwing a ValueError.
+    batch_size, seq_len = hidden_state.shape[:2]
     return jnp.zeros((batch_size, seq_len, self.config.vocab_size), dtype=self.config.dtype)
 
 


### PR DESCRIPTION
# Description

Adds native architecture support for the Multi-Token Prediction (MTP) step used by DeepSeek-V4.

Previously, DeepSeek-V4 models were unsupported with `mtp_num_layers > 0` because DeepSeek-V4 maintains a different hidden state projection topology compared to standard architectures. DeepSeek actively relies on an expanded 4-dimensional hidden tensor context (`[batch, seq, hc_mult, dim]`) that natively processes hyper-connections inside the MTP step, rather than operating sequentially on a pre-squashed 3D intermediate backbone state.

This PR aligns MaxText's `MultiTokenPredictionBlock` with the reference DeepSeek-V4 PyTorch architecture by refactoring the internal state propagation loop.
Specifically, it:
- Skips the explicit 4D -> 3D reduction step (`self.hc_head`) previously executed by default in `NNXDecoder.__call__` and moves it explicitly back into `apply_output_head` via an intercepted `reduce_mhc=True` toggle.
- Preserves the full unabridged 4D state and broadcasts positional embeddings accordingly within the MTP layer to process sequential tokens while fully preserving hyper-connection topologies across consecutive iterations.
- Automatically initializes standalone instances of `DeepSeek4HyperHead` explicitly for independent MTP blocks so that 4D reduction only occurs safely when projecting the final sequence into next-token prediction logits.

# Tests

- Configured and executed a local CPU Mock pipeline (`run_mock.py`) initialized with `deepseek4-tiny.yml` configured to `base_num_decoder_layers: 5` and `mtp_num_layers: 1` to ensure exact mesh parity and identical context-rolling structures against the upstream DeepSeek PyTorch reference.
- Passed all generic architecture tests in `tests/unit/multi_token_prediction_test.py` via `pytest`, modifying test mocks seamlessly to conform to the new `reduce_mhc` parameters.
- Deleted the explicit DeepSeek exception from `tests/unit/flop_calculation_test.py` and validated that FLOPs automatically scale to correctly encompass the DeepSeek MTP routing parameters. 
- Passed all remaining distributed gradient accumulation sweeps (`tests/unit/gradient_accumulation_nnx_test.py`, `tests/unit/train_nnx_test.py`, and `tests/unit/deepseek4_mtp_test.py`).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
