### PR TITLE
Gemma-4 vision: correct std_bias/std_scale classification per HF standardize (fidelity fix)

### DIFF
--- a/src/maxtext/configs/models/gemma4-26b.yml
+++ b/src/maxtext/configs/models/gemma4-26b.yml
@@ -61,3 +61,4 @@ num_attention_heads_for_vit: 16
 image_placeholder: "<|image|>"
 vision_output_length: 280
 num_position_embeddings_for_vit: 10240
+standardize_for_vit: true  # HF vision_config.standardize=true: std_bias/std_scale are checkpoint-resident buffers

--- a/src/maxtext/configs/models/gemma4-31b.yml
+++ b/src/maxtext/configs/models/gemma4-31b.yml
@@ -57,3 +57,4 @@ num_attention_heads_for_vit: 16
 image_placeholder: "<|image|>"
 vision_output_length: 280
 num_position_embeddings_for_vit: 10240
+standardize_for_vit: true  # HF vision_config.standardize=true: std_bias/std_scale are checkpoint-resident buffers

--- a/src/maxtext/configs/models/gemma4-e2b.yml
+++ b/src/maxtext/configs/models/gemma4-e2b.yml
@@ -58,3 +58,4 @@ num_attention_heads_for_vit: 12
 image_placeholder: "<|image|>"
 vision_output_length: 280
 num_position_embeddings_for_vit: 10240
+standardize_for_vit: false  # HF vision_config.standardize=false: no std_bias/std_scale in checkpoint (identity)

--- a/src/maxtext/configs/models/gemma4-e4b.yml
+++ b/src/maxtext/configs/models/gemma4-e4b.yml
@@ -59,3 +59,4 @@ num_attention_heads_for_vit: 12
 image_placeholder: "<|image|>"
 vision_output_length: 280
 num_position_embeddings_for_vit: 10240
+standardize_for_vit: false  # HF vision_config.standardize=false: no std_bias/std_scale in checkpoint (identity)

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2171,6 +2171,20 @@ class MultimodalGeneral(BaseModel):
       description="The style of VisionEncoderBlock to use (e.g., 'gemma3', 'llama4').",
   )
   freeze_vision_encoder_params: bool = Field(True, description="Freeze the parameters of the vision encoder.")
+  standardize_for_vit: bool | None = Field(
+      None,
+      description=(
+          "Whether the vision encoder standardizes exit embeddings with std_bias/std_scale. Mirrors HF"
+          " Gemma-4 vision_config.standardize and is a per-model-family semantic distinction, so it must be set"
+          " EXPLICITLY by every Gemma-4 multimodal model config (no global default is safe): HF registers"
+          " std_bias/std_scale as checkpoint-resident (non-trainable) buffers ONLY when standardize=True."
+          " Gemma-4 26B/31B ship standardize=True (2 std tensors); E2B/E4B ship standardize=False (0 std tensors)."
+          " When False the standardize op is an exact identity and MaxText must NOT construct std_bias/std_scale"
+          " (fabricating them wrongly enters checkpoint-restored committed arrays into the nnx.Param gradient"
+          " filter). None means unset: a Gemma-4 model with use_multimodal=True and this unset is a hard config"
+          " error (see validate_standardize_for_vit) — it must never silently inherit a value."
+      ),
+  )
   freeze_audio_encoder_params: bool = Field(True, description="Freeze the parameters of the audio encoder.")
   use_audio: bool = Field(False, description="Enable audio encoder for multimodal models.")
   image_size_for_vit: int | list[int] | None = Field(896, description="Input image size for the Vision Transformer.")
@@ -3608,6 +3622,15 @@ class MaxTextConfig(
     if self.model_name in ("gemma4-e2b", "gemma4-e4b") and self.scan_layers:
       raise ValueError(
           f"{self.model_name} requires scan_layers=False (per-layer KV sharing is incompatible with nn.scan)."
+      )
+    # Gemma 4 vision standardization is a per-model-family semantic distinction (HF vision_config.standardize)
+    # and must be set EXPLICITLY — it must never silently inherit a global default, or a standardize=True variant
+    # (26B/31B) would drop its checkpoint-resident std buffers, or a standardize=False variant (E2B/E4B) would
+    # fabricate spurious trainable std leaves. Fail closed when unset for any Gemma-4 model.
+    if self.model_name.startswith("gemma4-") and self.standardize_for_vit is None:
+      raise ValueError(
+          f"{self.model_name}: standardize_for_vit must be set explicitly (True for 26B/31B, False for E2B/E4B) "
+          "to mirror HF vision_config.standardize. Set it in the model config YAML; it must not inherit a default."
       )
     if self.use_multimodal:
       # Gemma 4 small (E2B / E4B) only supports text for now; multimodal

--- a/src/maxtext/models/gemma4_vision.py
+++ b/src/maxtext/models/gemma4_vision.py
@@ -85,6 +85,17 @@ def patchify(images: jax.Array, patch_size: int) -> tuple[jax.Array, jax.Array]:
   return patches, jnp.broadcast_to(positions_xy, tuple(b) + positions_xy.shape)
 
 
+class VisionStdVar(nnx.Variable):
+  """Checkpoint-resident, NON-trainable vision standardization state (std_bias / std_scale).
+
+  Mirrors HF `modeling_gemma4`, which registers `std_bias`/`std_scale` via `register_buffer`
+  (non-trainable) and only when `vision_config.standardize=True` (Gemma-4 26B/31B). As a plain
+  `nnx.Variable` (not `nnx.Param`), it is naturally excluded from the optimizer/weight-decay/grad
+  filter — which key on `nnx.Param` — while still being saved and restored by Orbax as part of the
+  model state. This is the same idiom MaxText uses for other non-trainable buffers (e.g. `MoEBiasVar`).
+  """
+
+
 class VisionEntry(nnx.Module):
   """The vision entry layer."""
 
@@ -566,12 +577,22 @@ class Gemma4VisionEncoderLayer(nnx.Module):
         rngs=self.rngs,
         precision=config.matmul_precision,
     )
