### PR TITLE
[maxtext] Add block-diffusion training primitives

### DIFF
--- a/src/maxtext/diffusion/__init__.py
+++ b/src/maxtext/diffusion/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Diffusion-model training and inference utilities."""

--- a/src/maxtext/diffusion/block_diffusion/README.md
+++ b/src/maxtext/diffusion/block_diffusion/README.md
@@ -1,0 +1,40 @@
+# Block-Diffusion Training Primitives
+
+Block diffusion generates or trains a sequence as bounded blocks rather than
+strictly one token at a time. Within the active block, tokens may use
+bidirectional context; completed blocks remain fixed context for later blocks.
+For background, see [Block Diffusion: Interpolating Between Autoregressive and
+Diffusion Language Models](https://arxiv.org/abs/2503.09573).
+
+This package contains model-independent primitives for preparing a training
+batch. Model attention, loss integration, and generation are added separately.
+
+## Terminology
+
+- **Canvas**: The fixed-length token slots being refined. A slot contains a
+  clean token or the configured mask token.
+- **Block**: A bounded region of the canvas that is corrupted and reconstructed
+  together. Earlier blocks are not modified while a later block is active.
+- **Corruption**: The forward noising step. `corrupt_tokens` independently masks
+  eligible tokens in each logical block and guarantees that every nonempty
+  eligible block contributes at least one training target.
+- **Validity mask**: Identifies real tokens and excludes padding from corruption
+  and supervision.
+- **Target loss mask**: Identifies token positions supervised for one sampled
+  corruption. It is distinct from the validity and corruption masks.
+- **Logit alignment**: Defines which model-output position predicts each clean
+  target. `same_position` uses the logit at the target position. `shifted` uses
+  the preceding logical position, matching models whose logits predict the next
+  token.
+
+## Supported Contracts
+
+The initial primitives intentionally support two explicit combinations:
+
+- `same_position` with `all_masked`: every eligible slot in a block may be
+  corrupted, and its same-position logit predicts the clean token.
+- `shifted` with `seed_and_mask`: the first slot seeds each block and the
+  remaining slots may be corrupted; shifted logits predict clean targets.
+
+Unsupported combinations fail during batch preparation instead of silently
+using ambiguous target semantics.

--- a/src/maxtext/diffusion/block_diffusion/__init__.py
+++ b/src/maxtext/diffusion/block_diffusion/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model-independent block-diffusion primitives."""

