### PR TITLE
[CI]: Improve test selection logic with cumulative flags and exclusions

### DIFF
--- a/.github/scripts/analyze_code_changes.sh
+++ b/.github/scripts/analyze_code_changes.sh
@@ -14,62 +14,75 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+# Analyzes git diff changes in a Pull Request against a base reference
+# to selectively enable or disable test suites and notebook executions.
+# This optimizes CI run times by only triggering relevant test environments
+# based on the specific files modified.
+#
+# Behavior & Logic Flow:
+#   1. Non-PR Events: If not a pull request, enables all test suites and notebooks.
+#   2. Empty Diff / Error: If no files are detected or diff fails, runs everything 
+#      as a fail-safe.
+#   3. Default State: All individual test and notebook flags are initialized to 'false'.
+#   4. File Evaluation Loop: Iterates through each changed file:
+#      - Evaluates against specific domain rules (notebook workflows, pathways, 
+#        TPU pre/post-training dependencies, GPU files, inference, etc.) and 
+#        cumulatively enables corresponding flags.
+#      - Tracks any unmatched files.
+#   5. Exclusion Filtering: Filters out pre-configured excluded patterns/directories 
+#      from the unmatched file list.
+#   6. Fallback Check: If any truly unmatched files remain, triggers a general fallback 
+#      enabling all core test suites (excluding notebooks).
 
-# Sequence of checks:
-# - Non-PR / Diff error: Run all suites (fail-open)
-# - Docs only: Skip all tests and notebooks
-# - Notebooks only: Run notebooks only
-# - Core CI & dependencies: Run all suites
-# - GPU only: Run GPU tests only (no notebooks, as notebooks run on TPU)
-# - Pathways only: Run Pathways tests only
-# - Post-training only: Run post-training tests and notebooks only
-# - General inference only: Run pretrain TPU/CPU suites only
-# - Default fallback: Run all suites (fail-open for core/shared code)
+set -e
 
 # Helper to output a key-value flag to GITHUB_OUTPUT (if set) and stdout
 emit_flag() {
   local key="$1"
   local val="$2"
-  echo "$key=$val"
+  # Only log if value is true
+  if [[ "$val" == "true" ]]; then
+    echo "$key=$val"
+  fi
+  # Always write to GITHUB_OUTPUT so GitHub Actions steps have the key
   if [[ -n "$GITHUB_OUTPUT" ]]; then
     echo "$key=$val" >> "$GITHUB_OUTPUT"
   fi
 }
 