-    self.std_bias = nnx.Param(
-        nnx.initializers.zeros(self.rngs.params(), (config.hidden_size_for_vit,), config.weight_dtype), sharding=(None,)
-    )
-    self.std_scale = nnx.Param(
-        nnx.initializers.ones(self.rngs.params(), (config.hidden_size_for_vit,), config.weight_dtype), sharding=(None,)
-    )
+    # Vision standardization (std_bias/std_scale) is CHECKPOINT-RESIDENT state that exists ONLY when the
+    # checkpoint ships std tensors, i.e. HF vision_config.standardize=True (Gemma-4 26B/31B). HF registers them
+    # via register_buffer (NON-trainable). Gemma-4 E2B/E4B have standardize=False and DO NOT store std_scale/
+    # std_bias in their safetensors; when disabled the standardize op is an EXACT identity, so we construct NO std
+    # state at all (fabricating trainable identity nnx.Param leaves wrongly enters checkpoint-restored committed
+    # arrays into the nnx.Param gradient filter). When enabled, we construct them as VisionStdVar (a plain
+    # nnx.Variable): checkpoint-resident and restored by Orbax, but NON-trainable — excluded from the optimizer /
+    # weight-decay / gradient filter (which key on nnx.Param), matching HF's register_buffer semantics.
+    self._standardize_for_vit = bool(config.standardize_for_vit)
+    if self._standardize_for_vit:
+      self.std_bias = VisionStdVar(
+          nnx.initializers.zeros(self.rngs.params(), (config.hidden_size_for_vit,), config.weight_dtype)
+      )
+      self.std_scale = VisionStdVar(
+          nnx.initializers.ones(self.rngs.params(), (config.hidden_size_for_vit,), config.weight_dtype)
+      )
 
   def __call__(self, inputs: jax.Array, deterministic: bool = False) -> jax.Array:
     """Applies the vision encoder layer."""
@@ -593,9 +614,10 @@ class Gemma4VisionEncoderLayer(nnx.Module):
     # We take the first result.
     (embeddings, _) = vision_exit_results[0]
 
-    embeddings = (embeddings - self.std_bias.value.astype(embeddings.dtype)) * self.std_scale.value.astype(
-        embeddings.dtype
-    )
+    if self._standardize_for_vit:
+      embeddings = (embeddings - self.std_bias.value.astype(embeddings.dtype)) * self.std_scale.value.astype(
+          embeddings.dtype
+      )
 
     # Unflatten batch and num_images
     final_x = jnp.reshape(embeddings, (b, n, embeddings.shape[1], embeddings.shape[2]))

