### PR TITLE
[maxtext] Add block-causal attention

### DIFF
--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -136,6 +136,7 @@ class AttentionType(enum.Enum):
   MLA = "mla"
   COMPRESSED = "compressed"
   FULL = "full"
+  BLOCK_DIFFUSION = "block_diffusion"
 
 
 class ShardMode(enum.Enum):

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -388,12 +388,15 @@ param_scan_axis: 1
 # The attention parameter dictates the specific algorithm/methodology used to compute the attention scores
 # The attention_type parameter determines the variants of attention, e.g. global or local_sliding
 attention: 'autoselected' # Supported attention: autoselected, dot_product, flash, cudnn_flash_te
-attention_type: 'global' # Supported attention_type: global, local_sliding, chunk, mla
+attention_type: 'global' # Supported attention_type: global, local_sliding, chunk, mla, full, compressed, block_diffusion
 share_kv_projections: false # Note: Not compatible with attention_type='mla'
 attention_bias: false # If true, adds a learnable bias to the query, key, and value projections
 attention_sink: false
 sliding_window_size: 0
 chunk_attn_window_size: 0
+# Token block size B for block-causal attention in Block Diffusion (arXiv:2503.09573).
+# Tokens attend bidirectionally within a block and causally across blocks.
+causal_block_size: 32
 attn_logits_soft_cap: 0.0
 final_logits_soft_cap: 0.0
 z_loss_multiplier: 0.0
@@ -1348,5 +1351,4 @@ elastic_backup_kind: "snapshot"
 elastic_timeout_seconds: 300
 elastic_max_retries: 10
 elastic_min_slice_count: -1
-
 

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -579,7 +579,7 @@ class Attention(BaseModel):
       "autoselected",
       description="The attention algorithm to use (dot_product, flash, cudnn_flash_te, vllm_rpa, vllm_batched_rpa, etc).",
   )
