### PR TITLE
Add ManifoldConstrainedHyperConnections to RLConfig and remove notebook exception masking

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -3942,6 +3942,7 @@ class MaxTextConfig(
 class RLConfig(
     LogitsAndLoss,
     Engram,
+    ManifoldConstrainedHyperConnections,
     RematAndOffload,
     Attention,
     Llama4Attention,

--- a/src/maxtext/examples/rl_llama3_demo.ipynb
+++ b/src/maxtext/examples/rl_llama3_demo.ipynb
@@ -239,6 +239,7 @@
     "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}\",\n",
     "    f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
     "    \"rollout_tensor_parallelism=4\",\n",
+    "    \"hbm_utilization_vllm=0.4\",\n",
     "    \"debug=True\",\n",
     "    f\"rl.loss_algo={LOSS_ALGO}\",\n",
     "    \"use_pathways=False\",\n",
@@ -263,11 +264,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import traceback\n",
-    "\n",
     "print(\"\\n\" + \"=\" * 80)\n",
     "print(f\"🚀 Starting {LOSS_ALGO} Training...\")\n",
     "print(\"=\" * 80)\n",
+    "\n",
     "try:\n",
     "    rl_train(argv=config_argv, kwargs={})\n",
     "    print(\"\\n\" + \"=\" * 80)\n",
@@ -275,12 +275,11 @@
     "    print(\"=\" * 80)\n",
     "except Exception:\n",
     "    print(\"\\n\" + \"=\" * 80)\n",
-    "    print(\"❌Training Failed!\")\n",
+    "    print(\"❌ Training Failed!\")\n",
     "    print(\"=\" * 80)\n",
-    "    traceback.print_exc()\n",
     "    print(\"\\nFor troubleshooting, refer to the Common Pitfalls & Debugging section:\")\n",
     "    print(\"https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html#common-pitfalls-debugging\")\n",
-    "    sys.exit(1)"
+    "    raise\n"
    ]
   },
   {

--- a/src/maxtext/examples/sft_llama3_demo_tpu.ipynb
+++ b/src/maxtext/examples/sft_llama3_demo_tpu.ipynb
@@ -290,8 +290,6 @@
    },
    "outputs": [],
    "source": [
-    "import traceback\n",
-    "\n",
     "print(\"=\" * 60)\n",
     "print(\"🚀 Starting SFT Training...\")\n",
     "print(\"=\" * 60)\n",
@@ -304,12 +302,11 @@
     "    print(f\"📁 Checkpoints saved to: {config.checkpoint_dir}\")\n",
     "except Exception:\n",
     "    print(\"\\n\" + \"=\" * 60)\n",
-    "    print(\"❌Training Failed!\")\n",
+    "    print(\"❌ Training Failed!\")\n",
     "    print(\"=\" * 60)\n",
-    "    traceback.print_exc()\n",
     "    print(\"\\nFor troubleshooting, refer to the Common Pitfalls & Debugging section:\")\n",
     "    print(\"https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html#common-pitfalls-debugging\")\n",
-    "    sys.exit(1)"
+    "    raise\n"
    ]
   },
   {

--- a/src/maxtext/examples/sft_multimodal_gemma3_demo.ipynb
+++ b/src/maxtext/examples/sft_multimodal_gemma3_demo.ipynb
@@ -267,8 +267,6 @@
     "if not flags.FLAGS.is_parsed():\n",
     "    flags.FLAGS.mark_as_parsed()\n",
     "\n",
-    "import traceback\n",
-    "\n",
     "print(\"=\" * 60)\n",
     "print(\"🚀 Starting SFT Training...\")\n",
     "print(\"=\" * 60)\n",
@@ -281,12 +279,11 @@
     "    print(f\"📁 Checkpoints saved to: {checkpoint_dir}\")\n",
     "except Exception:\n",
     "    print(\"\\n\" + \"=\" * 60)\n",
-    "    print(\"❌Training Failed!\")\n",
+    "    print(\"❌ Training Failed!\")\n",
     "    print(\"=\" * 60)\n",
-    "    traceback.print_exc()\n",
     "    print(\"\\nFor troubleshooting, refer to the Common Pitfalls & Debugging section:\")\n",
     "    print(\"https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html#common-pitfalls-debugging\")\n",
-    "    sys.exit(1)"
+    "    raise\n"
    ]
   },
   {


### PR DESCRIPTION
# Description

Fix broken notebook tests due to missing RLConfig. Changed notebooks to not use `sys.exit(1)`, because it suppressed the error messages during notebook test execution and made it impossible to understand why the notebook was failing. Now if an exception happens during the execution it will be properly captured and shown in the test logs.

Reduce `hbm_utilization_vllm` in `rl_llama3_demo.ipynb` to fix `JaxRuntimeError: RESOURCE_EXHAUSTED` errors in CI.

FIXES: b/543012394

# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
