### PR TITLE
Add JAX compilation cache clear fixture to prevent XLA memory accumulation

### DIFF
--- a/.github/scripts/analyze_code_changes.sh
+++ b/.github/scripts/analyze_code_changes.sh
@@ -25,6 +25,7 @@ set -e
 # - Pathways only: Run Pathways tests only
 # - Post-training only: Run post-training tests and notebooks only
 # - General inference only: Run pretrain TPU/CPU suites only
+# - Tests only: Run test suites only (no notebooks)
 # - Default fallback: Run all suites (fail-open for core/shared code)
 
 # Helper to output a key-value flag to GITHUB_OUTPUT (if set) and stdout
@@ -134,6 +135,13 @@ fi
 if matches_only_domain 'src/maxtext/inference/|tests/inference/'; then
   echo "Only inference files changed, enabling pretrain unit/integration tests only."
   enable_flags run_tests run_pretrain_tests
+  exit 0
+fi
+
+# Tests and test-tooling only changes (skips notebooks as tutorials are unaffected)
+if matches_only_domain '(^tests/|^\.github/scripts/|^pytest\.ini$|^\.coveragerc$)'; then
+  echo "Only test files and test configurations changed, enabling test suites (skipping notebooks)."
+  enable_flags run_tests run_pretrain_tests run_posttrain_tests run_pathways_tests run_gpu_tests
   exit 0
 fi
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ require external integrations or specific hardware (for example `tpu_only`)
 are not marked.
 """
 
+import gc
 import pytest
 import sys
 import warnings
@@ -220,6 +221,23 @@ def pytest_configure(config):
       "newly_added: newly introduced or modified tests in PRs, executed even if scheduled_only",
   ]:
     config.addinivalue_line("markers", m)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def clear_jax_compilation_cache():
+  """Clears JAX compilation caches and forces garbage collection after each test module.
+
+  Prevents XLA memory accumulation and compilation cache buildup across
+  long test runs while preserving intra-module compilation cache reuse.
+  """
+  yield
+  try:
+    has_accelerator = any(d.platform in ("tpu", "gpu", "proxy") for d in jax.devices())
+    if has_accelerator:
+      jax.clear_caches()
+      gc.collect()
+  except Exception:  # pylint: disable=broad-exception-caught
+    pass
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/deepseek_scan_engram_test.py
+++ b/tests/integration/deepseek_scan_engram_test.py
@@ -14,7 +14,6 @@
 
 """Unit tests for DeepSeek Engram across scanned decoder layers."""
 
-import gc
 import os
 import unittest
 from unittest.mock import patch
@@ -164,8 +163,6 @@ class TestDeepSeekScanEngram(unittest.TestCase):
     del variables
     del params
     del decoder
-    jax.clear_caches()
-    gc.collect()
 
   @pytest.mark.tpu_only
   @patch("transformers.AutoTokenizer.from_pretrained")

--- a/tests/integration/estimator_test.py
+++ b/tests/integration/estimator_test.py
@@ -96,7 +96,6 @@ class EstimatorE2ETest(unittest.TestCase):
     ]
     policy = RematPolicy(tensor_names=tensor_names, initial_level=Action.REMAT)
 
-    jax.clear_caches()
     result = is_oom(base_argv, policy, pdb=2.0)
 
     self.assertIsInstance(result, bool)
@@ -120,7 +119,6 @@ class EstimatorE2ETest(unittest.TestCase):
         "out_proj",
     ]
 
-    jax.clear_caches()
     result = search_policy_only(tensor_names, base_argv, pdb=2.0)
 
     # Should return a RematPolicy


### PR DESCRIPTION
# Description

This PR adds an autouse pytest fixture (`clear_jax_compilation_cache`) in `tests/conftest.py` that invokes `jax.clear_caches()` and `gc.collect()` after every test module execution to prevent XLA memory accumulation.
  
### Key benefits:
- Prevents compilation cache buildup and XLA memory fragmentation across long-running test suites (especially in TPU and Pathways CI environments).
- Eliminates memory-related test flakiness and OOM failures.
- Cleans up redundant manual `jax.clear_caches()` and `gc.collect()` calls in `tests/integration/estimator_test.py` and `tests/integration/deepseek_scan_engram_test.py`.

# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
