### PR TITLE
Enable megacore for splash attention dkv backward

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1114,6 +1114,7 @@ sa_block_kv_dkv_compute: 512
 sa_block_q_dq: 512
 sa_block_kv_dq: 512
 sa_use_fused_bwd_kernel: false
+sa_bwd_dkv_megacore: false  # megacore-parallel kv-head groups in the static dkv grid
 sa_q_layout: "HEAD_DIM_MINOR"
 sa_k_layout: "HEAD_DIM_MINOR"
 sa_v_layout: "HEAD_DIM_MINOR"

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -733,6 +733,10 @@ class SplashAttention(BaseModel):
   sa_block_q_dq: int = Field(512, description="Block size for Q_dq in splash attention.")
   sa_block_kv_dq: int = Field(512, description="Block size for KV_dq in splash attention.")
   sa_use_fused_bwd_kernel: bool = Field(False, description="Use fused backward kernel in splash attention.")
+  sa_bwd_dkv_megacore: bool = Field(
+      False,
+      description="Megacore-parallel kv-head groups in the static dkv grid. Needs >1 KV head; useful at local batch 1.",
+  )
   sa_q_layout: str = Field("HEAD_DIM_MINOR", description="Layout for Q in splash attention.")
   sa_k_layout: str = Field("HEAD_DIM_MINOR", description="Layout for K in splash attention.")
   sa_v_layout: str = Field("HEAD_DIM_MINOR", description="Layout for V in splash attention.")

--- a/src/maxtext/kernels/attention/tokamax_ring_attention.py
+++ b/src/maxtext/kernels/attention/tokamax_ring_attention.py
@@ -278,6 +278,7 @@ def build_splash_config(
       dq_reduction_steps=dq_reduction_steps if dq_reduction_steps > 0 else None,
       use_experimental_scheduler=config.use_splash_scheduler,
       ring_scan_unroll=config.ring_scan_unroll,
+      bwd_dkv_megacore=config.sa_bwd_dkv_megacore,
   )
 
 

--- a/src/maxtext/kernels/tokamax_splash_attention/ring_attention_kernel.py
+++ b/src/maxtext/kernels/tokamax_splash_attention/ring_attention_kernel.py
@@ -780,7 +780,7 @@ def make_ring_attention(
         mask,
         (bq_dkv, bkv_dkv),
         is_dkv=True,
-        return_dynamic_grid=config.dq_reduction_steps == 3,
+        return_dynamic_grid=config.dq_reduction_steps == 3 and not config.bwd_dkv_megacore,
     )
     assert (mask_function_fwd is None) == (mask_function_dkv is None)
     dkv_mask_sparsity = _mask_sparsity(dkv_mask_info)

--- a/src/maxtext/kernels/tokamax_splash_attention/splash_attention_kernel.py
+++ b/src/maxtext/kernels/tokamax_splash_attention/splash_attention_kernel.py
@@ -150,6 +150,8 @@ class SplashConfig:
   # An experimental scheduler that sometimes produces better softmax overlap.
   use_experimental_scheduler: bool = False
   ring_scan_unroll: int = 1
+  # Use both TensorCores in the dkv backward by splitting the grid over kv-head groups.
+  bwd_dkv_megacore: bool = False
 
   def __post_init__(self):
     if self.block_kv_compute is None:
@@ -1185,6 +1187,7 @@ def _flash_attention_dkv_kernel(
     mask_function: MaskFunctionType | None,
     q_heads_per_kv_head: int,
     config: SplashConfig,
+    megacore_groups: bool = False,
 ):
   del mask_next_ref, active_cols_ref
   HEAD_DIM_MINOR = QKVLayout.HEAD_DIM_MINOR
