### PR TITLE
Decouple vision & decoder block routing in multimodal processor

### DIFF
--- a/src/maxtext/multimodal/processor.py
+++ b/src/maxtext/multimodal/processor.py
@@ -14,12 +14,72 @@
 
 """Multimodal data preprocessor router."""
 
+import functools
+import os
+from maxtext.common.common_types import DecoderBlockType, VisionEncoderBlockType
 from maxtext.multimodal import utils as mm_utils
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
+import omegaconf
+
+
+@functools.lru_cache(maxsize=None)
+def _get_block_name_from_model_yml(model_name: str, block_name: str) -> str | None:
+  """Loads a model YAML from MAXTEXT_CONFIGS_DIR and returns the specified block name.
+
+  Args:
+    model_name: Name of the model configuration file (e.g., 'gemma3-4b').
+    block_name: The architectural attribute to retrieve, can only be
+     'vision_encoder_block' or 'decoder_block'.
+
+  Returns:
+    The string value of the block configuration if defined, otherwise None.
+  """
+  model_yml_path = os.path.join(MAXTEXT_CONFIGS_DIR, "models", f"{model_name}.yml")
+  if os.path.exists(model_yml_path):
+    try:
+      loaded = omegaconf.OmegaConf.load(model_yml_path)
+      if block_name in loaded and loaded[block_name] is not None:
+        return str(loaded[block_name])
+    except Exception:  # pylint: disable=broad-except
+      pass
+  return None
+
+
+def _get_vision_block(config_or_name):
+  """Extract vision encoder architecture from config."""
+  # If input is config, extract vision_encoder name
+  if hasattr(config_or_name, "vision_encoder_block"):
+    block = config_or_name.vision_encoder_block
+    if block != VisionEncoderBlockType.NONE:
+      return block.value.lower()
+  # If input is model_name (backward compatibility), find its corresponding config
+  elif isinstance(config_or_name, str):
+    val = _get_block_name_from_model_yml(config_or_name, "vision_encoder_block")
+    if val is not None and val.lower() != VisionEncoderBlockType.NONE.value:
+      return val.lower()
+  # If non-vision model, return None
+  return None
+
+
+def _get_decoder_block(config_or_name):
+  """Extract decoder architecture from config."""
+  # If input is config, extract decoder name
+  if hasattr(config_or_name, "decoder_block"):
+    block = config_or_name.decoder_block
+    if block != DecoderBlockType.DEFAULT:
+      return block.value.lower()
+  # If input is model_name (backward compatibility), find its corresponding config
+  elif isinstance(config_or_name, str):
+    val = _get_block_name_from_model_yml(config_or_name, "decoder_block")
+    if val is not None and val.lower() != DecoderBlockType.DEFAULT.value:
+      return val.lower()
+  # If decoder_block not found or is default, return model_name/default
+  return str(getattr(config_or_name, "model_name", config_or_name)).lower()
 
 
 def preprocess_mm_data(config):
   """Preprocesses multimodal data based on the provided configuration.
-  Routes to the appropriate preprocessing function based on the model name.
+  Routes to the appropriate preprocessing function based on the vision architecture.
 
   Args:
     config: A `pyconfig.Config` object containing configuration parameters.
@@ -28,90 +88,75 @@ def preprocess_mm_data(config):
     A `PreprocessorOutput` object containing the processed multimodal data.
   """
   processor_outputs = mm_utils.PreprocessorOutput()
+  vision_block = _get_vision_block(config)
 
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  if vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import preprocess_mm_data_gemma3  # pylint: disable=import-outside-toplevel
 
     images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
     processor_outputs = preprocess_mm_data_gemma3(images)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif vision_block in ["gemma4"]:
     from maxtext.multimodal.processor_gemma4 import preprocess_mm_data_gemma4  # pylint: disable=import-outside-toplevel
 
     images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
     processor_outputs = preprocess_mm_data_gemma4(images)
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif vision_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import preprocess_mm_data_llama4  # pylint: disable=import-outside-toplevel
 
     images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
     processor_outputs = preprocess_mm_data_llama4(images)
-  elif config.model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import preprocess_mm_data_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     processor_outputs = preprocess_mm_data_qwen3_omni(config)
   else:
-    raise ValueError(f"Model {config.model_name} not supported for multimodal preprocessing.")
+    raise ValueError(
+        f"Model {config.model_name} (vision block {vision_block}) not supported for multimodal preprocessing."
+    )
 
   return processor_outputs
 
 
 def preprocess_image_for_training(image, config):
-  """Preprocesses a single image for training based on the model name."""
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  """Preprocesses a single image for training based on the vision architecture."""
+  vision_block = _get_vision_block(config)
+  if vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import preprocess_mm_data_gemma3  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_gemma3(image)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif vision_block in ["gemma4"]:
     from maxtext.multimodal.processor_gemma4 import preprocess_mm_data_gemma4  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_gemma4(image)
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif vision_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import preprocess_mm_data_llama4  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_llama4(image)
-  elif config.model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import preprocess_mm_data_qwen3_omni_for_training  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_qwen3_omni_for_training(image, config)
   else:
-    raise ValueError(f"Model {config.model_name} not supported for image preprocessing.")
+    raise ValueError(f"Model {config.model_name} (vision block {vision_block}) not supported for image preprocessing.")
 
 
 def get_image_offsets(config, processor_output: mm_utils.PreprocessorOutput | None):
   """Get the increase in total token count after inserting image token placeholders"""
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  vision_block = _get_vision_block(config)
+
+  if vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import get_image_offsets_gemma3  # pylint: disable=import-outside-toplevel
 
     return get_image_offsets_gemma3(processor_output)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif vision_block in ["gemma4"]:
     from maxtext.multimodal.processor_gemma4 import get_image_offsets_gemma4  # pylint: disable=import-outside-toplevel
 
     return get_image_offsets_gemma4(processor_output)
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif vision_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import get_image_offsets_llama4  # pylint: disable=import-outside-toplevel
 
     return get_image_offsets_llama4(processor_output)
