### PR TITLE
fix(ci): Align Airflow E2E DAG parameter names with ml-auto-solutions

### DIFF
--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -57,13 +57,22 @@ jobs:
         env:
           AIRFLOW_URI: ${{ steps.info.outputs.airflow_uri }}
           BUILD_MODE: ${{ inputs.mode }}
-          MAXTEXT_SHA: ${{ inputs.maxtext_sha }}
+          COMMIT_SHA: ${{ inputs.maxtext_sha }}
           RUN_ID: ${{ inputs.run_id }}
           GITHUB_REPO: ${{ github.repository }}
-          AIRFLOW_CALLBACK_TOKEN: ${{ secrets.AIRFLOW_CALLBACK_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AIRFLOW_CALLBACK_TOKEN }}
         run: |
           IAP_TOKEN=$(gcloud auth print-access-token)
-          PAYLOAD=$(python3 -c 'import os, json; print(json.dumps({"conf": {"build_mode": os.environ["BUILD_MODE"], "maxtext_sha": os.environ["MAXTEXT_SHA"], "github_run_id": os.environ["RUN_ID"], "github_repo": os.environ["GITHUB_REPO"], "github_callback_token": os.environ["AIRFLOW_CALLBACK_TOKEN"]}}))')
+          PAYLOAD=$(python3 -c 'import json, os
+          print(json.dumps({
+              "conf": {
+                  "build_mode": os.environ["BUILD_MODE"],
+                  "commit_sha": os.environ["COMMIT_SHA"],
+                  "github_run_id": os.environ["RUN_ID"],
+                  "github_repo": os.environ["GITHUB_REPO"],
+                  "github_token": os.environ["GITHUB_TOKEN"],
+              }
+          }))')
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
             "${AIRFLOW_URI}/api/v1/dags/maxtext_e2e_tests/dagRuns" \
             -H "Authorization: Bearer ${IAP_TOKEN}" \


### PR DESCRIPTION
# Description

This PR updates the Airflow REST API request payload in `.github/workflows/run_e2e_tests.yml` to use `commit_sha` and `github_token` parameter names instead of `maxtext_sha` and `github_callback_token`.

### Background & Motivation
In `GoogleCloudPlatform/ml-auto-solutions` (commit `310ce8d` / PR #1329), the DAG parameters for `maxtext_e2e_tests` were standardized to generic names `commit_sha` and `github_token`. Because Airflow 2.10.x validates incoming `conf` parameters strictly against the DAG's defined `params`, triggering the DAG from MaxText's nightly/release workflows resulted in `HTTP 400 Bad Request: Invalid input for param commit_sha: No value passed and Param has no default value`.

Aligning the payload parameter keys in `run_e2e_tests.yml` resolves the HTTP 400 error and allows the E2E Airflow DAG to be triggered successfully.

# Tests

- Validated GitHub Actions workflow syntax via pre-commit hooks (`yamllint`, `codespell`).
- Verified parameter mapping against `dags/multipod/maxtext_e2e_tests.py` in `GoogleCloudPlatform/ml-auto-solutions`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
