### PR TITLE
fix(pylint): ignore datasets module to resolve E0611 no-name-in-module errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
       - id: pylint
         args:
           - '--disable=R0401,R0917,W0201,W0613'
+          - '--ignored-modules=datasets'
           - "--ignore-patterns='.pytype,.*pyi$'"
           - '--ignore-paths=src/maxtext/input_pipeline/protos|src/maxtext/eval/simple_evals_template'
 


### PR DESCRIPTION
PyLint fails with E0611 (no-name-in-module) for module datasets across multiple files because PyLint cannot statically resolve dynamic/lazy attributes in Hugging Face datasets without --ignored-modules=datasets.

Adding --ignored-modules=datasets to PyLint args in .pre-commit-config.yaml resolves all pylint pre-commit checks.