--- a/tests/unit/gemma4_vision_standardize_test.py
+++ b/tests/unit/gemma4_vision_standardize_test.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Gemma-4 vision standardization (std_bias/std_scale) contract.
+
+HF `modeling_gemma4` registers vision `std_bias`/`std_scale` via `register_buffer` (non-trainable) and ONLY when
+`vision_config.standardize=True`. Per-variant HF truth: Gemma-4 26B/31B ship standardize=True (2 std tensors);
+E2B/E4B ship standardize=False (0 std tensors). This test locks the MaxText contract:
+
+  * The `standardize_for_vit` config field is a per-model-family semantic distinction and must be set explicitly
+    by every Gemma-4 model config (no silent global default); an unset Gemma-4 config is a hard config error.
+  * standardize_for_vit=False  -> NO std state at all (the standardize op is an exact identity).
+  * standardize_for_vit=True   -> exactly two std leaves, constructed as VisionStdVar (a non-trainable
+    `nnx.Variable`, NOT `nnx.Param`), so they are checkpoint-resident but excluded from the optimizer/gradient.
+"""
+
+import unittest
+
+from flax import nnx
+import jax
+import numpy as np
+from jax.sharding import Mesh
+
+from maxtext.configs import pyconfig
+from maxtext.utils.globals import MAXTEXT_REPO_ROOT
+from maxtext.models.gemma4_vision import Gemma4VisionEncoderLayer, VisionStdVar
+
+
+def _init(model_name):
+  base_config_path = f"{MAXTEXT_REPO_ROOT}/src/maxtext/configs/base.yml"
+  argv = [
+      "",
+      base_config_path,
+      f"model_name={model_name}",
+      "attention=dot_product",
+      "matmul_precision=highest",
+      "dtype=float32",
+      "dtype_mm=float32",
+      "weight_dtype=float32",
+      "skip_jax_distributed_system=true",
+      "enable_checkpointing=false",
+      "run_name=std_test",
+      "base_output_directory=/tmp/std_test",
+  ]
+  if model_name in ("gemma4-e2b", "gemma4-e4b"):
+    argv.append("scan_layers=false")
+  return pyconfig.initialize(argv)
+
+
+class TestGemma4VisionStandardizeContract(unittest.TestCase):
+  """standardize_for_vit gates whether/how std_bias/std_scale exist, per HF vision_config.standardize."""
+
+  def setUp(self):
+    self.mesh = Mesh(np.array(jax.devices()[:1]), axis_names=("data",))
+
+  def _std_leaves(self, model, filt):
+    names = set()
+    for path, _ in jax.tree_util.tree_flatten_with_path(nnx.state(model, filt))[0]:
+      ps = "/".join(str(getattr(p, "key", p)) for p in path)
+      if "std_bias" in ps or "std_scale" in ps:
+        names.add(ps)
+    return names
+
+  def test_e2b_standardize_false_has_no_std_state(self):
+    """E2B (HF standardize=false): no std state at all; standardize is an exact identity."""
+    cfg = _init("gemma4-e2b")
+    self.assertFalse(cfg.standardize_for_vit)
+    model = Gemma4VisionEncoderLayer(cfg, self.mesh, rngs=nnx.Rngs(0))
+    self.assertFalse(hasattr(model, "std_bias"))
+    self.assertFalse(hasattr(model, "std_scale"))
+    self.assertEqual(self._std_leaves(model, nnx.Param), set())
+    self.assertEqual(self._std_leaves(model, nnx.Variable), set())
+
+  def test_26b_standardize_true_has_nontrainable_std_buffers(self):
+    """26B (HF standardize=true): exactly two std leaves as VisionStdVar, NOT in nnx.Param."""
+    cfg = _init("gemma4-26b")
+    self.assertTrue(cfg.standardize_for_vit)
+    model = Gemma4VisionEncoderLayer(cfg, self.mesh, rngs=nnx.Rngs(0))
+    self.assertIsInstance(model.std_bias, VisionStdVar)
+    self.assertIsInstance(model.std_scale, VisionStdVar)
+    # Present as (non-Param) Variables, absent from the Param (trainable) collection.
+    self.assertEqual(self._std_leaves(model, nnx.Param), set())
+    self.assertEqual(len(self._std_leaves(model, nnx.Variable)), 2)
+
+  def test_e2b_e4b_false_and_26b_31b_true(self):
+    """All four Gemma-4 configs resolve standardize_for_vit to their HF truth from the real YAMLs."""
+    self.assertFalse(_init("gemma4-e2b").standardize_for_vit)
+    self.assertFalse(_init("gemma4-e4b").standardize_for_vit)
+    self.assertTrue(_init("gemma4-26b").standardize_for_vit)
+    self.assertTrue(_init("gemma4-31b").standardize_for_vit)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary

Correct the classification and construction of the Gemma-4 vision **standardization** state (`std_bias`/`std_scale`) so it matches HuggingFace `modeling_gemma4` per model variant, and make the contract **explicit and fail-closed** for every Gemma-4 config.

This is a standalone **fidelity** fix. It does not add or change the multimodal feature itself (that is #4790), and it does not fix the separate params-only checkpoint-loader issue (tracked separately, see Non-goals).

## Exact model variants affected

| Variant | HF `vision_config.standardize` | std tensors in checkpoint | Correct MaxText state |
|---|---|---|---|
| gemma4-26b | **True** | 2 (`std_bias`, `std_scale`) | checkpoint-resident, **non-trainable** buffers |
| gemma4-31b | **True** | 2 | checkpoint-resident, **non-trainable** buffers |
| gemma4-e2b | **False** | 0 | **none** (standardize is an exact identity) |
| gemma4-e4b | **False** | 0 | **none** |

(Measured from `checkpoint_conversion/utils/hf_model_configs.py`, which mirrors the HF configs: 26B/31B `standardize=True`, E2B/E4B `standardize=False`.)

## The bug

The vision encoder unconditionally constructed `std_bias`/`std_scale` as **trainable `nnx.Param`** leaves and always applied the standardize op. For E2B/E4B (`standardize=False`) this fabricates two identity `nnx.Param` leaves that are absent from the HF model and its checkpoint, and that wrongly enter the `nnx.Param` gradient filter. For 26B/31B (`standardize=True`) the state existed but was modeled as trainable, whereas HF registers it via `register_buffer` (non-trainable).

Separately, the previous version of this field defaulted to `False` globally. Since a per-model-family semantic distinction must not inherit a global default, a 26B/31B config that failed to set the field would silently drop its std buffers.

## The fix

1. **Explicit, fail-closed config contract.** `standardize_for_vit: bool | None = None`. A `model_validator` hard-fails any `gemma4-*` model whose `standardize_for_vit` is unset. All four Gemma-4 model YAMLs set it explicitly (E2B/E4B `false`, 26B/31B `true`).
2. **Correct state construction.**
   - `standardize_for_vit=False`: construct **no** std state; the standardize op is an exact identity.
   - `standardize_for_vit=True`: construct `std_bias`/`std_scale` as `VisionStdVar` — a plain `nnx.Variable` (not `nnx.Param`). It is checkpoint-resident and restored by Orbax, but **non-trainable**: excluded from the optimizer, weight decay, and gradient filter (which all key on `nnx.Param`), matching HF's `register_buffer` semantics. This reuses the existing MaxText idiom for non-trainable buffers (`MoEBiasVar`/`Tid2EidVar` in `layers/moe.py`).

## 26B/31B compatibility

- Both remain `standardize_for_vit=true`; the std state is still constructed, used in the forward standardize op, and saved/restored — only its Variable *type* changes from `nnx.Param` to a non-trainable `nnx.Variable`, which is the HF-faithful classification.
- Orbax save/reload preserves the values byte-exactly; a known bias/scale transforms the output exactly.

## Tests

`tests/unit/gemma4_vision_standardize_test.py` (real model configs):
- E2B (`standardize=false`) → no std state anywhere (Param or Variable), no attribute.
- 26B (`standardize=true`) → exactly two `VisionStdVar` leaves, **zero** in `nnx.Param`.
- All four configs resolve `standardize_for_vit` to their HF truth from the real YAMLs.

Additional verified (state semantics, §A2): optimizer built with `wrt=nnx.Param` contains **zero** std leaves in its opt_state; Orbax round-trip preserves `std_bias`/`std_scale` exactly and keeps them as `VisionStdVar`; `(x - std_bias) * std_scale` matches expected within 1e-6.

## Composite integration validation (backprop evidence provenance)

The end-to-end backward/optimizer-apply evidence was produced by the composite stack — **not** by checking out this PR alone:

```
PR #4790 head <797842b1>            (Gemma-4 E2B multimodal feature: vision clipped-linears, PLE, masking)
+ PR #4807 candidate <this branch>  (std-fidelity fix)
+ a full-state checkpoint remap/splice bridge   (params-only θ0 -> full train-state; see Non-goals)
+ stock train.py
```

- **CPU:** real E2B θ0 → forward → backward → optimizer apply → save θ1: loss 14.941 → 11.596 (finite, decreasing); θ1 fresh-reload green; **448 vision clip bounds byte-identical θ0→θ1** (value-hash `750460d3…`); 751/751 non-clip trainable leaves changed.
- **TPU (tpu7x, single host):** same trainer path: loss 15.917 → 14.020 (finite, decreasing); θ1 saved with populated `opt_state` (proves gradients flowed + optimizer applied); trainer exit 0; no array deletion.

Clip-immutability provenance: **CPU byte-proves** the 448-bound immutability (pre/post value-hash identical). **TPU independently proves** backward, optimizer apply, and θ1 save. (A TPU-side pre/post 448-bound byte receipt is not asserted here.)

## Scope / non-goals

- This PR does **not** enable or modify the multimodal feature (that is #4790) and must not be read as replacing or superseding #4790.
- This PR does **not** fix the separate `load_parameters_path` params-only checkpoint issue (a converted params-only checkpoint currently drops a 69-leaf vision tail on restore; the E2E evidence used a full-state remap/splice bridge). That is a distinct checkpoint-loader issue tracked separately; the remap/splice bridge is evidence-only, not a proposed upstream loader path.
- The standalone "deleted array under `value_and_grad`" symptom seen in earlier debugging was an artifact of extracting/donating state from a live committed Orbax-restored model inside the transform (eager `value_and_grad`/`nnx.jit`/`nnx.split`); the production `train.py` does not follow that pattern. It is **not** the claim of this PR; the claim is the std-state fidelity correction above.
