### PR TITLE
fix the use of targets_segmentation in MTP

### DIFF
--- a/src/maxtext/layers/multi_token_prediction.py
+++ b/src/maxtext/layers/multi_token_prediction.py
@@ -287,7 +287,10 @@ class MultiTokenPredictionBlock(nnx.Module):
     # Rolling variables move prediction window one token to the right per iteration.
     rolled_input_ids = input_ids
     rolled_target_ids = target_ids
-    rolled_target_mask = target_mask
+    # Packed datasets use positive integer segment IDs (1, 2, ...) in
+    # targets_segmentation. MTP consumes this value as a loss/metric mask, so
+    # normalize it to binary validity before rolling
+    rolled_target_mask = target_mask != 0
     rolled_position_id = position_ids
 
     mtp_losses_list = []

--- a/tests/unit/multi_token_prediction_test.py
+++ b/tests/unit/multi_token_prediction_test.py
@@ -314,6 +314,29 @@ class MultiTokenPredictionBlockTest(unittest.TestCase):
     self.assertGreater(mtp_loss_for_logging, 0.0)
     self.assertFalse(jnp.isnan(mtp_loss_for_logging).any())
 
+  def test_packed_segment_ids_are_binary_loss_weights(self):
+    """Packed target segment IDs must not become numerical MTP weights."""
+    packed_target_segmentation = jnp.array([[1, 1, 2, 2, 3, 3, 0, 0]], dtype=jnp.int32)
+    packed_target_segmentation = jnp.repeat(packed_target_segmentation, self.batch_size, axis=0)
+
+    _ = self.test_model(
+        main_hidden_state=self.main_hidden_state,
+        input_ids=self.input_ids,
+        target_ids=self.target_ids,
+        target_mask=packed_target_segmentation,
+        position_ids=self.position_ids,
+        decoder_segment_ids=self.decoder_segment_ids,
+        model_mode=MODEL_MODE_TRAIN,
+        deterministic=True,
+    )
+    weights = nnx.state(self.test_model).mtp_block.weights[...]
+
+    # Each MTP layer shifts once more to the left. Starting from six valid
+    # targets, the two layers therefore have five and four valid positions per
+    # example, regardless of whether their packed segment IDs are 1, 2, or 3.
+    expected_weights = jnp.array([5, 4], dtype=jnp.float32) * self.batch_size
+    np.testing.assert_array_equal(weights, expected_weights)
+
 
 class TestRollAndMask(unittest.TestCase):
   """Test class for utility functions supporting Roll and Mask."""


### PR DESCRIPTION
# Description

b/542651398
targets_segmentation contains segment IDs [1, 1, 2, 2, 2, ...]. When used as a loss mask, it should be converted to binary first. In contrast, the segment IDs in inputs_segmentation should be preserved for attention boundary.

# Tests

added unit test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