--- a/src/maxtext/diffusion/block_diffusion/corruption.py
+++ b/src/maxtext/diffusion/block_diffusion/corruption.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Random token corruption for block-diffusion training."""
+
+from typing import NamedTuple
+
+import numpy as np
+
+
+_SUPPORTED_CONTRACTS = {
+    ("same_position", "all_masked"),
+    ("shifted", "seed_and_mask"),
+}
+
+
+class BlockDiffusionCorruptionResult(NamedTuple):
+  """Corrupted token canvas and its two independent supervision masks."""
+
+  inputs: np.ndarray
+  corruption_mask: np.ndarray
+  targets_loss_mask: np.ndarray
+
+
+def corrupt_tokens(
+    inputs: np.ndarray,
+    validity_mask: np.ndarray,
+    rng: np.random.Generator,
+    *,
+    block_size: int,
+    mask_id: int,
+    min_noise: float = 1.0e-3,
+    logit_alignment: str = "same_position",
+    canvas_policy: str = "all_masked",
+    axis: int = 1,
+) -> BlockDiffusionCorruptionResult:
+  """Masks valid tokens independently within each logical diffusion block.
+
+  ``inputs`` and ``validity_mask`` must have the same shape. With the default
+  ``axis=1``, that shape is ``[batch, sequence, ...]``; ``axis`` selects the
+  sequence dimension when a different layout is used. The returned arrays
+  have the same shape as ``inputs``.
+  """
+  inputs = np.asarray(inputs)
+  validity_mask = np.asarray(validity_mask, dtype=np.bool_)
+  if inputs.shape != validity_mask.shape:
+    raise ValueError(f"inputs and validity_mask must have identical shapes, got {inputs.shape} and {validity_mask.shape}")
+  if inputs.ndim == 0 or not -inputs.ndim <= axis < inputs.ndim:
+    raise ValueError(f"axis {axis} is invalid for inputs with {inputs.ndim} dimensions")
+  if inputs.shape[axis] == 0:
+    raise ValueError("the diffusion sequence axis must be nonempty")
+  if block_size <= 0:
+    raise ValueError(f"block_size must be positive, got {block_size}")
+  if mask_id < 0:
+    raise ValueError(f"mask_id must be nonnegative, got {mask_id}")
+  if not 0.0 < min_noise <= 1.0:
+    raise ValueError(f"min_noise must satisfy 0 < min_noise <= 1, got {min_noise}")
+  if (logit_alignment, canvas_policy) not in _SUPPORTED_CONTRACTS:
+    raise ValueError(
+        "Block diffusion supports only same_position/all_masked or shifted/seed_and_mask; "
+        f"got {logit_alignment}/{canvas_policy}"
+    )
+  if canvas_policy == "seed_and_mask" and block_size < 2:
+    raise ValueError("seed_and_mask requires block_size to be at least 2")
+
+  axis %= inputs.ndim
+  moved_validity = np.moveaxis(validity_mask, axis, -1)
+  rows = moved_validity.reshape(-1, inputs.shape[axis])
+  block_count = (rows.shape[-1] + block_size - 1) // block_size
+  padded_length = block_count * block_size
+  padded_rows = np.pad(rows, ((0, 0), (0, padded_length - rows.shape[-1])))
+  eligible_blocks = padded_rows.reshape(rows.shape[0], block_count, block_size)
+
+  seed_loss_blocks = np.zeros_like(eligible_blocks)
+  if canvas_policy == "seed_and_mask":
+    seed_positions = np.arange(block_size) == 0
+    seed_loss_blocks = eligible_blocks & seed_positions
+    seed_loss_blocks[:, 0, :] = False
+    eligible_blocks &= ~seed_positions
+
+  noise = rng.uniform(min_noise, 1.0, size=eligible_blocks.shape[:-1] + (1,))
+  selected_blocks = eligible_blocks & (rng.random(size=eligible_blocks.shape) < noise)
+
+  # A nonempty eligible block must always contribute at least one target.
+  needs_fallback = eligible_blocks.any(axis=-1) & ~selected_blocks.any(axis=-1)
+  fallback_scores = np.where(eligible_blocks, rng.random(size=eligible_blocks.shape), -1.0)
+  fallback_offsets = np.argmax(fallback_scores, axis=-1)
+  fallback = np.arange(block_size) == fallback_offsets[..., None]
+  selected_blocks |= needs_fallback[..., None] & fallback
+
+  corruption_rows = selected_blocks.reshape(rows.shape[0], padded_length)[:, : rows.shape[-1]]
+  loss_rows = (selected_blocks | seed_loss_blocks).reshape(rows.shape[0], padded_length)[:, : rows.shape[-1]]
+  corruption_mask = np.moveaxis(corruption_rows.reshape(moved_validity.shape), -1, axis)
+  targets_loss_mask = np.moveaxis(loss_rows.reshape(moved_validity.shape), -1, axis)
+  return BlockDiffusionCorruptionResult(
+      inputs=np.where(corruption_mask, inputs.dtype.type(mask_id), inputs),
+      corruption_mask=corruption_mask,
+      targets_loss_mask=targets_loss_mask,
+  )

--- a/src/maxtext/diffusion/block_diffusion/target_alignment.py
+++ b/src/maxtext/diffusion/block_diffusion/target_alignment.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Target alignment for discrete block-diffusion objectives."""
+
+import jax
+import jax.numpy as jnp
+
+
+def align_logits_to_targets(
+    logits: jax.Array,
+    alignment: str,
+    positions: jax.Array | None = None,
+    validity_mask: jax.Array | None = None,
+) -> jax.Array:
+  """Aligns model output positions with clean block-diffusion targets.
+
+  ``logits`` has shape ``[batch, sequence, vocabulary]``. Optional
+  ``positions`` and ``validity_mask`` arrays have shape ``[batch, sequence]``.
+  The returned logits have the same shape as the input logits.
+  """
+  if alignment == "same_position":
+    return logits
+  if alignment == "shifted":
+    if positions is None:
+      indices = jnp.maximum(jnp.arange(logits.shape[1], dtype=jnp.int32) - 1, 0)
+      return logits[:, indices, :]
+    positions = jnp.asarray(positions, dtype=jnp.int32)
+    if positions.shape != logits.shape[:2]:
+      raise ValueError(f"positions must match logits [batch, length]; got {positions.shape} and {logits.shape[:2]}")
+    if validity_mask is None:
+      validity_mask = jnp.ones_like(positions, dtype=jnp.bool_)
+    sequence_length = logits.shape[1]
+    array_indices = jnp.broadcast_to(jnp.arange(sequence_length, dtype=jnp.int32), positions.shape)
+    row_indices = jnp.broadcast_to(jnp.arange(logits.shape[0], dtype=jnp.int32)[:, None], positions.shape)
+    safe_positions = jnp.clip(positions, 0, sequence_length - 1)
+    updates = jnp.where(validity_mask, array_indices + 1, 0)
+    position_to_index = jnp.zeros_like(positions).at[row_indices, safe_positions].max(updates)
+    previous_positions = jnp.maximum(positions - 1, 0)
+    source_indices = jnp.take_along_axis(position_to_index, jnp.clip(previous_positions, 0, sequence_length - 1), axis=1)
+    source_indices = jnp.maximum(source_indices - 1, 0)
+    return jnp.take_along_axis(logits, source_indices[..., None], axis=1)
+  raise ValueError(f"Unsupported block-diffusion logit alignment: {alignment}")

