### PR TITLE
[onduty] nightly flax installation

### DIFF
--- a/src/dependencies/scripts/setup.sh
+++ b/src/dependencies/scripts/setup.sh
@@ -286,6 +286,9 @@ fi
 if [[ $MODE == "nightly" ]]; then
     install_maxtext_with_deps
 
+    # Install Flax HEAD to maintain compatibility with JAX nightly
+    python3 -m uv pip install -U --no-deps git+https://github.com/google/flax.git
+
     # Uninstall existing jax, jaxlib and libtpu
     python3 -m uv pip show jax && python3 -m uv pip uninstall jax
     python3 -m uv pip show jaxlib && python3 -m uv pip uninstall jaxlib


### PR DESCRIPTION
# Description

fix nightly docker image failure. Installing flax from head for nightly docker image setup


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