-# Helper to set all flags to 'true' or 'false'
-set_all_flags() {
-  local val="$1"
-  for flag in run_tests run_notebooks run_pretrain_tests run_posttrain_tests run_pathways_tests run_gpu_tests; do
-    emit_flag "$flag" "$val"
+# Helper to enable specific test flags and set all others to 'false'
+set_test_flags() {
+  local enable_tests="$1"
+  local enable_notebooks="$2"
+  for flag in run_tests run_pretrain_tests run_posttrain_tests run_pathways_tests run_gpu_tests; do
+    emit_flag "$flag" "$enable_tests"
   done
+  emit_flag "run_notebooks" "$enable_notebooks"
 }
 
 # Helper to enable specific flags and set all others to 'false'
 enable_flags() {
   local enabled=" $* "
   for flag in run_tests run_notebooks run_pretrain_tests run_posttrain_tests run_pathways_tests run_gpu_tests; do
-    if [[ "$enabled" =~ " $flag " ]]; then
+    if [[ "$enabled" == *" $flag "* ]]; then
       emit_flag "$flag" "true"
-    else
-      emit_flag "$flag" "false"
     fi
   done
 }
 
-# Helper to check if changed files exclusively match a specific domain pattern
-matches_only_domain() {
-  local pattern="$1"
-  echo "$CHANGED_FILES" | grep -E "$pattern" > /dev/null && \
-    ! echo "$CHANGED_FILES" | grep -v -E "($pattern|\.md$)" > /dev/null
+# Helper to check if a changed file matches a specific domain pattern
+matches_pattern() {
+  local changed_file="$1"
+  local pattern="$2"
+  [[ "$changed_file" =~ $pattern ]]
 }
 
 EVENT_NAME="${EVENT_NAME:-${GITHUB_EVENT_NAME:-pull_request}}"
 BASE_REF="${1:-${GITHUB_BASE_REF:-main}}"
 
 if [ "$EVENT_NAME" != "pull_request" ]; then
-  echo "Not a pull request (event: $EVENT_NAME), running all tests"
-  set_all_flags "true"
+  echo "Not a pull request (event: $EVENT_NAME), running all tests and notebooks"
+  set_test_flags "true" "true"
   exit 0
 fi
 
@@ -84,59 +97,118 @@ echo "$CHANGED_FILES"
 
 if [ -z "$CHANGED_FILES" ]; then
   echo "No files detected or diff failed. Running everything as a fail-safe."
-  set_all_flags "true"
+  set_test_flags "true" "true"
   exit 0
 fi
 
-# Documentation only changes
-if ! echo "$CHANGED_FILES" | grep -v -E '\.md$' > /dev/null; then
-  echo "Documentation-only files changed, skipping all tests and notebooks."
-  set_all_flags "false"
-  exit 0
-fi
+# Disable all tests by default
+set_test_flags "false" "false"
 
-# Notebook only changes
-if ! echo "$CHANGED_FILES" | grep -v -E '\.(ipynb|md)$' > /dev/null; then
-  echo "Only notebook/doc files changed, running notebooks only."
-  enable_flags run_notebooks
-  exit 0
-fi
+# Array to track files that didn't match any known pattern
+UNMATCHED_FILES=()
 
-# Core CI workflows or dependencies changes
-if echo "$CHANGED_FILES" | grep -E '(^|/)(src/dependencies/|\.github/workflows/)' | grep -v -E '(\.github/workflows/run_pathways_tests\.yml)' > /dev/null; then
-  echo "Core files (dependencies, workflows) changed, enabling all tests and notebooks."
-  set_all_flags "true"
-  exit 0
-fi
+# Pre-populated list of excluded patterns/files that shouldn't trigger tests
+EXCLUDED_FILES=(
+  '^\.github/scripts/'
+  '^tools/'
+  '\.md$'
+)
 
-# GPU only changes (note: notebooks run on TPU, so GPU changes skip notebooks)
-if matches_only_domain 'src/maxtext/configs/gpu/|src/maxtext/inference/gpu/|tests/end_to_end/gpu/'; then
-  echo "Only GPU files changed, enabling GPU tests only."
-  enable_flags run_tests run_gpu_tests
-  exit 0
-fi
+# Loop through every changed file
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
 
-# Pathways only changes
-if matches_only_domain 'src/maxtext/inference/jetstream_pathways/|\.github/workflows/run_pathways_tests\.yml'; then
-  echo "Only Pathways files changed, enabling Pathways tests only."
-  enable_flags run_tests run_pathways_tests
-  exit 0
-fi
+  matched=false
 
-# Post-training only changes
-if matches_only_domain 'src/maxtext/trainers/post_train/|tests/post_training/'; then
-  echo "Only post-training files changed, enabling post-training tests only."
-  enable_flags run_tests run_notebooks run_posttrain_tests
-  exit 0
-fi
+  # Notebook workflows changes
+  if matches_pattern "$file" "\.github/workflows/run_jupyter_notebooks.yml$"; then
+    echo "Notebook workflow changed, enabling notebook tests."
+    enable_flags run_notebooks
+    matched=true
+  fi
 
-# General inference only changes
-if matches_only_domain 'src/maxtext/inference/|tests/inference/'; then
-  echo "Only inference files changed, enabling pretrain unit/integration tests only."
-  enable_flags run_tests run_pretrain_tests
-  exit 0
-fi
+  # Pathways workflow changes
+  if matches_pattern "$file" "\.github/workflows/run_pathways_tests.yml$"; then
+    echo "Pathways workflow changed, enabling all pathways tests."
+    enable_flags run_tests run_pathways_tests
+    matched=true
+  fi
 
-# Default fallback: run all domain suites
-echo "General source changes detected, enabling all domain suites."
-set_all_flags "true"
+  # TPU pre-training dependencies changes
+  if matches_pattern "$file" "src/dependencies/requirements/generated_requirements/tpu-requirements.txt$"; then
+    echo "TPU pre-training dependencies changed, enabling TPU pre-training tests."
+    enable_flags run_tests run_pretrain_tests run_pathways_tests
+    matched=true
+  fi
+
+  # TPU post-training dependencies changes
+  if matches_pattern "$file" "src/dependencies/requirements/generated_requirements/tpu-post-train-requirements.txt$"; then
+    echo "TPU post-training dependencies changed, enabling TPU post-training tests."
+    enable_flags run_tests run_posttrain_tests run_pathways_tests
+    matched=true
+  fi
+
+  # GPU dependencies changes
+  if matches_pattern "$file" "src/dependencies/requirements/generated_requirements/cuda12-requirements.txt$"; then
+    echo "GPU dependencies changed, enabling GPU tests."
+    enable_flags run_tests run_gpu_tests
+    matched=true
+  fi
+
+  # GPU configs/source/test changes
+  if matches_pattern "$file" "src/maxtext/configs/gpu/|src/maxtext/inference/gpu/|tests/end_to_end/gpu/"; then
+    echo "GPU files changed, enabling GPU tests."
+    enable_flags run_tests run_gpu_tests
+    matched=true
+  fi
+
+  # Post-training source/test changes
+  if matches_pattern "$file" "src/maxtext/trainers/post_train/|tests/post_training/"; then
+    echo "Post-training files changed, enabling TPU post-training tests."
+    enable_flags run_tests run_posttrain_tests
+    matched=true
+  fi
+
+  # General inference only changes
+  if matches_pattern "$file" "src/maxtext/inference/|tests/inference/"; then
+    echo "Inference files changed, enabling TPU pre-training tests."
+    enable_flags run_tests run_pretrain_tests
+    matched=true
+  fi
+
+  # Notebook files changed
+  if matches_pattern "$file" "\.ipynb$"; then
+    echo "Notebook files changed, enabling notebook tests."
+    enable_flags run_notebooks
+    matched=true
+  fi
+
+  # If no rule matched this file, track it as unmatched
+  if [[ "$matched" == "false" ]]; then
+    UNMATCHED_FILES+=("$file")
+  fi
+
+done <<< "$CHANGED_FILES"
+
+# Filter out pre-populated EXCLUDED_FILES from UNMATCHED_FILES
+FINAL_UNMATCHED_FILES=()
+for file in "${UNMATCHED_FILES[@]}"; do
+  is_excluded="false"
+  for excluded in "${EXCLUDED_FILES[@]}"; do
+    if matches_pattern "$file" "$excluded"; then
+      is_excluded="true"
+      break
+    fi
+  done
+  if [[ "$is_excluded" == "false" ]]; then
+    FINAL_UNMATCHED_FILES+=("$file")
+  fi
+done
+
+# If there are any unmatched files, trigger general fallback
+if [ ${#FINAL_UNMATCHED_FILES[@]} -gt 0 ]; then
+  echo "The following changed files did not match any specific domain rules:"
+  printf '  - %s\n' "${FINAL_UNMATCHED_FILES[@]}"
+  echo "Enabling all test suites except notebook tests as a fallback."
+  enable_flags run_tests run_pretrain_tests run_posttrain_tests run_pathways_tests run_gpu_tests
+fi


### PR DESCRIPTION
# Description

This PR refactors the CI test selection script (`analyze_code_changes.sh`) to evaluate changed files individually rather than evaluating the entire diff as a single block. This optimizes CI run times by accurately triggering relevant test environments based on the specific files modified.

### Key Changes:

* Cumulative Test Selection: The script now loops through every changed file independently. It cumulatively enables test flags based on the domain rules that match each file (e.g., TPU pre-training, Pathways, GPU, Notebooks).
* Exclusion Filtering: Introduced a new `EXCLUDED_FILES` array for patterns like `.github/scripts/` and `tools/`. This prevents changes to these specific administrative or tooling files from triggering the entire suite of tests.
* Smart Fallback Mechanism: Any changed file that doesn't match a specific domain rule is tracked as an unmatched file. After filtering out the excluded files, if any unmatched files remain, the script triggers a general fallback that enables all core test suites, except notebooks.

# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
