### PR TITLE
Expose parallel_threads flag for HF conversion to prevent OOM

### DIFF
--- a/src/maxtext/checkpoint_conversion/to_huggingface.py
+++ b/src/maxtext/checkpoint_conversion/to_huggingface.py
@@ -117,6 +117,17 @@ flags.DEFINE_string(
     "the instruction-tuned one).",
 )
 
+flags.DEFINE_integer(
+    "parallel_threads",
+    4,
+    "Number of threads used for parallel saving of weights. Lower this value to reduce peak host RAM usage.",
+)
+flags.register_validator(
+    "parallel_threads",
+    lambda value: value > 0,
+    message="--parallel_threads must be a positive integer.",
+)
+
 FLAGS = flags.FLAGS
 
 
@@ -431,7 +442,14 @@ def _transform_and_save_weights(
       raise ValueError("Error: No weights were transformed. Check mappings and parameter paths.")
 
     max_logging.log("\nSaving HuggingFace model...")
-    save_model_files(transformed_hf_weights, hf_config_obj, tokenizer, processor, output_directory)
+    save_model_files(
+        transformed_hf_weights,
+        hf_config_obj,
+        tokenizer,
+        processor,
+        output_directory,
+        parallel_threads=FLAGS.parallel_threads,
+    )
     max_logging.log(f"✅ MaxText model successfully saved in HuggingFace format at {output_directory}")
 
   max_logging.log(f"Elapse for transform and save: {(time.time() - start) / 60:.2f} min")

--- a/src/maxtext/checkpoint_conversion/utils/utils.py
+++ b/src/maxtext/checkpoint_conversion/utils/utils.py
@@ -544,7 +544,7 @@ def save_weight_files(
     index,
     local_dir_to_save_to: str,
     output_dir_final: str,
-    parallel_threads=8,
+    parallel_threads=4,
     remove_local_copy_after_upload: bool = False,
 ):
   """Saves weight files and index if needed.
@@ -603,7 +603,7 @@ def save_model_files(
     tokenizer: None | Any,  # transformers.PreTrainedTokenizerBase
     processor,
     output_dir: str,
-    parallel_threads=8,
+    parallel_threads=4,
 ):
   """
   Saves model files (config and weights) to the specified directory.

--- a/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh
+++ b/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh
@@ -29,4 +29,5 @@ python3 -m maxtext.checkpoint_conversion.to_huggingface \
     base_output_directory=${BASE_OUTPUT_DIRECTORY}/to_huggingface/${scan_status}/${run_id} \
     use_multimodal=${USE_MULTIMODAL} \
     scan_layers=$SCAN_LAYERS \
-    weight_dtype=bfloat16
+    weight_dtype=bfloat16 \
+    --parallel_threads=2


### PR DESCRIPTION
## Description

Addresses Out-Of-Memory (OOM) failures encountered during MaxText to HuggingFace checkpoint conversions, particularly observed when converting large models like Llama3.1-70B on memory-constrained profiles (e.g., v5p-8).

Bug ticket: [b/538004926](https://buganizer.corp.google.com/issues/538004926)

## Root Cause

During the final "Saving HuggingFace model..." phase, the `save_weight_files()` utility defaults to `parallel_threads=8`. This results in 8 simultaneous serialized shards being kept in memory buffers before being flushed out. This rapid concurrency creates a massive memory spike (24+ GB) that instantly pushes the host beyond its 440 GB RAM capacity on v5p-8 chief nodes.

## Solution

1. Expose configurable flag: Added `--parallel_threads` in `to_huggingface.py` to allow manual concurrency limitations when running jobs on highly memory-constrained environments.
2. Safer Defaults: Reduced the default thread count from 8 to 4 in `utils.py` (`save_weight_files`, `save_model_files`) to provide a globally safe baseline balancing I/O speed and peak memory consumption.
3. E2E Script Update: Updated `test_llama3.1_70b_to_hf.sh` to explicitly explicitly use `--parallel_threads=2`.

# Tests

```bash
python -m maxtext.checkpoint_conversion.to_huggingface maxtext/configs/base.yml \
  model_name=llama3.1-70b \
  load_parameters_path='gs://runner-maxtext-logs/llama3.1-70b/train/pre-20260723T014531/checkpoints/4/items' \
  base_output_directory='gs://runner-maxtext-logs/llama3.1-70b/to_huggingface/unscanned/0730' \
  use_multimodal=false \
  scan_layers=false \
  weight_dtype=bfloat16 \
  --parallel_threads=2
```

Log: https://paste.googleplex.com/6271791877193728

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
