### PR TITLE
Download tokenizers from GCS in unit tests instead of HF

### DIFF
--- a/src/maxtext/utils/globals.py
+++ b/src/maxtext/utils/globals.py
@@ -20,11 +20,11 @@ import os.path
 # Since this file is at src/maxtext/utils/globals.py, we need to go up 2 levels
 MAXTEXT_PKG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# This is the maxtext repo root: with ".git" folder; "README.md"; "pyproject.toml"; &etc.
+# This is the maxtext repo root: with ".git" folder or file (when using Git worktrees); "README.md"; "pyproject.toml"; etc.
 MAXTEXT_REPO_ROOT = os.environ.get(
     "MAXTEXT_REPO_ROOT",
     r
-    if os.path.isdir(
+    if os.path.exists(
         os.path.join(r := os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))), ".git")
     )
     else MAXTEXT_PKG_DIR,

--- a/tests/post_training/integration/grpo_correctness.py
+++ b/tests/post_training/integration/grpo_correctness.py
@@ -34,7 +34,7 @@ import numpy as np
 import pytest
 import torch
 import transformers
-# from datasets import Dataset
+from tests.utils.test_helpers import ensure_tokenizer_downloaded
 
 from trl import GRPOConfig, GRPOTrainer
 
@@ -79,11 +79,11 @@ class GRPOTest(unittest.TestCase):
       init_state_fn = functools.partial(maxtext_utils.init_initial_state, self.model, None, self.cfg, False, self.rng)
       self.reference_model = None
       self.state, _ = maxtext_utils.setup_decode_state(self.cfg, mesh, None, init_state_fn)
+    tokenizer_path = ensure_tokenizer_downloaded("llama3.1-tokenizer", skip_test_on_failure=True)
     self.tokenizer_model = transformers.AutoTokenizer.from_pretrained(
-        "meta-llama/Llama-3.1-8B",
+        tokenizer_path,
         add_bos_token=False,
         add_eos_token=False,
-        token=self.cfg.hf_access_token,
     )
     self.input_str = "Hello world this is a test"
 

--- a/tests/post_training/integration/grpo_trainer_correctness_test.py
+++ b/tests/post_training/integration/grpo_trainer_correctness_test.py
@@ -27,7 +27,6 @@ Usage:
 
 import functools
 import os
-import subprocess
 import sys
 import unittest
 from flax import linen as nn
@@ -37,12 +36,13 @@ from jax.sharding import Mesh
 import jsonlines
 import maxtext as mt
 from maxtext.configs import pyconfig, types
-from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from flax import nnx
 from maxtext.experimental.rl import grpo_utils
 from maxtext.experimental.rl.grpo_trainer import _merge_grpo_state, grpo_loss_fn, grpo_loss_fn_nnx, setup_train_loop
 from maxtext.experimental.rl.grpo_utils import compute_log_probs, compute_log_probs_nnx
+from tests.utils.test_helpers import ensure_tokenizer_downloaded
 from maxtext.inference import offline_engine
 from maxtext.inference.maxengine import maxengine
 from maxtext.inference.offline_engine import InputData
@@ -143,17 +143,7 @@ class GrpoTrainerTest(unittest.TestCase):
   def setUp(self):
     super().setUp()
     jax.config.update("jax_default_prng_impl", "unsafe_rbg")
-    command = [
-        "gcloud",
-        "storage",
-        "cp",
-        "--recursive",
-        "gs://maxtext-dataset/hf/llama3.1-tokenizer",
-        os.path.join(MAXTEXT_ASSETS_ROOT, ""),
-    ]
-    exit_code = subprocess.call(command, cwd=os.path.dirname(MAXTEXT_PKG_DIR))
-    if exit_code != 0:
-      raise ValueError(f"{command} failed with exit code: {exit_code}")
+    tokenizer_path = ensure_tokenizer_downloaded("llama3.1-tokenizer", skip_test_on_failure=True)
     self.config = pyconfig.initialize(
         [
             None,
@@ -161,7 +151,7 @@ class GrpoTrainerTest(unittest.TestCase):
         ],
         config_class=types.RLConfig,
         run_name="unit_test_grpo_trainer",
-        tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "llama3.1-tokenizer"),
+        tokenizer_path=tokenizer_path,
         enable_checkpointing=False,
         train_data_columns="prompt",
     )
