### PR TITLE
Fix run_e2e_tests.yml missing jq command

### DIFF
--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -63,15 +63,7 @@ jobs:
           AIRFLOW_CALLBACK_TOKEN: ${{ secrets.AIRFLOW_CALLBACK_TOKEN }}
         run: |
           IAP_TOKEN=$(gcloud auth print-access-token)
-
-          PAYLOAD=$(jq -n \
-            --arg mode "$BUILD_MODE" \
-            --arg sha "$MAXTEXT_SHA" \
-            --arg run_id "$RUN_ID" \
-            --arg repo "$GITHUB_REPO" \
-            --arg token "$AIRFLOW_CALLBACK_TOKEN" \
-            '{conf: {build_mode: $mode, maxtext_sha: $sha, github_run_id: $run_id, github_repo: $repo, github_callback_token: $token}}')
-
+          PAYLOAD=$(python3 -c 'import os, json; print(json.dumps({"conf": {"build_mode": os.environ["BUILD_MODE"], "maxtext_sha": os.environ["MAXTEXT_SHA"], "github_run_id": os.environ["RUN_ID"], "github_repo": os.environ["GITHUB_REPO"], "github_callback_token": os.environ["AIRFLOW_CALLBACK_TOKEN"]}}))')
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
             "${AIRFLOW_URI}/api/v1/dags/maxtext_e2e_tests/dagRuns" \
             -H "Authorization: Bearer ${IAP_TOKEN}" \


### PR DESCRIPTION
# Description

Issue: 
- This PR fixes a failure in the `MaxText E2E Airflow Tests` workflow (`run_e2e_tests.yml`) caused by `jq` not being available in the `google/cloud-sdk` container image.  [b/540038899](https://b.corp.google.com/issues/540038899)

Backgroud:
 `jq` was introduced to fix a vulnerability:
- Manually constructing JSON strings using bash variable interpolation is fragile and can lead to malformed payloads if any of the environment variables (such as the secret token, repo name, or SHA) contain special characters (like quotes, backslashes, or newlines).
 
 Fix:
- Since jq is not available in the google/cloud-sdk container, an alternative is to use Python to safely serialize the JSON payload from environment variables. This avoids any syntax or injection issues.

FIXES: b/540038899


# Tests

- CI -> Github actions scan
- Build TPU Nightly Docker Images: https://github.com/AI-Hypercomputer/maxtext/actions/runs/31046892922

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