--- a/tests/unit/block_diffusion_test.py
+++ b/tests/unit/block_diffusion_test.py
@@ -1,0 +1,279 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for model-independent block-diffusion primitives."""
+
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from maxtext.diffusion.block_diffusion import corruption
+from maxtext.diffusion.block_diffusion import target_alignment
+
+
+pytestmark = pytest.mark.cpu_only
+
+
+def _make_batch():
+  """Builds padded rows with a partial final diffusion block."""
+  tokens = np.asarray(
+      [
+          [11, 12, 13, 14, 15, 16, 17, 18, 19, 0],
+          [21, 22, 23, 24, 25, 26, 0, 0, 0, 0],
+      ],
+      dtype=np.int32,
+  )
+  positions = np.broadcast_to(np.arange(tokens.shape[1], dtype=np.int32), tokens.shape).copy()
+  segmentation = (tokens != 0).astype(np.int32)
+  return {
+      "inputs": tokens.copy(),
+      "targets": tokens.copy(),
+      "inputs_segmentation": segmentation.copy(),
+      "targets_segmentation": segmentation.copy(),
+      "inputs_position": positions.copy(),
+      "targets_position": positions.copy(),
+  }
+
+
+class _ControlledRng:
+  """Supplies distinct noise rates while making token draws deterministic."""
+
+  def __init__(self):
+    self.uniform_calls = 0
+    self.random_calls = 0
+
+  def uniform(self, low, high, size):
+    del low, high
+    self.uniform_calls += 1
+    return np.asarray([[[0.1], [0.9], [0.1]], [[0.1], [0.9], [0.1]]]).reshape(size)
+
+  def random(self, size):
+    self.random_calls += 1
+    return np.full(size, 0.5)
+
+
+class BlockDiffusionCorruptionTest(unittest.TestCase):
+
+  def _apply(self, *, seed=0, **kwargs):
+    """Applies corruption and reconstructs the input batch for assertions."""
+    clean = _make_batch()
+    result = corruption.corrupt_tokens(
+        clean["inputs"],
+        clean["targets_segmentation"] != 0,
+        np.random.default_rng(seed),
+        block_size=4,
+        mask_id=99,
+        **kwargs,
+    )
+    return clean | {
+        "inputs": result.inputs,
+        "corruption_mask": result.corruption_mask.astype(np.int32),
+        "targets_loss_mask": result.targets_loss_mask.astype(np.int32),
+    }
+
+  def test_all_masked_contract_preserves_clean_targets_and_metadata(self):
+    clean = _make_batch()
+    output = self._apply(min_noise=1.0)
+
+    for key in (
+        "targets",
+        "inputs_segmentation",
+        "targets_segmentation",
+        "inputs_position",
+        "targets_position",
+    ):
+      np.testing.assert_array_equal(output[key], clean[key])
+    np.testing.assert_array_equal(output["corruption_mask"], clean["targets_segmentation"])
+    np.testing.assert_array_equal(output["targets_loss_mask"], output["corruption_mask"])
+    self.assertTrue(np.all(output["inputs"][output["corruption_mask"] != 0] == 99))
+    self.assertTrue(np.all(output["inputs"][clean["targets_segmentation"] == 0] == 0))
+
+  def test_every_nonempty_partial_or_full_block_has_a_target(self):
+    output = self._apply(seed=17)
+    validity = output["targets_segmentation"] != 0
+    loss_mask = output["targets_loss_mask"] != 0
+
+    for row in range(validity.shape[0]):
+      for start in range(0, validity.shape[1], 4):
+        stop = min(start + 4, validity.shape[1])
+        if np.any(validity[row, start:stop]):
+          self.assertTrue(np.any(loss_mask[row, start:stop]), (row, start, stop))
+    self.assertTrue(loss_mask[0, 8])
+
+  def test_noise_rate_is_sampled_once_per_logical_block(self):
+    rng = _ControlledRng()
+    clean = _make_batch()
+    result = corruption.corrupt_tokens(
+        clean["inputs"],
+        clean["targets_segmentation"] != 0,
+        rng,
+        block_size=4,
+        mask_id=99,
+    )
+
+    self.assertEqual(rng.uniform_calls, 1)
+    self.assertEqual(rng.random_calls, 2)
+    self.assertEqual(int(result.targets_loss_mask[0, :4].sum()), 1)
+    self.assertEqual(int(result.targets_loss_mask[0, 4:8].sum()), 4)
+
+  def test_shifted_seed_contract_keeps_anchors_clean_and_supervises_later_anchors(self):
+    output = self._apply(
+        min_noise=1.0,
+        logit_alignment="shifted",
+        canvas_policy="seed_and_mask",
+    )
+    clean = _make_batch()
+
+    self.assertFalse(output["corruption_mask"][:, ::4].any())
+    expected_loss = clean["targets_segmentation"].copy()
+    expected_loss[:, 0] = 0
+    np.testing.assert_array_equal(output["targets_loss_mask"], expected_loss)
+    np.testing.assert_array_equal(output["inputs"][:, ::4], clean["inputs"][:, ::4])
+
+  def test_fixed_seed_is_deterministic(self):
+    output_a = self._apply(seed=123)
+    output_b = self._apply(seed=123)
+
+    for key, value in output_a.items():
+      np.testing.assert_array_equal(value, output_b[key])
+
+  def test_all_invalid_row_has_no_corruption_or_loss(self):
+    result = corruption.corrupt_tokens(
+        np.zeros((1, 5), dtype=np.int32),
+        np.zeros((1, 5), dtype=np.bool_),
+        np.random.default_rng(0),
+        block_size=4,
+        mask_id=99,
+    )
+
+    self.assertFalse(result.corruption_mask.any())
+    self.assertFalse(result.targets_loss_mask.any())
+    np.testing.assert_array_equal(result.inputs, np.zeros((1, 5), dtype=np.int32))
+
+  def test_single_token_blocks_are_supported_only_for_all_masked_canvas(self):
+    all_masked = corruption.corrupt_tokens(
+        np.asarray([[11, 12]], dtype=np.int32),
+        np.ones((1, 2), dtype=np.bool_),
+        np.random.default_rng(0),
+        block_size=1,
+        mask_id=99,
+        min_noise=1.0,
+    )
+
+    np.testing.assert_array_equal(all_masked.inputs, [[99, 99]])
+    with self.assertRaisesRegex(ValueError, "at least 2"):
+      corruption.corrupt_tokens(
+          np.asarray([[11, 12]], dtype=np.int32),
+          np.ones((1, 2), dtype=np.bool_),
+          np.random.default_rng(0),
+          block_size=1,
+          mask_id=99,
+          logit_alignment="shifted",
+          canvas_policy="seed_and_mask",
+      )
+
+  def test_invalid_configuration_or_shape_raises(self):
+    invalid_kwargs = (
+        {"block_size": 4, "mask_id": 99, "axis": 2},
+        {"block_size": 0, "mask_id": 99},
+        {"block_size": 4, "mask_id": -1},
+        {"block_size": 4, "mask_id": 99, "min_noise": 0.0},
+        {
+            "block_size": 4,
+            "mask_id": 99,
+            "logit_alignment": "same_position",
+            "canvas_policy": "seed_and_mask",
+        },
+    )
+    for kwargs in invalid_kwargs:
+      with self.subTest(kwargs=kwargs), self.assertRaises(ValueError):
+        corruption.corrupt_tokens(
+            np.ones((1, 4), dtype=np.int32),
+            np.ones((1, 4), dtype=np.bool_),
+            np.random.default_rng(0),
+            **kwargs,
+        )
+
+    batch = _make_batch()
+    with self.assertRaisesRegex(ValueError, "identical shapes"):
+      corruption.corrupt_tokens(
+          batch["inputs"],
+          batch["targets_segmentation"][:, :-1],
+          np.random.default_rng(0),
+          block_size=4,
+          mask_id=99,
+      )
+    with self.assertRaisesRegex(ValueError, "nonempty"):
+      corruption.corrupt_tokens(
+          np.zeros((1, 0), dtype=np.int32),
+          np.zeros((1, 0), dtype=np.bool_),
+          np.random.default_rng(0),
+          block_size=4,
+          mask_id=99,
+      )
+
+
+class TargetAlignmentTest(unittest.TestCase):
+
+  def test_same_position_is_identity_and_shifted_uses_previous_logit(self):
+    logits = jnp.arange(8, dtype=jnp.float32).reshape(1, 4, 2)
+
+    same_position = target_alignment.align_logits_to_targets(logits, "same_position")
+    shifted = target_alignment.align_logits_to_targets(logits, "shifted")
+
+    np.testing.assert_array_equal(same_position, logits)
+    np.testing.assert_array_equal(shifted, logits[:, [0, 0, 1, 2], :])
+
+  def test_shifted_alignment_follows_logical_positions_after_reordering(self):
+    positions = jnp.asarray([[0, 3, 1, 2]], dtype=jnp.int32)
+    logits = positions[..., None].astype(jnp.float32)
+
+    shifted = target_alignment.align_logits_to_targets(
+        logits,
+        "shifted",
+        positions=positions,
+        validity_mask=jnp.ones_like(positions, dtype=jnp.bool_),
+    )
+
+    np.testing.assert_array_equal(shifted[..., 0], [[0, 2, 0, 1]])
+
+  def test_shifted_alignment_defaults_to_all_positions_valid(self):
+    positions = jnp.asarray([[0, 3, 1, 2]], dtype=jnp.int32)
+    logits = positions[..., None].astype(jnp.float32)
+
+    shifted = target_alignment.align_logits_to_targets(logits, "shifted", positions=positions)
+
+    np.testing.assert_array_equal(shifted[..., 0], [[0, 2, 0, 1]])
+
+  def test_invalid_padding_positions_do_not_override_logical_position_zero(self):
+    positions = jnp.asarray([[0, 3, 1, 2, 0, 0]], dtype=jnp.int32)
+    validity = jnp.asarray([[1, 1, 1, 1, 0, 0]], dtype=jnp.bool_)
+    logits = jnp.arange(6, dtype=jnp.float32).reshape(1, 6, 1)
+
+    shifted = target_alignment.align_logits_to_targets(logits, "shifted", positions, validity)
+
+    np.testing.assert_array_equal(shifted[0, :4, 0], [0, 3, 0, 2])
+
+  def test_invalid_alignment_or_positions_raise(self):
+    logits = jnp.zeros((1, 4, 2), dtype=jnp.float32)
+    with self.assertRaisesRegex(ValueError, "Unsupported"):
+      target_alignment.align_logits_to_targets(logits, "unknown")
+    with self.assertRaisesRegex(ValueError, "positions must match"):
+      target_alignment.align_logits_to_targets(logits, "shifted", positions=jnp.zeros((1, 3)))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Motivation

MaxText needs small, model-independent primitives for discrete block-diffusion
training before attention, input-pipeline, trainer, or post-training support is
introduced.

## Scope

This PR adds only:

- block corruption under `maxtext.diffusion.block_diffusion`;
- explicit target alignment for `same_position` and `shifted` logits; and
- focused unit tests for both supported contracts.

It does not change configuration, attention, model execution, training loops,
serving, SFT, distillation, or RL.

## Design

The corruption API consumes clean tokens, an explicit eligibility mask, a
logical block size, and one of two declared model contracts:

- `same_position` with an `all_masked` canvas; or
- `shifted` with a `seed_and_mask` canvas.

Each nonempty eligible block is guaranteed to retain at least one supervised
position. Padding remains untouched. Target alignment follows logical token
positions, including reordered physical layouts, instead of assuming that
array index equals sequence position.

## Compatibility

There is no behavior change for existing MaxText training or inference paths.
The new package is not activated by any configuration in this PR.

## Tests

`python -m pytest -q tests/unit/block_diffusion_test.py`

The tests cover partial blocks, per-block noise sampling, deterministic RNG,
all-invalid rows, seeded anchors, mask/loss provenance, reordered logical
positions, padding, and invalid contracts and shapes.

Current clean-head result: `13 passed`, `5 subtests passed`; Pyink, compileall,
and `git diff --check` also pass.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added comments or docstrings where the contracts are not self-evident.
- [x] End-to-end testing is not applicable to this default-off, pure primitive layer; focused CPU tests are listed above.
- [x] No standalone documentation page or toctree change is needed; the public design document is linked below.

## Follow-ups

Block-causal attention and pre-training integration will be proposed only after
this primitive contract is reviewed and landed. CFT/SFT, OPD, exact replay,
and RL remain separate later changes.

Design document:
https://docs.google.com/document/d/1N7KcCoAIErB2CV9EJ2G1u_mdN-AQgqwNUYSvM0mtqMI/edit