-  elif config.model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import get_mm_offsets_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     return get_mm_offsets_qwen3_omni(config, processor_output)
@@ -121,26 +166,25 @@ def get_image_offsets(config, processor_output: mm_utils.PreprocessorOutput | No
 
 def reformat_prompt(prompt, image_placeholder, model_name, num_images, video_placeholder="<|video|>", num_videos=0):
   """Reformat prompt for different models."""
-  if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  vision_block = _get_vision_block(model_name)
+  if vision_block is None:
+    return prompt
+
+  decoder_block = _get_decoder_block(model_name)
+
+  if decoder_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import reformat_prompt_gemma3  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_gemma3(prompt, image_placeholder, num_images)
-  elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif decoder_block in ["gemma4", "gemma4_small"]:
     from maxtext.multimodal.processor_gemma4 import reformat_prompt_gemma4  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_gemma4(prompt, image_placeholder, num_images)
-  elif model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif decoder_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import reformat_prompt_llama4  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_llama4(prompt, image_placeholder, num_images)
-  elif model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif decoder_block in ["qwen3", "qwen3_moe", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import reformat_prompt_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_qwen3_omni(
@@ -156,23 +200,22 @@ def reformat_prompt(prompt, image_placeholder, model_name, num_images, video_pla
 
 def reformat_response(response, model_name):
   """Reformat response for different models."""
-  if model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  vision_block = _get_vision_block(model_name)
+  if vision_block is None:
+    return response
+
+  decoder_block = _get_decoder_block(model_name)
+
+  if decoder_block in ["llama4"]:
     formatted_response = f"{response}<|eot|>"
     return formatted_response
-  elif model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  elif decoder_block in ["gemma3"]:
     formatted_response = f"{response}<end_of_turn>"
     return formatted_response
-  elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif decoder_block in ["gemma4", "gemma4_small"]:
     formatted_response = f"{response}<turn|>"
     return formatted_response
-  elif model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif decoder_block in ["qwen3", "qwen3_moe", "qwen3_5"]:
     formatted_response = f"{response}<|im_end|>"
     return formatted_response
   else:
@@ -181,53 +224,48 @@ def reformat_response(response, model_name):
 
 def prepare_text_for_image_fusion(tokens, config, processor_output=None):
   """Prepare text by adding extra tokens for image fusion based on the model."""
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  vision_block = _get_vision_block(config)
+  if vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import add_extra_tokens_for_images_gemma3  # pylint: disable=import-outside-toplevel
 
     return add_extra_tokens_for_images_gemma3(
         tokens, max_num_images=processor_output.num_images  # pyrefly: ignore[missing-attribute]
     )  # pyrefly: ignore[missing-attribute]
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif vision_block in ["gemma4"]:
     from maxtext.multimodal.processor_gemma4 import add_extra_tokens_for_images_gemma4  # pylint: disable=import-outside-toplevel
 
     return add_extra_tokens_for_images_gemma4(
         tokens, max_num_images=processor_output.num_images  # pyrefly: ignore[missing-attribute]
     )  # pyrefly: ignore[missing-attribute]
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif vision_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import add_extra_tokens_for_images_llama4  # pylint: disable=import-outside-toplevel
-    # pyrefly: ignore[bad-argument-type]
-    return add_extra_tokens_for_images_llama4(tokens, processor_output)
-  elif config.model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+
+    return add_extra_tokens_for_images_llama4(tokens, processor_output)  # pyrefly: ignore[bad-argument-type]
+  elif vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import add_extra_tokens_for_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     return add_extra_tokens_for_qwen3_omni(tokens, config, processor_output)
   else:
-    raise ValueError(f"Model {config.model_name} does not support multimodal inference.")
+    raise ValueError(f"Model {config.model_name} (vision block {vision_block}) does not support multimodal inference.")
 
 
 def get_dummy_image_shape_for_init(model_name, batch_size=1, num_image_per_sequence=1):
   """Return the shape of the dummy image for specific model's initialization."""
   image_shape = ()
-  if model_name.startswith("gemma3"):
+  vision_block = _get_vision_block(model_name)
+  if vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import get_dummy_image_shape_for_init_gemma3  # pylint: disable=import-outside-toplevel
 
     image_shape = get_dummy_image_shape_for_init_gemma3(batch_size, num_image_per_sequence)
-  elif model_name.startswith("gemma4"):
+  elif vision_block in ["gemma4"]:
     from maxtext.multimodal.processor_gemma4 import get_dummy_image_shape_for_init_gemma4  # pylint: disable=import-outside-toplevel
 
     image_shape = get_dummy_image_shape_for_init_gemma4(batch_size, num_image_per_sequence)
-  elif model_name.startswith("llama4"):
+  elif vision_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import get_dummy_image_shape_for_init_llama4  # pylint: disable=import-outside-toplevel
 
     image_shape = get_dummy_image_shape_for_init_llama4(batch_size, num_image_per_sequence)
-  elif model_name.startswith("qwen3-omni") or model_name.startswith("qwen3-vl") or model_name.startswith("qwen3.5"):
+  elif vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import get_dummy_image_shape_for_init_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     image_shape = get_dummy_image_shape_for_init_qwen3_omni(batch_size)
@@ -256,26 +294,26 @@ def get_dummy_audio_shape_for_init(config):
 def get_bidirectional_mask_vision(config, decoder_input_tokens, is_video: bool = False):
   """Get the bidirectional mask for specific models."""
   bidirectional_mask_vision = None
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+
+  vision_block = _get_vision_block(config)
+  if vision_block is None:
+    return bidirectional_mask_vision
+
+  decoder_block = _get_decoder_block(config)
+
+  if decoder_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import GEMMA_TOKEN_PLACEHOLDER  # pylint: disable=import-outside-toplevel
 
     bidirectional_mask_vision = decoder_input_tokens == GEMMA_TOKEN_PLACEHOLDER
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif decoder_block in ["gemma4", "gemma4_small"]:
     from maxtext.multimodal.processor_gemma4 import GEMMA4_TOKEN_PLACEHOLDER  # pylint: disable=import-outside-toplevel
 
     bidirectional_mask_vision = decoder_input_tokens == GEMMA4_TOKEN_PLACEHOLDER
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif decoder_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import LLAMA4_PATCH_TOKEN  # pylint: disable=import-outside-toplevel
 
     bidirectional_mask_vision = decoder_input_tokens == LLAMA4_PATCH_TOKEN
-  elif config.model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif decoder_block in ["qwen3", "qwen3_moe", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import QwenTokens  # pylint: disable=import-outside-toplevel
 
     tokens = QwenTokens(config)

--- a/src/maxtext/multimodal/processor.py
+++ b/src/maxtext/multimodal/processor.py
@@ -16,10 +16,65 @@
 
 from maxtext.multimodal import utils as mm_utils
 
+# model_name -> (vision_encoder_block, decoder_block) mapping
+_MODEL_TO_BLOCKS = {
+    # Gemma 3
+    "gemma3-4b": ("gemma3", "gemma3"),
+    "gemma3-12b": ("gemma3", "gemma3"),
+    "gemma3-27b": ("gemma3", "gemma3"),
+    # Gemma 4
+    "gemma4-26b": ("gemma4", "gemma4"),
+    "gemma4-31b": ("gemma4", "gemma4"),
+    "gemma4-e2b": ("gemma4", "gemma4_small"),
+    "gemma4-e4b": ("gemma4", "gemma4_small"),
+    # Llama 4
+    "llama4-17b-16e": ("llama4", "llama4"),
+    "llama4-17b-128e": ("llama4", "llama4"),
+    # Qwen 3 & 3.5
+    "qwen3-omni-30b-a3b": ("qwen3_omni", "qwen3_moe"),
+    "qwen3-vl-2b": ("qwen3_vl", "qwen3"),
+    "qwen3-vl-4b": ("qwen3_vl", "qwen3"),
+    "qwen3-vl-30b-a3b": ("qwen3_vl", "qwen3_moe"),
+    "qwen3.5-35b-a3b": ("qwen3_5", "qwen3_5"),
+    "qwen3.5-397b-a17b": ("qwen3_5", "qwen3_5"),
+}
+
+
+def _get_vision_block(config_or_name):
+  """Extract vision encoder architecture from config."""
+  # If input is config, extract vision_encoder name
+  if hasattr(config_or_name, "vision_encoder_block"):
+    block = config_or_name.vision_encoder_block
+    block_val = getattr(block, "value", str(block)).lower()
+    if block_val != "none":
+      return block_val
+  # If input is model_name (backward compatibility), find its corresponding encoder
+  elif isinstance(config_or_name, str):
+    if config_or_name.lower() in _MODEL_TO_BLOCKS:
+      return _MODEL_TO_BLOCKS[config_or_name.lower()][0]
+  # If non-vision model, return None
+  return None
+
+
+def _get_decoder_block(config_or_name):
+  """Extract decoder architecture from config."""
+  # If input is config, extract decoder name
+  if hasattr(config_or_name, "decoder_block"):
+    block = config_or_name.decoder_block
+    block_val = getattr(block, "value", str(block)).lower()
+    if block_val != "default":
+      return block_val
+  # If input is model_name (backward compatibility), find its corresponding decoder
+  elif isinstance(config_or_name, str):
+    if config_or_name.lower() in _MODEL_TO_BLOCKS:
+      return _MODEL_TO_BLOCKS[config_or_name.lower()][1]
+  # If decoder_block not found or is default, return model_name/default
+  return str(getattr(config_or_name, "model_name", config_or_name)).lower()
+
 
 def preprocess_mm_data(config):
   """Preprocesses multimodal data based on the provided configuration.
-  Routes to the appropriate preprocessing function based on the model name.
+  Routes to the appropriate preprocessing function based on the vision architecture.
 
   Args:
     config: A `pyconfig.Config` object containing configuration parameters.
@@ -28,90 +83,75 @@ def preprocess_mm_data(config):
     A `PreprocessorOutput` object containing the processed multimodal data.
   """
   processor_outputs = mm_utils.PreprocessorOutput()
+  vision_block = _get_vision_block(config)
 
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  if vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import preprocess_mm_data_gemma3  # pylint: disable=import-outside-toplevel
 
     images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
     processor_outputs = preprocess_mm_data_gemma3(images)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif vision_block in ["gemma4"]:
     from maxtext.multimodal.processor_gemma4 import preprocess_mm_data_gemma4  # pylint: disable=import-outside-toplevel
 
     images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
     processor_outputs = preprocess_mm_data_gemma4(images)
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif vision_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import preprocess_mm_data_llama4  # pylint: disable=import-outside-toplevel
 
     images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
     processor_outputs = preprocess_mm_data_llama4(images)
-  elif config.model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import preprocess_mm_data_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     processor_outputs = preprocess_mm_data_qwen3_omni(config)
   else:
-    raise ValueError(f"Model {config.model_name} not supported for multimodal preprocessing.")
+    raise ValueError(
+        f"Model {config.model_name} (vision block {vision_block}) not supported for multimodal preprocessing."
+    )
 
   return processor_outputs
 
 
 def preprocess_image_for_training(image, config):
-  """Preprocesses a single image for training based on the model name."""
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  """Preprocesses a single image for training based on the vision architecture."""
+  vision_block = _get_vision_block(config)
+  if vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import preprocess_mm_data_gemma3  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_gemma3(image)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif vision_block in ["gemma4"]:
     from maxtext.multimodal.processor_gemma4 import preprocess_mm_data_gemma4  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_gemma4(image)
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif vision_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import preprocess_mm_data_llama4  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_llama4(image)
-  elif config.model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import preprocess_mm_data_qwen3_omni_for_training  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_qwen3_omni_for_training(image, config)
   else:
-    raise ValueError(f"Model {config.model_name} not supported for image preprocessing.")
+    raise ValueError(f"Model {config.model_name} (vision block {vision_block}) not supported for image preprocessing.")
 
 
 def get_image_offsets(config, processor_output: mm_utils.PreprocessorOutput | None):
   """Get the increase in total token count after inserting image token placeholders"""
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  vision_block = _get_vision_block(config)
+
+  if vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import get_image_offsets_gemma3  # pylint: disable=import-outside-toplevel
 
     return get_image_offsets_gemma3(processor_output)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif vision_block in ["gemma4"]:
     from maxtext.multimodal.processor_gemma4 import get_image_offsets_gemma4  # pylint: disable=import-outside-toplevel
 
     return get_image_offsets_gemma4(processor_output)
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif vision_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import get_image_offsets_llama4  # pylint: disable=import-outside-toplevel
 
     return get_image_offsets_llama4(processor_output)
-  elif config.model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import get_mm_offsets_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     return get_mm_offsets_qwen3_omni(config, processor_output)
@@ -121,26 +161,25 @@ def get_image_offsets(config, processor_output: mm_utils.PreprocessorOutput | No
 
 def reformat_prompt(prompt, image_placeholder, model_name, num_images, video_placeholder="<|video|>", num_videos=0):
   """Reformat prompt for different models."""
-  if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  vision_block = _get_vision_block(model_name)
+  if vision_block is None:
+    return prompt
+
+  decoder_block = _get_decoder_block(model_name)
+
+  if decoder_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import reformat_prompt_gemma3  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_gemma3(prompt, image_placeholder, num_images)
-  elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif decoder_block in ["gemma4", "gemma4_small"]:
     from maxtext.multimodal.processor_gemma4 import reformat_prompt_gemma4  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_gemma4(prompt, image_placeholder, num_images)
-  elif model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif decoder_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import reformat_prompt_llama4  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_llama4(prompt, image_placeholder, num_images)
-  elif model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif decoder_block in ["qwen3", "qwen3_moe", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import reformat_prompt_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_qwen3_omni(
@@ -156,23 +195,22 @@ def reformat_prompt(prompt, image_placeholder, model_name, num_images, video_pla
 
 def reformat_response(response, model_name):
   """Reformat response for different models."""
-  if model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  vision_block = _get_vision_block(model_name)
+  if vision_block is None:
+    return response
+
+  decoder_block = _get_decoder_block(model_name)
+
+  if decoder_block in ["llama4"]:
     formatted_response = f"{response}<|eot|>"
     return formatted_response
-  elif model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  elif decoder_block in ["gemma3"]:
     formatted_response = f"{response}<end_of_turn>"
     return formatted_response
-  elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif decoder_block in ["gemma4", "gemma4_small"]:
     formatted_response = f"{response}<turn|>"
     return formatted_response
-  elif model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif decoder_block in ["qwen3", "qwen3_moe", "qwen3_5"]:
     formatted_response = f"{response}<|im_end|>"
     return formatted_response
   else:
@@ -181,53 +219,48 @@ def reformat_response(response, model_name):
 
 def prepare_text_for_image_fusion(tokens, config, processor_output=None):
   """Prepare text by adding extra tokens for image fusion based on the model."""
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  vision_block = _get_vision_block(config)
+  if vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import add_extra_tokens_for_images_gemma3  # pylint: disable=import-outside-toplevel
 
     return add_extra_tokens_for_images_gemma3(
         tokens, max_num_images=processor_output.num_images  # pyrefly: ignore[missing-attribute]
     )  # pyrefly: ignore[missing-attribute]
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif vision_block in ["gemma4"]:
     from maxtext.multimodal.processor_gemma4 import add_extra_tokens_for_images_gemma4  # pylint: disable=import-outside-toplevel
 
     return add_extra_tokens_for_images_gemma4(
         tokens, max_num_images=processor_output.num_images  # pyrefly: ignore[missing-attribute]
     )  # pyrefly: ignore[missing-attribute]
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif vision_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import add_extra_tokens_for_images_llama4  # pylint: disable=import-outside-toplevel
-    # pyrefly: ignore[bad-argument-type]
-    return add_extra_tokens_for_images_llama4(tokens, processor_output)
-  elif config.model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+
+    return add_extra_tokens_for_images_llama4(tokens, processor_output)  # pyrefly: ignore[bad-argument-type]
+  elif vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import add_extra_tokens_for_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     return add_extra_tokens_for_qwen3_omni(tokens, config, processor_output)
   else:
-    raise ValueError(f"Model {config.model_name} does not support multimodal inference.")
+    raise ValueError(f"Model {config.model_name} (vision block {vision_block}) does not support multimodal inference.")
 
 
 def get_dummy_image_shape_for_init(model_name, batch_size=1, num_image_per_sequence=1):
   """Return the shape of the dummy image for specific model's initialization."""
   image_shape = ()
-  if model_name.startswith("gemma3"):
+  vision_block = _get_vision_block(model_name)
+  if vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import get_dummy_image_shape_for_init_gemma3  # pylint: disable=import-outside-toplevel
 
     image_shape = get_dummy_image_shape_for_init_gemma3(batch_size, num_image_per_sequence)
-  elif model_name.startswith("gemma4"):
+  elif vision_block in ["gemma4"]:
     from maxtext.multimodal.processor_gemma4 import get_dummy_image_shape_for_init_gemma4  # pylint: disable=import-outside-toplevel
 
     image_shape = get_dummy_image_shape_for_init_gemma4(batch_size, num_image_per_sequence)
-  elif model_name.startswith("llama4"):
+  elif vision_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import get_dummy_image_shape_for_init_llama4  # pylint: disable=import-outside-toplevel
 
     image_shape = get_dummy_image_shape_for_init_llama4(batch_size, num_image_per_sequence)
-  elif model_name.startswith("qwen3-omni") or model_name.startswith("qwen3-vl") or model_name.startswith("qwen3.5"):
+  elif vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import get_dummy_image_shape_for_init_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     image_shape = get_dummy_image_shape_for_init_qwen3_omni(batch_size)
@@ -256,26 +289,26 @@ def get_dummy_audio_shape_for_init(config):
 def get_bidirectional_mask_vision(config, decoder_input_tokens, is_video: bool = False):
   """Get the bidirectional mask for specific models."""
   bidirectional_mask_vision = None
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+
+  vision_block = _get_vision_block(config)
+  if vision_block is None:
+    return bidirectional_mask_vision
+
+  decoder_block = _get_decoder_block(config)
+
+  if decoder_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import GEMMA_TOKEN_PLACEHOLDER  # pylint: disable=import-outside-toplevel
 
     bidirectional_mask_vision = decoder_input_tokens == GEMMA_TOKEN_PLACEHOLDER
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif decoder_block in ["gemma4", "gemma4_small"]:
     from maxtext.multimodal.processor_gemma4 import GEMMA4_TOKEN_PLACEHOLDER  # pylint: disable=import-outside-toplevel
 
     bidirectional_mask_vision = decoder_input_tokens == GEMMA4_TOKEN_PLACEHOLDER
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif decoder_block in ["llama4"]:
     from maxtext.multimodal.processor_llama4 import LLAMA4_PATCH_TOKEN  # pylint: disable=import-outside-toplevel
 
     bidirectional_mask_vision = decoder_input_tokens == LLAMA4_PATCH_TOKEN
-  elif config.model_name in [
-      "qwen3-omni-30b-a3b",
-      "qwen3-vl-2b",
-      "qwen3-vl-4b",
-      "qwen3-vl-30b-a3b",
-      "qwen3.5-35b-a3b",
-      "qwen3.5-397b-a17b",
-  ]:
+  elif decoder_block in ["qwen3", "qwen3_moe", "qwen3_5"]:
     from maxtext.multimodal.processor_qwen3_omni import QwenTokens  # pylint: disable=import-outside-toplevel
 
     tokens = QwenTokens(config)

--- a/tests/unit/multimodal_utils_test.py
+++ b/tests/unit/multimodal_utils_test.py
@@ -14,9 +14,11 @@
 
 """Tests for the common MaxText utilities"""
 import os
+import types
 import unittest
 import numpy as np
 
+from maxtext.common.common_types import DecoderBlockType, VisionEncoderBlockType
 from maxtext.configs import pyconfig
 from maxtext.utils.globals import MAXTEXT_REPO_ROOT
 from maxtext.multimodal import processor as mm_processor
@@ -373,6 +375,130 @@ class TestLlama4PostProcessing(unittest.TestCase):
 
     np.testing.assert_array_equal(merged[0, 2:5], video_embeddings[0, :3])
     np.testing.assert_array_equal(merged[0, 5:], text_embeddings[0, 5:])
+
+
+class TestMultimodalProcessorRouting(unittest.TestCase):
+  """Tests for multimodal processor prompt/response formatting and training preprocessing."""
+
+  def test_reformat_response_multimodal_vs_text_only(self):
+    # Multimodal Qwen3 model should append <|im_end|>
+    self.assertEqual(mm_processor.reformat_response("Hello world", "qwen3-vl-2b"), "Hello world<|im_end|>")
+    # Text-only Qwen3 model should return response unchanged
+    self.assertEqual(mm_processor.reformat_response("Hello world", "qwen3-4b"), "Hello world")
+    # Multimodal Gemma 3 model should append <end_of_turn>
+    self.assertEqual(mm_processor.reformat_response("Hello world", "gemma3-4b"), "Hello world<end_of_turn>")
+    # Multimodal Llama 4 model should append <|eot|>
+    self.assertEqual(mm_processor.reformat_response("Hello world", "llama4-17b-16e"), "Hello world<|eot|>")
+
+  def test_reformat_prompt_text_only_fallback(self):
+    # Text-only models should return prompt unchanged
+    self.assertEqual(
+        mm_processor.reformat_prompt("Tell me a story", "<img>", "qwen3-4b", num_images=0), "Tell me a story"
+    )
+    self.assertEqual(
+        mm_processor.reformat_prompt("Tell me a story", "<img>", "llama2-7b", num_images=0), "Tell me a story"
+    )
+
+  def test_get_vision_and_decoder_block_routing(self):
+    # pylint: disable=protected-access
+    # Multimodal Qwen3-VL
+    self.assertEqual(mm_processor._get_vision_block("qwen3-vl-2b"), "qwen3_vl")
+    self.assertEqual(mm_processor._get_decoder_block("qwen3-vl-2b"), "qwen3")
+
+    # Multimodal Qwen3.5
+    self.assertEqual(mm_processor._get_vision_block("qwen3.5-35b-a3b"), "qwen3_5")
+    self.assertEqual(mm_processor._get_decoder_block("qwen3.5-35b-a3b"), "qwen3_5")
+
+    # Small Gemma 4 (tests gemma4_small decoder block)
+    self.assertEqual(mm_processor._get_vision_block("gemma4-e4b"), "gemma4")
+    self.assertEqual(mm_processor._get_decoder_block("gemma4-e4b"), "gemma4_small")
+
+    # Text-only Qwen3-4B should have empty vision block and qwen3 decoder block
+    self.assertIsNone(mm_processor._get_vision_block("qwen3-4b"))
+    self.assertEqual(mm_processor._get_decoder_block("qwen3-4b"), "qwen3")
+
+    # Text-only Llama 2 should have empty vision block and llama2 decoder block
+    self.assertIsNone(mm_processor._get_vision_block("llama2-7b"))
+    self.assertEqual(mm_processor._get_decoder_block("llama2-7b"), "llama2")
+
+  def test_get_vision_and_decoder_block_routing_from_config(self):
+    # pylint: disable=protected-access
+    # Test with pyconfig Config objects
+    base_config_path = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "base.yml")
+    config_qwen3_vl = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="qwen3-vl-2b",
+        scan_layers=False,
+        skip_jax_distributed_system=True,
+    )
+    self.assertEqual(mm_processor._get_vision_block(config_qwen3_vl), "qwen3_vl")
+    self.assertEqual(mm_processor._get_decoder_block(config_qwen3_vl), "qwen3")
+
+    config_gemma3 = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="gemma3-4b",
+        skip_jax_distributed_system=True,
+    )
+    self.assertEqual(mm_processor._get_vision_block(config_gemma3), "gemma3")
+    self.assertEqual(mm_processor._get_decoder_block(config_gemma3), "gemma3")
+
+    config_text_only = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="qwen3-4b",
+        skip_jax_distributed_system=True,
+    )
+    self.assertIsNone(mm_processor._get_vision_block(config_text_only))
+    self.assertEqual(mm_processor._get_decoder_block(config_text_only), "qwen3")
+
+    # Test with config-like objects covering DecoderBlockType and VisionEncoderBlockType
+    mock_config = types.SimpleNamespace(
+        decoder_block=DecoderBlockType.GEMMA4_SMALL,
+        vision_encoder_block=VisionEncoderBlockType.GEMMA4,
+    )
+    self.assertEqual(mm_processor._get_vision_block(mock_config), "gemma4")
+    self.assertEqual(mm_processor._get_decoder_block(mock_config), "gemma4_small")
+
+    # Test config with DEFAULT decoder_block and NONE vision_encoder_block
+    mock_default = types.SimpleNamespace(
+        decoder_block=DecoderBlockType.DEFAULT,
+        vision_encoder_block=VisionEncoderBlockType.NONE,
+        model_name="custom_model",
+    )
+    self.assertIsNone(mm_processor._get_vision_block(mock_default))
+    self.assertEqual(mm_processor._get_decoder_block(mock_default), "custom_model")
+
+  def test_get_dummy_image_shape_for_init(self):
+    # Multimodal models should return non-empty dummy shape
+    self.assertGreater(len(mm_processor.get_dummy_image_shape_for_init("gemma3-4b")), 0)
+    self.assertGreater(len(mm_processor.get_dummy_image_shape_for_init("gemma4-26b")), 0)
+    self.assertGreater(len(mm_processor.get_dummy_image_shape_for_init("llama4-17b-16e")), 0)
+    self.assertGreater(len(mm_processor.get_dummy_image_shape_for_init("qwen3-vl-2b")), 0)
+
+    # Text-only models should return empty tuple ()
+    self.assertEqual(mm_processor.get_dummy_image_shape_for_init("qwen3-4b"), ())
+    self.assertEqual(mm_processor.get_dummy_image_shape_for_init("llama2-7b"), ())
+
+  def test_preprocess_image_for_training(self):
+    dummy_image = np.zeros((224, 224, 3), dtype=np.uint8)
+    base_config_path = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "base.yml")
+
+    # Multimodal model should return non-empty output
+    config_gemma3 = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="gemma3-4b",
+        skip_jax_distributed_system=True,
+    )
+    output = mm_processor.preprocess_image_for_training([dummy_image], config_gemma3)
+    self.assertIsNotNone(output)
+
+    # Text-only model should raise ValueError
+    config_text_only = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="qwen3-4b",
+        skip_jax_distributed_system=True,
+    )
+    with self.assertRaises(ValueError):
+      mm_processor.preprocess_image_for_training([dummy_image], config_text_only)
 
 
 if __name__ == "__main__":

--- a/tests/unit/multimodal_utils_test.py
+++ b/tests/unit/multimodal_utils_test.py
@@ -14,9 +14,11 @@
 
 """Tests for the common MaxText utilities"""
 import os
+import types
 import unittest
 import numpy as np
 
+from maxtext.common.common_types import DecoderBlockType, VisionEncoderBlockType
 from maxtext.configs import pyconfig
 from maxtext.utils.globals import MAXTEXT_REPO_ROOT
 from maxtext.multimodal import processor as mm_processor
@@ -373,6 +375,130 @@ class TestLlama4PostProcessing(unittest.TestCase):
 
     np.testing.assert_array_equal(merged[0, 2:5], video_embeddings[0, :3])
     np.testing.assert_array_equal(merged[0, 5:], text_embeddings[0, 5:])
+
+
+class TestMultimodalProcessorRouting(unittest.TestCase):
+  """Tests for multimodal processor prompt/response formatting and training preprocessing."""
+
+  def test_reformat_response_multimodal_vs_text_only(self):
+    # Multimodal Qwen3 model should append <|im_end|>
+    self.assertEqual(mm_processor.reformat_response("Hello world", "qwen3-vl-2b"), "Hello world<|im_end|>")
+    # Text-only Qwen3 model should return response unchanged
+    self.assertEqual(mm_processor.reformat_response("Hello world", "qwen3-4b"), "Hello world")
+    # Multimodal Gemma 3 model should append <end_of_turn>
+    self.assertEqual(mm_processor.reformat_response("Hello world", "gemma3-4b"), "Hello world<end_of_turn>")
+    # Multimodal Llama 4 model should append <|eot|>
+    self.assertEqual(mm_processor.reformat_response("Hello world", "llama4-17b-16e"), "Hello world<|eot|>")
+
+  def test_reformat_prompt_text_only_fallback(self):
+    # Text-only models should return prompt unchanged
+    self.assertEqual(
+        mm_processor.reformat_prompt("Tell me a story", "<img>", "qwen3-4b", num_images=0), "Tell me a story"
+    )
+    self.assertEqual(
+        mm_processor.reformat_prompt("Tell me a story", "<img>", "llama2-7b", num_images=0), "Tell me a story"
+    )
+
+  def test_get_vision_and_decoder_block_routing(self):
+    # pylint: disable=protected-access
+    # Multimodal Qwen3-VL
+    self.assertEqual(mm_processor._get_vision_block("qwen3-vl-2b"), "qwen3_vl")
+    self.assertEqual(mm_processor._get_decoder_block("qwen3-vl-2b"), "qwen3")
+
+    # Multimodal Qwen3.5
+    self.assertEqual(mm_processor._get_vision_block("qwen3.5-35b-a3b"), "qwen3_5")
+    self.assertEqual(mm_processor._get_decoder_block("qwen3.5-35b-a3b"), "qwen3_5")
+
+    # Small Gemma 4 (tests gemma4_small decoder block)
+    self.assertEqual(mm_processor._get_vision_block("gemma4-e4b"), "gemma4")
+    self.assertEqual(mm_processor._get_decoder_block("gemma4-e4b"), "gemma4_small")
+
+    # Text-only Qwen3-4B should have empty vision block and fallback to model_name
+    self.assertIsNone(mm_processor._get_vision_block("qwen3-4b"))
+    self.assertEqual(mm_processor._get_decoder_block("qwen3-4b"), "qwen3-4b")
+
+    # Text-only Llama 2 should have empty vision block and fallback to model_name
+    self.assertIsNone(mm_processor._get_vision_block("llama2-7b"))
+    self.assertEqual(mm_processor._get_decoder_block("llama2-7b"), "llama2-7b")
+
+  def test_get_vision_and_decoder_block_routing_from_config(self):
+    # pylint: disable=protected-access
+    # Test with pyconfig Config objects
+    base_config_path = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "base.yml")
+    config_qwen3_vl = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="qwen3-vl-2b",
+        scan_layers=False,
+        skip_jax_distributed_system=True,
+    )
+    self.assertEqual(mm_processor._get_vision_block(config_qwen3_vl), "qwen3_vl")
+    self.assertEqual(mm_processor._get_decoder_block(config_qwen3_vl), "qwen3")
+
+    config_gemma3 = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="gemma3-4b",
+        skip_jax_distributed_system=True,
+    )
+    self.assertEqual(mm_processor._get_vision_block(config_gemma3), "gemma3")
+    self.assertEqual(mm_processor._get_decoder_block(config_gemma3), "gemma3")
+
+    config_text_only = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="qwen3-4b",
+        skip_jax_distributed_system=True,
+    )
+    self.assertIsNone(mm_processor._get_vision_block(config_text_only))
+    self.assertEqual(mm_processor._get_decoder_block(config_text_only), "qwen3")
+
+    # Test with config-like objects covering DecoderBlockType and VisionEncoderBlockType
+    mock_config = types.SimpleNamespace(
+        decoder_block=DecoderBlockType.GEMMA4_SMALL,
+        vision_encoder_block=VisionEncoderBlockType.GEMMA4,
+    )
+    self.assertEqual(mm_processor._get_vision_block(mock_config), "gemma4")
+    self.assertEqual(mm_processor._get_decoder_block(mock_config), "gemma4_small")
+
+    # Test config with DEFAULT decoder_block and NONE vision_encoder_block
+    mock_default = types.SimpleNamespace(
+        decoder_block=DecoderBlockType.DEFAULT,
+        vision_encoder_block=VisionEncoderBlockType.NONE,
+        model_name="custom_model",
+    )
+    self.assertIsNone(mm_processor._get_vision_block(mock_default))
+    self.assertEqual(mm_processor._get_decoder_block(mock_default), "custom_model")
+
+  def test_get_dummy_image_shape_for_init(self):
+    # Multimodal models should return non-empty dummy shape
+    self.assertGreater(len(mm_processor.get_dummy_image_shape_for_init("gemma3-4b")), 0)
+    self.assertGreater(len(mm_processor.get_dummy_image_shape_for_init("gemma4-26b")), 0)
+    self.assertGreater(len(mm_processor.get_dummy_image_shape_for_init("llama4-17b-16e")), 0)
+    self.assertGreater(len(mm_processor.get_dummy_image_shape_for_init("qwen3-vl-2b")), 0)
+
+    # Text-only models should return empty tuple ()
+    self.assertEqual(mm_processor.get_dummy_image_shape_for_init("qwen3-4b"), ())
+    self.assertEqual(mm_processor.get_dummy_image_shape_for_init("llama2-7b"), ())
+
+  def test_preprocess_image_for_training(self):
+    dummy_image = np.zeros((224, 224, 3), dtype=np.uint8)
+    base_config_path = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "base.yml")
+
+    # Multimodal model should return non-empty output
+    config_gemma3 = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="gemma3-4b",
+        skip_jax_distributed_system=True,
+    )
+    output = mm_processor.preprocess_image_for_training([dummy_image], config_gemma3)
+    self.assertIsNotNone(output)
+
+    # Text-only model should raise ValueError
+    config_text_only = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="qwen3-4b",
+        skip_jax_distributed_system=True,
+    )
+    with self.assertRaises(ValueError):
+      mm_processor.preprocess_image_for_training([dummy_image], config_text_only)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

