### PR TITLE
Make tensorflow optional

### DIFF
--- a/src/maxtext/input_pipeline/packing/sequence_packing.py
+++ b/src/maxtext/input_pipeline/packing/sequence_packing.py
@@ -14,7 +14,10 @@
 
 """Packed Sequence Op."""
 
-import tensorflow as tf
+try:
+  import tensorflow as tf
+except ImportError as error:
+  raise ImportError("TensorFlow is required. Run `pip install tensorflow`") from error
 
 AUTOTUNE = tf.data.experimental.AUTOTUNE
 

--- a/src/maxtext/input_pipeline/tfds_data_processing.py
+++ b/src/maxtext/input_pipeline/tfds_data_processing.py
@@ -12,15 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Input pipeline for a LM1B dataset."""
+"""DEPRECATED: Input pipeline for TFDS dataset."""
 
 import functools
 import math
 
 import ml_collections
 
-import tensorflow as tf
-import tensorflow_datasets as tfds
+try:
+  import tensorflow as tf
+  import tensorflow_datasets as tfds
+except ImportError as error:
+  raise ImportError(
+      "TensorFlow and tensorflow-datasets are required. Run `pip install tensorflow tensorflow-datasets`"
+  ) from error
 
 import jax
 

--- a/src/maxtext/input_pipeline/tfds_data_processing_c4_mlperf.py
+++ b/src/maxtext/input_pipeline/tfds_data_processing_c4_mlperf.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Input pipeline for gpt3 c4 mlperf dataset."""
+"""DEPRECATED: Input pipeline for c4 mlperf dataset."""
 
 import functools
 
@@ -20,8 +20,14 @@ import numpy as np
 
 import ml_collections
 
-import tensorflow as tf
-import tensorflow_datasets as tfds
+try:
+  import tensorflow as tf
+  import tensorflow_datasets as tfds
+except ImportError as error:
+  raise ImportError(
+      "TensorFlow and tensorflow-datasets are required. Run `pip install tensorflow tensorflow-datasets`"
+  ) from error
+
 
 import jax
 import jax.numpy as jnp

--- a/src/maxtext/trainers/post_train/distillation/save_top_k_teacher_logits.py
+++ b/src/maxtext/trainers/post_train/distillation/save_top_k_teacher_logits.py
@@ -26,7 +26,12 @@ import argparse
 import time
 import sys
 from etils import epath
-import tensorflow as tf
+
+try:
+  import tensorflow as tf
+except ImportError:
+  sys.exit("Tensorflow is required. Run `pip install tensorflow`")
+
 import re
 import numpy as np
 

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -29,7 +29,12 @@ import optax
 
 import pathwaysutils  # pylint: disable=unused-import
 
-import tensorflow as tf
+try:
+  import tensorflow as tf
+
+  _TF_AVAILABLE = True
+except ImportError:
+  _TF_AVAILABLE = False
 
 import jax
 import jax.numpy as jnp