-  attention_type: Literal["global", "local_sliding", "chunk", "mla", "full", "compressed"] = Field(
+  attention_type: Literal["global", "local_sliding", "chunk", "mla", "full", "compressed", "block_diffusion"] = Field(
       "global", description="The variant of attention to use."
   )
   share_kv_projections: bool = Field(
@@ -626,6 +626,10 @@ class Attention(BaseModel):
   )
   sliding_window_size: NonNegativeInt = Field(0, description="The size of the sliding window for local attention.")
   chunk_attn_window_size: NonNegativeInt = Field(0, description="The window size for chunked attention.")
+  causal_block_size: PositiveInt = Field(
+      32,
+      description="The number of token positions in each bidirectional block for block-causal attention.",
+  )
   attn_logits_soft_cap: None | NonNegativeFloat = Field(
       None, description="Soft-cap value for attention logits. None means no cap."
   )
@@ -3500,6 +3504,19 @@ class MaxTextConfig(
         not isinstance(self.sliding_window_size, int) or self.sliding_window_size <= 0
     ):
       raise ValueError("`sliding_window_size` must be an integer > 0 for 'local_sliding' attention.")
+    if self.attention_type == AttentionType.BLOCK_DIFFUSION.value:
+      if self.packing:
+        # Document-local block origins inside a packed sequence are not tracked
+        # in attention metadata; packing without realignment would cause
+        # cross-document block-attention leakage.
+        raise ValueError("Block-diffusion attention does not support packing; set `packing=False`.")
+      if self.attention not in ("autoselected", "dot_product", "flash"):
+        raise ValueError("Block-diffusion attention is supported only by dot_product attention and TPU Splash attention.")
+      if self.attention in ("autoselected", "flash") and self.hardware != "tpu":
+        raise ValueError(
+            "Block-diffusion attention with attention='autoselected' or attention='flash' requires hardware='tpu'; "
+            "use attention='dot_product' on other hardware."
+        )
     if self.quantize_kvcache and not self.kv_quant_axis:
       raise ValueError("`kv_quant_axis` cannot be empty when quantize_kvcache is True.")
     if (

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -84,6 +84,16 @@ from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_
 dynamic_vector_slice_in_dim = jax.vmap(lax.dynamic_slice_in_dim, in_axes=(None, 0, None, None))
 
 
+def _resolve_attention_type(config: Config, attention_type: AttentionType | str | None) -> AttentionType:
+  configured_attention_type = AttentionType(getattr(config, "attention_type", AttentionType.GLOBAL.value))
+  if attention_type is None:
+    return configured_attention_type
+  resolved_attention_type = AttentionType(attention_type)
+  if configured_attention_type == AttentionType.BLOCK_DIFFUSION and resolved_attention_type == AttentionType.GLOBAL:
+    return configured_attention_type
+  return resolved_attention_type
+
+
 def validate_compute_axis_order(s: AxisIdxes) -> None:
   valid_compute_axis_order = ((0, 1, 2, 3), (0, 2, 1, 3))
   if s not in valid_compute_axis_order:  # currently supported compute_axis_order
@@ -204,6 +214,50 @@ class ChunkedCausalMask(splash_attention_mask._ComputableMask):  # pylint: disab
     )
 
 
+class BlockCausalMask(splash_attention_mask._ComputableMask):  # pylint: disable=protected-access,abstract-method
+  """Lazy mask with bidirectional attention within causal blocks."""
+
+  causal_block_size: int
+
+  def __init__(
+      self,
+      shape: tuple[int, int],
+      causal_block_size: int,
+      shard_count: int = 1,
+  ):
+    if causal_block_size <= 0:
+      raise ValueError("causal_block_size must be positive")
+    self.causal_block_size = causal_block_size
+
+    def block_causal_mask_function(q_ids, kv_ids):
+      return (q_ids // self.causal_block_size) >= (kv_ids // self.causal_block_size)
+
+    super().__init__(
+        shape=shape,
+        mask_function=block_causal_mask_function,
+        shard_count=shard_count,
+    )
+
+  def __eq__(self, other: object):
+    if not isinstance(other, type(self)):
+      return NotImplemented
+    return (
+        self.shape == other.shape
+        and self.causal_block_size == other.causal_block_size
+        and np.array_equal(self.q_sequence, other.q_sequence)
+    )
+
+  def __hash__(self):
+    return hash(
+        (
+            type(self),
+            self.shape,
+            self.causal_block_size,
+            self.q_sequence.tobytes() if self.q_sequence is not None else None,
+        )
+    )
+
+
 def _generate_chunk_attention_mask(mask_shape: tuple[int, int], chunk_size: int, q_offset: int = 0) -> jax.Array:
   """Generates an explicit boolean mask for chunked causal attention.
 
@@ -232,6 +286,32 @@ def _generate_chunk_attention_mask(mask_shape: tuple[int, int], chunk_size: int,
   same_chunk = (row_ids // chunk_size) == (col_ids // chunk_size)
   chunk_mask = same_chunk & (row_ids >= col_ids)
   return chunk_mask
+
+
+def _generate_block_causal_attention_mask(
+    mask_shape: tuple[int, int], causal_block_size: int, q_offset: int = 0
+) -> jax.Array:
+  """Generates a block-causal mask for Block Diffusion Language Models (BD3LMs).
+
+  Implements the block-causal attention pattern (M_BC) described in Arriola et
+  al., "Block Diffusion: Interpolating Between Autoregressive and Diffusion
+  Language Models" (https://arxiv.org/abs/2503.09573).
+
+  For block size B = causal_block_size, query index q, and key index k:
+
+  * Within block i (floor(q/B) == floor(k/B)), tokens attend bidirectionally.
+  * Across blocks (floor(q/B) > floor(k/B)), block i attends causally to every
+    preceding block, but not to future blocks.
+
+  B = 1 reduces to standard causal attention, while B equal to the sequence
+  length reduces to full bidirectional attention.
+  """
+  if causal_block_size <= 0:
+    raise ValueError("causal_block_size must be positive")
+
+  row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0) + q_offset
+  col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+  return (row_ids // causal_block_size) >= (col_ids // causal_block_size)
 
 
 def _make_block_mask_indices(bidirectional_mask):
@@ -479,7 +559,13 @@ class AttentionOp(nnx.Module):
     self.dtype = dtype
     self.quant = quant
     self.kv_quant = kv_quant
-    self.attention_type = attention_type
+    self.attention_type = _resolve_attention_type(self.config, attention_type)
+    self.causal_block_size = getattr(self.config, "causal_block_size", None)
+    if self.attention_type == AttentionType.BLOCK_DIFFUSION:
+      if self.causal_block_size is None or self.causal_block_size <= 0:
+        raise ValueError("causal_block_size must be positive for block-diffusion attention")
+      if self.attention_kernel not in ("autoselected", "dot_product", "flash"):
+        raise ValueError("Block-diffusion attention is supported only by dot_product attention and TPU Splash attention.")
     # Block sizes are only used by TPU splash attention kernels. Exclude non-splash kernels
     if self.attention_kernel not in (
         "dot_product",
@@ -783,6 +869,7 @@ class AttentionOp(nnx.Module):
     if model_mode != MODEL_MODE_AUTOREGRESSIVE and self.attention_type not in (
         AttentionType.FULL,
         AttentionType.COMPRESSED,
+        AttentionType.BLOCK_DIFFUSION,
     ):
       if use_segment_positions:
         causal_mask = (position_col_ids <= position_row_ids)[:, None, None, :, :]
@@ -906,6 +993,22 @@ class AttentionOp(nnx.Module):
             q_offset=next_pos,
         )
       output_mask = chunk_mask * output_mask
+
+    # For standard token-by-token autoregressive decoding, keep the existing
+    # causal mask path unchanged. BD3LM generation instead uses block-level
+    # parallel sampling.
+    elif self.attention_type == AttentionType.BLOCK_DIFFUSION and model_mode != MODEL_MODE_AUTOREGRESSIVE:
+      if use_segment_positions:
+        block_mask = ((position_row_ids // self.causal_block_size) >= (position_col_ids // self.causal_block_size))[
+            :, None, None, :, :
+        ]
+      else:
+        block_mask = _generate_block_causal_attention_mask(
+            mask_shape=(q_seq_len, kv_seq_len),
+            causal_block_size=self.causal_block_size,
+            q_offset=next_pos,
+        )[None, None, None, :, :]
+      output_mask = block_mask if output_mask is None else jnp.logical_and(output_mask, block_mask)
 
     if bidirectional_mask is not None:
       image_mask = _make_bidirectional_block_mask(bidirectional_mask)
@@ -1173,6 +1276,11 @@ class AttentionOp(nnx.Module):
         return out, None, None
 
       else:
+        if self.attention_type == AttentionType.BLOCK_DIFFUSION:
+          raise ValueError(
+              "Block-diffusion flash attention is supported only by TPU Splash; "
+              "use attention='dot_product' on other hardware."
+          )
         if model_mode == MODEL_MODE_AUTOREGRESSIVE:
           # fallback to dot_product as pallas gpu flash attention doesn't support decode stage
           return self.apply_attention_dot(
@@ -1459,13 +1567,24 @@ class AttentionOp(nnx.Module):
       sa_config = create_sa_config(self.config, query, key, attn_logits_soft_cap)
       mask_shape = (query.shape[2], key.shape[2])  # (q_seq_len, kv_seq_len)
       mask_module = tokamax_splash_mask if self.config.use_tokamax_splash else splash_attention_mask
+      use_load_balanced_cp = cp_size > 1 and load_balanced_context_parallel
       if self.attention_type == AttentionType.FULL:
         mask = mask_module.FullMask(mask_shape)
+      elif self.attention_type == AttentionType.BLOCK_DIFFUSION:
+        mask_type = LoadBalancedBlockCausalMask if use_load_balanced_cp else BlockCausalMask
+        mask_kwargs = {"cp_size": cp_size} if use_load_balanced_cp else {}
+        mask = mask_type(
+            shape=mask_shape,
+            causal_block_size=self.causal_block_size,
+            **mask_kwargs,
+        )
       else:
         mask = mask_module.CausalMask(shape=mask_shape)
 
-      use_load_balanced_cp = cp_size > 1 and load_balanced_context_parallel
-      if use_load_balanced_cp and self.attention_type != AttentionType.FULL:
+      if use_load_balanced_cp and self.attention_type not in (
+          AttentionType.FULL,
+          AttentionType.BLOCK_DIFFUSION,
+      ):
         mask = LoadBalancedCausalMask(shape=mask_shape, cp_size=cp_size)
 
       # Apply local masking if local sliding attention is enabled.
@@ -2484,6 +2603,24 @@ class LoadBalancedChunkedCausalMask(ChunkedCausalMask):
     super().__init__(
         shape=shape,
         chunk_size=chunk_size,
+        shard_count=shard_count,
+    )
+    self.q_sequence = _load_balanced_q_sequence(shape, cp_size)
+
+
+class LoadBalancedBlockCausalMask(BlockCausalMask):  # pylint: disable=abstract-method
+  """Lazy block-causal mask with load-balanced query positions."""
+
+  def __init__(
+      self,
+      shape: tuple[int, int],
+      causal_block_size: int,
+      cp_size: int,
+      shard_count: int = 1,
+  ):
+    super().__init__(
+        shape=shape,
+        causal_block_size=causal_block_size,
         shard_count=shard_count,
     )
     self.q_sequence = _load_balanced_q_sequence(shape, cp_size)

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -51,7 +51,7 @@ from maxtext.common.common_types import (
     AttentionType,
 )
 from maxtext.layers import nnx_wrappers
-from maxtext.layers.attention_op import AttentionOp
+from maxtext.layers.attention_op import AttentionOp, _resolve_attention_type
 from maxtext.layers.embeddings import (
     LLaMARotaryEmbedding,
     LlamaVisionRotaryEmbedding,
@@ -120,7 +120,7 @@ def attention_as_linen(
     float32_logits: bool = False,  # cast logits in float32 for stability.
     quant: Optional[Quant] = None,
     kv_quant: Optional[KVQuant] = None,
-    attention_type: AttentionType = AttentionType.GLOBAL,  # Default to global attention
+    attention_type: AttentionType = AttentionType.GLOBAL,
     attn_logits_soft_cap: float | None = None,
     sliding_window_size: int | None = None,
     use_ragged_attention: bool = False,
@@ -277,7 +277,7 @@ class Attention(nnx.Module):
       float32_logits: bool = False,  # cast logits in float32 for stability.
       quant: Optional[Quant] = None,
       kv_quant: Optional[KVQuant] = None,
-      attention_type: AttentionType = AttentionType.GLOBAL,  # Default to global attention
+      attention_type: AttentionType = AttentionType.GLOBAL,
       attn_logits_soft_cap: float | None = None,
       sliding_window_size: int | None = None,
       use_ragged_attention: bool = False,
@@ -388,7 +388,7 @@ class Attention(nnx.Module):
     self.float32_logits = float32_logits
     self.quant = quant
     self.kv_quant = kv_quant
-    self.attention_type = attention_type
+    self.attention_type = _resolve_attention_type(self.config, attention_type)
     self.attn_logits_soft_cap = attn_logits_soft_cap
     self.sliding_window_size = sliding_window_size
     self.use_ragged_attention = use_ragged_attention

--- a/tests/post_training/unit/learn_to_init_test.py
+++ b/tests/post_training/unit/learn_to_init_test.py
@@ -243,6 +243,7 @@ class ApplyLtiModificationTest(unittest.TestCase):
     mock_config.max_target_length = 32
     mock_config.max_prefill_predict_length = 32
     mock_config.attention = "dot_product"
+    mock_config.attention_type = "global"
     mock_config.dropout_rate = 0.0
     mock_config.float32_qk_product = False
     mock_config.float32_logits = False

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -45,9 +45,12 @@ from maxtext.layers.attention_mla import MLA
 from maxtext.layers import attention_op
 from maxtext.layers.attention_op import (
     AttentionOp,
+    BlockCausalMask,
     ChunkedCausalMask,
+    _generate_block_causal_attention_mask,
     _generate_chunk_attention_mask,
     _make_bidirectional_block_mask,
+    _resolve_attention_type,
 )
 from maxtext.layers.attentions import Attention
 from maxtext.layers import embeddings
@@ -331,6 +334,327 @@ class ChunkedCausalMaskTest(unittest.TestCase):
       _generate_chunk_attention_mask(mask_shape=(4, 4), chunk_size=0)
 
 
+class BlockCausalMaskTest(unittest.TestCase):
+  """Tests the shared dense and Splash block-causal masks."""
+
+  def _make_op(self, sequence_length, *, attention_type=AttentionType.BLOCK_DIFFUSION):
+    """Builds a minimal dot-product attention operator."""
+    config = types.SimpleNamespace(
+        causal_block_size=4,
+        context_parallel_load_balance=False,
+        context_sharding="context",
+    )
+    mesh = types.SimpleNamespace(shape={})
+    kwargs = {}
+    if attention_type is not None:
+      kwargs["attention_type"] = attention_type
+    return AttentionOp(
+        config=config,
+        num_query_heads=1,
+        num_kv_heads=1,
+        max_target_length=sequence_length,
+        mesh=mesh,
+        attention_kernel="dot_product",
+        **kwargs,
+    )
+
+  def _make_flash_op(
+      self,
+      *,
+      attention_type=AttentionType.BLOCK_DIFFUSION,
+      context_parallel_size=1,
+      context_parallel_load_balance=False,
+  ):
+    """Builds a minimal flash-attention operator for dispatch tests."""
+    config = types.SimpleNamespace(
+        causal_block_size=4,
+        context_parallel_strategy="all_gather",
+        context_parallel_load_balance=context_parallel_load_balance,
+        context_sharding="context",
+        sa_block_q=4,
+        sa_block_kv=4,
+        sa_block_kv_compute=4,
+        sa_block_q_dkv=4,
+        sa_block_kv_dkv=4,
+        sa_block_kv_dkv_compute=4,
+        sa_block_q_dq=4,
+        sa_block_kv_dq=4,
+        sa_use_fused_bwd_kernel=True,
+        sa_q_layout="HEAD_DIM_MINOR",
+        sa_k_layout="HEAD_DIM_MINOR",
+        sa_v_layout="HEAD_DIM_MINOR",
+        use_splash_scheduler=False,
+        sa_fuse_reciprocal=False,
+        sa_use_base2_exp=False,
+        use_tokamax_splash=False,
+        use_jax_splash=False,
+    )
+    device = types.SimpleNamespace(platform="cpu")
+    mesh = types.SimpleNamespace(
+        devices=np.asarray([device], dtype=object),
+        shape={"context": context_parallel_size},
+    )
+    return AttentionOp(
+        config=config,
+        num_query_heads=1,
+        num_kv_heads=1,
+        max_target_length=8,
+        mesh=mesh,
+        attention_kernel="flash",
+        attention_type=attention_type,
+    )
+
+  def test_dense_and_splash_masks_match(self):
+    sequence_length = 10
+    block_size = 4
+    query_positions = np.arange(sequence_length)[:, None]
+    key_positions = np.arange(sequence_length)[None, :]
+    expected = query_positions // block_size >= key_positions // block_size
+
+    splash_mask = BlockCausalMask((sequence_length, sequence_length), block_size)
+    dense_mask = _generate_block_causal_attention_mask((sequence_length, sequence_length), block_size)
+
+    np.testing.assert_array_equal(splash_mask[:, :], expected)
+    np.testing.assert_array_equal(dense_mask, expected)
+    self.assertTrue(expected[1, 3])
+    self.assertFalse(expected[3, 4])
+    self.assertTrue(expected[4, 3])
+    self.assertTrue(expected[8, 9])
+
+  def test_splash_mask_equality_and_hash(self):
+    mask = BlockCausalMask((8, 8), 4)
+    equivalent_mask = BlockCausalMask((8, 8), 4)
+
+    self.assertEqual(mask, equivalent_mask)
+    self.assertEqual(hash(mask), hash(equivalent_mask))
+    self.assertNotEqual(mask, object())
+
+  def test_rectangular_dense_mask_respects_query_offset(self):
+    dense_mask = _generate_block_causal_attention_mask(
+        mask_shape=(3, 8),
+        causal_block_size=4,
+        q_offset=2,
+    )
+    query_positions = np.arange(2, 5)[:, None]
+    key_positions = np.arange(8)[None, :]
+    expected = query_positions // 4 >= key_positions // 4
+
+    np.testing.assert_array_equal(dense_mask, expected)
+
+  def test_dot_product_mask_respects_segment_boundaries(self):
+    sequence_length = 12
+    query = jnp.zeros((1, sequence_length, 1, 8))
+    key = jnp.zeros((1, sequence_length, 1, 8))
+    segment_ids = jnp.asarray([[1] * 8 + [2] * 4], dtype=jnp.int32)
+
+    mask = self._make_op(sequence_length).generate_attention_mask(
+        query,
+        key,
+        segment_ids,
+        MODEL_MODE_TRAIN,
+    )
+
+    positions = np.arange(sequence_length)
+    expected = (positions[:, None] // 4 >= positions[None, :] // 4) & (
+        np.asarray(segment_ids[0])[:, None] == np.asarray(segment_ids[0])[None, :]
+    )
+    np.testing.assert_array_equal(np.asarray(mask == 0.0)[0, 0, 0], expected)
+
+  def test_dot_product_mask_uses_original_load_balanced_positions(self):
+    sequence_length = 8
+    positions = jnp.asarray([[0, 1, 6, 7, 2, 3, 4, 5]], dtype=jnp.int32)
+    query = jnp.zeros((1, sequence_length, 1, 8))
+    key = jnp.zeros((1, sequence_length, 1, 8))
+    segment_ids = jnp.ones((1, sequence_length), dtype=jnp.int32)
+    config = types.SimpleNamespace(
+        causal_block_size=4,
+        context_parallel_load_balance=True,
+        context_sharding="context",
+    )
+    op = AttentionOp(
+        config=config,
+        num_query_heads=1,
+        num_kv_heads=1,
+        max_target_length=sequence_length,
+        mesh=types.SimpleNamespace(shape={"context": 2}),
+        attention_kernel="dot_product",
+        attention_type=AttentionType.BLOCK_DIFFUSION,
+    )
+
+    mask = op.generate_attention_mask(
+        query,
+        key,
+        segment_ids,
+        MODEL_MODE_TRAIN,
+        segment_positions=positions,
+    )
+
+    expected = np.asarray(positions[0])[:, None] // 4 >= np.asarray(positions[0])[None, :] // 4
+    np.testing.assert_array_equal(np.asarray(mask == 0.0)[0, 0, 0], expected)
+
+  def test_autoregressive_mask_is_unchanged(self):
+    key_length = 8
+    query = jnp.zeros((1, 1, 1, 8))
+    key = jnp.zeros((1, key_length, 1, 8))
+    segment_ids = jnp.asarray([[1, 1, 0, 1, 0, 0, 1, 0]], dtype=jnp.int32)
+
+    default_mask = self._make_op(key_length, attention_type=None).generate_attention_mask(
+        query,
+        key,
+        segment_ids,
+        MODEL_MODE_AUTOREGRESSIVE,
+    )
+    block_diffusion_mask = self._make_op(key_length).generate_attention_mask(
+        query,
+        key,
+        segment_ids,
+        MODEL_MODE_AUTOREGRESSIVE,
+    )
+
+    np.testing.assert_array_equal(block_diffusion_mask, default_mask)
+    np.testing.assert_array_equal(
+        np.asarray(default_mask == 0.0)[0, 0, 0, 0],
+        np.asarray(segment_ids[0] == DECODING_ACTIVE_SEQUENCE_INDICATOR),
+    )
+
+  def test_invalid_block_size_raises(self):
+    with self.assertRaises(ValueError):
+      BlockCausalMask((4, 4), 0)
+    with self.assertRaises(ValueError):
+      _generate_block_causal_attention_mask((4, 4), -1)
+
+  def test_attention_op_rejects_invalid_block_diffusion_configuration(self):
+    kwargs = {
+        "num_query_heads": 1,
+        "num_kv_heads": 1,
+        "max_target_length": 8,
+        "mesh": types.SimpleNamespace(shape={}),
+        "attention_type": AttentionType.BLOCK_DIFFUSION,
+    }
+
+    with self.assertRaisesRegex(ValueError, "causal_block_size must be positive"):
+      AttentionOp(
+          config=types.SimpleNamespace(causal_block_size=0),
+          attention_kernel="dot_product",
+          **kwargs,
+      )
+    with self.assertRaisesRegex(ValueError, "supported only by dot_product attention"):
+      AttentionOp(
+          config=types.SimpleNamespace(causal_block_size=4),
+          attention_kernel="paged",
+          **kwargs,
+      )
+
+  def test_flash_attention_dispatch_on_non_tpu(self):
+    query = jnp.zeros((1, 8, 1, 8))
+    block_op = self._make_flash_op()
+
+    with self.assertRaisesRegex(ValueError, "supported only by TPU Splash"):
+      block_op.apply_attention(
+          query,
+          query,
+          query,
+          decoder_segment_ids=None,
+          segment_positions=None,
+          lengths=None,
+          model_mode=MODEL_MODE_TRAIN,
+          qk_product_einsum=jnp.einsum,
+          wv_product_einsum=jnp.einsum,
+      )
+
+    global_op = self._make_flash_op(attention_type=AttentionType.GLOBAL)
+    expected = (query, None, None)
+    with mock.patch.object(global_op, "apply_attention_dot", return_value=expected) as apply_dot:
+      actual = global_op.apply_attention(
+          query[:, :1],
+          query,
+          query,
+          decoder_segment_ids=None,
+          segment_positions=None,
+          lengths=None,
+          model_mode=MODEL_MODE_AUTOREGRESSIVE,
+          qk_product_einsum=jnp.einsum,
+          wv_product_einsum=jnp.einsum,
+      )
+
+    self.assertIs(actual, expected)
+    apply_dot.assert_called_once()
+
+  def test_tpu_splash_selects_block_causal_masks(self):
+    query = jnp.zeros((1, 8, 1, 8))
+    cases = (
+        (AttentionType.BLOCK_DIFFUSION, 1, False, BlockCausalMask),
+        (AttentionType.BLOCK_DIFFUSION, 2, True, attention_op.LoadBalancedBlockCausalMask),
+        (AttentionType.GLOBAL, 2, True, attention_op.LoadBalancedCausalMask),
+    )
+
+    for attention_type, cp_size, load_balanced, expected_mask_type in cases:
+      with self.subTest(attention_type=attention_type, cp_size=cp_size):
+        op = self._make_flash_op(
+            attention_type=attention_type,
+            context_parallel_size=cp_size,
+            context_parallel_load_balance=load_balanced,
+        )
+        with (
+            mock.patch.object(AttentionOp, "_logical_to_mesh_axes", return_value=None),
+            mock.patch.object(
+                attention_op.splash_attention_mask,
+                "MultiHeadMask",
+                side_effect=RuntimeError("mask captured"),
+            ) as make_multi_head_mask,
+            self.assertRaisesRegex(RuntimeError, "mask captured"),
+        ):
+          op.tpu_flash_attention(query, query, query, decoder_segment_ids=None)
+
+        selected_mask = make_multi_head_mask.call_args.kwargs["masks"][0]
+        self.assertIsInstance(selected_mask, expected_mask_type)
+
+
+class AttentionTypeResolutionTest(unittest.TestCase):
+
+  def test_config_selects_block_diffusion_without_model_dispatch(self):
+    config = types.SimpleNamespace(attention_type=AttentionType.BLOCK_DIFFUSION.value)
+
+    self.assertEqual(_resolve_attention_type(config, None), AttentionType.BLOCK_DIFFUSION)
+    self.assertEqual(_resolve_attention_type(config, AttentionType.GLOBAL), AttentionType.BLOCK_DIFFUSION)
+    self.assertEqual(_resolve_attention_type(config, AttentionType.FULL), AttentionType.FULL)
+    self.assertEqual(_resolve_attention_type(config, AttentionType.LOCAL_SLIDING), AttentionType.LOCAL_SLIDING)
+    self.assertEqual(
+        _resolve_attention_type(types.SimpleNamespace(attention_type=AttentionType.GLOBAL.value), AttentionType.FULL),
+        AttentionType.FULL,
+    )
+    self.assertEqual(_resolve_attention_type(types.SimpleNamespace(), None), AttentionType.GLOBAL)
+
+  def test_attention_op_honors_config_without_overriding_specialized_layers(self):
+    config = types.SimpleNamespace(
+        attention_type=AttentionType.BLOCK_DIFFUSION.value,
+        causal_block_size=4,
+    )
+    op = AttentionOp(
+        config=config,
+        num_query_heads=1,
+        num_kv_heads=1,
+        max_target_length=8,
+        mesh=types.SimpleNamespace(shape={}),
+        attention_kernel="dot_product",
+        attention_type=AttentionType.GLOBAL,
+    )
+
+    self.assertEqual(op.attention_type, AttentionType.BLOCK_DIFFUSION)
+
+    full_op = AttentionOp(
+        config=config,
+        num_query_heads=1,
+        num_kv_heads=1,
+        max_target_length=8,
+        mesh=types.SimpleNamespace(shape={}),
+        attention_kernel="dot_product",
+        attention_type=AttentionType.FULL,
+    )
+
+    self.assertEqual(full_op.attention_type, AttentionType.FULL)
+
+
 class LoadBalancedMaskTest(unittest.TestCase):
   """Tests for load-balanced Splash masks."""
 
@@ -370,6 +694,20 @@ class LoadBalancedMaskTest(unittest.TestCase):
     )
 
     np.testing.assert_array_equal((causal_mask & chunk_mask)[:, :], expected_mask)
+
+  def test_load_balanced_block_causal_mask(self):
+    sequence_length = 8
+    block_size = 2
+    mask = attention_op.LoadBalancedBlockCausalMask(
+        shape=(sequence_length, sequence_length),
+        causal_block_size=block_size,
+        cp_size=2,
+    )
+    query_positions = mask.q_sequence[:, None]
+    key_positions = np.arange(sequence_length)[None, :]
+    expected = query_positions // block_size >= key_positions // block_size
+
+    np.testing.assert_array_equal(mask[:, :], expected)
 
   def test_dot_product_local_mask_uses_segment_positions(self):
     config = types.SimpleNamespace(context_parallel_load_balance=True, context_sharding="context")

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -242,6 +242,7 @@ class ConfigTest(absltest.TestCase):
         (["attention_type=compressed"], [], "attention_type"),
         (["attention_type=mla", "packing=True"], ["packing=False"], "packing"),
         (["attention_type=mla", "use_batch_split_schedule=True"], [], "batch-split"),
+        (["attention_type=block_diffusion"], [], "attention_type"),
         (
             [
                 "context_parallel_load_balance=True",
@@ -298,6 +299,59 @@ class ConfigTest(absltest.TestCase):
 
     self.assertEqual(config.attention_type, "chunk")
     self.assertTrue(config.context_parallel_load_balance)
+
+  def test_block_diffusion_attention_config(self):
+    config = pyconfig.initialize(
+        [
+            "",
+            _BASE_CONFIG_PATH,
+            "run_name=test",
+            "steps=1",
+            "attention=dot_product",
+            "attention_type=block_diffusion",
+            "causal_block_size=7",
+            "vocab_size=256",
+            "max_target_length=2048",
+            "hardware=cpu",
+            "packing=False",
+            "skip_jax_distributed_system=True",
+        ]
+    )
+
+    self.assertEqual(config.attention_type, "block_diffusion")
+    self.assertEqual(config.causal_block_size, 7)
+    self.assertNotEqual(config.max_target_length % config.causal_block_size, 0)
+
+  def test_block_diffusion_attention_rejects_unsupported_configs(self):
+    base_overrides = {
+        "run_name": "test",
+        "steps": 1,
+        "attention": "dot_product",
+        "attention_type": "block_diffusion",
+        "causal_block_size": 32,
+        "vocab_size": 256,
+        "max_target_length": 2048,
+        "hardware": "cpu",
+        "packing": False,
+        "skip_jax_distributed_system": True,
+    }
+    cases = (
+        {"causal_block_size": 0},
+        {"packing": True},
+        {"attention": "cudnn_flash_te"},
+        {"attention": "flash", "hardware": "gpu"},
+    )
+    for overrides in cases:
+      with self.subTest(overrides=overrides):
+        values = base_overrides | overrides
+        argv = ["", _BASE_CONFIG_PATH, *(f"{key}={value}" for key, value in values.items())]
+        with self.assertRaises((ValueError, pydantic.ValidationError)):
+          pyconfig.initialize(argv)
+
+  def test_default_attention_remains_global(self):
+    config = pyconfig.initialize(["", _BASE_CONFIG_PATH, "run_name=test", "steps=1"])
+
+    self.assertEqual(config.attention_type, "global")
 
   @unittest.mock.patch.dict(os.environ, {pyconfig.yaml_key_to_env_key("steps"): "123"})
   def test_env_override(self):
@@ -361,6 +415,7 @@ class ConfigTest(absltest.TestCase):
     ]
     with self.assertRaises(pydantic.ValidationError):
       pyconfig.initialize(argv)
+
   def test_indexer_cutoff_threshold_remat_policy(self):
     """Tests custom remat policy and validation for indexer_cutoff_threshold."""
     # 1. Verify custom remat policy puts indexer_cutoff_threshold on device

--- a/tests/unit/tokamax_splash_attention_mask_test.py
+++ b/tests/unit/tokamax_splash_attention_mask_test.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from maxtext.kernels.tokamax_splash_attention import splash_attention_mask
 from maxtext.kernels.tokamax_splash_attention import splash_attention_mask_info
+from maxtext.layers.attention_op import BlockCausalMask
 
 
 class TokamaxSplashAttentionMaskTest(absltest.TestCase):
@@ -109,6 +110,22 @@ class TokamaxSplashAttentionMaskTest(absltest.TestCase):
     right.kv_sequence = np.arange(7, -1, -1, dtype=np.int32)
 
     self.assertNotEqual(hash(left), hash(right))
+
+  def test_process_block_causal_mask_keeps_lazy_mask_function(self):
+    mask = BlockCausalMask((8, 8), causal_block_size=4)
+
+    mask_info, mask_function = splash_attention_mask_info.process_mask(
+        mask,
+        block_shape=(2, 2),
+        q_seq_shards=1,
+        kv_seq_shards=1,
+        return_dynamic_grid=True,
+    )
+
+    self.assertIs(mask_function, mask.mask_function)
+    self.assertIsNotNone(mask_info.q_sequence)
+    self.assertIsNone(mask_info.partial_mask_blocks)
+    np.testing.assert_array_equal(mask_info.q_sequence, np.arange(8, dtype=np.int32))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Block diffusion needs attention that is causal across blocks while remaining
bidirectional within the block currently being corrupted or denoised. This is
an attention-kernel concern and can be reviewed independently of corruption,
training objectives, rollout, and RL.

## Scope

This PR adds only:

- an opt-in `block_diffusion` attention type and positive
  `causal_block_size` configuration;
- equivalent dense dot-product and TPU Tokamax Splash block-causal masks;
- load-balanced context-parallel mask support;
- validation that rejects packing and unsupported attention/hardware
  combinations; and
- focused mask, configuration, and autoregressive-regression tests.

It does not depend on the block-diffusion primitive PR, corrupt training data,
change a loss function, add a model-specific branch, or enable diffusion by
default.

## Mask semantics

For query position `q` and key position `k`, attention is allowed when

```text
floor(q / block_size) >= floor(k / block_size)
```

Therefore, all positions in the current block can attend to one another and to
all earlier blocks, but no earlier block can attend to a later block. Segment
boundaries remain enforced. Packing is rejected because document-local block
origins are not yet represented by the attention metadata. Autoregressive
decode keeps the existing causal mask path unchanged.

## Compatibility

The default remains `attention_type=global`. The new behavior is activated only
when `attention_type=block_diffusion` is selected explicitly. Specialized
per-layer attention declarations continue to override the global configuration.

This implementation remains code-independent from the primitives landed in
#4737: it does not import or activate them. The branch is rebased onto the
current `main` containing #4737 so reviewers see only this attention change.

## Tests

```text
python -m pytest -q \
  tests/unit/attention_test.py \
  tests/unit/configs_value_test.py \
  tests/unit/tokamax_splash_attention_mask_test.py

76 passed, 48 skipped, 36 subtests passed
```

The skipped cases require unavailable platform-specific kernels. Pyink, Python
compilation, and `git diff --check` also pass for the changed files.

Focused branch coverage for the changed executable code in
`src/maxtext/layers/attention_op.py` is complete: 53/53 changed lines and
26/26 changed branches are covered.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I added comments or docstrings for the non-obvious block-mask invariants.
- [x] I added focused dense, Splash, load-balanced, configuration, and autoregressive-regression tests.
- [x] End-to-end model training is not applicable to this default-off attention layer; the affected CPU suites are listed above.
- [x] No standalone documentation page or toctree change is needed; the public design document is linked below.

Design document:
https://docs.google.com/document/d/1N7KcCoAIErB2CV9EJ2G1u_mdN-AQgqwNUYSvM0mtqMI/edit