# Description

This PR refactors multimodal preprocessing routing in MaxText by replacing rigid model-name-based whitelists with component-based whitelists. 

This change decouples vision encoder blocks from LLM decoder blocks, and gives a modular foundation for future mix-and-match implementations while eliminating the maintenance needed to manually update the model whitelisting every time a new model or a new stitched model is added.


This is Step 2.5 of a 5-step Proof-of-Concept for any-to-any multimodal alignment in MaxText. Overall goal is to align a pretrained vision encoders with another text-only LLM, and connecting the two with a dynamically configured adaptation layer (customized MLP connector), special tokenizer mapping for visual placeholder tokens, and train only the MLP using supervised fine tuning.

FIXES: b/543524347

# Changes
## `src/maxtext/multimodal/processor.py`
- Refactored routing functions to use `_get_vision_block()` and `_get_decoder_block()` to get each model's encoder and decoder block names respectively. 
- Rerouted to process the vision & prompts based on the vision & text block names instead of the model name. 
- Added YAML config lookup (`_get_block_name_from_model_yml`).
- *Note*: Changes were made to vision/prompt preprocessing only. Audio parts remain unchanged.

## `tests/unit/multimodal_utils_test.py`
- Added additional unit tests verifying vision/decoder block extraction, prompt reformatting fallbacks, dummy shape generation, and training image preprocessing across multimodal and text-only models.