@@ -943,9 +948,10 @@ def initialize(argv: Sequence[str]) -> tuple[pyconfig.HyperParameters, Any]:
   """Initialization of hyperparameters and utilities"""
   pathwaysutils.initialize()
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
-  # TF allocates extraneous GPU memory when using TFDS data
-  # this leads to CUDA OOMs. WAR for now is to hide GPUs from TF
-  tf.config.set_visible_devices([], "GPU")
+  if _TF_AVAILABLE:
+    # TF allocates extraneous GPU memory when using TFDS data
+    # this leads to CUDA OOMs. WAR for now is to hide GPUs from TF
+    tf.config.set_visible_devices([], "GPU")
   if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
     os.environ["LIBTPU_INIT_ARGS"] = (
         os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"

--- a/tests/assets/local_datasets/convert_arrayrecord_to_tfrecord.py
+++ b/tests/assets/local_datasets/convert_arrayrecord_to_tfrecord.py
@@ -47,7 +47,10 @@ except ModuleNotFoundError:
   print("Error: array_record module not found. Install appropriate package before running.")
   sys.exit(1)
 
-import tensorflow as tf
+try:
+  import tensorflow as tf
+except ImportError:
+  sys.exit("Tensorflow is required. Run `pip install tensorflow`")
 
 
 def discover_shards(version_dir: str, split: str) -> List[str]:

--- a/tests/assets/local_datasets/generate_tfds_metadata.py
+++ b/tests/assets/local_datasets/generate_tfds_metadata.py
@@ -28,9 +28,14 @@ After running, you can point TFDS to ``--root`` and load with
 """
 from __future__ import annotations
 import os
+import sys
 import json
 import argparse
-import tensorflow_datasets as tfds  # type: ignore
+
+try:
+  import tensorflow_datasets as tfds  # type: ignore
+except ImportError:
+  sys.exit("tensorflow_datasets is required. Run `pip install tensorflow-datasets`")
 
 
 def write_metadata(root: str, version_dir: str, dataset_version: str, force: bool = False) -> None:

--- a/tests/assets/local_datasets/get_minimal_c4_en_dataset.py
+++ b/tests/assets/local_datasets/get_minimal_c4_en_dataset.py
@@ -31,7 +31,11 @@ from minio.error import S3Error
 
 # ArrayRecord Python bindings
 from array_record.python.array_record_module import ArrayRecordWriter, ArrayRecordReader
-import tensorflow as tf
+
+try:
+  import tensorflow as tf
+except ImportError:
+  sys.exit("Tensorflow is required. Run `pip install tensorflow`")
 
 
 # -----------------------

--- a/tests/assets/local_datasets/get_minimal_hf_c4_parquet.py
+++ b/tests/assets/local_datasets/get_minimal_hf_c4_parquet.py
@@ -24,13 +24,17 @@ tests/integration/train_tests.py:
 
 import argparse
 import os
+import sys
 from pathlib import Path
 
 from minio import Minio
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-import tensorflow as tf
+try:
+  import tensorflow as tf
+except ImportError:
+  sys.exit("Tensorflow is required. Run `pip install tensorflow`")
 
 # ---------------- Environment / Defaults ----------------
 MINIO_ENDPOINT = os.environ.get("MINIO_ENDPOINT", "minio-frameworks.amd.com")

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -15,6 +15,8 @@
 """Tests for pyconfig."""
 
 import os.path
+import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -148,6 +150,38 @@ class PyconfigTest(unittest.TestCase):
     module_file = train_module.__file__
     result = _module_from_path(module_file)
     self.assertEqual(result, "maxtext.trainers.pre_train.train")
+
+  def test_train_import_without_tensorflow(self):
+    """Verifies that importing the pre-training entrypoint does not require TensorFlow.
+
+    This runs in a subprocess because TensorFlow may already be cached in the main process.
+    The subprocess temporarily replaces Python's built-in import function with
+    a wrapper that raises ``ModuleNotFoundError`` only for TensorFlow imports.
+    A successful subprocess proves that ``train`` remains importable and sets
+    ``_TF_AVAILABLE`` to False when TensorFlow is absent.
+    """
+    script = """
+import builtins
+
+# Save Python's real import function so non-TensorFlow imports continue to work.
+original_import = builtins.__import__
+
+
+def import_without_tensorflow(name, *args, **kwargs):
+  if name == "tensorflow" or name.startswith("tensorflow."):
+    raise ModuleNotFoundError("TensorFlow blocked by test")
+  return original_import(name, *args, **kwargs)
+
+
+# Simulate TensorFlow not being installed for the remainder of this subprocess.
+builtins.__import__ = import_without_tensorflow
+
+from maxtext.trainers.pre_train import train
+
+assert train._TF_AVAILABLE is False
+"""
+
+    subprocess.run([sys.executable, "-c", script], check=True)
 
   def test_hlo_dump_module_names_none_coercion(self):
     config = pyconfig.initialize(

--- a/tools/data_generation/reshard_tfds.py
+++ b/tools/data_generation/reshard_tfds.py
@@ -42,13 +42,18 @@ For Multiple Splits Dataset:
 
 import argparse
 import os
+import sys
 import json
 import multiprocessing
 import queue
 import threading
 
-import tensorflow as tf
-import tensorflow_datasets as tfds
+try:
+  import tensorflow as tf
+  import tensorflow_datasets as tfds
+except ImportError:
+  sys.exit("Tensorflow and tensorflow_datasets are required. Run `pip install tensorflow tensorflow-datasets`")
+
 from tqdm import tqdm
 
 


### PR DESCRIPTION
# Description

* allow train.py to run in non-tf environment
* For modules, raise clear error message
* For standalone script requiring tf, use try-except block

# Tests
added unit test to ensure importing train.py works without TF 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
