### PR TITLE
[Fix] Apply partial MRoPE to Qwen3.5 attention

### DIFF
--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -851,6 +851,9 @@ class Attention(nnx.Module):
           cast_as_fprop_dtype=True,
           fprop_dtype=self.dtype,
           mrope_section=self.mrope_section,
+          partial_rotary_factor=(
+              self.partial_rotary_factor if self.partial_rotary_factor is not None else self.config.partial_rotary_factor
+          ),
           rngs=self.rngs,
       )
 

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -1784,6 +1784,7 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
       cast_as_fprop_dtype: bool = True,
       fprop_dtype: DType = jnp.bfloat16,
       mrope_section: tuple[int, int, int] | None = None,
+      partial_rotary_factor: float = 1.0,
       attention_scaling: float = 1.0,
       rngs: nnx.Rngs = None,
   ):
@@ -1792,19 +1793,30 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
     Args:
       min_timescale: Start of the geometric index (typically 1).
       max_timescale: End of the geometric index (rope_theta, e.g., 1000000).
-      embedding_dims: Dimension of the embedding (head_dim).
+      embedding_dims: Dimension of the attention head.
       cast_as_fprop_dtype: Whether to cast output to fprop dtype.
       fprop_dtype: The dtype of the output.
       mrope_section: Tuple of (temporal_dim, height_dim, width_dim) for MRoPE.
                      Defaults to [24, 20, 20] if None.
+      partial_rotary_factor: Fraction of the head dimensions to rotate. The
+        remaining suffix is passed through unchanged.
       attention_scaling: Scaling factor applied to cos/sin embeddings. Defaults to 1.0.
       rngs: rng keys passed in by nnx.bridge.to_linen.
     """
+    if partial_rotary_factor is None or not 0.0 < partial_rotary_factor <= 1.0:
+      raise ValueError(f"partial_rotary_factor must be in (0, 1], got {partial_rotary_factor}.")
+
+    self.head_dim = embedding_dims
+    self.partial_rotary_factor = partial_rotary_factor
+    self.rotary_dim = int(self.head_dim * self.partial_rotary_factor)
+    if self.rotary_dim <= 0 or self.rotary_dim % 2:
+      raise ValueError("Rotary dim for rotary position embedding must be a positive multiple of 2.")
+
     super().__init__(
         min_timescale=min_timescale,
         max_timescale=max_timescale,
         mesh=None,
-        embedding_dims=embedding_dims,
+        embedding_dims=self.rotary_dim,
         cast_as_fprop_dtype=cast_as_fprop_dtype,
         fprop_dtype=fprop_dtype,
         rngs=rngs,
@@ -1812,8 +1824,11 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
     self.mrope_section = mrope_section if mrope_section is not None else (24, 20, 20)
     self.attention_scaling = attention_scaling
 
-    if self.embedding_dims % 2:
-      raise ValueError("Embedding dim for rotary position embedding must be a multiple of 2.")
+    if sum(self.mrope_section) != self.rotary_dim // 2:
+      raise ValueError(
+          f"mrope_section must describe rotary_dim / 2 frequencies; got {self.mrope_section} "
+          f"for rotary_dim={self.rotary_dim}."
+      )
 
   def _apply_interleaved_mrope(self, freqs: jax.Array) -> jax.Array:
     """Apply interleaved MRoPE pattern to 3D rotary embeddings.
@@ -1822,16 +1837,16 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
     interleaved [THTHWHTHW...], preserving frequency continuity.
 
     Args:
