### PR TITLE
Honor partial_rotary_factor on the MRoPE path

### DIFF
--- a/tests/unit/partial_rotary_embedding_test.py
+++ b/tests/unit/partial_rotary_embedding_test.py
@@ -30,7 +30,12 @@ from jax.sharding import Mesh
 from flax import nnx
 import numpy as np
 
-from maxtext.layers.embeddings import PartialRotaryEmbedding, RotaryEmbedding, Gemma4PartialRotaryEmbedding
+from maxtext.layers.embeddings import (
+    PartialRotaryEmbedding,
+    RotaryEmbedding,
+    Gemma4PartialRotaryEmbedding,
+    Qwen3OmniMoeThinkerTextRotaryEmbedding,
+)
 from maxtext.configs import pyconfig
 from maxtext.utils import maxtext_utils
 from tests.utils.test_helpers import get_test_config_path
@@ -307,6 +312,170 @@ class Gemma4PartialRotaryEmbeddingTest(unittest.TestCase):
 
     expected = jnp.array([[[[1.0, 1.0, 1.0, 1.0]], [[-0.300781, 1.0, 1.38281, 1.0]]]])
     np.testing.assert_allclose(outputs, expected, atol=1e-5)
+
+
+class Qwen3OmniMoeThinkerTextRotaryEmbeddingPartialTest(unittest.TestCase):
+  """Tests that the MRoPE layer honors `partial_rotary_factor`."""
+
+  def setUp(self):
+    super().setUp()
+    self.cfg = pyconfig.initialize(
+        [sys.argv[0], get_test_config_path()],
+        run_name="test_embeddings",
+        enable_checkpointing=False,
+    )
+    devices_array = maxtext_utils.create_device_mesh(self.cfg)
+    self.mesh = Mesh(devices_array, self.cfg.mesh_axes)
+    self.nnx_rng = nnx.Rngs(params=0)
+
+  def test_mrope_partial_rotary_passthrough(self):
+    """Only the leading rotary_dim channels are rotated, the rest pass through."""
+    batch_size, seq_len, num_heads, head_dim = 2, 8, 4, 32
+    partial_rotary_factor = 0.25
+    rotary_dim = int(head_dim * partial_rotary_factor)
+    inputs = jax.random.normal(jax.random.PRNGKey(0), (batch_size, seq_len, num_heads, head_dim))
+    # Positions start at 1 so that every token is actually rotated.
+    positions = jnp.broadcast_to(jnp.arange(1, seq_len + 1, dtype=jnp.int32), (batch_size, seq_len))
+
+    rope = Qwen3OmniMoeThinkerTextRotaryEmbedding(
+        min_timescale=1,
+        max_timescale=10000,
+        embedding_dims=head_dim,
+        mrope_section=(2, 1, 1),
+        partial_rotary_factor=partial_rotary_factor,
+        cast_as_fprop_dtype=False,
+        rngs=self.nnx_rng,
+    )
+
+    y = rope(inputs, positions)
+
+    self.assertEqual(y.shape, inputs.shape)
+    np.testing.assert_allclose(
+        y[..., rotary_dim:],
+        inputs[..., rotary_dim:],
+        rtol=1e-6,
+        atol=1e-6,
+        err_msg="Channels beyond the rotary slice should pass through untouched.",
+    )
+    self.assertFalse(
+        np.allclose(y[..., :rotary_dim], inputs[..., :rotary_dim], rtol=1e-6, atol=1e-6),
+        msg="The leading rotary slice should be rotated.",
+    )
+
+  def test_mrope_partial_matches_partial_rotary_embedding(self):
+    """For text-only positions MRoPE degenerates to RoPE, so it must match PartialRotaryEmbedding."""
+    batch_size, seq_len, num_heads, head_dim = 2, 8, 4, 32
+    partial_rotary_factor = 0.5
+    inputs = jax.random.normal(jax.random.PRNGKey(0), (batch_size, seq_len, num_heads, head_dim))
+    positions = jnp.broadcast_to(jnp.arange(1, seq_len + 1, dtype=jnp.int32), (batch_size, seq_len))
+
+    rope_mrope = Qwen3OmniMoeThinkerTextRotaryEmbedding(
+        min_timescale=1,
+        max_timescale=10000,
+        embedding_dims=head_dim,
+        mrope_section=(4, 2, 2),
+        partial_rotary_factor=partial_rotary_factor,
+        cast_as_fprop_dtype=False,
+        rngs=self.nnx_rng,
+    )
+    rope_partial = PartialRotaryEmbedding(
+        min_timescale=1,
+        max_timescale=10000,
+        mesh=self.mesh,
+        embedding_dims=head_dim,
+        partial_rotary_factor=partial_rotary_factor,
+        cast_as_fprop_dtype=False,
+        rngs=self.nnx_rng,
+    )
+
+    np.testing.assert_allclose(
+        rope_mrope(inputs, positions),
+        rope_partial(inputs, positions),
+        rtol=1e-5,
+        atol=1e-5,
+        err_msg="MRoPE with a partial factor should agree with PartialRotaryEmbedding on text positions.",
+    )
+
+  def test_mrope_default_rotates_full_head_dim(self):
+    """Verify the default full-rotation output values against captured snapshot."""
+    layer = Qwen3OmniMoeThinkerTextRotaryEmbedding(
+        min_timescale=1,
+        max_timescale=10000,
+        embedding_dims=4,
+        mrope_section=(2, 0, 0),
+        rngs=self.nnx_rng,
+    )
+    inputs = jnp.ones((1, 2, 1, 4))
+    position = jnp.array([[0, 1]])
+    outputs = layer(inputs, position)
+
+    expected = jnp.array([[[[1.0, 1.0, 1.0, 1.0]], [[-0.300781, 0.988281, 1.38281, 1.00781]]]])
+    np.testing.assert_allclose(outputs, expected, atol=1e-5)
+
+  def test_mrope_full_factor_matches_default(self):
+    """An explicit partial factor of 1.0 leaves the full-rotation behavior untouched."""
+    batch_size, seq_len, num_heads, head_dim = 1, 8, 2, 16
+    inputs = jax.random.normal(jax.random.PRNGKey(0), (batch_size, seq_len, num_heads, head_dim))
+    positions = jnp.broadcast_to(jnp.arange(seq_len, dtype=jnp.int32), (batch_size, seq_len))
+
+    kwargs = {
+        "min_timescale": 1,
+        "max_timescale": 10000,
+        "embedding_dims": head_dim,
+        "mrope_section": (4, 2, 2),
+        "cast_as_fprop_dtype": False,
+        "rngs": self.nnx_rng,
+    }
+    y_default = Qwen3OmniMoeThinkerTextRotaryEmbedding(**kwargs)(inputs, positions)
+    y_full = Qwen3OmniMoeThinkerTextRotaryEmbedding(partial_rotary_factor=1.0, **kwargs)(inputs, positions)
+
+    np.testing.assert_allclose(
+        y_full,
+        y_default,
+        rtol=1e-6,
+        atol=1e-6,
+        err_msg="A partial factor of 1.0 should match the default full rotation.",
+    )
+
+  def test_shipped_mrope_configs_apply_partial_rotary(self):
+    """The shipped MRoPE configs that set a partial factor rotate only the leading slice."""
+    for model_name in ("qwen3.5-35b-a3b", "qwen3.5-397b-a17b"):
+      with self.subTest(model_name=model_name):
+        cfg = pyconfig.initialize(
+            [sys.argv[0], get_test_config_path()],
+            model_name=model_name,
+            run_name="test_embeddings",
+            enable_checkpointing=False,
+        )
+        self.assertTrue(cfg.use_mrope)
+        rotary_dim = int(cfg.head_dim * cfg.partial_rotary_factor)
+        # MRoPE duplicates the angles across both halves of the rotated slice, so the
+        # sections of these configs only add up to half of the rotary dimension.
+        self.assertEqual(sum(cfg.mrope_section), rotary_dim // 2)
+
+        rope = Qwen3OmniMoeThinkerTextRotaryEmbedding(
+            min_timescale=cfg.rope_min_timescale,
+            max_timescale=cfg.rope_max_timescale,
+            embedding_dims=cfg.head_dim,
+            mrope_section=tuple(cfg.mrope_section),
+            partial_rotary_factor=cfg.partial_rotary_factor,
+            cast_as_fprop_dtype=False,
+            rngs=self.nnx_rng,
+        )
+        self.assertEqual(rope.rotary_dim, rotary_dim)
+
+        seq_len = 4
+        inputs = jax.random.normal(jax.random.PRNGKey(0), (1, seq_len, 1, cfg.head_dim))
+        positions = jnp.broadcast_to(jnp.arange(1, seq_len + 1, dtype=jnp.int32), (1, seq_len))
+        y = rope(inputs, positions)
+
+        np.testing.assert_allclose(
+            y[..., rotary_dim:],
+            inputs[..., rotary_dim:],
+            rtol=1e-6,
+            atol=1e-6,
+            err_msg=f"{model_name} should leave the channels beyond rotary_dim untouched.",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

`partial_rotary_factor` was silently dropped on the MRoPE path, so the two shipped configs that set both `use_mrope: true` and `partial_rotary_factor: 0.25` applied RoPE to the full head dimension instead of the leading quarter. Reported in #4616.

The defect: `Attention.init_rotary_embedding` in `src/maxtext/layers/attentions.py` routes every `use_mrope` layer to `Qwen3OmniMoeThinkerTextRotaryEmbedding` through the `elif self.use_mrope:` branch. That branch passed `embedding_dims=rope_embedding_dims`, which is the full `head_dim`, and never passed a partial rotary factor because the class did not accept one. `PartialRotaryEmbedding` already implements the intended behavior, but only the non-MRoPE branches can reach it, and the `is_qwen3_hybrid` branch that does construct it sits below the MRoPE branch in the same chain. There was no error and no shape mismatch, so the misconfiguration was invisible at runtime.

Affected shipped configs, both `head_dim: 256`:

- `src/maxtext/configs/models/qwen3.5-35b-a3b.yml`
- `src/maxtext/configs/models/qwen3.5-397b-a17b.yml`

Both set `partial_rotary_factor: 0.25`, so 64 of the 256 head channels should be rotated. Their `mrope_section` of `[11, 11, 10]` sums to 32, which is half of that intended 64 channel slice rather than half of `head_dim`, so the frequency layout was wrong too: the interleaved MRoPE sections only reached the first 33 of the 128 angles that the full head dimension produces.

The fix teaches `Qwen3OmniMoeThinkerTextRotaryEmbedding` the construction `PartialRotaryEmbedding` already uses. It takes a `partial_rotary_factor`, computes `rotary_dim = int(head_dim * partial_rotary_factor)`, and initializes the base class with `embedding_dims=self.rotary_dim` so the timescale, and therefore the inverse frequencies, span only the rotated slice. In `__call__` the leading `rotary_dim` channels are split off, rotated, and the untouched remainder is concatenated back. The shape check now compares against `head_dim` instead of the reduced `embedding_dims`. `init_rotary_embedding` passes `config.partial_rotary_factor` through, matching what the neighboring qwen3 hybrid branch already does.

The factor defaults to 1.0. In that case no split happens and the output is unchanged, so `qwen3-vl-*` and `qwen3-omni-*`, which do not set the factor, are unaffected. I verified this directly: dumping the default layer output at `head_dim=128` with `mrope_section=(24, 20, 20)`, for both 3D multimodal positions and 2D text positions, gives bitwise identical arrays before and after the change.

# Tests

Five new cases in `tests/unit/partial_rotary_embedding_test.py`, in a `Qwen3OmniMoeThinkerTextRotaryEmbeddingPartialTest` class alongside the existing partial rotary tests:

- channels beyond `rotary_dim` pass through untouched and the leading slice is rotated,
- with text-only positions MRoPE degenerates to ordinary RoPE, so the output must agree with `PartialRotaryEmbedding` channel for channel,
- a snapshot of the default full rotation output, which pins the existing behavior,
- an explicit factor of 1.0 matches the default construction,
- the two affected shipped configs are loaded through `pyconfig`, their `mrope_section` is checked against `rotary_dim // 2`, and the passthrough property is asserted at their real `head_dim` of 256.

Command:

```
python -m pytest tests/unit/partial_rotary_embedding_test.py -q
```

Fail before, with `src/maxtext/layers/embeddings.py` and `src/maxtext/layers/attentions.py` checked out from the base ref and only the test file carrying the change:

```
E     TypeError: Qwen3OmniMoeThinkerTextRotaryEmbedding.__init__() got an unexpected keyword argument 'partial_rotary_factor'

=========================== short test summary info ============================
FAILED tests/unit/partial_rotary_embedding_test.py::Qwen3OmniMoeThinkerTextRotaryEmbeddingPartialTest::test_mrope_full_factor_matches_default
FAILED tests/unit/partial_rotary_embedding_test.py::Qwen3OmniMoeThinkerTextRotaryEmbeddingPartialTest::test_mrope_partial_matches_partial_rotary_embedding
FAILED tests/unit/partial_rotary_embedding_test.py::Qwen3OmniMoeThinkerTextRotaryEmbeddingPartialTest::test_mrope_partial_rotary_passthrough
SUBFAILED(model_name='qwen3.5-35b-a3b') tests/unit/partial_rotary_embedding_test.py::Qwen3OmniMoeThinkerTextRotaryEmbeddingPartialTest::test_shipped_mrope_configs_apply_partial_rotary
SUBFAILED(model_name='qwen3.5-397b-a17b') tests/unit/partial_rotary_embedding_test.py::Qwen3OmniMoeThinkerTextRotaryEmbeddingPartialTest::test_shipped_mrope_configs_apply_partial_rotary
5 failed, 10 passed in 8.98s
```

Pass after, with both source files restored:

```
.............                                                          [100%]
13 passed, 2 subtests passed in 9.37s
```

The pre-existing cases in that file, including the `PartialRotaryEmbedding` and `Gemma4PartialRotaryEmbedding` suites, pass in both runs. `tests/unit/embeddings_test.py` is also green. Ran on CPU. Formatted with the pinned pyink 24.10.1 at `--pyink-indentation=2 --line-length=122`, and pylint 3.3.8 rates the changed files 10.00/10.

FIXES: #4616