@@ -172,7 +162,7 @@ class GrpoTrainerTest(unittest.TestCase):
         ],
         config_class=types.RLConfig,
         run_name="unit_test_grpo_trainer_inference",
-        tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "llama3.1-tokenizer"),
+        tokenizer_path=tokenizer_path,
         enable_checkpointing=False,
         ici_tensor_parallelism=4,
         per_device_batch_size=self.config.per_device_batch_size * self.config.rl["num_generations"],

--- a/tests/post_training/integration/sft_trainer_correctness_test.py
+++ b/tests/post_training/integration/sft_trainer_correctness_test.py
@@ -26,11 +26,9 @@ Usage:
 
 import functools
 import os.path
-import subprocess
 import sys
 import unittest
 
-import filelock
 from flax.linen import partitioning as nn_partitioning
 import jax
 import jax.numpy as jnp
@@ -44,9 +42,8 @@ from maxtext.models import models
 from maxtext.utils import maxtext_utils
 from maxtext.utils import maxtext_utils_nnx
 from maxtext.utils import model_creation_utils
-from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
-from maxtext.utils.globals import MAXTEXT_PKG_DIR
-from maxtext.utils.globals import MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
+from tests.utils.test_helpers import ensure_tokenizer_downloaded
 import numpy as np
 import pytest
 from transformers import AutoTokenizer
@@ -67,7 +64,7 @@ def initialize_config():
       [sys.argv[0], os.path.join(MAXTEXT_PKG_DIR, "configs/post_train", "sft.yml")],
       run_name="test-sft-trainer-correctness",
       model_name="default",
-      tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer"),
+      tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "llama2-chat-tokenizer"),
       enable_checkpointing=False,
       max_target_length=32,
       per_device_batch_size=1,
@@ -178,21 +175,7 @@ class SFTTrainerCorrectnessTest(unittest.TestCase):
           os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
       )
 
-    tokenizer_dir = os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer")
-    lock_path = os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer.lock")
-    with filelock.FileLock(lock_path):
-      if not os.path.exists(tokenizer_dir):
-        command = [
-            "gcloud",
-            "storage",
-            "cp",
-            "--recursive",
-            "gs://maxtext-dataset/hf/llama2-chat-tokenizer",
-            os.path.join(MAXTEXT_ASSETS_ROOT, ""),
-        ]
-        exit_code = subprocess.call(command)
-        if exit_code != 0:
-          raise ValueError(f"Download tokenizer failed ({exit_code})")
+    ensure_tokenizer_downloaded("llama2-chat-tokenizer", skip_test_on_failure=True)
 
   @pytest.mark.skip(reason="Logit output test fragile, failing on jax upgrade to 0.6.2 b/425997645")
   @pytest.mark.integration_test

--- a/tests/post_training/unit/distillation_data_processing_test.py
+++ b/tests/post_training/unit/distillation_data_processing_test.py
@@ -20,8 +20,6 @@ pytestmark = [pytest.mark.post_training]
 
 import argparse
 import os
-import filelock
-import subprocess
 import unittest
 
 import transformers