-      freqs: Shape (3, batch, seq_len, head_dim // 2)
+      freqs: Shape (3, batch, seq_len, rotary_dim // 2)
         Dimension 0: temporal frequencies
         Dimension 1: height frequencies
         Dimension 2: width frequencies
 
     Returns:
-      freqs_t: Shape (batch, seq_len, head_dim // 2) with interleaved pattern
+      freqs_t: Shape (batch, seq_len, rotary_dim // 2) with interleaved pattern
     """
     # Start with temporal frequencies (dimension 0)
-    freqs_t = freqs[0]  # (batch, seq_len, head_dim // 2)
+    freqs_t = freqs[0]  # (batch, seq_len, rotary_dim // 2)
 
     # Create interleaved pattern
     # For each spatial dimension (H, W), place frequencies at positions:
@@ -1854,7 +1869,9 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
     """Generates rotary position embeddings for multimodal sequences.
 
     Args:
-      inputs: Input tensor of shape [batch, sequence, heads, head_dim].
+      inputs: Input tensor of shape [batch, sequence, heads, head_dim]. MRoPE
+        is applied to the first ``rotary_dim`` features and the rest are
+        returned unchanged.
       position: Position IDs with shape:
         - [batch, sequence] for text-only (2D)
         - [3, batch, sequence] for multimodal with vision (3D)
@@ -1865,10 +1882,8 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
     """
     if len(inputs.shape) != 4:
       raise ValueError("Input is assumed to be a rank 4 tensor of shape [batch, sequence, heads, head_dim].")
-    if self.embedding_dims != inputs.shape[3]:
-      raise ValueError(
-          "The embedding dims of the rotary position embedding must match the hidden dimension of the inputs."
-      )
+    if self.head_dim != inputs.shape[3]:
+      raise ValueError("The head dim of the rotary position embedding must match the hidden dimension of the inputs.")
 
     # Handle both 2D (text-only) and 3D (multimodal) position IDs
     if position.ndim == 2:
@@ -1877,25 +1892,27 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
     elif position.ndim != 3 or position.shape[0] != 3:
       raise ValueError(f"Position IDs must be 2D (batch, seq) or 3D (3, batch, seq), got shape {position.shape}")
 
-    # Compute frequencies: (3, batch, seq, 1) @ (head_dim // 2, 1) -> (3, batch, seq, head_dim // 2)
-    inv_freq_expanded = (1.0 / self.timescale)[jnp.newaxis, jnp.newaxis, jnp.newaxis, :]  # (1, 1, 1, head_dim//2)
+    # Compute frequencies over the rotated prefix only.
+    inv_freq_expanded = (1.0 / self.timescale)[jnp.newaxis, jnp.newaxis, jnp.newaxis, :]
     position_expanded = position[..., jnp.newaxis]  # (3, batch, seq, 1)
-    freqs = position_expanded * inv_freq_expanded  # (3, batch, seq, head_dim//2)
+    freqs = position_expanded * inv_freq_expanded  # (3, batch, seq, rotary_dim // 2)
 
     # Apply interleaved MRoPE pattern for 3D positions
-    freqs = self._apply_interleaved_mrope(freqs)  # (batch, seq, head_dim//2)
+    freqs = self._apply_interleaved_mrope(freqs)  # (batch, seq, rotary_dim // 2)
 
     # Compute sin and cos
-    # Concatenate to get full head_dim: (batch, seq, head_dim//2) -> (batch, seq, head_dim)
-    emb = jnp.concatenate([freqs, freqs], axis=-1)  # Duplicate for both halves
-    cos_emb = jnp.cos(emb) * self.attention_scaling  # (batch, seq, head_dim)
-    sin_emb = jnp.sin(emb) * self.attention_scaling  # (batch, seq, head_dim)
+    # Duplicate frequencies for the two halves of the rotated prefix.
+    emb = jnp.concatenate([freqs, freqs], axis=-1)
+    cos_emb = jnp.cos(emb) * self.attention_scaling
+    sin_emb = jnp.sin(emb) * self.attention_scaling
 
-    # Expand for heads dimension: (batch, seq, head_dim) -> (batch, seq, 1, head_dim)
+    # Expand for the heads dimension.
     cos_emb = cos_emb[:, :, jnp.newaxis, :]
     sin_emb = sin_emb[:, :, jnp.newaxis, :]
 
-    x_out = self.apply_rotary(inputs, cos_emb, sin_emb)
+    inputs_rotary, inputs_pass = jnp.split(inputs, [self.rotary_dim], axis=-1)
+    rotated = self.apply_rotary(inputs_rotary, cos_emb, sin_emb)
+    x_out = jnp.concatenate([rotated, inputs_pass], axis=-1)
 
     if self.cast_as_fprop_dtype:
       x_out = x_out.astype(self.fprop_dtype)

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -361,6 +361,7 @@ class ConfigTest(absltest.TestCase):
     ]
     with self.assertRaises(pydantic.ValidationError):
       pyconfig.initialize(argv)
+
   def test_indexer_cutoff_threshold_remat_policy(self):
     """Tests custom remat policy and validation for indexer_cutoff_threshold."""
     # 1. Verify custom remat policy puts indexer_cutoff_threshold on device

--- a/tests/unit/multi_token_prediction_test.py
+++ b/tests/unit/multi_token_prediction_test.py
@@ -923,6 +923,8 @@ class TestRollAndMaskBySegmentWithCp(unittest.TestCase):
     self.assertEqual(result.shape, (B, T, F))
     self.assertTrue(jnp.all(result[:, 7, :] == 0), "Boundary position should be all-zero")
     self.assertTrue(jnp.all(result[:, 15, :] == 0), "Last position should be all-zero")
+
+
 class CrossEntropyWithIntegerLabelsTest(unittest.TestCase):
   """Unit tests verifying _cross_entropy_with_integer_labels alignment."""
 

--- a/tests/unit/qwen35_partial_mrope_test.py
+++ b/tests/unit/qwen35_partial_mrope_test.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests Qwen3.5 partial multi-dimensional rotary embeddings."""
+
+import unittest
+from types import SimpleNamespace
+
+from flax import nnx
+import jax.numpy as jnp
+import numpy as np
+
+from maxtext.layers.attentions import Attention
+from maxtext.layers.embeddings import Qwen3OmniMoeThinkerTextRotaryEmbedding
+
+
+_HEAD_DIM = 256
+_PARTIAL_ROTARY_FACTOR = 0.25
+_ROTARY_DIM = 64
+_MROPE_SECTION = (11, 11, 10)
+_ROPE_THETA = 10_000_000
+
+
+def _reference_partial_mrope(inputs: np.ndarray, positions: np.ndarray) -> np.ndarray:
+  """Independent NumPy implementation of the Qwen3.5 partial-MRoPE rule."""
+  if positions.ndim == 2:
+    positions = np.broadcast_to(positions[np.newaxis, ...], (3,) + positions.shape)
+
+  inv_freq = 1.0 / (_ROPE_THETA ** (np.arange(0, _ROTARY_DIM, 2, dtype=np.float32) / _ROTARY_DIM))
+  freqs = positions[..., np.newaxis].astype(np.float32) * inv_freq
+  interleaved = np.array(freqs[0], copy=True)
+  for dim, offset in enumerate((1, 2), start=1):
+    idx = slice(offset, _MROPE_SECTION[dim] * 3, 3)
+    interleaved[..., idx] = freqs[dim, ..., idx]
+
+  angles = np.concatenate([interleaved, interleaved], axis=-1)
+  cos = np.cos(angles)[:, :, np.newaxis, :]
+  sin = np.sin(angles)[:, :, np.newaxis, :]
+
+  rotary, passthrough = np.split(inputs, [_ROTARY_DIM], axis=-1)
+  first_half, second_half = np.split(rotary, 2, axis=-1)
+  rotate_half = np.concatenate([-second_half, first_half], axis=-1)
+  rotated = rotary * cos + rotate_half * sin
+  return np.concatenate([rotated, passthrough], axis=-1)
+
+
+class Qwen35PartialMropeTest(unittest.TestCase):
+
+  def test_matches_reference_and_preserves_unrotated_suffix(self):
+    inputs = np.linspace(-1.0, 1.0, num=2 * 4 * 3 * _HEAD_DIM, dtype=np.float32).reshape((2, 4, 3, _HEAD_DIM))
+    text_positions = np.broadcast_to(np.arange(4, dtype=np.int32), (2, 4))
+    multimodal_positions = np.stack([text_positions, text_positions + 3, text_positions + 7], axis=0)
+    embedding = Qwen3OmniMoeThinkerTextRotaryEmbedding(
+        min_timescale=1,
+        max_timescale=_ROPE_THETA,
+        embedding_dims=_HEAD_DIM,
+        partial_rotary_factor=_PARTIAL_ROTARY_FACTOR,
+        cast_as_fprop_dtype=False,
+        fprop_dtype=jnp.float32,
+        mrope_section=_MROPE_SECTION,
+        rngs=nnx.Rngs(0),
+    )
+
+    self.assertEqual(embedding.rotary_dim, _ROTARY_DIM)
+    self.assertEqual(embedding.timescale.shape, (_ROTARY_DIM // 2,))
+    for positions in (text_positions, multimodal_positions):
+      with self.subTest(position_rank=positions.ndim):
+        actual = np.asarray(embedding(jnp.asarray(inputs), jnp.asarray(positions)))
+        expected = _reference_partial_mrope(inputs, positions)
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
+        np.testing.assert_array_equal(actual[..., _ROTARY_DIM:], inputs[..., _ROTARY_DIM:])
+
+  def test_factor_one_preserves_full_width_mrope_behavior(self):
+    inputs = np.linspace(-1.0, 1.0, num=2 * 4 * 3 * _ROTARY_DIM, dtype=np.float32).reshape((2, 4, 3, _ROTARY_DIM))
+    positions = np.broadcast_to(np.arange(4, dtype=np.int32), (2, 4))
+    embedding = Qwen3OmniMoeThinkerTextRotaryEmbedding(
+        min_timescale=1,
+        max_timescale=_ROPE_THETA,
+        embedding_dims=_ROTARY_DIM,
+        partial_rotary_factor=1.0,
+        cast_as_fprop_dtype=False,
+        fprop_dtype=jnp.float32,
+        mrope_section=_MROPE_SECTION,
+        rngs=nnx.Rngs(0),
+    )
+
+    actual = np.asarray(embedding(jnp.asarray(inputs), jnp.asarray(positions)))
+    expected = _reference_partial_mrope(inputs, positions)
+    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
+
+  def test_attention_wires_qwen35_partial_factor_into_mrope(self):
+    attention = SimpleNamespace(
+        config=SimpleNamespace(
+            attention_type="global",
+            rope_use_scale=False,
+            rope_min_timescale=1,
+            partial_rotary_factor=_PARTIAL_ROTARY_FACTOR,
+        ),
+        qk_rope_head_dim=0,
+        head_dim=_HEAD_DIM,
+        rope_type="default",
+        is_vision=False,
+        use_mrope=True,
+        rope_max_timescale=_ROPE_THETA,
+        dtype=jnp.float32,
+        mrope_section=_MROPE_SECTION,
+        partial_rotary_factor=None,
+        rngs=nnx.Rngs(0),
+    )
+
+    embedding = Attention.init_rotary_embedding(attention)
+
+    self.assertIsInstance(embedding, Qwen3OmniMoeThinkerTextRotaryEmbedding)
+    self.assertEqual(embedding.head_dim, _HEAD_DIM)
+    self.assertEqual(embedding.rotary_dim, _ROTARY_DIM)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/utils/forward_pass_logit_checker.py
+++ b/tests/utils/forward_pass_logit_checker.py
@@ -96,6 +96,40 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 absl.logging.set_verbosity(absl.logging.INFO)  # for max_logging.log
 
+# Passage repeated to build the long regression prompt below. The content is
+# arbitrary; only its length matters.
+_LONG_PROMPT_PASSAGE = (
+    "The city of Lyon sits at the confluence of the Rhone and Saone rivers in eastern France. "
+    "Founded as a Roman colony in 43 BC, it served for centuries as the capital of the Gauls. "
+    "Its silk industry flourished in the sixteenth century, drawing weavers from across Europe. "
+    "The old town preserves narrow covered passageways known as traboules, built so that silk "
+    "merchants could carry bolts of fabric between workshops without exposing them to rain. "
+)
+
+
+def build_long_prompt(repeats=5):
+  """Builds a ~500 token prompt for position-dependent regression coverage.
+
+  Short prompts cannot detect bugs in position-dependent code such as RoPE. The
+  rotation applied at position 0 is the identity and is near-identity for the
+  next few positions, so an implementation that rotates the wrong number of head
+  dimensions still produces correct-looking logits on a 3-4 token prompt.
+
+  Measured on Qwen3.5-35B-A3B for identifying partial-RoPE bugs, e.g. where the
+  full 256-dim head was rotated instead of
+  `head_dim * partial_rotary_factor = 64`. Compared against HuggingFace golden
+  logits with `--max_kl_div=0.1`, such a bug is undetected by the short prompts
+  above but is caught by this one.
+
+  Args:
+    repeats: Number of times to repeat the base passage. 5 yields ~493 tokens.
+
+  Returns:
+    A long prompt string ending in a question that depends on the passage.
+  """
+  question = "\n\nBased on the passage above, the traboules of Lyon were originally built so that"
+  return _LONG_PROMPT_PASSAGE * repeats + question
+
 
 def upload_blob(bucket_name, source_file_name, destination_blob_name):
   """Uploads a file to the bucket."""
@@ -388,8 +422,18 @@ def main(config, test_args):  # pylint: disable=W0621
 
       with jsonlines.open(input_golden_data_path, "r") as f:
         golden_data = list(f)
+    elif input_golden_data_path.suffix in (".pickle", ".pkl"):
+      # generate_hf_golden_logits.py can emit --output-format=pickle, which keeps
+      # full float32 precision at a fraction of the size: JSON re-encodes every
+      # logit as decimal text, so a golden file storing seq_len x vocab_size
+      # floats is several times larger than the equivalent pickle.
+      max_logging.log("loading hf goldens from pickle file")
+      import pickle  # pylint: disable=import-outside-toplevel
+
+      with open(input_golden_data_path, "rb") as f:
+        golden_data = pickle.load(f)
     else:
-      raise ValueError("golden_logits_path must end with .jsonl")
+      raise ValueError("golden_logits_path must end with .jsonl, .pickle, or .pkl")
     max_logging.log(f"loaded {len(golden_data)} golden data points")
     all_data_to_save = []
     for golden_data_index, golden_data_point in enumerate(golden_data):
@@ -614,10 +658,12 @@ def main(config, test_args):  # pylint: disable=W0621
       else:
         maxtext_state, _ = model_creation_utils.setup_decode_state_from_nnx(maxtext_model, config, rng1, mesh)
 
-    prompts = ["I love to", "Today is a", "What is the"]
+    # The long prompt is required to catch position-dependent regressions (e.g. RoPE);
+    # the short prompts above cannot detect them. See build_long_prompt().
+    prompts = ["I love to", "Today is a", "What is the", build_long_prompt()]
     all_data_to_save = []
     for input_text in prompts:
-      max_logging.log(f"\n--- Prompt: {input_text} ---")
+      max_logging.log(f"\n--- Prompt: {input_text[:80]}{'...' if len(input_text) > 80 else ''} ---")
 
       # Tokenize for HF
       inputs = tokenizer(


### PR DESCRIPTION
# Description

Before this fix, partial_rotary_factor is not applied in Qwen3OmniMoeThinkerTextRotaryEmbedding, resulting in repetition / corrupted output during generation. 

Added a long prompt test to `forward_pass_logit_checker.py` to catch such RoPE related issues in future

Added support for reading pkl files in `forward_pass_logit_checker.py`

FIXES: b/543115324

# Tests

- Ran this fix with vllm serve on a local TPU VM v5p-8 and ensures logits matched.
- Added a long prompt test to `forward_pass_logit_checker.py` to catch such RoPE related issues in future

```
P="The city of Lyon sits at the confluence of the Rhone and Saone rivers in eastern France. Founded as a Roman colony in 43 BC, it served for centuries as the capital of the Gauls. Its silk industry flourished in the sixteenth century, drawing weavers from across Europe. The old town preserves narrow covered passageways known as traboules, built so that silk merchants could carry bolts of fabric between workshops without exposing them to rain. "
PROMPT="$P$P$P$P$P"$'\n\n'"Based on the passage above, the traboules of Lyon were originally built so that"

python3 -m tests.assets.logits_generation.generate_hf_golden_logits \
  --model-id=Qwen/Qwen3.5-35B-A3B \
  --hf-model-path=<> \
  --hf-load-dtype=float32 \
  --prompts="$PROMPT" \
  --output-path=/mnt/disks/persist/golden_qwen35_longprompt.pkl \
  --output-format=pickle

python3 -m tests.utils.forward_pass_logit_checker src/maxtext/configs/base.yml \
  model_name=qwen3.5-35b-a3b tokenizer_path=<> \
  load_parameters_path=gs://maxtext-model-checkpoints/qwen3.5-35b-a3b/unscanned/0/items \
  scan_layers=false enable_nnx=true pure_nnx_decoder=true \
  use_multimodal=false per_device_batch_size=1 dtype=bfloat16 weight_dtype=bfloat16 \
  max_target_length=512 \
  --max_kl_div=0.1 --golden_logits_path=/mnt/disks/persist/golden_qwen35_longprompt.pkl
```
This can be used for running the tests in CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