# Tests

## Unit tests
```bash
JAX_PLATFORMS=cpu python3 -m pytest -v tests/unit/multimodal_utils_test.py tests/unit/qwen3_omni_layers_test.py
```
* **Original processor implementation (with `test_get_vision_and_decoder_block_routing` and `test_get_vision_and_decoder_block_routing_from_config` deselected):** `53 passed, 1 skipped, 2 deselected`
* **New processor implementation:** `55 passed, 1 skipped`

## Model decoding
Verify if the model decoding responses are identical before and after new processor.py implementation (to ensure that new processor changes do not affect the model's functionality).

### Qwen-VL-2B
```bash
python3 -m maxtext.inference.decode src/maxtext/configs/base.yml model_name=qwen3-vl-2b \
    tokenizer_path=Qwen/Qwen3-VL-2B-Instruct tokenizer_type=huggingface use_multimodal=true \
    load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/qwen3-vl-2b-processor/0/items \
    prompt='Describe this image' image_path='tests/assets/test_image.jpg' \
    per_device_batch_size=1 scan_layers=false max_prefill_predict_length=512 max_target_length=768 \
    ici_tensor_parallelism=4 override_model_config=true attention='dot_product' hf_access_token=<your-token>
```

Original processor implmentation
Input `<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>Describe this image<|im_end|>\n<|im_start|>assistant\n` -> `This is a panoramic view of the Seattle skyline on a bright, sunny day. The image is taken from a high vantage point, looking down on the city.\n\nThe most prominent feature is the **Space Needle**, a distinctive observation tower located on the left side of the frame. It stands tall among the city's modern skyscrapers, which are a mix of glass and steel structures. The buildings are densely packed, creating a dense urban landscape.`

New processor implmentation
Input `<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>Describe this image<|im_end|>\n<|im_start|>assistant\n` -> `This is a panoramic view of the Seattle skyline on a bright, sunny day. The image is taken from a high vantage point, looking down on the city.\n\nThe most prominent feature is the **Space Needle**, a distinctive observation tower located on the left side of the frame. It stands tall among the city's modern skyscrapers, which are a mix of glass and steel structures. The buildings are densely packed, creating a dense urban landscape.`


### Qwen3-0.6B
```bash
python3 -m maxtext.inference.decode src/maxtext/configs/base.yml model_name=qwen3-0.6b \
    tokenizer_path=src/maxtext/assets/tokenizers/qwen3-tokenizer \
    load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/qwen3-0.6b-processor/0/items \
    prompt='How many r are there in the word strawberry' \
    per_device_batch_size=1 scan_layers=false max_prefill_predict_length=512 max_target_length=768 \
    checkpoint_storage_use_ocdbt=false checkpoint_storage_use_zarr3=false \
    ici_tensor_parallelism=4 override_model_config=true attention='dot_product' hf_access_token=<your-token>
```

Original
Input `How many r are there in the word strawberry` -> `? Let's see, the word is strawberry. Let's break it down. The letters are S, T, R, E, W, A, R, T, E, S. So, how many times does the letter R appear? Let's count. First, S, T, R, E, W, A, R, T, E, S. So, the first R is at position 3, then another R at position 7. So that's two R's. Therefore, the answer should be 2. But wait, let me double-check. Maybe I missed something. Let me write them out again: S, T, R, E, W, A, R, T, E, S. Yes, two R's. So the answer is 2.\nThe answer is 2.`

New
Input `How many r are there in the word strawberry` -> `? Let's see, the word is strawberry. Let's break it down. The letters are S, T, R, E, W, A, R, T, E, S. So, how many times does the letter R appear? Let's count. First, S, T, R, E, W, A, R, T, E, S. So, the first R is at position 3, then another R at position 7. So that's two R's. Therefore, the answer should be 2. But wait, let me double-check. Maybe I missed something. Let me write them out again: S, T, R, E, W, A, R, T, E, S. Yes, two R's. So the answer is 2.\nThe answer is 2.`



### Gemma2-2B
```bash
python3 -m maxtext.inference.decode src/maxtext/configs/base.yml model_name=gemma2-2b \
    tokenizer_path=src/maxtext/assets/tokenizers/tokenizer.gemma \
    load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/gemma2-2b-processor/0/items \
    prompt='How many r are there in the word strawberry' \
    per_device_batch_size=1 scan_layers=false max_prefill_predict_length=512 max_target_length=768 \
    checkpoint_storage_use_ocdbt=false checkpoint_storage_use_zarr3=false \
    ici_tensor_parallelism=4 override_model_config=true attention='dot_product' hf_access_token=<your-token>
```

Original
Input `How many r are there in the word strawberry` -> `?\n[Answer 1]\nThere are <strong>10</strong> r's in the word strawberry.\n<blockquote>The word strawberry has 10 r's.</blockquote>`

New
Input `How many r are there in the word strawberry` -> `?\n[Answer 1]\nThere are <strong>10</strong> r's in the word strawberry.\n<blockquote>The word strawberry has 10 r's.</blockquote>`

### Gemma3-4B
```bash
python3 -m maxtext.inference.decode src/maxtext/configs/base.yml model_name=gemma3-4b \
    tokenizer_path=src/maxtext/assets/tokenizers/tokenizer.gemma3 use_multimodal=true \
    load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/gemma3-4b-processor/0/items \
    prompt='Describe this image' image_path='tests/assets/test_image.jpg' \
    per_device_batch_size=1 scan_layers=false max_prefill_predict_length=512 max_target_length=768 \
    checkpoint_storage_use_ocdbt=false checkpoint_storage_use_zarr3=false \
    ici_tensor_parallelism=4 override_model_config=true attention='dot_product' hf_access_token=<your-token>
```

Original
Input `<start_of_turn>user\n\nDescribe this image<end_of_turn>\n<start_of_turn>model\n` -> `Here's a description of the image:\n\n**Overall Impression:**\n\nThe image captures a stunning panoramic view of Seattle, Washington, on a bright, sunny day. The city skyline dominates the foreground, with the majestic Cascade Mountains visible in the distance.`

New
Input `<start_of_turn>user\n\nDescribe this image<end_of_turn>\n<start_of_turn>model\n` -> `Here's a description of the image:\n\n**Overall Impression:**\n\nThe image captures a stunning panoramic view of Seattle, Washington, on a bright, sunny day. The city skyline dominates the foreground, with the majestic Cascade Mountains visible in the distance.`

### Gemma4-e2b
```bash
python3 -m maxtext.inference.decode src/maxtext/configs/base.yml model_name=gemma4-e2b \
    tokenizer_path=src/maxtext/assets/tokenizers/tokenizer_gemma4.model tokenizer_type=sentencepiece \
    load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/gemma4-e2b-processor/0/items \
    prompt="<bos><|turn>system\nYou are a helpful assistant.<turn|>\n<|turn>user\nHow many r are there in the word strawberry<turn|>\n<|turn>model\n" \
    per_device_batch_size=1 scan_layers=false use_multimodal=false max_prefill_predict_length=512 max_target_length=768 \
    checkpoint_storage_use_ocdbt=False checkpoint_storage_use_zarr3=False ici_tensor_parallelism=1 \
    override_model_config=true attention=dot_product decode_sampling_strategy=composite \
    decode_sampling_temperature=1.0 decode_sampling_nucleus_p=0.95 decode_sampling_top_k=64
```

Original
Input `<bos><|turn>system You are a helpful assistant.<turn|> <|turn>user How many r are there in the word strawberry<turn|> <|turn>model` -> ` there are **3** "r"s in the word "strawberry".<turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|>`

New
Input `<bos><|turn>system You are a helpful assistant.<turn|> <|turn>user How many r are there in the word strawberry<turn|> <|turn>model` -> ` there are **3** "r"s in the word "strawberry".<turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|>`

### Gemma4-26B
```bash
python3 -m maxtext.inference.decode src/maxtext/configs/base.yml model_name=gemma4-26b \
    tokenizer_type="huggingface" tokenizer_path=google/gemma-4-26b-a4b-it use_multimodal=true \
    load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/gemma4-26b-processor/0/items \
    prompt='Describe this image <|image|>' image_path='tests/assets/test_image.jpg' \
    per_device_batch_size=1 scan_layers=false max_prefill_predict_length=512 max_target_length=768 \
    checkpoint_storage_use_ocdbt=false checkpoint_storage_use_zarr3=false \
    ici_fsdp_parallelism=4 parameter_memory_host_offload=True override_model_config=true attention='dot_product' hf_access_token=<your-token>
```

Original
Input `<bos><|turn>user\nDescribe this image <|image|><turn|>\n<|turn>model\n` -> `thought\nA wide, eye-level shot shows the Seattle skyline under a bright blue sky with white clouds. The Space Needle, a tall, white, futuristic-looking tower with a saucer-shaped top, is on the left side of the frame. Behind it, a dense cluster of skyscrapers of various heights and colors, mostly blue and gray, fills the center and left of the frame. In the background, a range of snow-capped mountains is visible under a layer of white clouds. In the foreground, several multi-story buildings in shades of white, gray, and brown are partially obscured by lush green trees. The lighting is bright and even, suggesting a sunny day.`

New
Input `<bos><|turn>user\nDescribe this image <|image|><turn|>\n<|turn>model\n` -> `thought\nA wide, eye-level shot shows the Seattle skyline under a bright blue sky with white clouds. The Space Needle, a tall, white, futuristic-looking tower with a saucer-shaped top, is on the left side of the frame. Behind it, a dense cluster of skyscrapers of various heights and colors, mostly blue and gray, fills the center and left of the frame. In the background, a range of snow-capped mountains is visible under a layer of white clouds. In the foreground, several multi-story buildings in shades of white, gray, and brown are partially obscured by lush green trees. The lighting is bright and even, suggesting a sunny day.`


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).