@@ -30,6 +28,9 @@ from datasets import Dataset
 
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.input_pipeline import distillation_data_processing
+from tests.utils.test_helpers import ensure_tokenizer_downloaded
+
+LLAMA2_TOKENIZER_PATH = os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "llama2-chat-tokenizer")
 
 PROMPT_DATA = [
     [
@@ -81,26 +82,12 @@ class DistillationDataProcessingTest(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
     super().setUpClass()
-    tokenizer_dir = os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer")
-    lock_path = os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer.lock")
-    with filelock.FileLock(lock_path):
-      if not os.path.exists(tokenizer_dir):
-        command = [
-            "gcloud",
-            "storage",
-            "cp",
-            "--recursive",
-            "gs://maxtext-dataset/hf/llama2-chat-tokenizer",
-            os.path.join(MAXTEXT_ASSETS_ROOT, ""),
-        ]
-        exit_code = subprocess.call(command)
-        if exit_code != 0:
-          raise ValueError(f"Download tokenizer failed ({exit_code})")
+    ensure_tokenizer_downloaded("llama2-chat-tokenizer", LLAMA2_TOKENIZER_PATH, skip_test_on_failure=True)
 
   def setUp(self):
     super().setUp()
     self.tokenizer = transformers.AutoTokenizer.from_pretrained(
-        os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer"),
+        LLAMA2_TOKENIZER_PATH,
     )
     self.parser = argparse.ArgumentParser()
     self.parser = add_arguments_to_parser(self.parser)

--- a/tests/post_training/unit/sft_data_processing_test.py
+++ b/tests/post_training/unit/sft_data_processing_test.py
@@ -17,10 +17,8 @@ import pytest
 
 pytestmark = [pytest.mark.post_training]
 
-import subprocess
 import unittest
 import os.path
-import filelock
 import numpy as np
 import jax
 from jax.sharding import Mesh
@@ -34,6 +32,11 @@ from maxtext.input_pipeline import hf_data_processing
 from maxtext.input_pipeline import input_pipeline_interface
 from maxtext.input_pipeline.hf_data_processing import _get_pad_id
 from maxtext.input_pipeline.input_pipeline_utils import apply_chat_template, SFTPromptMasking, tokenization
+from tests.utils.test_helpers import ensure_tokenizer_downloaded
+
+QWEN3_TOKENIZER_PATH = os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "qwen3-tokenizer")
+GEMMA4_TOKENIZER_PATH = os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "gemma4-tokenizer")
+LLAMA2_TOKENIZER_PATH = os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "llama2-chat-tokenizer")
 
 PROMPT_DATA = [
     [
@@ -102,7 +105,7 @@ MESSAGES_DATA = [
 ]
 
 LLAMA2_DATA = {
-    "tokenizer_path": None,
+    "tokenizer_path": LLAMA2_TOKENIZER_PATH,
     "messages": {
         "truncated_exp1_inputs": (
             "<s>[INST] <<SYS>>\nthe system prompt\n<</SYS>>\n\nexample one question one [/INST] "
@@ -200,7 +203,7 @@ LLAMA2_DATA = {
 }
 
 QWEN_DATA = {
-    "tokenizer_path": "Qwen/Qwen3-4B",
+    "tokenizer_path": QWEN3_TOKENIZER_PATH,
     "messages": {
         "truncated_exp1_inputs": (
             "<|im_start|>system\nthe system prompt<|im_end|>\n"
@@ -321,27 +324,12 @@ class SFTDataProcessingTest(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
     super().setUpClass()
-    tokenizer_dir = os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer")
-    lock_path = os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer.lock")
-    with filelock.FileLock(lock_path):
-      if not os.path.exists(tokenizer_dir):
-        command = [
-            "gcloud",
-            "storage",
-            "cp",
-            "--recursive",
-            "gs://maxtext-dataset/hf/llama2-chat-tokenizer",
-            os.path.join(MAXTEXT_ASSETS_ROOT, ""),
-        ]
-        exit_code = subprocess.call(command)
-        if exit_code != 0:
-          raise unittest.SkipTest(f"Download tokenizer failed ({exit_code})")
+    ensure_tokenizer_downloaded("qwen3-tokenizer", QWEN3_TOKENIZER_PATH, skip_test_on_failure=True)
+    ensure_tokenizer_downloaded("llama2-chat-tokenizer", LLAMA2_TOKENIZER_PATH, skip_test_on_failure=True)
 
   def setUp(self):
     super().setUp()
-    tokenizer_path = self.test_data.get("tokenizer_path")
-    if tokenizer_path is None:
-      tokenizer_path = os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer")
+    tokenizer_path = self.test_data.get("tokenizer_path", LLAMA2_TOKENIZER_PATH)
 
     self.config = pyconfig.initialize(
         [os.path.join(MAXTEXT_PKG_DIR, "sft_trainer"), os.path.join(MAXTEXT_CONFIGS_DIR, "post_train", "sft.yml")],
@@ -491,31 +479,19 @@ class SFTDataProcessingTest(unittest.TestCase):
 
 @pytest.mark.external_training
 class SFTChatTemplateLogicTest(unittest.TestCase):
-  LLAMA_TOKENIZER_PATH = os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer")
 
   @classmethod
   def setUpClass(cls):
     super().setUpClass()
-    lock_path = os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer.lock")
-    with filelock.FileLock(lock_path):
-      if not os.path.exists(cls.LLAMA_TOKENIZER_PATH):
-        command = [
-            "gcloud",
-            "storage",
-            "cp",
-            "-r",
-            "gs://maxtext-dataset/hf/llama2-chat-tokenizer",
-            os.path.join(MAXTEXT_ASSETS_ROOT, ""),
-        ]
-        exit_code = subprocess.call(command)
-        if exit_code != 0:
-          raise unittest.SkipTest("Download tokenizer failed")
+    ensure_tokenizer_downloaded("qwen3-tokenizer", QWEN3_TOKENIZER_PATH, skip_test_on_failure=True)
+    ensure_tokenizer_downloaded("llama2-chat-tokenizer", LLAMA2_TOKENIZER_PATH, skip_test_on_failure=True)
+    ensure_tokenizer_downloaded("gemma4-tokenizer", GEMMA4_TOKENIZER_PATH, skip_test_on_failure=True)
 
   def setUp(self):
     super().setUp()
-    self.qwen3_tokenizer = transformers.AutoTokenizer.from_pretrained("Qwen/Qwen3-4B")
-    self.llama2_tokenizer = transformers.AutoTokenizer.from_pretrained(self.LLAMA_TOKENIZER_PATH)
-    self.gemma4_tokenizer = transformers.AutoTokenizer.from_pretrained("google/gemma-4-26B-A4B-it")
+    self.qwen3_tokenizer = transformers.AutoTokenizer.from_pretrained(QWEN3_TOKENIZER_PATH)
+    self.llama2_tokenizer = transformers.AutoTokenizer.from_pretrained(LLAMA2_TOKENIZER_PATH)
+    self.gemma4_tokenizer = transformers.AutoTokenizer.from_pretrained(GEMMA4_TOKENIZER_PATH)
 
   def _apply_chat_template(self, tokenizer):
     """Helper function to apply the chat template to a sample input and return the result for testing."""
@@ -562,11 +538,17 @@ class SFTChatTemplateLogicTest(unittest.TestCase):
 @pytest.mark.external_training
 class SFTPromptMaskingTest(unittest.TestCase):
 
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    ensure_tokenizer_downloaded("qwen3-tokenizer", QWEN3_TOKENIZER_PATH, skip_test_on_failure=True)
+    ensure_tokenizer_downloaded("gemma4-tokenizer", GEMMA4_TOKENIZER_PATH, skip_test_on_failure=True)
+
   def setUp(self):
     super().setUp()
     self.max_target_length = 50
-    self.qwen3_tokenizer = transformers.AutoTokenizer.from_pretrained("Qwen/Qwen3-4B")
-    self.gemma4_tokenizer = transformers.AutoTokenizer.from_pretrained("google/gemma-4-26B-A4B-it")
+    self.qwen3_tokenizer = transformers.AutoTokenizer.from_pretrained(QWEN3_TOKENIZER_PATH)
+    self.gemma4_tokenizer = transformers.AutoTokenizer.from_pretrained(GEMMA4_TOKENIZER_PATH)
 
   def _apply_prompt_masking(self, tokenizer, unk_id, completion_only=True):
     """Helper function to apply the prompt masking to a sample input and return the result for testing."""

--- a/tests/unit/tokenizer_test.py
+++ b/tests/unit/tokenizer_test.py
@@ -21,8 +21,8 @@ from maxtext.trainers.tokenizer import train_tokenizer
 from maxtext.common.gcloud_stub import is_decoupled
 
 import unittest
-import subprocess
 import os
+from tests.utils.test_helpers import ensure_tokenizer_downloaded
 
 
 @unittest.skipIf(is_decoupled(), "Bypassed in offline decoupled runs (no GCS/internet)")
@@ -100,15 +100,8 @@ class HFTokenizerTest(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    source = "gs://maxtext-gemma/huggingface/gemma2-2b"
-    destination = os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers")
-    subprocess.run(
-        ["gcloud", "storage", "cp", "-R", source, destination],
-        check=True,
-    )
-    cls.hf_tokenizer = input_pipeline_utils.get_tokenizer(
-        os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "gemma2-2b"), "huggingface", add_bos=False, add_eos=False
-    )
+    gemma2_path = ensure_tokenizer_downloaded("gemma2-2b", skip_test_on_failure=False)
+    cls.hf_tokenizer = input_pipeline_utils.get_tokenizer(gemma2_path, "huggingface", add_bos=False, add_eos=False)
     cls.sp_tokenizer = input_pipeline_utils.get_tokenizer(
         os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "tokenizer.gemma"), "sentencepiece", add_bos=False, add_eos=False
     )

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -20,8 +20,53 @@ of Google Cloud Storage paths.
 """
 
 import os
+import shutil
+import subprocess
+import unittest
+import filelock
 from maxtext.common.gcloud_stub import is_decoupled
-from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_CONFIGS_DIR
+
+
+def ensure_tokenizer_downloaded(
+    tokenizer_name: str,
+    target_path: str | None = None,
+    skip_test_on_failure: bool = False,
+) -> str:
+  """Ensures a tokenizer directory exists locally and is non-empty, downloading from GCS if missing.
+
+  Args:
+    tokenizer_name: Name of the tokenizer folder in gs://maxtext-dataset/hf/ (e.g. 'llama2-chat-tokenizer').
+    target_path: Optional local target path. Defaults to os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", tokenizer_name).
+    skip_test_on_failure: If True, raises unittest.SkipTest on download failure instead of RuntimeError.
+
+  Returns:
+    The local path to the tokenizer directory.
+  """
+  if target_path is None:
+    target_path = os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", tokenizer_name)
+
+  lock_path = target_path + ".lock"
+  with filelock.FileLock(lock_path):
+    if not os.path.exists(target_path) or not os.listdir(target_path):
+      os.makedirs(os.path.dirname(target_path), exist_ok=True)
+      exit_code = subprocess.call(
+          [
+              "gcloud",
+              "storage",
+              "cp",
+              "--recursive",
+              f"gs://maxtext-dataset/hf/{tokenizer_name}",
+              os.path.join(os.path.dirname(target_path), ""),
+          ]
+      )
+      if exit_code != 0:
+        shutil.rmtree(target_path, ignore_errors=True)
+        msg = f"Failed to download {tokenizer_name} from GCS with exit code {exit_code}"
+        if skip_test_on_failure:
+          raise unittest.SkipTest(f"Skipping test: {msg}")
+        raise RuntimeError(msg)
+  return target_path
 
 
 def get_test_config_path(relative_path: str = "base.yml"):
@@ -91,6 +136,7 @@ def get_test_base_output_directory(cloud_path=None):
 
 
 __all__ = [
+    "ensure_tokenizer_downloaded",
     "get_test_base_output_directory",
     "is_rocm_backend",
     "get_test_config_path",


### PR DESCRIPTION
# Description

This PR refactors unit and integration tests to dynamically pull required tokenizers from `gs://maxtext-dataset/hf/` into local assets on demand during test setup.

This helps avoid downloads from HuggingFace. Unfortunately, we cannot simply put these tokenizers in our assets directory because their license is not Apache 2.0.

The new helper function `test_helpers.ensure_tokenizer_downloaded` has a `skip_test_on_failure` parameter that allows us to skip the test if copying of the tokenizer from the GS bucket fails.

Additionally, this PR fixes repository root detection in `src/maxtext/utils/globals.py` when running inside Git worktrees.

# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
