### PR TITLE
Support extracting router replay expert indices from MaxText inference

### DIFF
--- a/src/maxtext/configs/inference/vllm.yml
+++ b/src/maxtext/configs/inference/vllm.yml
@@ -33,7 +33,7 @@ vllm_additional_config: {}
 
 
 # -------------- Logical Axis Rules --------------
-mesh_axes: ['data', 'attn_dp', 'model', 'expert', 'attn_dp_expert']
+mesh_axes: ['data', 'attn_dp', 'model', 'expert', 'attn_dp_expert', 'dcp', 'pcp']
 logical_axis_rules: [
                       # ==========================================
                       # Vocabulary Embedding

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4383,6 +4383,8 @@ class MaxTextConfig(
         "autoregressive": self.ici_autoregressive_parallelism,
         "attn_dp": (1),  # initialized to 1, vLLM will auto calculate this value based on TP and num_kv_heads
         "attn_dp_expert": (1),  # initialized to 1, vLLM will auto calculate this value based on EP
+        "dcp": (1),
+        "pcp": (1),
     }
     self.ici_parallelism = [ici_map[axis] for axis in self.mesh_axes]
 
@@ -4403,6 +4405,8 @@ class MaxTextConfig(
         "autoregressive": self.dcn_autoregressive_parallelism,
         "attn_dp": (1),  # initialized to 1, vLLM will auto calculate this value based on TP and num_kv_heads
         "attn_dp_expert": (1),  # initialized to 1, vLLM will auto calculate this value based on EP
+        "dcp": (1),
+        "pcp": (1),
     }
     self.dcn_parallelism = [dcn_map[axis] for axis in self.mesh_axes]
 

--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -266,7 +266,7 @@ class MaxTextForCausalLM(nnx.Module):
     with self.mesh, nn.logical_axis_rules(self.maxtext_config.logical_axis_rules):
       aux_hidden_states = []
       expert_indices = None
-      hidden, kv_caches = self.model(
+      res = self.model(
           decoder_input_tokens=input_ids,
           decoder_positions=input_positions,
           kv_caches=kv_caches,
@@ -274,6 +274,11 @@ class MaxTextForCausalLM(nnx.Module):
           model_mode=self.model_mode,
           **kwargs,
       )
+
+      if isinstance(res, tuple) and len(res) == 3:
+        hidden, kv_caches, expert_indices = res
+      else:
+        hidden, kv_caches = res
 
       # To be compatible with vLLM, we reshape to (batch * seq, dim).
       hidden = hidden.reshape((-1, hidden.shape[-1]))

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -3119,6 +3119,9 @@ class RoutedMoE(nnx.Module):
     hidden_states = jnp.reshape(inputs, (batch_size * seq_len, emb_dim))
     gating_output = jnp.reshape(gate_logits, (batch_size * seq_len, self.num_experts))
 
+    _, top_k_indices = jax.lax.top_k(gating_output, self.num_experts_per_tok)
+    self.selected_experts = nnx.Intermediate(top_k_indices)
+
     # Concatenate gate and up projections: [E, D, H] + [E, D, H] -> [E, D, 2H]
     # fused_moe_func splits this internally: gate=w1[..., :H], up=w1[..., H:]
     if fused_kernel is None:

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -18,6 +18,7 @@
 
 import functools
 import inspect
+import re
 from typing import Any
 import warnings
 
@@ -2032,6 +2033,34 @@ class NNXDecoder(nnx.Module):
     else:
       logits = self.apply_output_head(shared_embedding, hidden_state, deterministic, model_mode)
 
+    expert_indices = None
+    try:
+
+      def _path_sort_key(path):
+        key = []
+        for part in path:
+          nums = re.findall(r"\d+", str(part))
+          key.append(int(nums[0]) if nums else str(part))
+        return tuple(key)
+
+      intermediates = nnx.state(self, nnx.Intermediate)
+      flat_items = [
+          (path, val.value if hasattr(val, "value") else val)
+          for path, val in intermediates.flat_state()
+          if path and str(path[-1]) == "selected_experts"
+      ]
+      flat_items.sort(key=lambda item: _path_sort_key(item[0]))
+      expert_indices_list = [v for _, v in flat_items]
+      if expert_indices_list:
+        # Scanned blocks already carry a leading layer axis (3D); sequential
+        # layers are 2D and need that axis added before concatenating.
+        expert_indices_list = [v if v.ndim == 3 else jnp.expand_dims(v, axis=0) for v in expert_indices_list]
+        expert_indices = jnp.concatenate(expert_indices_list, axis=0)
+    except Exception:  # pylint: disable=broad-exception-caught
+      expert_indices = None
+
+    if expert_indices is not None:
+      return logits, hidden_state, kv_caches, expert_indices
     return logits, hidden_state, kv_caches
 
   def _apply_deepseek4_scanned_blocks(

--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -549,7 +549,7 @@ class Transformer(nnx.Module):
       mutable_collections.append("intermediates")
 
     if self.config.pure_nnx_decoder:
-      logits, hidden_state, kv_caches = self.decoder(
+      res = self.decoder(
           shared_embedding=self.token_embedder,
           decoder_input_tokens=decoder_input_tokens,
           decoder_positions=decoder_positions,
@@ -563,8 +563,13 @@ class Transformer(nnx.Module):
           attention_metadata=attention_metadata,
           deepstack_visual_embeds=deepstack_visual_embeds,
       )  # pytype: disable=wrong-keyword-args
+      if isinstance(res, tuple) and len(res) == 4:
+        logits, hidden_state, kv_caches, expert_indices = res
+      else:
+        logits, hidden_state, kv_caches = res
+        expert_indices = None
     else:
-      logits, hidden_state, kv_caches = self.decoder(
+      res = self.decoder(
           shared_embedding=self.token_embedder,
           decoder_input_tokens=decoder_input_tokens,
           decoder_positions=decoder_positions,
@@ -579,6 +584,11 @@ class Transformer(nnx.Module):
           deepstack_visual_embeds=deepstack_visual_embeds,
           mutable=mutable_collections,  # pyrefly: ignore[unexpected-keyword]
       )  # pytype: disable=wrong-keyword-args
+      if isinstance(res, tuple) and len(res) == 4:
+        logits, hidden_state, kv_caches, expert_indices = res
+      else:
+        logits, hidden_state, kv_caches = res
+        expert_indices = None
 
     # If we are initializing the model AND MTP is enabled, we must create
     # dummy target tensors. This allows Flax to trace the MTPBlock and create
@@ -614,6 +624,8 @@ class Transformer(nnx.Module):
 
     if self.config.attention in ("vllm_rpa", "vllm_batched_rpa"):
       # In vLLM, logits are computed separately after updating the KV cache.
+      if expert_indices is not None:
+        return hidden_state, kv_caches, expert_indices
       return hidden_state, kv_caches
 
     return logits

--- a/tests/post_training/integration/inference_router_replay_test.py
+++ b/tests/post_training/integration/inference_router_replay_test.py
@@ -1,0 +1,144 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration Test: Extract Router Replay Data from MaxText MoE Inference.
+
+Validates:
+1. MaxText MoE inference execution (attention="vllm_rpa", fused_moe_matmul) capturing `selected_experts` / `expert_indices`.
+2. Router replay extraction from intermediate state and decoder outputs with shape (batch_size, seq_len, top_k).
+"""
+
+import os
+
+os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
+os.environ["NEW_MODEL_DESIGN"] = "1"
+os.environ["SKIP_JAX_PRECOMPILE"] = "1"
+os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+import sys
+import unittest
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh
+import pytest
+
+from maxtext.configs import pyconfig
+from maxtext.models import models
+from maxtext.utils import maxtext_utils
+from maxtext.common.common_types import (
+    DECODING_ACTIVE_SEQUENCE_INDICATOR,
+    MODEL_MODE_PREFILL,
+)
+from tests.utils.test_helpers import get_test_config_path
+
+pytestmark = [pytest.mark.post_training, pytest.mark.integration_test, pytest.mark.tpu_only]
+
+
+class InferenceRouterReplayExtractionTest(unittest.TestCase):
+
+  def setUp(self):
+    os.environ["NEW_MODEL_DESIGN"] = "1"
+    os.environ["SKIP_JAX_PRECOMPILE"] = "1"
+    os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+
+  def test_extract_router_replay_from_inference(self):
+    if jax.device_count() < 4:
+      self.skipTest("Requires >=4 devices for ici_tensor_parallelism=4 with attention=vllm_rpa.")
+
+    seq_len = 16
+    batch_size = 2
+    num_layers = 1
+    num_experts = 4
+    top_k = 2
+
+    test_tokens = [791, 7155, 315, 9342, 374, 9897, 323, 374] * 4
+    raw_tokens = test_tokens[:seq_len]
+
+    base_kwargs = {
+        "run_name": "test_router_replay_extraction_fast",
+        "enable_checkpointing": False,
+        "override_model_config": True,
+        "base_num_decoder_layers": num_layers,
+        "num_decoder_layers": num_layers,
+        "model_name": "qwen3.5-35b-a3b",
+        "num_experts": num_experts,
+        "num_experts_per_tok": top_k,
+        "base_emb_dim": 512,
+        "base_num_query_heads": 2,
+        "base_num_kv_heads": 2,
+        "head_dim": 256,
+        "partial_rotary_factor": 0.25,
+        "base_mlp_dim": 1024,
+        "base_moe_mlp_dim": 1024,
+        "vocab_size": 1000,
+        "max_target_length": seq_len,
+        "max_prefill_predict_length": seq_len,
+        "per_device_batch_size": float(batch_size),
+        "scan_layers": False,
+        "weight_dtype": "bfloat16",
+        "dtype": "bfloat16",
+        "log_config": False,
+        "skip_jax_distributed_system": True,
+        "ici_tensor_parallelism": 4,
+        "ici_data_parallelism": 1,
+        "ici_expert_parallelism": 1,
+        "enable_nnx": True,
+        "pure_nnx": True,
+        "pure_nnx_decoder": True,
+    }
+
+    cfg_infer = pyconfig.initialize(
+        [sys.argv[0], get_test_config_path("inference/vllm.yml"), "attention=vllm_rpa"],
+        **base_kwargs,
+    )
+
+    devices_array = maxtext_utils.create_device_mesh(cfg_infer)
+    mesh = Mesh(devices_array, cfg_infer.mesh_axes)
+    rng = jax.random.PRNGKey(42)
+
+    ids = jnp.tile(jnp.expand_dims(jnp.array(raw_tokens, dtype=jnp.int32), axis=0), (batch_size, 1))
+    decoder_positions = jnp.tile(jnp.expand_dims(jnp.arange(seq_len, dtype=jnp.int32), axis=0), (batch_size, 1))
+    segment_ids = jnp.zeros((batch_size, seq_len), dtype=jnp.int32) + DECODING_ACTIVE_SEQUENCE_INDICATOR
+
+    model_infer = models.transformer_as_linen(config=cfg_infer, mesh=mesh, quant=None, model_mode=MODEL_MODE_PREFILL)
+    init_params_rng, init_dropout_rng = jax.random.split(rng)
+    vars_dict_init = model_infer.init(
+        {"params": init_params_rng, "dropout": init_dropout_rng},
+        ids,
+        decoder_positions,
+        segment_ids,
+        enable_dropout=False,
+    )
+    vars_infer = dict(vars_dict_init)
+
+    # Run inference prefill
+    out, _ = model_infer.apply(
+        vars_infer,
+        ids,
+        decoder_positions,
+        segment_ids,
+        enable_dropout=False,
+        model_mode=MODEL_MODE_PREFILL,
+        mutable=["cache", "intermediates"],
+    )
+
+    self.assertIsInstance(out, tuple, "Inference output must be a tuple")
+    self.assertEqual(len(out), 3, "Inference output must be (hidden_state, kv_caches, expert_indices)")
+    _, _, expert_indices = out
+    self.assertIsNotNone(expert_indices, "expert_indices must not be None")
+    self.assertEqual(expert_indices.shape[1:], (batch_size * seq_len, top_k))
+    print(f"\n[Inference Router Extraction] Extracted routing data shape: {expert_indices.shape}")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/compile_cache_test.py
+++ b/tests/unit/compile_cache_test.py
@@ -81,6 +81,10 @@ def test_train_step_cache_hit():
     env["JAX_ENABLE_COMPILATION_CACHE"] = "true"
     env["JAX_COMPILATION_CACHE_DIR"] = temp_dir
     env["JAX_LOG_COMPILES"] = "1"
+    # The tiny model used here compiles in well under JAX's default 1 second
+    # minimum compile time for writing to the persistent cache, so lower the
+    # threshold to ensure the cache is actually populated.
+    env["JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS"] = "0"
 
     print("Running CPU training subprocess:", " ".join(cmd))
     result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=True)


### PR DESCRIPTION


# Description

- In RoutedMoE, record selected_experts as nnx.Intermediate in fused_moe_matmul
- In NNXDecoder, extract selected_experts from intermediates and return expert_indices
- In Transformer, forward expert_indices from decoder to vLLM caller
- In MaxTextForCausalLM vLLM adapter, return expert_indices in forward outputs
- Added dcp/pcp axes to ici_map, dcn_map and vllm.yml for TPU vLLM shard_map compatibility
- Added fast lightweight test_inference_router_replay.py integration test

You can also provide a comma-separated list. If you don't want to close a bug but
simply to reference it, use BUGS, e.g.:
BUGS: b/536114593

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
