### PR TITLE
Re-enable once pure_nnx config issue for DeepseekV4

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -562,6 +562,7 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
     new_state = state
 
     # Apply updates for Auxiliary-Loss-Free load balancing for DeepSeek family
+    # pylint: disable=too-many-nested-blocks
     if config.routed_bias and config.routed_bias_update_rate > 0.0:
       if config.model_name.startswith("deepseek4"):
         max_logging.log("DeepSeek V4: Applying auxiliary-loss-free routing bias via pure NNX MoEBiasVar.")

--- a/tests/unit/optimizers_test.py
+++ b/tests/unit/optimizers_test.py
@@ -260,22 +260,7 @@ _DEEPSEEK4_MLP = {
     },
 }
 
-_DEEPSEEK4_MLP_SCANNED = {
-    "MoeBlock_0": {
-        "gate": {
-            "bias": None,
-            "kernel": mdn(reduction_axis=(0,), output_axis=(-1,)),
-        },
-        "wi_0": mdn(reduction_axis=(-2,), output_axis=(-1,)),
-        "wi_1": mdn(reduction_axis=(-2,), output_axis=(-1,)),
-        "wo": mdn(reduction_axis=(-2,), output_axis=(-1,)),
-    },
-    "shared_experts": {
-        "wi_0": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
-        "wi_1": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
-        "wo": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
-    },
-}
+_DEEPSEEK4_MLP_SCANNED = _DEEPSEEK4_MLP
 
 _DEEPSEEK4_ATTN_BASIC = {
     "kv_norm": {"scale": None},
@@ -399,7 +384,7 @@ class MuonDimensionTest(parameterized.TestCase):
   @parameterized.named_parameters(
       ("deepseek2-16b", "deepseek2-16b", DEEPSEEK2_DIMENSION_NUMBER),
       ("deepseek3-671b", "deepseek3-671b", DEEPSEEK3_DIMENSION_NUMBER),
-      # ("deepseek4-284b", "deepseek4-284b", DEEPSEEK4_DIMENSION_NUMBER),  # TODO(b/544531325): Re-enable once pure_nnx config issue is resolved.
+      ("deepseek4-284b", "deepseek4-284b", DEEPSEEK4_DIMENSION_NUMBER),
       ("kimi-k2-1t", "kimi-k2-1t", DEEPSEEK3_DIMENSION_NUMBER),
       ("llama2-7b", "llama2-7b", LLAMA2_DIMENSION_NUMBER),
       ("llama3-8b", "llama3-8b", LLAMA2_DIMENSION_NUMBER),
@@ -414,7 +399,8 @@ class MuonDimensionTest(parameterized.TestCase):
     Initializes the specified MaxText model and asserts that the generated
     Muon dimension numbers match the hardcoded reference.
     """
-    actual_output = muon_utils.get_model_mdn(model_name, scan_layers=True, pure_nnx=False)
+    is_pure_nnx = model_name in {"deepseek4-284b"}
+    actual_output = muon_utils.get_model_mdn(model_name, scan_layers=True, pure_nnx=is_pure_nnx)
     if "params" in expected_output and "params" in actual_output:
       self.assertEqual(actual_output["params"], expected_output["params"])
     else:


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

https://b.corp.google.com/issues/544531325

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/544531325

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