@@ -1200,16 +1203,24 @@ def _flash_attention_dkv_kernel(
     should_initialize = bounds_start_ref[grid_idx].astype(jnp.bool_)
     should_write = bounds_end_ref[grid_idx].astype(jnp.bool_)
   else:
-    kv_index, q_head, q_index = (
-        pl.program_id(0),
-        pl.program_id(1),
-        pl.program_id(2),
-    )
+    if megacore_groups:
+      kv_index, q_head_index_per_kv_head, q_index = (
+          pl.program_id(1),
+          pl.program_id(2),
+          pl.program_id(3),
+      )
+    else:
+      kv_index, q_head, q_index = (
+          pl.program_id(0),
+          pl.program_id(1),
+          pl.program_id(2),
+      )
     grid_idx = (kv_index * q_steps) + q_index
     should_initialize = q_index == 0
     should_write = True if q_steps <= 2 else q_index == q_steps - 1
     if q_heads_per_kv_head > 1:
-      q_head_index_per_kv_head = lax.rem(q_head, q_heads_per_kv_head)
+      if not megacore_groups:
+        q_head_index_per_kv_head = lax.rem(q_head, q_heads_per_kv_head)
       should_initialize = jnp.logical_and(should_initialize, q_head_index_per_kv_head == 0)
       should_write = jnp.logical_and(should_write, q_head_index_per_kv_head == q_heads_per_kv_head - 1)
 
@@ -1407,6 +1418,12 @@ def _splash_attention_bwd_dkv(
   kv_steps = kv_seq_len // bkv
   q_steps = q_seq_len // bq
   q_heads_per_kv_head = num_q_heads // num_kv_heads
+  if config.bwd_dkv_megacore and (is_mqa or num_kv_heads == 1):
+    raise ValueError(
+        f"bwd_dkv_megacore requires more than one KV head; got is_mqa={is_mqa}, " f"num_kv_heads={num_kv_heads}."
+    )
+  # The kv-head group split needs a static grid.
+  megacore_groups = config.bwd_dkv_megacore and not dynamic_grid
 
   if dynamic_grid:
 
@@ -1424,6 +1441,16 @@ def _splash_attention_bwd_dkv(
     def mask_index_map(h, grid_idx, rows_ref, cols_ref, mask_next_ref=None, *_):
       del h, rows_ref, cols_ref  # Unused.
       next_m = to_i32(mask_next_ref[grid_idx])  # pyrefly: ignore[unsupported-operation]
+      return next_m, 0, 0
+
+  elif megacore_groups:
+    unravel = lambda f: lambda g, j, gi, i, *_: f(g * q_heads_per_kv_head + gi, i, j)
+    grid = (num_kv_heads, kv_steps, q_heads_per_kv_head, q_steps)
+
+    def mask_index_map(g, j, gi, i, rows_ref, cols_ref, mask_next_ref=None, *_):
+      del g, gi, rows_ref, cols_ref  # Unused.
+      grid_idx = j * q_steps + i
+      next_m = to_i32(mask_next_ref[grid_idx])
       return next_m, 0, 0
 
   else:
@@ -1599,6 +1626,7 @@ def _splash_attention_bwd_dkv(
       bkv=bkv,
       mask_function=mask_function,
       q_heads_per_kv_head=q_heads_per_kv_head,
+      megacore_groups=megacore_groups,
   )
 
   kernel_name = get_kernel_name(
@@ -1749,7 +1777,13 @@ def _splash_attention_bwd_dkv(
         # 2) for kv_seq_len, the splash attention prefetch schedule assumes no
         #     megacore
         # 3) for q_seq_len, we are reducing over it to compute dkv
-        compiler_params=pltpu.CompilerParams(dimension_semantics=("arbitrary",) * len(grid)),
+        # With megacore_groups the kv-head group dimension is independent (each
+        # group owns its dk/dv/dq blocks), so it is marked parallel.
+        compiler_params=pltpu.CompilerParams(
+            dimension_semantics=(("parallel",) + ("arbitrary",) * (len(grid) - 1))
+            if megacore_groups
+            else (("arbitrary",) * len(grid))
+        ),
         name=kernel_name,
         cost_estimate=cost_estimate,
         interpret=config.interpret,
@@ -2014,7 +2048,7 @@ def _make_splash_attention(
         mask,
         (bq_dkv, bkv_dkv),
         is_dkv=True,
-        return_dynamic_grid=config.dq_reduction_steps == 3,
+        return_dynamic_grid=config.dq_reduction_steps == 3 and not config.bwd_dkv_megacore,
     )
 
     assert (mask_function_fwd is None) == (mask_function_dkv is None)

--- a/tests/unit/kernels_test.py
+++ b/tests/unit/kernels_test.py
@@ -14,11 +14,14 @@
 
 """Tests for kernels."""
 
+import dataclasses
 import unittest
 
 import jax
 import jax.numpy as jnp
 from maxtext.kernels.attention.ragged_attention import ragged_gqa, ragged_mha, ragged_mqa, reference_gqa, reference_mha, reference_mqa
+from maxtext.kernels.tokamax_splash_attention import splash_attention_kernel as tokamax_splash_kernel
+from maxtext.kernels.tokamax_splash_attention import splash_attention_mask as tokamax_splash_mask
 import numpy as np
 import pytest
 
@@ -177,6 +180,70 @@ class RaggedAttentionCpuTest(unittest.TestCase):
         jnp.max(abs(ragged_out - reference_out)) < 1.5e-1,
         msg=f"Max difference: {jnp.max(abs(ragged_out - reference_out))} > 1e-1",
     )
+
+
+class SplashAttentionDkvMegacoreCpuTest(unittest.TestCase):
+  """Tests for the splash attention dkv backward kv-head group split on CPU (interpret mode)."""
+
+  num_kv_heads = 2
+  num_query_heads = 4
+  seq_len = 256  # Two blocks per grid dimension at the default block size of 128
+  head_dim = 128
+
+  dtype = jnp.float32
+
+  def _grads(self, bwd_dkv_megacore, num_kv_heads, interpret=True):
+    """Returns (dq, dk, dv) of the causal splash kernel for the given flag and KV head count."""
+    config = dataclasses.replace(
+        tokamax_splash_kernel.SplashConfig.get_default(),
+        interpret=interpret,
+        bwd_dkv_megacore=bwd_dkv_megacore,
+    )
+    mask = tokamax_splash_mask.CausalMask((self.seq_len, self.seq_len))
+    kernel = tokamax_splash_kernel.make_splash_mha_single_device(mask, config=config)
+    k1, k2, k3 = jax.random.split(jax.random.key(0), 3)
+    q = jax.random.normal(k1, (self.num_query_heads, self.seq_len, self.head_dim), dtype=self.dtype)
+    k = jax.random.normal(k2, (num_kv_heads, self.seq_len, self.head_dim), dtype=self.dtype)
+    v = jax.random.normal(k3, (num_kv_heads, self.seq_len, self.head_dim), dtype=self.dtype)
+    return jax.grad(lambda q, k, v: kernel(q, k, v).sum(), argnums=(0, 1, 2))(q, k, v)
+
+  def test_megacore_grads_match_single_core_gqa(self):
+    reference = self._grads(bwd_dkv_megacore=False, num_kv_heads=self.num_kv_heads)
+    megacore = self._grads(bwd_dkv_megacore=True, num_kv_heads=self.num_kv_heads)
+    for expected, actual in zip(reference, megacore):
+      np.testing.assert_array_equal(expected, actual)
+
+  def test_megacore_grads_match_single_core_mha(self):
+    reference = self._grads(bwd_dkv_megacore=False, num_kv_heads=self.num_query_heads)
+    megacore = self._grads(bwd_dkv_megacore=True, num_kv_heads=self.num_query_heads)
+    for expected, actual in zip(reference, megacore):
+      np.testing.assert_array_equal(expected, actual)
+
+  def test_megacore_rejects_single_kv_head(self):
+    with self.assertRaisesRegex(ValueError, "more than one KV head"):
+      self._grads(bwd_dkv_megacore=True, num_kv_heads=1)
+
+  @pytest.mark.tpu_only
+  def test_megacore_grads_match_single_core_gqa_tpu(self):
+    reference = self._grads(bwd_dkv_megacore=False, num_kv_heads=self.num_kv_heads, interpret=False)
+    megacore = self._grads(bwd_dkv_megacore=True, num_kv_heads=self.num_kv_heads, interpret=False)
+    for expected, actual in zip(reference, megacore):
+      np.testing.assert_array_equal(expected, actual)
+
+  def test_megacore_rejects_mqa(self):
+    config = dataclasses.replace(
+        tokamax_splash_kernel.SplashConfig.get_default(),
+        interpret=True,
+        bwd_dkv_megacore=True,
+    )
+    mask = tokamax_splash_mask.CausalMask((self.seq_len, self.seq_len))
+    kernel = tokamax_splash_kernel.make_splash_mqa_single_device(mask, config=config)
+    k1, k2, k3 = jax.random.split(jax.random.key(0), 3)
+    q = jax.random.normal(k1, (self.num_query_heads, self.seq_len, self.head_dim), dtype=self.dtype)
+    k = jax.random.normal(k2, (self.seq_len, self.head_dim), dtype=self.dtype)
+    v = jax.random.normal(k3, (self.seq_len, self.head_dim), dtype=self.dtype)
+    with self.assertRaisesRegex(ValueError, "more than one KV head"):
+      jax.grad(lambda q, k, v: kernel(q, k, v).sum(), argnums=(0, 1, 2))(q, k, v)
 
 
 if __name__ == "__main__":

--- a/tests/unit/tokamax_ring_attention_test.py
+++ b/tests/unit/tokamax_ring_attention_test.py
@@ -152,6 +152,7 @@ class TokamaxRingAttentionTest(absltest.TestCase):
         use_splash_scheduler=False,
         ring_scan_unroll=2,
         context_parallel_load_balance=False,
+        sa_bwd_dkv_megacore=False,
     )
 
     splash_config = tokamax_ring_attention.build_splash_config(
@@ -181,6 +182,7 @@ class TokamaxRingAttentionTest(absltest.TestCase):
         use_splash_scheduler=False,
         ring_scan_unroll=1,
         context_parallel_load_balance=False,
+        sa_bwd_dkv_megacore=False,
     )
 
     splash_config = tokamax_ring_attention.build_splash_config(


### PR DESCRIPTION
# Description

This PR adds the flag `sa_bwd_dkv_megacore`. When set to True, the static dkv grid changes from
(kv_steps, num_q_heads, q_steps) to (num_kv_heads, kv_steps, q_heads_per_kv_head, q_steps) and the leading dimension becomes "parallel". dk/dv accumulate within one KV head group, so groups are independent and can run on separate cores. With dq_reduction_steps=3 the flag forces the static dkv grid. 

MQA and num_kv_heads=1 raise a ValueError.

## Performance

v5p-128, llama3.1-8b with head_dim=256, 16 query heads, 4 KV heads, ring CP=64, block sizes 1024, synthetic data:

| Config | Context | MFU flag off | MFU flag on | Step time |
|---|---|---|---|---|
| batch 1, dq_reduction_steps=0 | 256K | 34.5% [Xprof](http://xprof.corp.google.com/trace_viewer/htn-11683570770883506035) | 46.7% [Xprof](http://xprof.corp.google.com/trace_viewer/htn-17415528724194145841) | -26% |
| batch 1, dq_reduction_steps=0 | 1M | 39.0% [Xprof](http://xprof.corp.google.com/trace_viewer/htn-17601052804012555500) | 57.7% [Xprof](http://xprof.corp.google.com/trace_viewer/htn-4772183944023096872) | -32% |
| batch 4, dq_reduction_steps=0 | 256K | | | -0.4% |
| batch 1, dq_reduction_steps=3 | 256K | 37.6% | 51.2% | -27% |
| batch 1, dq_reduction_steps=3 | 1M | 43.0% | 61.4% | -30% |


 The flag is observed to be only useful at per-device batch 1.

Losses identical to the baseline at every step and same peak memory

# Tests

- `python3 -m pytest tests/unit/kernels_test.py -k Megacore`: dq/dk/dv are bitwise identical with the flag on and off for GQA and MHA in interpret mode on CPU. 
- The TPU runs in the table, 8 steps each on v5p-128

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
