### PR TITLE
Support inserting and replaying router expert decisions in trainer

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2830,6 +2830,26 @@ class DerivedValues(BaseModel):
 # ----------------------------------------------------------------------------
 
 
+# Decoder blocks that support router replay (`forced_routed_experts`). All are
+# homogeneous-MoE, so a 4D layer axis is just the decoder layer index;
+# interleaved architectures (Llama4/Envy) would need a MoE-only counter.
+# Requires the pure-NNX decoder. GEMMA4 is unscanned-only (see nnx_decoders.py).
+FORCED_ROUTING_SUPPORTED_DECODER_BLOCKS = (
+    DecoderBlockType.QWEN3_5,
+    DecoderBlockType.MIXTRAL,
+    DecoderBlockType.GEMMA4,
+)
+
+
+def check_forced_routing_support(decoder_block: DecoderBlockType) -> None:
+  """Raises NotImplementedError if `decoder_block` does not support router replay."""
+  if decoder_block not in FORCED_ROUTING_SUPPORTED_DECODER_BLOCKS:
+    raise NotImplementedError(
+        "Forced routing (router replay) is only supported for decoder_block in "
+        f"{FORCED_ROUTING_SUPPORTED_DECODER_BLOCKS}; got decoder_block={decoder_block!r}."
+    )
+
+
 def _normalize_axes(axes: Any) -> tuple[str, ...]:
   """Normalize a logical-rule mapping value to a tuple of axis name strings.
 

--- a/src/maxtext/integration/tunix/tunix_adapter.py
+++ b/src/maxtext/integration/tunix/tunix_adapter.py
@@ -108,6 +108,7 @@ class TunixMaxTextAdapter(nnx.Module):
       attention_mask: Optional[Array],  # [B, L, L] or None
       decoder_segment_ids: Optional[Array] = None,
       output_hidden_states: bool = False,  # ignored
+      forced_routed_experts: Optional[Array] = None,
   ) -> Tuple[Array, None]:
     """Forward compatible with Tunix Trainers default loss.
     Returns logits, None.
@@ -118,6 +119,7 @@ class TunixMaxTextAdapter(nnx.Module):
         decoder_input_tokens=input_tokens,
         decoder_positions=positions,
         decoder_segment_ids=decoder_segment_ids,
+        forced_routed_experts=forced_routed_experts,
     )
     return logits, None
 

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -226,6 +226,12 @@ def random_routing(rng_key, gate_logits, num_experts_per_tok):
   return top_k_weights, top_k_indices
 
 
+def valid_expert_mask(indices, num_experts):
+  """True where an expert id is real. Forced routing marks unused slots with -1,
+  and any out-of-range id is treated the same way."""
+  return (indices >= 0) & (indices < num_experts)
+
+
 def calculate_load_balance_updates(top_k_indices, num_experts, rate):
   """
   Computes a bias adjustment update based on expert load.
@@ -241,9 +247,10 @@ def calculate_load_balance_updates(top_k_indices, num_experts, rate):
       update: The value to add to the expert bias. Shape (num_experts,).
   """
   flat_indices = top_k_indices.ravel()
-  expert_counts = jnp.bincount(flat_indices, length=num_experts)
-
-  total_tokens = flat_indices.size
+  # one_hot rather than bincount: bincount clips out-of-range values, so the -1
+  # padding that forced routing uses would all be counted as expert 0.
+  expert_counts = jnp.sum(jax.nn.one_hot(flat_indices, num_experts, dtype=jnp.int32), axis=0)
+  total_tokens = jnp.sum(expert_counts)
   average_load = total_tokens / num_experts
   direction = jnp.sign(average_load - expert_counts)
   output = direction * rate
@@ -738,47 +745,74 @@ class RoutedMoE(nnx.Module):
     """
     return self.config.routed_bias and self.config.routed_bias_update_rate > 0.0 and not self.is_hash_routing
 
-  def get_topk(self, gate_logits, pre_bias_logits, rngs=None, input_ids=None):
+  def get_topk(self, gate_logits, pre_bias_logits, rngs=None, input_ids=None, forced_routed_experts=None):
     """get topk."""
     # shape of top_k_weights & top_k_indices:
     # (batch, sequence, num_experts_per_tok).
-    if self.config.use_random_routing:
-      if rngs is None:
-        raise ValueError("The random key cannot be None for random routing.")
-      # Reuse the 'params' RNG stream to ensure random routing
-      rng = rngs.params() if hasattr(rngs, "params") and callable(getattr(rngs, "params")) else rngs
-      top_k_weights, top_k_indices = random_routing(rng, gate_logits, self.num_experts_per_tok)
-      return top_k_weights, top_k_indices
-
-    if self.is_hash_routing:
-      if input_ids is None:
-        raise ValueError("input_ids cannot be None when is_hash_routing is True")
-      # Access the static routing table
-      tid2eid_int = self.tid2eid.value
-      # Cast the float32 array to int32 (JAX automatically assigns 0.0 gradients to integer casts)
-      tid2eid_int = tid2eid_int.astype(jnp.int32)
-      # Cast input_ids to int32 to safely index the hash routing table
-      top_k_indices = tid2eid_int[input_ids.astype(jnp.int32)]
-      top_k_weights = jnp.take_along_axis(pre_bias_logits, top_k_indices, axis=-1)
-    # NOTE: deepseek2 has a different pattern
-    elif self.config.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2")):
-      top_k_weights, top_k_indices = self.deepseek_routing(gate_logits, pre_bias_logits)
-    elif self.config.decoder_block == ctypes.DecoderBlockType.GEMMA4:
-      router_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1)
-      _, top_k_indices = jax.lax.top_k(gate_logits, self.num_experts_per_tok)
-      top_k_weights = jnp.take_along_axis(router_probs, top_k_indices, axis=-1).astype(self.dtype)
+    valid_token_mask = None
+    if forced_routed_experts is not None:
+      top_k_indices = forced_routed_experts
+      # Any id outside [0, num_experts) is an unused slot, same as the -1 sentinel.
+      valid_token_mask = valid_expert_mask(top_k_indices, self.num_experts)
+      # Gather at 0, not -1: take_along_axis would wrap -1 onto the last expert and
+      # that value reaches the softmax denominator before the mask zeroes it.
+      gather_indices = jnp.where(valid_token_mask, top_k_indices, 0)
+      if self.config.decoder_block == ctypes.DecoderBlockType.GEMMA4:
+        router_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1)
+        top_k_weights = jnp.take_along_axis(router_probs, gather_indices, axis=-1).astype(self.dtype)
+      else:
+        top_k_weights = jnp.take_along_axis(gate_logits, gather_indices, axis=-1)
     else:
-      top_k_weights, top_k_indices = jax.lax.top_k(gate_logits, self.num_experts_per_tok)
+      if self.config.use_random_routing:
+        if rngs is None:
+          raise ValueError("The random key cannot be None for random routing.")
+        # Reuse the 'params' RNG stream to ensure random routing
+        rng = rngs.params() if hasattr(rngs, "params") and callable(getattr(rngs, "params")) else rngs
+        top_k_weights, top_k_indices = random_routing(rng, gate_logits, self.num_experts_per_tok)
+        return top_k_weights, top_k_indices
+
+      if self.is_hash_routing:
+        if input_ids is None:
+          raise ValueError("input_ids cannot be None when is_hash_routing is True")
+        # Access the static routing table
+        tid2eid_int = self.tid2eid.value
+        # Cast the float32 array to int32 (JAX automatically assigns 0.0 gradients to integer casts)
+        tid2eid_int = tid2eid_int.astype(jnp.int32)
+        # Cast input_ids to int32 to safely index the hash routing table
+        top_k_indices = tid2eid_int[input_ids.astype(jnp.int32)]
+        top_k_weights = jnp.take_along_axis(pre_bias_logits, top_k_indices, axis=-1)
+      # NOTE: deepseek2 has a different pattern
+      elif self.config.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2")):
+        top_k_weights, top_k_indices = self.deepseek_routing(gate_logits, pre_bias_logits)
+      elif self.config.decoder_block == ctypes.DecoderBlockType.GEMMA4:
+        router_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1)
+        _, top_k_indices = jax.lax.top_k(gate_logits, self.num_experts_per_tok)
+        top_k_weights = jnp.take_along_axis(router_probs, top_k_indices, axis=-1).astype(self.dtype)
+      else:
+        top_k_weights, top_k_indices = jax.lax.top_k(gate_logits, self.num_experts_per_tok)
 
     if self.config.decoder_block in (ctypes.DecoderBlockType.DEEPSEEK, ctypes.DecoderBlockType.DEEPSEEK4):
       top_k_weights = self.deepseek_scale_weights(top_k_weights)
+      if valid_token_mask is not None:
+        top_k_weights = top_k_weights * valid_token_mask
     else:
       if self.config.decoder_block not in (ctypes.DecoderBlockType.LLAMA4, ctypes.DecoderBlockType.GEMMA4):
+        if valid_token_mask is not None:
+          # Padding must stay out of the softmax denominator or it rescales the
+          # real slots. Large-negative, not -inf: a fully-padded token would be NaN.
+          top_k_weights = jnp.where(valid_token_mask, top_k_weights, jnp.finfo(jnp.float32).min / 2)
         top_k_weights = jax.nn.softmax(top_k_weights.astype(jnp.float32), axis=-1).astype(self.dtype)
+
+      if valid_token_mask is not None:
+        top_k_weights = top_k_weights * valid_token_mask
 
       # Normalization of router weights (e.g. used by Qwen3, Gemma4).
       if self.config.norm_topk_prob:
-        top_k_weights /= top_k_weights.sum(axis=-1, keepdims=True)
+        weight_sum = top_k_weights.sum(axis=-1, keepdims=True)
+        if valid_token_mask is not None:
+          # A fully-padded token sums to zero; 0/0 would NaN the whole batch loss.
+          weight_sum = jnp.where(weight_sum == 0, 1.0, weight_sum)
+        top_k_weights /= weight_sum
 
       if self.per_expert_scale is not None and not (
           self.config.model_call_mode == "inference" and self.config.fuse_expert_scales
@@ -902,13 +936,15 @@ class RoutedMoE(nnx.Module):
       rngs=None,
       roll_to_expert_id=None,
       input_ids=None,
+      forced_routed_experts=None,
   ):
     """Permute tokens to group by expert to fit gmm call."""
     # reshape inputs (batch, sequence, emb) to (batch * sequence, emb)
     inputs_shape = inputs.shape
     bsz_times_seq_len = inputs_shape[0] * inputs_shape[1]
     inputs_2d = jnp.reshape(inputs, (bsz_times_seq_len, inputs_shape[2]))
-    weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs, input_ids)
+    weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs, input_ids, forced_routed_experts)
+
     lb_loss = None
     # Using pre_bias_logits ensures the router bias does not leak into the auxiliary loss gradient
     probs_logits = pre_bias_logits if pre_bias_logits is not None else gate_logits
@@ -943,6 +979,13 @@ class RoutedMoE(nnx.Module):
     buffer_size = None
     if use_ragged_in_permute:
       topk_indices_2d = jnp.reshape(selected_experts, (bsz_times_seq_len, selected_experts.shape[2]))
+      if forced_routed_experts is not None:
+        # Padding -> a virtual expert past the last real one: ring_ragged_sort
+        # sorts by argsort but counts with one_hot, so -1 would sort before
+        # expert 0 while counting as nothing and offset every shard's window.
+        topk_indices_2d = jnp.where(
+            valid_expert_mask(topk_indices_2d, self.config.num_experts), topk_indices_2d, self.config.num_experts
+        )
       # roll_to_expert_id is not directly used in the kernel, ep axis id is directly called
       if self.config.ragged_buffer_factor > 0.0:
         balanced_size = (bsz_times_seq_len // num_expert_parallelism) * self.num_experts_per_tok
@@ -975,17 +1018,31 @@ class RoutedMoE(nnx.Module):
     else:
       flatten_selected_experts = jnp.ravel(selected_experts)
 
+      # Must precede roll_to_expert_id: `(-1 - roll) % num_experts` wraps padding
+      # onto a real expert id, so a mask computed after it sees no padding at all.
+      if forced_routed_experts is not None:
+        valid_mask = valid_expert_mask(flatten_selected_experts, self.num_experts)
+
       if roll_to_expert_id is not None:
         flatten_selected_experts = (flatten_selected_experts - roll_to_expert_id) % self.num_experts
-      sorted_selected_experts = jnp.argsort(flatten_selected_experts)
+
+      if forced_routed_experts is not None:
+        # Spread padding round-robin: it carries zero weight but still counts in
+        # group_size, so under ragged_buffer_factor > 0 it can evict real tokens.
+        dummy_indices = jnp.arange(flatten_selected_experts.shape[0]) % self.num_experts
+        flatten_selected_experts_safe = jnp.where(valid_mask, flatten_selected_experts, dummy_indices)
+      else:
+        flatten_selected_experts_safe = flatten_selected_experts
+
+      sorted_selected_experts = jnp.argsort(flatten_selected_experts_safe)
       if self.config.moe_use_direct_token_gather:
-        sorted_inputs = _route_activations(inputs_2d, flatten_selected_experts).astype(self.dtype)
+        sorted_inputs = _route_activations(inputs_2d, flatten_selected_experts_safe).astype(self.dtype)
       else:
         replicated_inputs_2d = jnp.repeat(inputs_2d, self.num_experts_per_tok, axis=0)
         sorted_inputs = _sort_activations(replicated_inputs_2d, sorted_selected_experts, use_custom_sort_vjp).astype(
             self.dtype
         )
-      group_size = jnp.bincount(flatten_selected_experts, length=self.num_experts)
+      group_size = jnp.bincount(flatten_selected_experts_safe, length=self.num_experts)
 
     num_tokens = bsz_times_seq_len * self.num_experts_per_tok
     use_truncated_buffer = use_ragged_in_permute and buffer_size is not None and buffer_size < num_tokens
@@ -1440,6 +1497,7 @@ class RoutedMoE(nnx.Module):
       w1_bias,
       wo_bias,
       input_ids=None,
+      forced_routed_experts=None,
   ):
     """Perform sparse matrix multiplication of inputs and Experts."""
 
@@ -1742,7 +1800,9 @@ class RoutedMoE(nnx.Module):
     decoder_tokens_pspec = maybe_replicate_incompatible_batch(decoder_tokens_pspec, input_ids)
     output_pspec = maybe_replicate_incompatible_batch(output_pspec, inputs)
 
-    def roe_ag_and_route(x, logits, pre_bias_logits, num_ep, expert_shard_id, rngs, input_ids=None):
+    def roe_ag_and_route(
+        x, logits, pre_bias_logits, num_ep, expert_shard_id, rngs, input_ids=None, forced_routed_experts=None
+    ):
       # The ring-of-experts strategy first duplicates the inputs to all
       # expert shards, and then routes within each shard.
 
@@ -1750,6 +1810,12 @@ class RoutedMoE(nnx.Module):
       x, logits, pre_bias_logits = tuple(
           jax.lax.all_gather(z, axis_name=self._expert_parallelism_name, tiled=True) for z in (x, logits, pre_bias_logits)
       )
+      if forced_routed_experts is not None:
+        # Must follow the same all-gather as logits: routing is done on the
+        # gathered batch, so a shard-local replay would not line up.
+        forced_routed_experts = jax.lax.all_gather(
+            forced_routed_experts, axis_name=self._expert_parallelism_name, tiled=True
+        )
 
       # "Route" tokens within each shard.
       num_experts_per_shard = self.config.num_experts // num_ep
@@ -1770,6 +1836,7 @@ class RoutedMoE(nnx.Module):
           roll_to_expert_id=num_experts_per_shard * expert_shard_id,
           rngs=rngs,
           input_ids=input_ids,
+          forced_routed_experts=forced_routed_experts,
       )
       return (
           x,
@@ -1790,7 +1857,9 @@ class RoutedMoE(nnx.Module):
           ),
       )
 
-    def ra2a_and_route(x, logits, pre_bias_logits, num_ep, expert_shard_id, rngs, input_ids=None):
+    def ra2a_and_route(
+        x, logits, pre_bias_logits, num_ep, expert_shard_id, rngs, input_ids=None, forced_routed_experts=None
+    ):
       local_sorted_indices = None
       all_shards_group_sizes = None
       reshaped_group_sizes = None
@@ -1810,6 +1879,7 @@ class RoutedMoE(nnx.Module):
           self.config.use_custom_sort_vjp,
           rngs,
           input_ids=input_ids,
+          forced_routed_experts=forced_routed_experts,
       )
 
       if num_ep > 1:
@@ -1891,7 +1961,7 @@ class RoutedMoE(nnx.Module):
           ),
       )
 
-    def route(x, logits, pre_bias_logits, rngs, input_ids=None):
+    def route(x, logits, pre_bias_logits, rngs, input_ids=None, forced_routed_experts=None):
       """Performs both across device and within device token routing/sorting"""
       num_ep = self.get_expert_parallelism_size()
       expert_shard_id = jax.lax.axis_index(self._expert_parallelism_name) if num_ep > 1 else 0
@@ -1905,6 +1975,7 @@ class RoutedMoE(nnx.Module):
             expert_shard_id,
             rngs,
             input_ids=input_ids,
+            forced_routed_experts=forced_routed_experts,
         )
       else:
         return ra2a_and_route(
@@ -1915,6 +1986,7 @@ class RoutedMoE(nnx.Module):
             expert_shard_id,
             rngs,
             input_ids=input_ids,
+            forced_routed_experts=forced_routed_experts,
         )
 
     def get_active_sharding_axes(pspec_dim_axes, tensor_dim_index):
@@ -2146,6 +2218,7 @@ class RoutedMoE(nnx.Module):
         sharded_input_ids,
         rngs,
         embed_dim,
+        forced_routed_experts=None,
     ):
       """Overlap token all-gather and GMM computation along embedding dimension."""
       num_ep = self.get_expert_parallelism_size()
@@ -2165,6 +2238,7 @@ class RoutedMoE(nnx.Module):
           expert_shard_id,
           chunk_rngs_key,
           input_ids=sharded_input_ids,
+          forced_routed_experts=forced_routed_experts,
       )
 
       if self.config.mlp_bias:
@@ -2199,6 +2273,7 @@ class RoutedMoE(nnx.Module):
             expert_shard_id,
             chunk_rngs_key,
             input_ids=sharded_input_ids,
+            forced_routed_experts=forced_routed_experts,
         )
         return (next_x, next_ps0, next_ps1, chunk_idx + 1), None
 
@@ -2243,6 +2318,7 @@ class RoutedMoE(nnx.Module):
         wo_bias,
         sharded_input_ids,
         rngs,
+        forced_routed_experts=None,
     ):
       batch_size, sequence_length, embed_dim = x.shape
       if self.config.num_moe_emb_chunks > 0:
@@ -2258,9 +2334,12 @@ class RoutedMoE(nnx.Module):
             sharded_input_ids,
             rngs,
             embed_dim,
+            forced_routed_experts=forced_routed_experts,
         )
       else:
-        x, routing, route_metadata = route(x, logits, pre_bias_logits, rngs, input_ids=sharded_input_ids)
+        x, routing, route_metadata = route(
+            x, logits, pre_bias_logits, rngs, input_ids=sharded_input_ids, forced_routed_experts=forced_routed_experts
+        )
         mask = jnp.arange(x.shape[0]) < valid_token_count(x, routing, route_metadata)
 
         if self.config.mlp_bias:
@@ -2366,6 +2445,10 @@ class RoutedMoE(nnx.Module):
             wo_bias_pspec,
             decoder_tokens_pspec,
             P(),  # Replicate the input key
+            # Reuse gate_logits_pspec (which forced_routed_experts is sharded
+            # with below); recomputing it would skip
+            # maybe_replicate_incompatible_batch.
+            gate_logits_pspec if forced_routed_experts is not None else None,
         ),
         out_specs=(
             output_pspec,
@@ -2386,6 +2469,7 @@ class RoutedMoE(nnx.Module):
         wo_bias,
         sharded_input_ids,
         rngs,
+        forced_routed_experts=None,
     ):
       # The expert weights (w0/w1/wo) are all-gathered over FSDP once at this
       # shard_map entry (implicitly, via the `embed_tensor_transpose` pspec which
@@ -2405,6 +2489,7 @@ class RoutedMoE(nnx.Module):
             wo_bias,
             sharded_input_ids,
             rngs,
+            forced_routed_experts,
         )
 
       # Chunked ring-of-experts pipeline: split the per-shard tokens along the
@@ -2439,6 +2524,7 @@ class RoutedMoE(nnx.Module):
             wo_bias,
             None if sharded_input_ids is None else sharded_input_ids[:, sl],
             rngs,
+            None if forced_routed_experts is None else forced_routed_experts[:, sl, :],
         )
         if self.config.moe_chunk_barrier:
           _prev = out_c
@@ -2487,6 +2573,12 @@ class RoutedMoE(nnx.Module):
         pre_bias_logits_pspec,
         logical_axes=pre_bias_logits_logical_axes,
     )
+    if forced_routed_experts is not None:
+      forced_routed_experts = self._maybe_shard_with_pspec(
+          forced_routed_experts,
+          gate_logits_pspec,
+          logical_axes=gate_logits_logical_axes,
+      )
 
     w0_kernel = self._maybe_shard_with_pspec(w0_kernel, w0_pspec)
     w1_kernel = self._maybe_shard_with_pspec(w1_kernel, w1_pspec)
@@ -2510,27 +2602,49 @@ class RoutedMoE(nnx.Module):
         wo_bias,
         input_ids,
         self.rngs,
+        forced_routed_experts,
     )
 
-  def reshape_and_update_weights(self, weights, indices):
-    """reshape and update weights."""
+  def reshape_and_update_weights(self, weights, indices, safe_updates=False):
+    """Reshape and update weights.
+
+    safe_updates (forced routing): padding is masked to (index 0, weight 0) and
+    the scatter accumulates instead of setting.
+    """
     # input of weights and indices: (batch_size, seq_len, num_experts_per_tok)
     # output of updated weights: (batch_size, seq_len, num_experts)
     update_weights = jnp.zeros((weights.shape[0], weights.shape[1], self.num_experts), dtype=self.dtype)
+    if safe_updates:
+      valid_mask = indices >= 0
+      safe_indices = jnp.where(valid_mask, indices, 0)
+      safe_weights = jnp.where(valid_mask, weights, 0.0)
+    else:
+      safe_indices = indices
+      safe_weights = weights
+
     index_update = (
         self._maybe_shard_with_logical(
             jnp.arange(weights.shape[0])[:, None, None],
             ("activation_batch", None, None),
         ),
         self._maybe_shard_with_logical(jnp.arange(weights.shape[1])[:, None], ("activation_length", None)),
-        indices,
+        safe_indices,
     )
     weight_sharding = (
         create_sharding(self.mesh, ("activation_batch", "activation_length", None))
         if self.config.shard_mode == ShardMode.EXPLICIT
         else None
     )
-    update_weights = update_weights.at[index_update].set(weights, out_sharding=weight_sharding)
+    if safe_updates:
+      # Forced routing may replay duplicate expert indices for the same token
+      # (e.g. multiple padding slots mapped to index 0). `.set()` with
+      # duplicate indices has undefined ordering in the underlying scatter,
+      # so accumulate with `.add()` instead: padding slots always carry a
+      # zero weight, so summing duplicates is safe and avoids silently
+      # dropping a real weight update.
+      update_weights = update_weights.at[index_update].add(safe_weights, out_sharding=weight_sharding)
+    else:
+      update_weights = update_weights.at[index_update].set(safe_weights, out_sharding=weight_sharding)
     return update_weights
 
   def get_context_partition_and_sub_seq(self, seq_len):
@@ -2797,6 +2911,7 @@ class RoutedMoE(nnx.Module):
       w1_bias,
       wo_bias,
       input_ids=None,
+      forced_routed_experts=None,
   ) -> tuple[jax.Array, Optional[jax.Array], Optional[jax.Array]]:
     """Dense matrix multiplication."""
     # gate_logits: batch, length, expert
@@ -2807,13 +2922,21 @@ class RoutedMoE(nnx.Module):
       pre_bias_logits = self._maybe_shard_with_logical(
           pre_bias_logits, ("activation_batch_moe", "activation_length_moe", None)
       )
-    top_k_weights, top_k_indices = self.get_topk(gate_logits, pre_bias_logits, self.rngs, input_ids=input_ids)
+    if forced_routed_experts is not None:
+      forced_routed_experts = self._maybe_shard_with_logical(
+          forced_routed_experts, ("activation_batch_moe", "activation_length_moe", None)
+      )
+    top_k_weights, top_k_indices = self.get_topk(
+        gate_logits, pre_bias_logits, self.rngs, input_ids=input_ids, forced_routed_experts=forced_routed_experts
+    )
     is_llama4_decoder_layer = self.config.decoder_block == ctypes.DecoderBlockType.LLAMA4
     if is_llama4_decoder_layer:
       router_scores = jax.nn.sigmoid(top_k_weights.astype(jnp.float32)).astype(self.dtype)
       inputs = inputs * router_scores
     else:
-      weights = self.reshape_and_update_weights(top_k_weights, top_k_indices)
+      weights = self.reshape_and_update_weights(
+          top_k_weights, top_k_indices, safe_updates=(forced_routed_experts is not None)
+      )
     matmul_precision = jax.lax.Precision(self.config.matmul_precision)
 
     # Calculate load balance loss
@@ -3082,7 +3205,9 @@ class RoutedMoE(nnx.Module):
         intermediate_layer = adc.checkpoint_name(adc.checkpoint_name(intermediate_layer, "mlpwo"), "moe_mlpwo")
       with jax.named_scope("weight_sum"):
         if is_llama4_decoder_layer:
-          weights = self.reshape_and_update_weights(jnp.ones_like(top_k_weights), top_k_indices)
+          weights = self.reshape_and_update_weights(
+              jnp.ones_like(top_k_weights), top_k_indices, safe_updates=(forced_routed_experts is not None)
+          )
         if self.config.float32_weight_sum:
           intermediate_layer = intermediate_layer.astype(jnp.float32)
           weights = weights.astype(jnp.float32)
@@ -3103,12 +3228,15 @@ class RoutedMoE(nnx.Module):
       w0_kernel=None,
       w1_kernel=None,
       fused_kernel=None,
+      forced_routed_experts=None,
   ) -> tuple[jax.Array, None, None]:
     """Fused MoE via tpu_inference fused_moe_func (vllm_rpa path only).
 
     fused_moe_func handles routing, GMM, and weighted combination internally.
     It does not compute lb_loss or bias_updates (inference-only).
     """
+    if forced_routed_experts is not None:
+      raise NotImplementedError("Forced routing via forced_routed_experts is not supported with fused_moe_matmul.")
     try:
       # pylint: disable=import-outside-toplevel
       # pytype: disable=import-error
@@ -3205,6 +3333,7 @@ class RoutedMoE(nnx.Module):
       input_ids: jax.Array | None = None,
       gate_inputs: jax.Array | None = None,
       out_sharding: NamedSharding | None = None,
+      forced_routed_experts: jax.Array | None = None,
   ) -> tuple[jax.Array, Optional[jax.Array], Optional[jax.Array]]:
     """Executes the routed MoE block.
 
@@ -3273,6 +3402,7 @@ class RoutedMoE(nnx.Module):
           w0_kernel=w0_kernel,
           w1_kernel=w1_kernel,
           fused_kernel=fused_kernel,
+          forced_routed_experts=forced_routed_experts,
       )
     elif cfg.sparse_matmul:
       if quantizations.in_serve_mode(self.quant):
@@ -3297,7 +3427,8 @@ class RoutedMoE(nnx.Module):
           w0_bias,
           w1_bias,
           wo_bias,
-          input_ids,
+          input_ids=input_ids,
+          forced_routed_experts=forced_routed_experts,
       )
     else:
       output, lb_loss, bias_updates = self.dense_matmul(
@@ -3310,7 +3441,8 @@ class RoutedMoE(nnx.Module):
           w0_bias,
           w1_bias,
           wo_bias,
-          input_ids,
+          input_ids=input_ids,
+          forced_routed_experts=forced_routed_experts,
       )
     return output, lb_loss, bias_updates
 
@@ -3400,6 +3532,7 @@ class RoutedAndSharedMoE(nnx.Module):
       intermediate_sharding: NamedSharding | None = None,
       out_sharding: NamedSharding | None = None,
       input_ids: jax.Array | None = None,
+      forced_routed_experts: jax.Array | None = None,
   ) -> tuple[jax.Array, Optional[jax.Array], Optional[jax.Array]]:
     """Executes both the routed experts and the shared expert block.
 
@@ -3421,6 +3554,7 @@ class RoutedAndSharedMoE(nnx.Module):
         gate_inputs=gate_inputs,
         out_sharding=out_sharding,
         input_ids=input_ids,
+        forced_routed_experts=forced_routed_experts,
     )
     shared_experts = self.shared_experts(
         inputs,

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -37,6 +37,7 @@ from maxtext.common.common_types import (
     MultimodalInput,
     ShardMode,
 )
+from maxtext.configs.types import check_forced_routing_support
 from maxtext.layers import initializers, linears, mhc, moe, normalizations, quantizations
 from maxtext.layers import nnx_scan, nnx_wrappers
 from maxtext.layers.attentions import Attention
@@ -227,6 +228,47 @@ class NNXDecoderLayer(nnx.Module):
       return layer_output, None
     else:
       return layer_output, kv_cache
+
+
+def reshape_forced_routed_experts_for_scan(
+    forced_routed_experts: jax.Array,
+    num_layers: int,
+    scan_length: int,
+    layers_per_cycle: int,
+) -> jax.Array:
+  """Reshapes a batch's forced_routed_experts into jax.lax.scan's xs layout.
+
+  The outer scan runs `scan_length` iterations, each covering a cycle of
+  `layers_per_cycle` decoder layers. Every supported architecture is
+  homogeneous-MoE, so the layer axis is simply the decoder layer index.
+
+  Args:
+    forced_routed_experts: `[batch, seq, num_layers, top_k]` (per-layer) or
+      `[batch, seq, top_k]` (broadcast to every layer).
+    num_layers: Total decoder layers (`scan_length * layers_per_cycle`).
+    scan_length: Number of outer scan iterations.
+    layers_per_cycle: Decoder layers per cycle.
+
+  Returns:
+    Array shaped `[scan_length, layers_per_cycle, batch, seq, top_k]`.
+
+  Raises:
+    ValueError: If forced_routed_experts is not 3D or 4D.
+  """
+  fre = forced_routed_experts
+  if fre.ndim not in (3, 4):
+    raise ValueError(
+        "forced_routed_experts must be [batch, seq, top_k] (3D, broadcast to every layer) "
+        f"or [batch, seq, num_layers, top_k] (4D, per-layer); got ndim={fre.ndim} with shape "
+        f"{fre.shape}."
+    )
+  if fre.ndim == 4:
+    # [batch, seq, num_layers, top_k] -> [num_layers, batch, seq, top_k]
+    fre = jnp.moveaxis(fre, 2, 0)
+  else:
+    # [batch, seq, top_k]: same forced routing for every layer.
+    fre = jnp.broadcast_to(fre[None], (num_layers,) + fre.shape)
+  return jnp.reshape(fre, (scan_length, layers_per_cycle) + fre.shape[1:])
 
 
 def deepstack_process(hidden_states, bidirectional_mask, visual_embeds):
@@ -927,6 +969,7 @@ class NNXDecoder(nnx.Module):
       skip_block_remat: bool = False,
       unroll: int = 1,
       metadata_axis_name: str = "layers",
+      forced_routed_experts_scanned=None,
       **kwargs,
   ):
     """Runs the layer stack using nnx.scan.
@@ -953,6 +996,9 @@ class NNXDecoder(nnx.Module):
         This must perfectly match the string passed to `_create_scanned_layers`
         (e.g., "layers", "scanned_blocks") to prevent strict JAX `pjit` PyTree
         metadata mismatch errors when using custom `nnx.Variable` types (like `MoEBiasVar`).
+      forced_routed_experts_scanned: Optional `[length, ...]` array, one slice per
+        scan iteration, threaded through jax.lax.scan's xs alongside params/state
+        and passed to each layer as `forced_routed_experts=`.
       **kwargs: Keyword args forwarded to the layer (filtered by the layer signature).
 
     Returns:
@@ -988,6 +1034,7 @@ class NNXDecoder(nnx.Module):
     updated_graphdef = [graphdef]
 
     use_kv = kv_caches_stacked is not None
+    use_forced_routing = forced_routed_experts_scanned is not None
 
     def layer_fn(carry, scanned_vars):
       # Ensure metadata rank matches the sliced values
@@ -996,9 +1043,14 @@ class NNXDecoder(nnx.Module):
       # Unpack the sliced variables for THIS layer
       if use_kv:
         current_params, current_state, kv_cache_layer = scanned_vars
+        forced_routed_experts_layer = None
+      elif use_forced_routing:
+        current_params, current_state, forced_routed_experts_layer = scanned_vars
+        kv_cache_layer = None
       else:
         current_params, current_state = scanned_vars
         kv_cache_layer = None
+        forced_routed_experts_layer = None
 
       if self.config.parameter_memory_host_offload:
         current_params = jax.tree.map(
@@ -1008,10 +1060,12 @@ class NNXDecoder(nnx.Module):
 
       layer = nnx.merge(graphdef, current_params, current_state)
 
-      # Build call kwargs, injecting per-layer kv_cache when available
+      # Build call kwargs, injecting per-layer kv_cache / forced routing when available
       call_kwargs = dict(valid_kwargs)
       if kv_cache_layer is not None:
         call_kwargs["kv_cache"] = kv_cache_layer
+      if use_forced_routing:
+        call_kwargs["forced_routed_experts"] = forced_routed_experts_layer
 
       layer_out = layer(carry, *args, **call_kwargs)
 
@@ -1075,7 +1129,11 @@ class NNXDecoder(nnx.Module):
       params = maxtext_utils_nnx.nnx_ensure_scan_leading_axis(params, length)
       state = maxtext_utils_nnx.nnx_ensure_scan_leading_axis(state, length)
 
-      final_carry, scanned_state = jax.lax.scan(layer_fn_wrapped, x_in, (params, state), unroll=unroll)
+      if use_forced_routing:
+        scan_xs = (params, state, forced_routed_experts_scanned)
+      else:
+        scan_xs = (params, state)
+      final_carry, scanned_state = jax.lax.scan(layer_fn_wrapped, x_in, scan_xs, unroll=unroll)
       returned_kv_stacked = None
 
       # Move the scan axis to each variable's param_scan_axis and restore its name
@@ -1602,9 +1660,35 @@ class NNXDecoder(nnx.Module):
       attention_metadata=None,
       deepstack_visual_embeds: None | list[jnp.ndarray] = None,
       multimodal_input: None | MultimodalInput = None,
+      forced_routed_experts: jnp.ndarray | None = None,
   ):
     cfg = self.config
     assert decoder_input_tokens.ndim == 2  # [batch, len]
+
+    if forced_routed_experts is not None:
+      check_forced_routing_support(cfg.decoder_block)
+      if getattr(cfg, "mtp_num_layers", 0) > 0:
+        # The MTP side-car reuses the decoder layer blueprint but is invoked
+        # separately, so it would re-route freely while the main stack replays.
+        raise NotImplementedError(
+            "Forced routing (router replay) is not supported with multi-token prediction; "
+            f"got mtp_num_layers={cfg.mtp_num_layers}."
+        )
+      if getattr(cfg, "using_pipeline_parallelism", False):
+        # The pipeline path forwards layer_kwargs to every layer unchanged, so
+        # forced_routed_experts would be broadcast instead of sliced per layer.
+        raise NotImplementedError(
+            "Forced routing (router replay) is not supported with pipeline parallelism; "
+            "the pipeline path cannot slice forced_routed_experts per layer."
+        )
+      if cfg.scan_layers and cfg.decoder_block == DecoderBlockType.GEMMA4:
+        # _apply_gemma4_scanned_blocks is a triple-nested scan that doesn't
+        # thread forced_routed_experts; the kwarg filter would silently strip it.
+        raise NotImplementedError(
+            "Forced routing with scan_layers=True is not yet implemented for GEMMA4 "
+            "(its scanned path is structurally different from the other supported "
+            "architectures); set scan_layers=False to use forced routing with Gemma4."
+        )
 
     policy = self.get_remat_policy()
 
@@ -1648,6 +1732,9 @@ class NNXDecoder(nnx.Module):
 
     if cfg.engram_layers and decoder_input_tokens is not None:
       layer_kwargs["decoder_input_tokens"] = decoder_input_tokens
+
+    if forced_routed_experts is not None:
+      layer_kwargs["forced_routed_experts"] = forced_routed_experts
 
     if getattr(cfg, "using_pipeline_parallelism", False):
       logical_partition_spec = (
@@ -1871,7 +1958,34 @@ class NNXDecoder(nnx.Module):
               kv_caches=kv_caches,
           )
         else:
-          scan_length = int(cfg.num_decoder_layers / cfg.inhomogeneous_layer_cycle_interval)
+          cycle_interval = cfg.inhomogeneous_layer_cycle_interval
+          scan_length = int(cfg.num_decoder_layers / cycle_interval)
+          forced_routed_experts_scanned = None
+          if forced_routed_experts is not None:
+            if kv_caches is not None:
+              # The kv-cache branch below cannot take scan xs, so the routing
+              # would be broadcast whole to every layer instead of sliced.
+              raise NotImplementedError(
+                  "Forced routing is not supported together with externally-managed (vLLM) "
+                  "kv_caches in scanned layers."
+              )
+            # Only the per-layer slices may reach the layers from here on.
+            layer_kwargs.pop("forced_routed_experts", None)
+            forced_routed_experts_scanned = reshape_forced_routed_experts_for_scan(
+                forced_routed_experts,
+                num_layers=cfg.num_decoder_layers,
+                scan_length=scan_length,
+                layers_per_cycle=cycle_interval,
+            )
+            if cfg.decoder_block == DecoderBlockType.MIXTRAL:
+              # Mixtral has no ScannableBlock: one scan iteration is one layer,
+              # so drop the (size-1) per-cycle axis the layer would slice.
+              if cycle_interval != 1:
+                raise NotImplementedError(
+                    "Forced routing with scanned MIXTRAL requires "
+                    f"inhomogeneous_layer_cycle_interval == 1; got {cycle_interval}."
+                )
+              forced_routed_experts_scanned = jnp.squeeze(forced_routed_experts_scanned, axis=1)
           if kv_caches is not None:
             # Pass the kv_caches list directly to avoid copying in jnp.stack,
             # which breaks vLLM PagedAttention in-place memory updates.
@@ -1891,20 +2005,21 @@ class NNXDecoder(nnx.Module):
                 y,
                 *layer_args,
                 length=scan_length,
+                forced_routed_experts_scanned=forced_routed_experts_scanned,
                 **layer_kwargs,
             )
       else:
         prevent_cse = maxtext_utils.should_prevent_cse_in_remat(cfg)
         dynamic_graph_init = bool(getattr(self, "disable_quant_stats_update", False))
 
-        def pure_layer_fn(graphdef_in, state_in, y_in, kv_in):
+        def pure_layer_fn(graphdef_in, state_in, y_in, kv_in, valid_kwargs):
           if cfg.parameter_memory_host_offload:
             state_in = jax.tree.map(
                 lambda x: jax.device_put(x, max_utils.device_space()),
                 state_in,
             )
           merged_layer = nnx.merge(graphdef_in, state_in)
-          out_y, out_kv = merged_layer(y_in, *layer_args, kv_cache=kv_in, **layer_kwargs)
+          out_y, out_kv = merged_layer(y_in, *layer_args, kv_cache=kv_in, **valid_kwargs)
           state_out = nnx.state(merged_layer)
 
           if dynamic_graph_init:
@@ -1961,10 +2076,34 @@ class NNXDecoder(nnx.Module):
           if input_tokens is not None:
             layer_kwargs["decoder_input_tokens"] = input_tokens
 
+          current_kwargs = dict(layer_kwargs)
+
+          routed_experts = current_kwargs.pop("forced_routed_experts", None)
+          if routed_experts is not None:
+            # Every supported decoder_block is homogeneous-MoE, so the layer
+            # axis is just `lyr`.
+            if routed_experts.ndim not in (3, 4):
+              raise ValueError(
+                  "forced_routed_experts must be [batch, seq, top_k] (3D, broadcast to every "
+                  "layer) or [batch, seq, num_layers, top_k] (4D, per-layer); got ndim="
+                  f"{routed_experts.ndim} with shape {routed_experts.shape}."
+              )
+            if routed_experts.ndim == 4 and routed_experts.shape[2] != cfg.num_decoder_layers:
+              # jnp clamps an out-of-range static index, so a short layer axis
+              # would silently replay the last slice on every later layer.
+              raise ValueError(
+                  "forced_routed_experts layer axis must equal num_decoder_layers "
+                  f"({cfg.num_decoder_layers}); got {routed_experts.shape[2]} from shape "
+                  f"{routed_experts.shape}."
+              )
+            current_kwargs["forced_routed_experts"] = (
+                routed_experts[:, :, lyr, :] if routed_experts.ndim == 4 else routed_experts
+            )
+
           if cfg.remat_policy != "none":
-            y, kv_cache, new_state, new_graphdef = checkpointed_fn(graphdef, state, y, kv_cache)
+            y, kv_cache, new_state, new_graphdef = checkpointed_fn(graphdef, state, y, kv_cache, current_kwargs)
           else:
-            y, kv_cache, new_state, new_graphdef = pure_layer_fn(graphdef, state, y, kv_cache)
+            y, kv_cache, new_state, new_graphdef = pure_layer_fn(graphdef, state, y, kv_cache, current_kwargs)
 
           if dynamic_graph_init:
             new_layer = nnx.merge(new_graphdef, new_state)

--- a/src/maxtext/models/gemma4.py
+++ b/src/maxtext/models/gemma4.py
@@ -121,6 +121,7 @@ class Gemma4MoE(nnx.Module):
       original_inputs: jax.Array | None = None,
       intermediate_sharding: jax.sharding.NamedSharding | None = None,
       out_sharding: jax.sharding.NamedSharding | None = None,
+      forced_routed_experts: jax.Array | None = None,
   ) -> tuple[jax.Array, Optional[jax.Array], Optional[jax.Array]]:
     shared_experts = self.moe_block.shared_experts(
         inputs, intermediate_sharding=intermediate_sharding, out_sharding=out_sharding
@@ -140,7 +141,7 @@ class Gemma4MoE(nnx.Module):
 
     # 3. Pass both to routed_moe
     routed_experts, load_balance_loss, moe_bias_updates = self.moe_block.routed_moe(
-        routed_inputs, gate_inputs=gate_inputs, out_sharding=out_sharding
+        routed_inputs, gate_inputs=gate_inputs, out_sharding=out_sharding, forced_routed_experts=forced_routed_experts
     )
     routed_experts = self.post_feedforward_layernorm_2(routed_experts)
 
@@ -321,6 +322,7 @@ class Gemma4DecoderLayer(nnx.Module):
       bidirectional_mask=None,
       kv_cache=None,
       attention_metadata=None,
+      forced_routed_experts: jnp.ndarray | None = None,
   ):
     cfg = self.config
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
@@ -365,7 +367,9 @@ class Gemma4DecoderLayer(nnx.Module):
 
     # MLP block.
     if getattr(self.config, "num_experts", 1) > 1:
-      mlp_lnx, load_balance_loss, _ = self.mlp(attn_output, original_inputs=attention_lnx)
+      mlp_lnx, load_balance_loss, _ = self.mlp(
+          attn_output, original_inputs=attention_lnx, forced_routed_experts=forced_routed_experts
+      )
       if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
         self.sow(nnx.Intermediate, "moe_lb_loss", load_balance_loss)
     else:

--- a/src/maxtext/models/mixtral.py
+++ b/src/maxtext/models/mixtral.py
@@ -135,6 +135,7 @@ class MixtralDecoderLayer(nnx.Module):
       slot=None,
       kv_cache=None,
       attention_metadata=None,
+      forced_routed_experts: jnp.ndarray | None = None,
   ):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):
@@ -168,7 +169,7 @@ class MixtralDecoderLayer(nnx.Module):
     # NOTE: the naming mismatch here is to ensure reverse compatibility with existing checkpoints.
     # The `name` represents the weight name in JAX/checkpoints and so the class name
     # is just for readability.
-    mlp_lnx, load_balance_loss, _ = self.MoeBlock_0(hidden_states)
+    mlp_lnx, load_balance_loss, _ = self.MoeBlock_0(hidden_states, forced_routed_experts=forced_routed_experts)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
 
     layer_output = mlp_lnx + intermediate_inputs

--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -41,6 +41,11 @@ from maxtext.utils import max_utils
 # The network: Transformer Definitions
 # ------------------------------------------------------------------------------
 
+_FORCED_ROUTING_NEEDS_PURE_NNX = (
+    "Forced routing (router replay) is only implemented for the pure-NNX decoder (NNXDecoder). "
+    "Use the NNX model path with pure_nnx_decoder=True (both are the defaults)."
+)
+
 
 class TransformerLinenPure(nn.Module):
   """An autoregressive transformer model."""
@@ -143,6 +148,7 @@ class TransformerLinenPure(nn.Module):
       nnx_method=None,
       kv_caches: list[jax.Array] | None = None,
       attention_metadata: dict[str, Any] | None = None,
+      forced_routed_experts: jnp.ndarray | None = None,
   ):
     """Applies Transformer decoder-branch on encoded-input and target.
 
@@ -205,6 +211,9 @@ class TransformerLinenPure(nn.Module):
           bidirectional_mask=bidirectional_mask_image,
           bidirectional_mask_video=bidirectional_mask_video,
       )
+
+    if forced_routed_experts is not None:
+      raise NotImplementedError(_FORCED_ROUTING_NEEDS_PURE_NNX)
 
     logits, hidden_state, kv_caches = self.decoder(
         shared_embedding=self.shared_embedding,
@@ -462,6 +471,7 @@ class Transformer(nnx.Module):
       decoder_target_mask: jax.Array | None = None,
       kv_caches: list[jax.Array] | None = None,
       attention_metadata: dict[str, Any] | None = None,
+      forced_routed_experts: jnp.ndarray | None = None,
   ):
     """Applies the Zero-1 FSDP wrapped Transformer model.
 
@@ -562,6 +572,7 @@ class Transformer(nnx.Module):
           kv_caches=kv_caches,
           attention_metadata=attention_metadata,
           deepstack_visual_embeds=deepstack_visual_embeds,
+          forced_routed_experts=forced_routed_experts,
       )  # pytype: disable=wrong-keyword-args
       if isinstance(res, tuple) and len(res) == 4:
         logits, hidden_state, kv_caches, expert_indices = res
@@ -569,6 +580,9 @@ class Transformer(nnx.Module):
         logits, hidden_state, kv_caches = res
         expert_indices = None
     else:
+      if forced_routed_experts is not None:
+        raise NotImplementedError(_FORCED_ROUTING_NEEDS_PURE_NNX)
+
       res = self.decoder(
           shared_embedding=self.token_embedder,
           decoder_input_tokens=decoder_input_tokens,

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -1174,7 +1174,9 @@ class Qwen3NextSparseMoeBlock(nnx.Module):
       self.shared_expert = None
       self.shared_expert_gate = None
 
-  def __call__(self, hidden_states: Array, deterministic: bool) -> tuple[Array, Array | None]:
+  def __call__(
+      self, hidden_states: Array, deterministic: bool, forced_routed_experts: jnp.ndarray | None = None
+  ) -> tuple[Array, Array | None]:
     """
     Applies the sparse MoE block to the input hidden states.
 
@@ -1188,7 +1190,7 @@ class Qwen3NextSparseMoeBlock(nnx.Module):
         - The load balancing loss from the routed experts, if applicable during training.
     """
     # 1. Apply the routed experts block.
-    routed_output, load_balance_loss, _ = self.routed_experts(hidden_states)
+    routed_output, load_balance_loss, _ = self.routed_experts(hidden_states, forced_routed_experts=forced_routed_experts)
 
     if not self.use_shared_expert:
       return routed_output, load_balance_loss

--- a/src/maxtext/models/qwen3_5.py
+++ b/src/maxtext/models/qwen3_5.py
@@ -89,12 +89,17 @@ class Qwen3_5ScannableBlock(nnx.Module):
       model_mode: str,
       previous_chunk=None,
       slot: None | int = None,
+      forced_routed_experts: jnp.ndarray | None = None,
   ) -> tuple[Array, None]:
     cfg = self.config
     x = carry
 
     for i in range(cfg.inhomogeneous_layer_cycle_interval):
       layer = getattr(self, f"layer_{i}")
+      # forced_routed_experts, when present, is shaped
+      # [inhomogeneous_layer_cycle_interval, batch, seq, top_k]: one slice per
+      # sub-layer in this cycle (see nnx_decoders.py's scan wiring).
+      layer_forced_routed_experts = forced_routed_experts[i] if forced_routed_experts is not None else None
       x, _ = layer(
           x,
           decoder_segment_ids,
@@ -103,6 +108,7 @@ class Qwen3_5ScannableBlock(nnx.Module):
           model_mode,
           previous_chunk,
           slot,
+          forced_routed_experts=layer_forced_routed_experts,
       )
 
     return x, None
@@ -185,6 +191,7 @@ class Qwen3_5DecoderLayer(nnx.Module):
       slot: None | int = None,
       kv_cache: None | dict[str, Array] = None,
       attention_metadata: None | dict[str, Any] = None,
+      forced_routed_experts: jnp.ndarray | None = None,
   ):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):
@@ -227,7 +234,9 @@ class Qwen3_5DecoderLayer(nnx.Module):
     hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
 
     # Instantiate and call our `Qwen3_5SparseMoEBlock`.
-    mlp_output, load_balance_loss = self.mlp(hidden_states, deterministic=deterministic)
+    mlp_output, load_balance_loss = self.mlp(
+        hidden_states, deterministic=deterministic, forced_routed_experts=forced_routed_experts
+    )
 
     # We sow the load balancing loss so it can be collected and added to the total loss
     # during training.

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -145,6 +145,12 @@ def loss_fn(model, config, data, dropout_rng, params, sparsity_state=None, is_tr
   else:
     for k, v in data.items():
       data[k] = v[: config.micro_batch_size_to_eval_on, :]
+  # Only forward the kwarg when router replay is actually in use, so models
+  # and adapters whose __call__ predates the feature keep working.
+  forced_routing_kwargs = (
+      {"forced_routed_experts": data["forced_routed_experts"]} if "forced_routed_experts" in data else {}
+  )
+
   if is_block_diffusion:
     targets_loss_mask = (data["targets_loss_mask"] != 0) & (data["targets_segmentation"] != 0)
     target_positions = data.get("targets_position", data["inputs_position"])
@@ -209,6 +215,7 @@ def loss_fn(model, config, data, dropout_rng, params, sparsity_state=None, is_tr
         mutable=mutable_collections,
         decoder_target_tokens=data["targets"],
         decoder_target_mask=data["targets_segmentation"],
+        **forced_routing_kwargs,
     )
 
     if (config.use_indexer and not config.indexer_sparse_training) and is_train:
@@ -265,6 +272,7 @@ def loss_fn(model, config, data, dropout_rng, params, sparsity_state=None, is_tr
         enable_dropout=config.enable_dropout if is_train else False,
         decoder_target_tokens=data["targets"],
         decoder_target_mask=data["targets_segmentation"],
+        **forced_routing_kwargs,
     )
     # mtp_losses and mtp_acceptance subclass nnx.Intermediate, and nnx type filters match
     # subclasses. Pop them before the generic Intermediate pop below, which would otherwise

--- a/src/maxtext/training_engine/maxtext_engine.py
+++ b/src/maxtext/training_engine/maxtext_engine.py
@@ -31,6 +31,7 @@ from flax.traverse_util import flatten_dict
 from flax.traverse_util import unflatten_dict
 import jax
 import jax.numpy as jnp
+from jax.typing import ArrayLike  # pylint: disable=g-importing-member
 import numpy as np
 from maxtext.common import common_types
 from maxtext.common import train_state_nnx
@@ -143,6 +144,129 @@ _UNCOMPARABLE_STRUCTURE_HINT = (
     "dtypes, which compare cleanly. Recompilation stays correct, but the cost is now paid "
     "every step, so this is worth reporting rather than living with."
 )
+
+
+@dataclasses.dataclass(kw_only=True)
+class RouterReplayTrainerPayload(abstract_engine.TrainerPayload):
+  """A TrainerPayload extension carrying forced router-replay expert decisions.
+
+  Pairs with `router_replay_gen_model_input_fn` (via `with_gen_model_input_fn`)
+  and `make_router_replay_loss_fn` (via `with_loss_fn`) below to let a caller
+  (e.g. an RL rollout that already computed expert routing decisions) replay
+  them during the forward pass instead of letting the model's gate re-route.
+
+  Attributes:
+    token_ids: Inherited from TrainerPayload; redeclared here (rather than
+      relying only on inheritance) so static-analysis tools that can't
+      introspect tunix's `TrainerPayload` dataclass still resolve these as
+      valid constructor keyword arguments.
+    token_mask: See TrainerPayload.
+    segment_ids: See TrainerPayload.
+    forced_routed_experts: Optional `[batch, seq, top_k]` (or
+      `[batch, seq, num_layers, top_k]` for a distinct routing per layer)
+      array of expert indices to replay, overriding the model's normal top-k
+      routing. `-1` marks a padded/unused slot. See
+      `check_forced_routing_support` in `maxtext.configs.types` for which
+      decoder_blocks accept this.
+  """
+
+  token_ids: ArrayLike
+  token_mask: ArrayLike
+  segment_ids: ArrayLike | None = None
+  forced_routed_experts: ArrayLike | None = None
+
+
+def router_replay_gen_model_input_fn(payload: RouterReplayTrainerPayload) -> dict[str, Any]:
+  """Adapts a RouterReplayTrainerPayload into router_replay_loss_fn's kwargs.
+
+  Output keys are unpacked directly as `loss_fn(model, **kwargs)` by
+  `_fwd_bwd_kernel`, so they must match the loss function's parameter names --
+  they are not nested inside a `data` dict.
+
+  Args:
+    payload: A RouterReplayTrainerPayload (or subclass).
+
+  Returns:
+    `inputs`, `inputs_position`, `inputs_segmentation`, `targets`,
+    `targets_segmentation`, and (when present) `forced_routed_experts`.
+  """
+  token_ids = jnp.asarray(payload.token_ids)
+  token_mask = jnp.asarray(payload.token_mask) if payload.token_mask is not None else jnp.ones_like(token_ids)
+  segment_ids = jnp.asarray(payload.segment_ids) if payload.segment_ids is not None else token_mask
+
+  # TrainerPayload rows are left-padded prompt + right-padded completion, so a
+  # plain arange would give the first real token a nonzero RoPE position and
+  # shift every token relative to the rollout that produced the routing.
+  positions = jnp.maximum(jnp.cumsum(token_mask != 0, axis=-1) - 1, 0).astype(jnp.int32)
+
+  # roll(-1) wraps token 0 into the last position, which is not its real next
+  # token; mask that position out instead of training on the wrap-around. Do
+  # the same wherever a packed segment ends, since the next row belongs to a
+  # different sequence.
+  targets_segmentation = token_mask.at[:, -1].set(0)
+  same_segment = segment_ids[:, :-1] == segment_ids[:, 1:]
+  targets_segmentation = targets_segmentation.at[:, :-1].multiply(same_segment.astype(token_mask.dtype))
+
+  kwargs = {
+      "inputs": token_ids,
+      "inputs_position": positions,
+      "inputs_segmentation": segment_ids,
+      "targets": jnp.roll(token_ids, -1, axis=-1),
+      "targets_segmentation": targets_segmentation,
+  }
+  forced_routed_experts = getattr(payload, "forced_routed_experts", None)
+  if forced_routed_experts is not None:
+    kwargs["forced_routed_experts"] = jnp.asarray(forced_routed_experts)
+  return kwargs
+
+
+def make_router_replay_loss_fn(
+    config: pyconfig.HyperParameters, dropout_rng: jax.Array | None = None
+) -> Callable[..., Any]:
+  """Builds a loss fn with the flat kwarg names router_replay_gen_model_input_fn
+  produces, wrapping train.loss_fn's `(model, config, data, ...)` calling
+  convention so the pair can be used together via `with_gen_model_input_fn` +
+  `with_loss_fn` (see `_fwd_bwd_kernel`'s `loss_callable(mdl, **b)` call).
+
+  Args:
+    config: The MaxText config to pass through to `train.loss_fn`.
+    dropout_rng: Required when `config.enable_dropout` is set.
+
+  Returns:
+    A callable `(model, inputs, inputs_position, inputs_segmentation,
+    targets, targets_segmentation, forced_routed_experts=None)` suitable for
+    `MaxTextTrainingEngine.with_loss_fn`.
+
+  Raises:
+    ValueError: If dropout is enabled but no `dropout_rng` was supplied.
+  """
+  if config.enable_dropout and dropout_rng is None:
+    raise ValueError(
+        "make_router_replay_loss_fn requires a dropout_rng when config.enable_dropout is set; "
+        "pass one, or set enable_dropout=False for router replay."
+    )
+
+  def router_replay_loss_fn(
+      model,
+      inputs,
+      inputs_position,
+      inputs_segmentation,
+      targets,
+      targets_segmentation,
+      forced_routed_experts=None,
+  ):
+    data = {
+        "inputs": inputs,
+        "inputs_position": inputs_position,
+        "inputs_segmentation": inputs_segmentation,
+        "targets": targets,
+        "targets_segmentation": targets_segmentation,
+    }
+    if forced_routed_experts is not None:
+      data["forced_routed_experts"] = forced_routed_experts
+    return maxtext_train.loss_fn(model, config, data, dropout_rng=dropout_rng, params=None, is_train=True)
+
+  return router_replay_loss_fn
 
 
 class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):

--- a/tests/post_training/unit/router_replay_engine_test.py
+++ b/tests/post_training/unit/router_replay_engine_test.py
@@ -1,0 +1,295 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for router-replay (forced routing) support in MaxTextTrainingEngine.
+
+Lives under tests/post_training/ (not tests/unit/) because it imports
+maxtext.training_engine.maxtext_engine, which pulls in tunix -- a dependency
+only installed for post-training test environments. See
+tests/unit/router_replay_test.py for the tunix-independent router-replay
+coverage (moe.py unit tests, scan-support helpers, trainer integration
+tests).
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+import jax
+import pytest
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import Mesh
+
+from maxtext.configs import pyconfig
+from maxtext.models import models
+from maxtext.utils import maxtext_utils
+from maxtext.training_engine import maxtext_engine
+from tests.utils.test_helpers import get_test_config_path
+
+# Without this the file is deselected by every CI job: tests/conftest.py
+# auto-marks it cpu_only, and the cpu/tpu post-training jobs additionally
+# filter on post_training while the unit jobs --ignore tests/post_training.
+pytestmark = [pytest.mark.post_training]
+
+
+def _init_test_cfg(extra_args=(), **kwargs):
+  """pyconfig.initialize with this file's common test defaults folded in."""
+  kwargs.setdefault("enable_checkpointing", False)
+  kwargs.setdefault("log_config", False)
+  kwargs.setdefault("skip_jax_distributed_system", True)
+  return pyconfig.initialize(
+      [sys.argv[0], get_test_config_path(), *extra_args],
+      **kwargs,
+  )
+
+
+def _tiny_qwen35_kwargs(seq_len, batch_size, num_experts, top_k, **overrides):
+  """Base kwargs for a CPU-friendly, shrunk-down Qwen3.5 MoE config."""
+  kwargs = {
+      "override_model_config": True,
+      "model_name": "qwen3.5-35b-a3b",
+      "num_experts": num_experts,
+      "num_experts_per_tok": top_k,
+      "base_emb_dim": 256,
+      "base_num_query_heads": 2,
+      "base_num_kv_heads": 2,
+      "head_dim": 256,
+      "partial_rotary_factor": 0.25,
+      "base_mlp_dim": 256,
+      "base_moe_mlp_dim": 256,
+      "vocab_size": 1000,
+      "max_target_length": seq_len,
+      "max_prefill_predict_length": seq_len,
+      "per_device_batch_size": float(batch_size),
+      "weight_dtype": "bfloat16",
+  }
+  kwargs.update(overrides)
+  return kwargs
+
+
+def _router_replay_cfg(**overrides):
+  """Minimal config for exercising make_router_replay_loss_fn's validation."""
+  return _init_test_cfg(
+      extra_args=["attention=dot_product"],
+      **_tiny_qwen35_kwargs(
+          8,
+          1,
+          4,
+          2,
+          run_name="test_router_replay_loss_fn_factory",
+          base_num_decoder_layers=1,
+          num_decoder_layers=1,
+          scan_layers=False,
+          **overrides,
+      ),
+  )
+
+
+class RouterReplayEngineTest(unittest.TestCase):
+  """Demonstrates that MaxTextTrainingEngine can accept forced router-replay
+  expert decisions (router replay logits) on a TrainerPayload and thread them
+  all the way through to the model's MoE layers via `train.loss_fn`.
+
+  This does not touch the input pipeline: the payload is constructed
+  directly by the caller (e.g. an RL rollout worker), exactly like
+  `TrainerPayload` subclasses are meant to be used. `router_replay_gen_model_input_fn`
+  is the "last-mile adapter" (via `with_gen_model_input_fn`) that maps it into
+  keyword arguments, and `make_router_replay_loss_fn` (via `with_loss_fn`) is
+  the loss function matching those kwarg names, wrapping `train.loss_fn`'s own
+  `(model, config, data, ...)` calling convention.
+  """
+
+  def setUp(self):
+    os.environ["NEW_MODEL_DESIGN"] = "1"
+    os.environ["SKIP_JAX_PRECOMPILE"] = "1"
+
+  def _build_engine(self, cfg, mesh):
+    """Builds a MaxTextTrainingEngine around a real (unmocked) tiny Qwen3.5
+    model, only mocking the checkpoint-loading step of from_pretrained -- the
+    routing/model math itself is entirely real."""
+    real_model = models.Transformer(config=cfg, mesh=mesh, quant=None, model_mode="train", rngs=nnx.Rngs(42))
+    with mock.patch.object(maxtext_engine.model_creation_utils, "from_pretrained", return_value=real_model):
+      engine = maxtext_engine.MaxTextTrainingEngine(cfg, mesh=mesh)
+    return engine
+
+  def test_engine_accepts_router_replay_payload_and_loss_is_finite(self):
+    seq_len, batch_size, top_k = 16, 2, 2
+
+    cfg = _init_test_cfg(
+        extra_args=["attention=flash"],
+        **_tiny_qwen35_kwargs(
+            seq_len,
+            batch_size,
+            num_experts=4,
+            top_k=top_k,
+            run_name="router_replay_engine_test",
+            base_num_decoder_layers=1,
+            num_decoder_layers=1,
+            scan_layers=False,
+        ),
+    )
+    devices_array = maxtext_utils.create_device_mesh(cfg)
+    mesh = Mesh(devices_array, cfg.mesh_axes)
+
+    engine = self._build_engine(cfg, mesh)
+    engine.with_gen_model_input_fn(maxtext_engine.router_replay_gen_model_input_fn)
+    engine.with_loss_fn(maxtext_engine.make_router_replay_loss_fn(cfg))
+
+    tokens = jnp.array([10, 20, 30, 40] * 4, dtype=jnp.int32)[:seq_len]
+    token_ids = jnp.tile(jnp.expand_dims(tokens, axis=0), (batch_size, 1))
+    token_mask = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
+
+    # Synthetic router-replay logits: [batch, seq_len, top_k], with the last
+    # two tokens of every sequence padded (-1) to exercise the same
+    # padding-mask/scatter-safety/NaN-guard code paths as
+    # tests/unit/router_replay_test.py::TrainerRouterReplayTest.
+    forced_routed_experts = jnp.zeros((batch_size, seq_len, top_k), dtype=jnp.int32)
+    forced_routed_experts = forced_routed_experts.at[:, :, 0].set(1)
+    forced_routed_experts = forced_routed_experts.at[:, :, 1].set(3)
+    forced_routed_experts = forced_routed_experts.at[:, -2:, :].set(-1)
+
+    payload = maxtext_engine.RouterReplayTrainerPayload(
+        token_ids=token_ids,
+        token_mask=token_mask,
+        forced_routed_experts=forced_routed_experts,
+    )
+
+    # Sanity check the adapter itself: forced_routed_experts must reach the
+    # kwargs router_replay_loss_fn is called with, unmodified.
+    adapted_batch = maxtext_engine.router_replay_gen_model_input_fn(payload)
+    self.assertIn("forced_routed_experts", adapted_batch)
+    self.assertTrue((adapted_batch["forced_routed_experts"] == forced_routed_experts).all())
+
+    engine.compile(payload)
+    engine.fwd_bwd(payload)
+
+    self.assertEqual(len(engine._cached_losses), 1)  # pylint: disable=protected-access
+    loss = engine._cached_losses[-1]  # pylint: disable=protected-access
+    self.assertIsNotNone(loss)
+    # train.loss_fn's (loss, aux) return is converted to a WeightedMetric by
+    # _fwd_bwd_kernel (aux carries xent_sum/total_weights); .compute() reduces
+    # it back to a scalar, matching how the engine itself reports "loss".
+    if hasattr(loss, "compute"):
+      loss = loss.compute()
+    self.assertFalse(jnp.isnan(loss), "Loss must not be NaN when replaying router expert decisions")
+    print(f"\n[Router Replay Engine] Computed loss with forced routing via MaxTextTrainingEngine: {loss}")
+
+  def test_different_replays_give_different_losses_through_the_engine(self):
+    """Pins the payload -> gen_model_input_fn -> loss_fn -> model chain.
+
+    The finite-loss test above passes even if router_replay_loss_fn drops the
+    key, because the model then just routes normally.
+    """
+    seq_len, batch_size, top_k = 8, 1, 2
+    cfg = _router_replay_cfg()
+    devices_array = maxtext_utils.create_device_mesh(cfg)
+    mesh = Mesh(devices_array, cfg.mesh_axes)
+    engine = self._build_engine(cfg, mesh)
+    engine.with_gen_model_input_fn(maxtext_engine.router_replay_gen_model_input_fn)
+    engine.with_loss_fn(maxtext_engine.make_router_replay_loss_fn(cfg))
+
+    token_ids = jnp.tile(jnp.arange(seq_len, dtype=jnp.int32)[None, :] % 40 + 10, (batch_size, 1))
+    token_mask = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
+
+    def loss_for(first, second):
+      forced = jnp.zeros((batch_size, seq_len, top_k), dtype=jnp.int32)
+      forced = forced.at[:, :, 0].set(first).at[:, :, 1].set(second)
+      payload = maxtext_engine.RouterReplayTrainerPayload(
+          token_ids=token_ids, token_mask=token_mask, forced_routed_experts=forced
+      )
+      engine.compile(payload)
+      engine.fwd_bwd(payload)
+      loss = engine._cached_losses[-1]  # pylint: disable=protected-access
+      return float(loss.compute() if hasattr(loss, "compute") else loss)
+
+    self.assertNotAlmostEqual(
+        loss_for(0, 1),
+        loss_for(2, 3),
+        places=4,
+        msg="two different replays gave the same loss through the engine",
+    )
+
+  def test_gen_model_input_fn_omits_forced_routed_experts_when_absent(self):
+    """When a payload doesn't set forced_routed_experts, the adapter must not
+    inject a `None` value into the batch (train.loss_fn's per-key batch-size
+    decimation loop indexes every value, which would crash on None)."""
+    payload = maxtext_engine.RouterReplayTrainerPayload(
+        token_ids=jnp.ones((1, 4), dtype=jnp.int32),
+        token_mask=jnp.ones((1, 4), dtype=jnp.int32),
+    )
+    batch = maxtext_engine.router_replay_gen_model_input_fn(payload)
+    self.assertNotIn("forced_routed_experts", batch)
+
+  def test_last_position_is_masked_out_of_the_loss(self):
+    """`targets` is a roll(-1) of `token_ids`, so the final position's target is
+    the wrapped-around first token, not a real next token. It must be masked,
+    without disturbing the caller's own padding mask."""
+    seq_len = 4
+    ids = jnp.arange(seq_len, dtype=jnp.int32)[None, :]
+
+    unpadded = maxtext_engine.router_replay_gen_model_input_fn(
+        maxtext_engine.RouterReplayTrainerPayload(token_ids=ids, token_mask=jnp.ones((1, seq_len), dtype=jnp.int32))
+    )
+    # roll(-1) really does wrap token 0 into the last slot, and that slot must
+    # not contribute to the loss while every earlier position still does.
+    self.assertEqual(int(unpadded["targets"][0, -1]), 0)
+    self.assertEqual(unpadded["targets_segmentation"].tolist(), [[1, 1, 1, 0]])
+
+    padded = maxtext_engine.router_replay_gen_model_input_fn(
+        maxtext_engine.RouterReplayTrainerPayload(token_ids=ids, token_mask=jnp.array([[1, 1, 0, 0]], dtype=jnp.int32))
+    )
+    # Position 1 is dropped too: its roll(-1) target is ids[2], a pad token, so
+    # the token_mask alone over-counts the trainable positions by one.
+    self.assertEqual(padded["targets_segmentation"].tolist(), [[1, 0, 0, 0]])
+
+  def test_positions_respect_left_padding(self):
+    """TrainerPayload rows are left-padded, so a plain arange would shift every
+    real token's RoPE position relative to the rollout that produced the
+    routing."""
+    token_ids = jnp.array([[0, 0, 5, 6, 7]], dtype=jnp.int32)
+    token_mask = jnp.array([[0, 0, 1, 1, 1]], dtype=jnp.int32)
+    batch = maxtext_engine.router_replay_gen_model_input_fn(
+        maxtext_engine.RouterReplayTrainerPayload(token_ids=token_ids, token_mask=token_mask)
+    )
+    # The first real token must start at position 0, not at 2.
+    self.assertEqual(batch["inputs_position"].tolist(), [[0, 0, 0, 1, 2]])
+
+  def test_packed_segment_boundaries_are_masked(self):
+    """roll(-1) makes the last token of a packed segment predict the first
+    token of the next one; that position must not contribute to the loss."""
+    token_ids = jnp.arange(6, dtype=jnp.int32)[None, :]
+    token_mask = jnp.ones((1, 6), dtype=jnp.int32)
+    segment_ids = jnp.array([[1, 1, 1, 2, 2, 2]], dtype=jnp.int32)
+    batch = maxtext_engine.router_replay_gen_model_input_fn(
+        maxtext_engine.RouterReplayTrainerPayload(token_ids=token_ids, token_mask=token_mask, segment_ids=segment_ids)
+    )
+    # Index 2 is the last token of segment 1, index 5 is the wrap-around.
+    self.assertEqual(batch["targets_segmentation"].tolist(), [[1, 1, 0, 1, 1, 0]])
+
+  def test_loss_fn_factory_validates_dropout_rng(self):
+    with self.assertRaisesRegex(ValueError, "dropout_rng"):
+      maxtext_engine.make_router_replay_loss_fn(_router_replay_cfg(enable_dropout=True))
+    # Supplying one clears the guard.
+    self.assertTrue(
+        callable(
+            maxtext_engine.make_router_replay_loss_fn(
+                _router_replay_cfg(enable_dropout=True), dropout_rng=jax.random.PRNGKey(0)
+            )
+        )
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/post_training/unit/tunix_adapter_test.py
+++ b/tests/post_training/unit/tunix_adapter_test.py
@@ -40,10 +40,11 @@ class _CallableStubBase:
     self.config = SimpleNamespace(model_name=_STUB_MODEL_NAME)
     self.captured = {}
 
-  def __call__(self, *, decoder_input_tokens, decoder_positions, decoder_segment_ids):
+  def __call__(self, *, decoder_input_tokens, decoder_positions, decoder_segment_ids, forced_routed_experts=None):
     self.captured["decoder_input_tokens"] = decoder_input_tokens
     self.captured["decoder_positions"] = decoder_positions
     self.captured["decoder_segment_ids"] = decoder_segment_ids
+    self.captured["forced_routed_experts"] = forced_routed_experts
     # Return dummy logits shaped [B, L, V=2] so the adapter has something to forward.
     b, l = decoder_input_tokens.shape
     return jnp.zeros((b, l, 2), dtype=jnp.float32)
@@ -114,6 +115,28 @@ class TunixAdapterSegmentIdsTest(unittest.TestCase):
     adapter(input_tokens, positions, None, None, decoder_segment_ids=explicit_seg)
 
     np.testing.assert_array_equal(np.asarray(self.base.captured["decoder_segment_ids"]), np.asarray(explicit_seg))
+
+  def test_forwards_forced_routed_experts(self):
+    """The stub captures the kwarg but nothing asserted on it, so deleting the
+    forwarding from the adapter would have passed CI."""
+    adapter = TunixMaxTextAdapter(base_model=self.base, pad_id=99)
+
+    input_tokens = jnp.array([[10, 11, 12, 99, 99]], dtype=jnp.int32)
+    positions = jnp.arange(5, dtype=jnp.int32)[None, :]
+    forced = jnp.zeros((1, 5, 2), dtype=jnp.int32)
+
+    adapter(input_tokens, positions, None, None, forced_routed_experts=forced)
+
+    np.testing.assert_array_equal(np.asarray(self.base.captured["forced_routed_experts"]), np.asarray(forced))
+
+  def test_omits_forced_routed_experts_by_default(self):
+    adapter = TunixMaxTextAdapter(base_model=self.base, pad_id=99)
+    input_tokens = jnp.array([[10, 11, 12, 99, 99]], dtype=jnp.int32)
+    positions = jnp.arange(5, dtype=jnp.int32)[None, :]
+
+    adapter(input_tokens, positions, None, None)
+
+    self.assertIsNone(self.base.captured["forced_routed_experts"])
 
   def test_returns_logits_and_none_tuple(self):
     """Adapter's __call__ contract: return (logits, None) to match Tunix's

--- a/tests/unit/router_replay_test.py
+++ b/tests/unit/router_replay_test.py
@@ -1,0 +1,1217 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for router replay (forced routing): unit tests for moe.py's
+forced_routed_experts handling, the scan-support helpers, and end-to-end
+trainer integration tests.
+
+MaxTextTrainingEngine integration lives separately in
+tests/post_training/unit/router_replay_engine_test.py, since it imports
+maxtext.training_engine.maxtext_engine, which pulls in tunix -- a dependency
+only installed for post-training test environments, not the pretrain-unit
+environment this file runs under.
+"""
+
+import os
+import sys
+import unittest
+
+import jax
+import jax.numpy as jnp
+import pytest
+from jax.sharding import Mesh
+from flax import nnx
+from flax.linen import partitioning as nn_partitioning
+
+from maxtext.layers import moe
+from maxtext.layers.initializers import nd_dense_init
+from maxtext.layers.nnx_decoders import reshape_forced_routed_experts_for_scan
+from maxtext.configs.types import check_forced_routing_support
+from maxtext.configs import pyconfig
+from maxtext.models import models
+from maxtext.utils import maxtext_utils
+from maxtext.trainers.pre_train import train
+from maxtext.common import common_types as ctypes
+from tests.utils.test_helpers import get_test_config_path
+
+
+def _init_test_cfg(extra_args=(), **kwargs):
+  """pyconfig.initialize with this file's common test defaults folded in.
+
+  Only pass kwargs that actually need to differ from base.yml (or from the
+  selected model's own yaml) -- e.g. omit ici_*_parallelism, enable_nnx,
+  pure_nnx, pure_nnx_decoder, sparse_matmul, dtype, and scan_layers=True,
+  which already match their base.yml defaults.
+  """
+  kwargs.setdefault("enable_checkpointing", False)
+  kwargs.setdefault("log_config", False)
+  kwargs.setdefault("skip_jax_distributed_system", True)
+  return pyconfig.initialize(
+      [sys.argv[0], get_test_config_path(), *extra_args],
+      **kwargs,
+  )
+
+
+def _tiny_qwen35_kwargs(seq_len, batch_size, num_experts, top_k, **overrides):
+  """Base kwargs for a CPU-friendly, shrunk-down Qwen3.5 MoE config."""
+  kwargs = {
+      "override_model_config": True,
+      "model_name": "qwen3.5-35b-a3b",
+      "num_experts": num_experts,
+      "num_experts_per_tok": top_k,
+      "base_emb_dim": 256,
+      "base_num_query_heads": 2,
+      "base_num_kv_heads": 2,
+      "head_dim": 256,
+      "partial_rotary_factor": 0.25,
+      "base_mlp_dim": 256,
+      "base_moe_mlp_dim": 256,
+      "vocab_size": 1000,
+      "max_target_length": seq_len,
+      "max_prefill_predict_length": seq_len,
+      "per_device_batch_size": float(batch_size),
+      "weight_dtype": "bfloat16",
+  }
+  kwargs.update(overrides)
+  return kwargs
+
+
+class DummyConfig:
+  """Minimal stand-in for MaxTextConfig, for direct RoutedMoE method calls."""
+
+  def __init__(self, model_name="default", decoder_block=ctypes.DecoderBlockType.DEFAULT):
+    self.model_name = model_name
+    self.decoder_block = decoder_block
+    self.norm_topk_prob = False
+    self.use_random_routing = False
+    self.shard_mode = ctypes.ShardMode.AUTO
+    self.routed_score_func = ""
+    self.routed_scaling_factor = 2.5
+    self.model_call_mode = "train"
+    self.fuse_expert_scales = False
+    self.n_routing_groups = -1
+    self.topk_routing_group = 1
+
+
+class DummyRoutedMoE:
+  """Minimal stand-in for RoutedMoE, for calling its methods unbound."""
+
+  def __init__(self, config, per_expert_scale=None):
+    self.config = config
+    self.dtype = jnp.float32
+    self.num_experts_per_tok = 2
+    self.num_experts = 3
+    self.is_hash_routing = False
+    self.per_expert_scale = None if per_expert_scale is None else nnx.Param(jnp.asarray(per_expert_scale))
+
+  def _maybe_shard_with_logical(self, x, spec):
+    return x
+
+  def deepseek_scale_weights(self, weights):
+    return moe.RoutedMoE.deepseek_scale_weights(self, weights)
+
+  def deepseek_routing(self, gate_logits, pre_bias_logits):
+    return moe.RoutedMoE.deepseek_routing(self, gate_logits, pre_bias_logits)
+
+  def get_topk_indices(self, *args, **kwargs):
+    return moe.RoutedMoE.get_topk_indices(self, *args, **kwargs)
+
+  def get_topk(self, *args, **kwargs):
+    return moe.RoutedMoE.get_topk(self, *args, **kwargs)
+
+
+class ForcedRoutingTest(unittest.TestCase):
+
+  def test_basic_override(self):
+    config = DummyConfig()
+    model = DummyRoutedMoE(config)
+
+    gate_logits = jnp.array([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]])  # (1, 2, 3)
+    pre_bias_logits = gate_logits  # Not DeepSeek
+    forced_routed_experts = jnp.array([[[2, 1], [0, 2]]])  # (1, 2, 2)
+
+    top_k_weights, top_k_indices = moe.RoutedMoE.get_topk(
+        model, gate_logits, pre_bias_logits, forced_routed_experts=forced_routed_experts
+    )
+
+    # Check that indices are overridden
+    self.assertTrue((top_k_indices == forced_routed_experts).all())
+    # Check that weights are extracted correctly and softmaxed
+    # For token 0: indices 2, 1 -> logits 3.0, 2.0 -> softmax([3.0, 2.0])
+    # For token 1: indices 0, 2 -> logits 4.0, 6.0 -> softmax([4.0, 6.0])
+    expected_weights = jax.nn.softmax(jnp.array([[[3.0, 2.0], [4.0, 6.0]]]).astype(jnp.float32), axis=-1)
+    self.assertTrue(jax.numpy.allclose(top_k_weights, expected_weights, rtol=1e-5, atol=1e-5))
+
+  def test_gemma4_softmax(self):
+    config = DummyConfig(decoder_block=ctypes.DecoderBlockType.GEMMA4)
+    model = DummyRoutedMoE(config)
+
+    gate_logits = jnp.array([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]])  # (1, 2, 3)
+    pre_bias_logits = gate_logits
+    forced_routed_experts = jnp.array([[[2, 1], [0, 2]]])  # (1, 2, 2)
+
+    top_k_weights, top_k_indices = moe.RoutedMoE.get_topk(
+        model, gate_logits, pre_bias_logits, forced_routed_experts=forced_routed_experts
+    )
+
+    # Check that indices are overridden
+    self.assertTrue((top_k_indices == forced_routed_experts).all())
+
+    # For Gemma 4, it applies softmax to gate_logits first!
+
+    expected_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1)
+    expected_weights = jnp.take_along_axis(expected_probs, forced_routed_experts, axis=-1)
+
+    self.assertTrue(jax.numpy.allclose(top_k_weights, expected_weights, rtol=1e-5, atol=1e-5))
+
+  def test_reshape_and_update_weights(self):
+    config = DummyConfig()
+    model = DummyRoutedMoE(config)
+
+    weights = jnp.array([[[0.1, 0.2], [0.3, 0.4]]])  # (1, 2, 2)
+    indices = jnp.array([[[2, -1], [-1, 1]]])  # (1, 2, 2)
+
+    update_weights = moe.RoutedMoE.reshape_and_update_weights(model, weights, indices, safe_updates=True)
+
+    # Expected shape: (1, 2, 3) where 3 is num_experts!
+    # For token 0: index 2 -> 0.1. Index -1 -> mapped to 0 but weight 0.0!
+    # So for expert 0: 0.0. Expert 1: 0.0. Expert 2: 0.1.
+    # For token 1: index -1 -> mapped to 0 but weight 0.0! Index 1 -> 0.4.
+    # So for expert 0: 0.0. Expert 1: 0.4. Expert 2: 0.0.
+    expected_update_weights = jnp.array([[[0.0, 0.0, 0.1], [0.0, 0.4, 0.0]]])
+
+    self.assertTrue(jax.numpy.allclose(update_weights, expected_update_weights, rtol=1e-5, atol=1e-5))
+
+  def test_reshape_and_update_weights_duplicate_indices_use_add_not_set(self):
+    """A regression test for the `.set()` -> `.add()` scatter-safety fix.
+
+    Forced-routing replay can legitimately produce duplicate expert indices
+    for the same token (e.g. two padding slots, which both remap to dummy
+    index 0). `.set()` has undefined behavior for duplicate scatter indices,
+    so we must use `.add()`. Since both duplicate slots carry a real,
+    nonzero weight here, `.add()` and `.set()` produce different, checkable
+    results: `.add()` sums to the total, `.set()` would keep only one.
+    """
+    config = DummyConfig()
+    model = DummyRoutedMoE(config)
+
+    # Token 0 has expert index 1 selected twice with different weights.
+    weights = jnp.array([[[0.3, 0.7]]])  # (1, 1, 2)
+    indices = jnp.array([[[1, 1]]])  # (1, 1, 2)
+
+    update_weights = moe.RoutedMoE.reshape_and_update_weights(model, weights, indices, safe_updates=True)
+
+    # `.add()` must sum both contributions at expert index 1.
+    expected_update_weights = jnp.array([[[0.0, 1.0, 0.0]]])
+    self.assertTrue(jax.numpy.allclose(update_weights, expected_update_weights, rtol=1e-5, atol=1e-5))
+
+
+class CheckForcedRoutingSupportTest(unittest.TestCase):
+  """Regression tests for the decoder_block validation gate: forced routing
+  is supported (scanned or not) only for a fixed set of decoder_blocks."""
+
+  def test_supported_decoder_blocks_are_allowed(self):
+    for decoder_block in (
+        ctypes.DecoderBlockType.QWEN3_5,
+        ctypes.DecoderBlockType.MIXTRAL,
+        ctypes.DecoderBlockType.GEMMA4,
+    ):
+      check_forced_routing_support(decoder_block)  # must not raise
+
+  def test_unsupported_decoder_blocks_raise(self):
+    for decoder_block in (
+        ctypes.DecoderBlockType.QWEN3_MOE,
+        ctypes.DecoderBlockType.QWEN3_NEXT,
+        ctypes.DecoderBlockType.LLAMA4,
+        ctypes.DecoderBlockType.ENVY,
+        ctypes.DecoderBlockType.DEEPSEEK,
+        ctypes.DecoderBlockType.DEEPSEEK4,
+        ctypes.DecoderBlockType.DEFAULT,
+    ):
+      with self.assertRaises(NotImplementedError):
+        check_forced_routing_support(decoder_block)
+
+
+class UnsupportedConfigGuardTest(unittest.TestCase):
+  """Configurations forced routing rejects must fail loudly, not silently
+  drop the replayed routing and train on normally-routed tokens."""
+
+  def setUp(self):
+    os.environ["NEW_MODEL_DESIGN"] = "1"
+    os.environ["SKIP_JAX_PRECOMPILE"] = "1"
+    self.seq_len, self.batch_size, self.top_k = 8, 1, 2
+
+  def _run(self, **overrides):
+    """Builds a tiny model and applies it with forced routing enabled."""
+    cfg = _init_test_cfg(
+        extra_args=["attention=dot_product"],
+        **_tiny_qwen35_kwargs(
+            self.seq_len,
+            self.batch_size,
+            4,
+            self.top_k,
+            run_name="test_router_replay_guard",
+            base_num_decoder_layers=1,
+            num_decoder_layers=1,
+            **overrides,
+        ),
+    )
+    mesh = Mesh(maxtext_utils.create_device_mesh(cfg), cfg.mesh_axes)
+    ids = jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32)
+    positions = jnp.arange(self.seq_len, dtype=jnp.int32)[None, :]
+    segmentation = jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32)
+    forced = jnp.zeros((self.batch_size, self.seq_len, self.top_k), dtype=jnp.int32)
+
+    model = models.transformer_as_linen(config=cfg, mesh=mesh, quant=None, model_mode="train")
+    params = model.init(
+        {"params": jax.random.PRNGKey(0), "dropout": jax.random.PRNGKey(1)},
+        ids,
+        positions,
+        segmentation,
+        enable_dropout=False,
+    )
+    return model.apply(params, ids, positions, segmentation, enable_dropout=False, forced_routed_experts=forced)
+
+  def test_linen_decoder_rejects_forced_routing(self):
+    with self.assertRaisesRegex(NotImplementedError, "pure-NNX decoder"):
+      self._run(scan_layers=False, pure_nnx_decoder=False)
+
+  def test_linen_decoder_without_forced_routing_still_works(self):
+    """The guard must not break the Linen path when replay is unused."""
+    cfg = _init_test_cfg(
+        extra_args=["attention=dot_product"],
+        **_tiny_qwen35_kwargs(
+            self.seq_len,
+            self.batch_size,
+            4,
+            self.top_k,
+            run_name="test_router_replay_guard_linen_ok",
+            base_num_decoder_layers=1,
+            num_decoder_layers=1,
+            scan_layers=False,
+            pure_nnx_decoder=False,
+        ),
+    )
+    mesh = Mesh(maxtext_utils.create_device_mesh(cfg), cfg.mesh_axes)
+    ids = jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32)
+    positions = jnp.arange(self.seq_len, dtype=jnp.int32)[None, :]
+    segmentation = jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32)
+    model = models.transformer_as_linen(config=cfg, mesh=mesh, quant=None, model_mode="train")
+    params = model.init(
+        {"params": jax.random.PRNGKey(0), "dropout": jax.random.PRNGKey(1)},
+        ids,
+        positions,
+        segmentation,
+        enable_dropout=False,
+    )
+    self.assertIsNotNone(params)
+
+  def test_gemma4_scanned_rejects_forced_routing(self):
+    cfg = _init_test_cfg(
+        extra_args=["attention=dot_product"],
+        override_model_config=True,
+        model_name="gemma4-26b",
+        num_experts=4,
+        num_experts_per_tok=self.top_k,
+        base_emb_dim=256,
+        base_num_query_heads=2,
+        base_num_kv_heads=2,
+        head_dim=128,
+        base_mlp_dim=256,
+        base_moe_mlp_dim=256,
+        vocab_size=1000,
+        max_target_length=self.seq_len,
+        max_prefill_predict_length=self.seq_len,
+        per_device_batch_size=float(self.batch_size),
+        weight_dtype="bfloat16",
+        run_name="test_router_replay_guard_gemma4_scan",
+        base_num_decoder_layers=2,
+        num_decoder_layers=2,
+        scan_layers=True,
+    )
+    mesh = Mesh(maxtext_utils.create_device_mesh(cfg), cfg.mesh_axes)
+    ids = jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32)
+    positions = jnp.arange(self.seq_len, dtype=jnp.int32)[None, :]
+    segmentation = jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32)
+    forced = jnp.zeros((self.batch_size, self.seq_len, self.top_k), dtype=jnp.int32)
+    model = models.transformer_as_linen(config=cfg, mesh=mesh, quant=None, model_mode="train")
+    params = model.init(
+        {"params": jax.random.PRNGKey(0), "dropout": jax.random.PRNGKey(1)},
+        ids,
+        positions,
+        segmentation,
+        enable_dropout=False,
+    )
+    with self.assertRaisesRegex(NotImplementedError, "GEMMA4"):
+      model.apply(params, ids, positions, segmentation, enable_dropout=False, forced_routed_experts=forced)
+
+
+class ReshapeForcedRoutedExpertsForScanTest(unittest.TestCase):
+  """Regression tests for the scan-xs reshape used to support forced routing
+  with scan_layers=True (see check_forced_routing_support in configs/types.py
+  for which decoder_blocks)."""
+
+  def test_4d_input_preserves_per_layer_values_in_scan_order(self):
+    """Homogeneous-MoE case (e.g. QWEN3_5): every sub-layer in the cycle is
+    MoE, so layers_per_cycle == cycle_interval and num_layers ==
+    num_decoder_layers."""
+    num_decoder_layers = 8
+    cycle_interval = 4
+    scan_length = num_decoder_layers // cycle_interval
+    batch, seq, top_k = 2, 3, 2
+
+    # [batch, seq, num_layers, top_k], where every entry for layer L is L.
+    layer_ids = jnp.arange(num_decoder_layers, dtype=jnp.int32)
+    forced_routed_experts = jnp.broadcast_to(layer_ids[None, None, :, None], (batch, seq, num_decoder_layers, top_k))
+
+    scanned = reshape_forced_routed_experts_for_scan(
+        forced_routed_experts,
+        num_layers=num_decoder_layers,
+        scan_length=scan_length,
+        layers_per_cycle=cycle_interval,
+    )
+
+    self.assertEqual(scanned.shape, (scan_length, cycle_interval, batch, seq, top_k))
+    # Layer L must land at scanned[L // cycle_interval, L % cycle_interval],
+    # since jax.lax.scan slices axis 0 (scan_length) automatically per outer
+    # iteration, then the ScannableBlock's static loop indexes axis 0 of the
+    # remaining [cycle_interval, ...] chunk by sub-layer position.
+    for layer in range(num_decoder_layers):
+      cycle_idx, sub_idx = divmod(layer, cycle_interval)
+      self.assertTrue((scanned[cycle_idx, sub_idx] == layer).all(), f"layer {layer} landed in the wrong scan slot")
+
+  def test_3d_input_broadcasts_same_routing_to_every_layer(self):
+    num_layers = 4
+    layers_per_cycle = 4
+    scan_length = num_layers // layers_per_cycle
+    batch, seq, top_k = 1, 2, 2
+
+    forced_routed_experts = jnp.array([[[1, 3], [0, 2]]])  # [batch, seq, top_k]
+
+    scanned = reshape_forced_routed_experts_for_scan(
+        forced_routed_experts,
+        num_layers=num_layers,
+        scan_length=scan_length,
+        layers_per_cycle=layers_per_cycle,
+    )
+
+    self.assertEqual(scanned.shape, (scan_length, layers_per_cycle, batch, seq, top_k))
+    for sub_idx in range(layers_per_cycle):
+      self.assertTrue((scanned[0, sub_idx] == forced_routed_experts).all())
+
+  def test_rejects_unexpected_ndim(self):
+    """Only 3D ([batch, seq, top_k]) or 4D ([batch, seq, num_layers,
+    top_k]) forced_routed_experts are valid; anything else (a caller bug,
+    e.g. an unbatched or over-batched array) must raise, not silently
+    misroute or crash deeper in the stack."""
+    for bad_shape in ((4,), (2, 4), (2, 4, 8, 2, 1)):  # ndim 1, 2, 5
+      with self.assertRaises(ValueError):
+        reshape_forced_routed_experts_for_scan(
+            jnp.zeros(bad_shape, dtype=jnp.int32),
+            num_layers=4,
+            scan_length=1,
+            layers_per_cycle=4,
+        )
+
+
+class TrainerRouterReplayTest(unittest.TestCase):
+  """Integration tests: forced routing threaded end-to-end through
+  train.loss_fn, both unscanned and scanned, across every architecture that
+  supports it (see check_forced_routing_support in configs/types.py)."""
+
+  def setUp(self):
+    os.environ["NEW_MODEL_DESIGN"] = "1"
+    os.environ["SKIP_JAX_PRECOMPILE"] = "1"
+
+  def _assert_forced_routing_loss_finite(self, cfg, seq_len, batch_size, forced_experts, label):
+    """Builds a real model for `cfg`, runs train.loss_fn with a batch carrying
+    `forced_experts`, and asserts the resulting loss is finite."""
+    devices_array = maxtext_utils.create_device_mesh(cfg)
+    mesh = Mesh(devices_array, cfg.mesh_axes)
+    rng = jax.random.PRNGKey(42)
+
+    tokens = jnp.array(([10, 20, 30, 40] * ((seq_len // 4) + 1))[:seq_len], dtype=jnp.int32)
+    inputs = jnp.tile(jnp.expand_dims(tokens, axis=0), (batch_size, 1))
+    positions = jnp.tile(jnp.expand_dims(jnp.arange(seq_len, dtype=jnp.int32), axis=0), (batch_size, 1))
+    segmentation = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
+    targets = jnp.roll(inputs, -1, axis=-1)
+
+    data_batch = {
+        "inputs": inputs,
+        "inputs_position": positions,
+        "inputs_segmentation": segmentation,
+        "targets": targets,
+        "targets_segmentation": segmentation,
+        "forced_routed_experts": forced_experts,
+    }
+
+    model = models.transformer_as_linen(config=cfg, mesh=mesh, quant=None, model_mode="train")
+    init_params_rng, init_dropout_rng = jax.random.split(rng)
+    params = model.init(
+        {"params": init_params_rng, "dropout": init_dropout_rng},
+        inputs,
+        positions,
+        segmentation,
+        enable_dropout=False,
+    )
+
+    loss, aux = train.loss_fn(
+        model,
+        cfg,
+        data_batch,
+        dropout_rng=init_dropout_rng,
+        params=params,
+        is_train=True,
+    )
+
+    self.assertIsNotNone(loss)
+    self.assertFalse(jnp.isnan(loss), "Loss must not be NaN")
+    print(f"\n[Trainer Router Replay][{label}] Computed loss with forced routing + padding: {loss}")
+    return loss, aux
+
+  def _loss_for_routing(self, cfg, seq_len, batch_size, forced_experts):
+    """train.loss_fn for one routing, reusing fixed params so losses compare."""
+    mesh = Mesh(maxtext_utils.create_device_mesh(cfg), cfg.mesh_axes)
+    tokens = jnp.array(([10, 20, 30, 40] * ((seq_len // 4) + 1))[:seq_len], dtype=jnp.int32)
+    inputs = jnp.tile(jnp.expand_dims(tokens, axis=0), (batch_size, 1))
+    positions = jnp.tile(jnp.expand_dims(jnp.arange(seq_len, dtype=jnp.int32), axis=0), (batch_size, 1))
+    segmentation = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
+
+    model = models.transformer_as_linen(config=cfg, mesh=mesh, quant=None, model_mode="train")
+    params_rng, dropout_rng = jax.random.split(jax.random.PRNGKey(42))
+    params = model.init(
+        {"params": params_rng, "dropout": dropout_rng}, inputs, positions, segmentation, enable_dropout=False
+    )
+
+    data_batch = {
+        "inputs": inputs,
+        "inputs_position": positions,
+        "inputs_segmentation": segmentation,
+        "targets": jnp.roll(inputs, -1, axis=-1),
+        "targets_segmentation": segmentation,
+    }
+    if forced_experts is not None:
+      data_batch["forced_routed_experts"] = forced_experts
+    loss, _ = train.loss_fn(model, cfg, data_batch, dropout_rng=dropout_rng, params=params, is_train=True)
+    return float(loss)
+
+  def _assert_routing_is_load_bearing(self, cfg, seq_len, batch_size, forced_a, forced_b, label):
+    """Two different replays must give two different losses.
+
+    Every "loss is finite" assertion in this class also passes when
+    forced_routed_experts is silently dropped anywhere along the chain from
+    train.loss_fn down to RoutedMoE.get_topk, because the model just routes
+    normally. This is the assertion that actually pins the plumbing.
+    """
+    loss_a = self._loss_for_routing(cfg, seq_len, batch_size, forced_a)
+    loss_b = self._loss_for_routing(cfg, seq_len, batch_size, forced_b)
+    loss_none = self._loss_for_routing(cfg, seq_len, batch_size, None)
+    print(f"\n[Router Replay][{label}] a={loss_a} b={loss_b} unforced={loss_none}")
+    self.assertNotAlmostEqual(loss_a, loss_b, places=4, msg=f"[{label}] two different replays gave the same loss")
+    self.assertNotAlmostEqual(loss_a, loss_none, places=4, msg=f"[{label}] replay matched the unforced loss")
+
+  def test_loss_fn_with_forced_routed_experts(self):
+    seq_len, batch_size, top_k, num_experts = 16, 2, 2, 4
+    cfg = _init_test_cfg(
+        extra_args=["attention=flash"],
+        **_tiny_qwen35_kwargs(
+            seq_len,
+            batch_size,
+            num_experts,
+            top_k,
+            run_name="test_trainer_router_replay",
+            base_num_decoder_layers=1,
+            num_decoder_layers=1,
+            scan_layers=False,
+        ),
+    )
+
+    # Synthetic forced routed experts: [batch, seq_len, top_k]
+    forced_experts = jnp.zeros((batch_size, seq_len, top_k), dtype=jnp.int32)
+    forced_experts = forced_experts.at[:, :, 0].set(1)
+    forced_experts = forced_experts.at[:, :, 1].set(3)
+    # Mark the last two tokens of every sequence as padding (-1) in every
+    # expert slot, exercising the padding-mask/scatter-safety/NaN-guard code
+    # paths end-to-end, not just in isolated unit tests.
+    forced_experts = forced_experts.at[:, -2:, :].set(-1)
+
+    self._assert_forced_routing_loss_finite(cfg, seq_len, batch_size, forced_experts, "qwen3.5")
+
+  def _qwen35_cfg(self, seq_len, batch_size, num_experts, top_k, run_name, **overrides):
+    return _init_test_cfg(
+        extra_args=["attention=dot_product"],
+        **_tiny_qwen35_kwargs(
+            seq_len,
+            batch_size,
+            num_experts,
+            top_k,
+            run_name=run_name,
+            weight_dtype="float32",
+            dtype="float32",
+            **overrides,
+        ),
+    )
+
+  def test_different_replays_give_different_losses_unscanned(self):
+    seq_len, batch_size, top_k, num_experts = 8, 1, 2, 4
+    cfg = self._qwen35_cfg(
+        seq_len,
+        batch_size,
+        num_experts,
+        top_k,
+        "test_router_replay_differential",
+        base_num_decoder_layers=1,
+        num_decoder_layers=1,
+        scan_layers=False,
+    )
+    a = jnp.tile(jnp.array([0, 1], jnp.int32), (batch_size, seq_len, 1))
+    b = jnp.tile(jnp.array([2, 3], jnp.int32), (batch_size, seq_len, 1))
+    self._assert_routing_is_load_bearing(cfg, seq_len, batch_size, a, b, "qwen3.5 unscanned")
+
+  def test_per_layer_routing_is_not_broadcast_unscanned(self):
+    """4D per-layer replay must land layer L's routing on layer L.
+
+    Reversing the layer axis has to change the loss; if the slicing collapsed
+    to a broadcast of one layer, both orders would agree.
+    """
+    seq_len, batch_size, top_k, num_experts, layers = 8, 1, 2, 4, 2
+    cfg = self._qwen35_cfg(
+        seq_len,
+        batch_size,
+        num_experts,
+        top_k,
+        "test_router_replay_per_layer_unscanned",
+        base_num_decoder_layers=layers,
+        num_decoder_layers=layers,
+        scan_layers=False,
+    )
+    per_layer = jnp.stack(
+        [jnp.full((batch_size, seq_len, top_k), 0, jnp.int32), jnp.full((batch_size, seq_len, top_k), 3, jnp.int32)],
+        axis=2,
+    )
+    self._assert_routing_is_load_bearing(
+        cfg, seq_len, batch_size, per_layer, per_layer[:, :, ::-1, :], "qwen3.5 unscanned per-layer"
+    )
+
+  def test_per_layer_routing_is_not_broadcast_scanned(self):
+    """Same, through jax.lax.scan's xs -- the path that reshapes to
+    [scan_length, layers_per_cycle, ...]."""
+    seq_len, batch_size, top_k, num_experts = 8, 1, 2, 4
+    cycle_interval, layers = 2, 4
+    cfg = self._qwen35_cfg(
+        seq_len,
+        batch_size,
+        num_experts,
+        top_k,
+        "test_router_replay_per_layer_scanned",
+        base_num_decoder_layers=layers,
+        num_decoder_layers=layers,
+        inhomogeneous_layer_cycle_interval=cycle_interval,
+    )
+    layer_ids = jnp.arange(layers, dtype=jnp.int32) % num_experts
+    per_layer = jnp.broadcast_to(layer_ids[None, None, :, None], (batch_size, seq_len, layers, top_k))
+    self._assert_routing_is_load_bearing(
+        cfg, seq_len, batch_size, per_layer, per_layer[:, :, ::-1, :], "qwen3.5 scanned per-layer"
+    )
+
+  def test_loss_fn_with_forced_routed_experts_gemma4(self):
+    """Gemma4 is supported unscanned only (its scanned path raises), and it is
+    the one supported block that derives weights from softmaxed gate logits
+    rather than the raw ones."""
+    seq_len, batch_size, top_k, num_experts = 16, 2, 2, 4
+    cfg = _init_test_cfg(
+        extra_args=["attention=dot_product"],
+        override_model_config=True,
+        model_name="gemma4-26b",
+        num_experts=num_experts,
+        num_experts_per_tok=top_k,
+        base_emb_dim=256,
+        base_num_query_heads=2,
+        base_num_kv_heads=2,
+        head_dim=128,
+        base_mlp_dim=256,
+        base_moe_mlp_dim=256,
+        vocab_size=1000,
+        max_target_length=seq_len,
+        max_prefill_predict_length=seq_len,
+        per_device_batch_size=float(batch_size),
+        weight_dtype="bfloat16",
+        run_name="test_trainer_router_replay_gemma4",
+        base_num_decoder_layers=1,
+        num_decoder_layers=1,
+        scan_layers=False,
+    )
+
+    forced_experts = jnp.zeros((batch_size, seq_len, top_k), dtype=jnp.int32)
+    forced_experts = forced_experts.at[:, :, 0].set(1)
+    forced_experts = forced_experts.at[:, :, 1].set(3)
+    forced_experts = forced_experts.at[:, -2:, :].set(-1)
+
+    self._assert_forced_routing_loss_finite(cfg, seq_len, batch_size, forced_experts, "gemma4")
+
+  def test_loss_fn_with_forced_routed_experts_scanned_qwen3_5(self):
+    """Qwen3.5 supports forced routing together with `scan_layers=True` (see
+    `check_forced_routing_support` in configs/types.py for the full list of
+    supported decoder_blocks). This exercises that scanned path end-to-end:
+    forced_routed_experts is threaded through jax.lax.scan's xs (one slice
+    per layer) instead of being broadcast.
+    """
+    seq_len, batch_size, top_k, num_experts = 16, 2, 2, 4
+    cycle_interval = 4
+    num_layers = 2 * cycle_interval  # 2 scan iterations of one cycle each.
+
+    cfg = _init_test_cfg(
+        extra_args=["attention=dot_product"],
+        **_tiny_qwen35_kwargs(
+            seq_len,
+            batch_size,
+            num_experts,
+            top_k,
+            run_name="test_trainer_router_replay_scanned_qwen3_5",
+            base_num_decoder_layers=num_layers,
+            num_decoder_layers=num_layers,
+            inhomogeneous_layer_cycle_interval=cycle_interval,
+        ),
+    )
+
+    # Synthetic forced routed experts, one distinct value per layer:
+    # [batch, seq_len, num_layers, top_k].
+    layer_ids = jnp.arange(num_layers, dtype=jnp.int32)
+    forced_experts = jnp.broadcast_to(
+        layer_ids[None, None, :, None] % num_experts,
+        (batch_size, seq_len, num_layers, top_k),
+    )
+    forced_experts = forced_experts.at[:, -2:, :, :].set(-1)
+
+    self._assert_forced_routing_loss_finite(cfg, seq_len, batch_size, forced_experts, "scanned qwen3.5")
+
+  def test_loss_fn_with_forced_routed_experts_scanned_mixtral(self):
+    """Mixtral has no ScannableBlock wrapper: every scan iteration is exactly
+    one (always-MoE) decoder layer, so this exercises the "no per-cycle
+    nesting" branch of the scan wiring (layers_per_cycle=1, squeezed)."""
+    seq_len, batch_size, top_k, num_experts = 16, 2, 2, 4
+    num_layers = 4  # 4 scan iterations of 1 layer each (cycle_interval=1).
+
+    cfg = _init_test_cfg(
+        extra_args=["attention=dot_product"],
+        run_name="test_trainer_router_replay_scanned_mixtral",
+        override_model_config=True,
+        base_num_decoder_layers=num_layers,
+        num_decoder_layers=num_layers,
+        model_name="mixtral-8x7b",
+        num_experts=num_experts,
+        num_experts_per_tok=top_k,
+        base_emb_dim=256,
+        base_num_query_heads=2,
+        base_num_kv_heads=2,
+        head_dim=256,
+        base_mlp_dim=256,
+        base_moe_mlp_dim=256,
+        vocab_size=1000,
+        max_target_length=seq_len,
+        max_prefill_predict_length=seq_len,
+        per_device_batch_size=float(batch_size),
+        weight_dtype="bfloat16",
+    )
+
+    # One distinct forced routing per layer: [batch, seq_len, num_layers, top_k].
+    layer_ids = jnp.arange(num_layers, dtype=jnp.int32)
+    forced_experts = jnp.broadcast_to(
+        layer_ids[None, None, :, None] % num_experts,
+        (batch_size, seq_len, num_layers, top_k),
+    )
+    forced_experts = forced_experts.at[:, -2:, :, :].set(-1)
+
+    self._assert_forced_routing_loss_finite(cfg, seq_len, batch_size, forced_experts, "scanned mixtral")
+
+  def test_forced_routing_reproduces_unforced_output_when_all_experts_selected(self):
+    """Replay identity: replaying the routing the model would have chosen must
+    reproduce the unforced forward pass.
+
+    Using num_experts_per_tok == num_experts makes the selected *set* the full
+    expert set no matter what the gate scores, so `arange(num_experts)` is
+    exactly what the router picks. The per-slot order differs, but the combine
+    is a weighted sum over experts and so is order-invariant -- meaning forced
+    and unforced must agree.
+    """
+    seq_len, batch_size, num_experts = 8, 2, 4
+    top_k = num_experts
+
+    def build_cfg(run_name):
+      return _init_test_cfg(
+          extra_args=["attention=dot_product"],
+          **_tiny_qwen35_kwargs(
+              seq_len,
+              batch_size,
+              num_experts,
+              top_k,
+              run_name=run_name,
+              base_num_decoder_layers=1,
+              num_decoder_layers=1,
+              scan_layers=False,
+              weight_dtype="float32",
+              dtype="float32",
+          ),
+      )
+
+    cfg = build_cfg("test_router_replay_identity")
+    devices_array = maxtext_utils.create_device_mesh(cfg)
+    mesh = Mesh(devices_array, cfg.mesh_axes)
+
+    tokens = jnp.array(([10, 20, 30, 40] * ((seq_len // 4) + 1))[:seq_len], dtype=jnp.int32)
+    inputs = jnp.tile(jnp.expand_dims(tokens, axis=0), (batch_size, 1))
+    positions = jnp.tile(jnp.expand_dims(jnp.arange(seq_len, dtype=jnp.int32), axis=0), (batch_size, 1))
+    segmentation = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
+
+    model = models.transformer_as_linen(config=cfg, mesh=mesh, quant=None, model_mode="train")
+    init_params_rng, init_dropout_rng = jax.random.split(jax.random.PRNGKey(0))
+    params = model.init(
+        {"params": init_params_rng, "dropout": init_dropout_rng},
+        inputs,
+        positions,
+        segmentation,
+        enable_dropout=False,
+    )
+
+    def logits_for(forced):
+      return model.apply(
+          params,
+          inputs,
+          positions,
+          segmentation,
+          enable_dropout=False,
+          forced_routed_experts=forced,
+      )
+
+    all_experts = jnp.broadcast_to(
+        jnp.arange(num_experts, dtype=jnp.int32)[None, None, :],
+        (batch_size, seq_len, top_k),
+    )
+
+    unforced_logits = logits_for(None)
+    forced_logits = logits_for(all_experts)
+
+    self.assertEqual(unforced_logits.shape, forced_logits.shape)
+    self.assertTrue(
+        jnp.allclose(unforced_logits, forced_logits, rtol=2e-4, atol=2e-4),
+        "Replaying the router's own choice must reproduce the unforced logits; max abs diff "
+        f"{float(jnp.max(jnp.abs(unforced_logits - forced_logits)))}",
+    )
+
+
+class GetTopkUnforcedRegressionTest(unittest.TestCase):
+  """Guards that adding forced routing did not change the *unforced* path.
+
+  Both cases below regressed when the forced-routing branch was first wrapped
+  around get_topk's body: `norm_topk_prob` escaped the non-DeepSeek `else`, and
+  `per_expert_scale` became nested inside `if norm_topk_prob`.
+  """
+
+  def test_deepseek_scaling_is_not_renormalized_by_norm_topk_prob(self):
+    # deepseek4-284b sets decoder_block=deepseek4, routed_score_func=sqrtsoftplus
+    # and norm_topk_prob=true simultaneously. deepseek_scale_weights already
+    # normalizes and then applies routed_scaling_factor, so norm_topk_prob must
+    # NOT run again and cancel it out.
+    config = DummyConfig(model_name="deepseek3-671b", decoder_block=ctypes.DecoderBlockType.DEEPSEEK4)
+    config.routed_score_func = "sqrtsoftplus"
+    config.norm_topk_prob = True
+    config.routed_scaling_factor = 2.5
+    model = DummyRoutedMoE(config)
+
+    gate_logits = jnp.array([[[1.0, 2.0, 0.5]]])
+    top_k_weights, _ = moe.RoutedMoE.get_topk(model, gate_logits, gate_logits)
+
+    self.assertAlmostEqual(
+        float(jnp.sum(top_k_weights)),
+        config.routed_scaling_factor,
+        places=4,
+        msg="DeepSeek weights must keep routed_scaling_factor; norm_topk_prob must not re-normalize them.",
+    )
+
+  def test_per_expert_scale_applies_when_norm_topk_prob_is_false(self):
+    # per_expert_scale only exists for GEMMA4. It is independent of
+    # norm_topk_prob and must be applied either way.
+    scale = [10.0, 20.0, 30.0]
+    config = DummyConfig(decoder_block=ctypes.DecoderBlockType.GEMMA4)
+    config.norm_topk_prob = False
+    model = DummyRoutedMoE(config, per_expert_scale=scale)
+
+    gate_logits = jnp.array([[[1.0, 2.0, 0.5]]])
+    top_k_weights, top_k_indices = moe.RoutedMoE.get_topk(model, gate_logits, gate_logits)
+
+    unscaled_model = DummyRoutedMoE(DummyConfig(decoder_block=ctypes.DecoderBlockType.GEMMA4))
+    unscaled_weights, _ = moe.RoutedMoE.get_topk(unscaled_model, gate_logits, gate_logits)
+    expected = unscaled_weights * jnp.take_along_axis(jnp.asarray(scale)[None, None, :], top_k_indices, axis=-1)
+
+    self.assertTrue(
+        jnp.allclose(top_k_weights, expected, rtol=1e-5, atol=1e-5),
+        "per_expert_scale must be applied even when norm_topk_prob is False.",
+    )
+
+  def test_per_expert_scale_applies_when_norm_topk_prob_is_true(self):
+    scale = [10.0, 20.0, 30.0]
+    config = DummyConfig(decoder_block=ctypes.DecoderBlockType.GEMMA4)
+    config.norm_topk_prob = True
+    model = DummyRoutedMoE(config, per_expert_scale=scale)
+
+    gate_logits = jnp.array([[[1.0, 2.0, 0.5]]])
+    top_k_weights, top_k_indices = moe.RoutedMoE.get_topk(model, gate_logits, gate_logits)
+
+    # Normalization happens before scaling, so dividing the scale back out must
+    # leave weights summing to 1.
+    applied = jnp.take_along_axis(jnp.asarray(scale)[None, None, :], top_k_indices, axis=-1)
+    self.assertAlmostEqual(float(jnp.sum(top_k_weights / applied)), 1.0, places=4)
+
+
+class PaddingExcludedFromSoftmaxTest(unittest.TestCase):
+  """Padding must not enter the top-k softmax denominator.
+
+  Gathering with a -1 index wraps to the last expert, and softmaxing that
+  value before masking rescales the *real* slots. With norm_topk_prob the
+  renormalization happens to cancel it, but Mixtral is supported and defaults
+  to norm_topk_prob=false, so the error survives there.
+  """
+
+  def _weights(self, forced, norm_topk_prob, decoder_block=ctypes.DecoderBlockType.MIXTRAL):
+    config = DummyConfig(model_name="mixtral-8x7b", decoder_block=decoder_block)
+    config.norm_topk_prob = norm_topk_prob
+    config.routed_scaling_factor = 1.0
+    # Expert 2 has a large logit; it is the one -1 wraps onto.
+    gate_logits = jnp.array([[[0.0, 1.0, 5.0]]])
+    weights, _ = moe.RoutedMoE.get_topk(DummyRoutedMoE(config), gate_logits, gate_logits, forced_routed_experts=forced)
+    return weights
+
+  def test_single_real_expert_keeps_full_weight(self):
+    # One real slot (expert 1) and one padding slot. The real slot is the only
+    # thing routed to, so after softmax it must carry all the weight.
+    weights = self._weights(jnp.array([[[1, -1]]]), norm_topk_prob=False)
+    self.assertAlmostEqual(float(weights[0, 0, 0]), 1.0, places=5)
+    self.assertEqual(float(weights[0, 0, 1]), 0.0)
+
+  def test_fully_padded_token_is_zero_not_nan(self):
+    weights = self._weights(jnp.array([[[-1, -1]]]), norm_topk_prob=False)
+    self.assertFalse(bool(jnp.any(jnp.isnan(weights))))
+    self.assertEqual(float(jnp.sum(weights)), 0.0)
+
+  def test_unpadded_forced_routing_is_unaffected(self):
+    """The masking must not perturb the no-padding case."""
+    weights = self._weights(jnp.array([[[1, 2]]]), norm_topk_prob=False)
+    expected = jax.nn.softmax(jnp.array([1.0, 5.0]))
+    self.assertTrue(jnp.allclose(weights[0, 0], expected, rtol=1e-5, atol=1e-5))
+
+
+class ForcedRoutingGradientTest(unittest.TestCase):
+  """Replay must not cut the gradient to the router.
+
+  The weights are still derived from gate_logits, so the gate must keep
+  learning under replay. A stray stop_gradient or an over-broad mask would
+  silently freeze the router and break RL training while every forward-only
+  test stayed green.
+  """
+
+  def test_gate_logits_receive_gradient_under_forced_routing(self):
+    config = DummyConfig(model_name="mixtral-8x7b", decoder_block=ctypes.DecoderBlockType.MIXTRAL)
+    config.routed_scaling_factor = 1.0
+    model = DummyRoutedMoE(config)
+    forced = jnp.array([[[1, -1], [0, 2]]])
+
+    def loss(gate_logits):
+      weights, _ = moe.RoutedMoE.get_topk(model, gate_logits, gate_logits, forced_routed_experts=forced)
+      return jnp.sum(weights**2)
+
+    grads = jax.grad(loss)(jnp.array([[[0.0, 1.0, 5.0], [2.0, 0.5, 1.0]]]))
+    self.assertTrue(bool(jnp.all(jnp.isfinite(grads))))
+    self.assertGreater(float(jnp.max(jnp.abs(grads))), 0.0)
+
+  def test_fully_padded_token_has_zero_gradient(self):
+    config = DummyConfig(model_name="mixtral-8x7b", decoder_block=ctypes.DecoderBlockType.MIXTRAL)
+    config.routed_scaling_factor = 1.0
+    model = DummyRoutedMoE(config)
+
+    def loss(gate_logits):
+      weights, _ = moe.RoutedMoE.get_topk(model, gate_logits, gate_logits, forced_routed_experts=jnp.array([[[-1, -1]]]))
+      return jnp.sum(weights**2)
+
+    grads = jax.grad(loss)(jnp.array([[[0.0, 1.0, 5.0]]]))
+    self.assertTrue(bool(jnp.all(grads == 0.0)))
+
+
+class OutOfRangeExpertIdTest(unittest.TestCase):
+  """An expert id outside [0, num_experts) must behave like an unused slot.
+
+  Before this was masked, take_along_axis clamped the gather while the scatter
+  in reshape_and_update_weights dropped the index, producing a NaN loss that
+  silently poisoned the whole accumulated gradient.
+  """
+
+  def _model(self):
+    config = DummyConfig(model_name="mixtral-8x7b", decoder_block=ctypes.DecoderBlockType.MIXTRAL)
+    config.routed_scaling_factor = 1.0
+    model = DummyRoutedMoE(config)
+    model.num_experts = 4
+    return model
+
+  def test_out_of_range_id_is_masked_not_nan(self):
+    gate_logits = jnp.array([[[0.0, 1.0, 5.0, 2.0]]])
+    weights, _ = moe.RoutedMoE.get_topk(
+        self._model(), gate_logits, gate_logits, forced_routed_experts=jnp.array([[[1, 9]]])
+    )
+    self.assertFalse(bool(jnp.any(jnp.isnan(weights))))
+    # The one valid slot keeps all the weight, exactly as for a -1 slot.
+    self.assertAlmostEqual(float(weights[0, 0, 0]), 1.0, places=5)
+    self.assertEqual(float(weights[0, 0, 1]), 0.0)
+
+  def test_out_of_range_matches_negative_sentinel(self):
+    gate_logits = jnp.array([[[0.0, 1.0, 5.0, 2.0]]])
+    oob, _ = moe.RoutedMoE.get_topk(self._model(), gate_logits, gate_logits, forced_routed_experts=jnp.array([[[1, 9]]]))
+    pad, _ = moe.RoutedMoE.get_topk(self._model(), gate_logits, gate_logits, forced_routed_experts=jnp.array([[[1, -1]]]))
+    self.assertTrue(jnp.allclose(oob, pad))
+
+
+class LoadBalanceUpdatePaddingTest(unittest.TestCase):
+  """Padding must not be attributed to expert 0.
+
+  jnp.bincount clips out-of-range values, so the -1 sentinel used to land on
+  expert 0 and skew the routed-bias update.
+  """
+
+  def test_padding_does_not_change_the_update(self):
+    with_padding = moe.calculate_load_balance_updates(jnp.array([[[-1, -1], [0, 2]]]), 3, 0.1)
+    without_padding = moe.calculate_load_balance_updates(jnp.array([[[0, 2]]]), 3, 0.1)
+    self.assertTrue(jnp.array_equal(with_padding, without_padding))
+
+
+class GetTopkForcedRoutingParityTest(unittest.TestCase):
+  """Replaying the indices the unforced path selected must give the same weights."""
+
+  def _assert_parity(self, config):
+    """Asserts replaying the unforced indices reproduces the unforced weights."""
+    model = DummyRoutedMoE(config)
+    gate_logits = jnp.array([[[1.0, 2.0, 0.5], [0.25, -1.0, 3.0]]])
+
+    unforced_weights, unforced_indices = moe.RoutedMoE.get_topk(model, gate_logits, gate_logits)
+    forced_weights, forced_indices = moe.RoutedMoE.get_topk(
+        model, gate_logits, gate_logits, forced_routed_experts=unforced_indices
+    )
+
+    self.assertTrue(jnp.array_equal(unforced_indices, forced_indices))
+    self.assertTrue(
+        jnp.allclose(unforced_weights, forced_weights, rtol=1e-5, atol=1e-5),
+        f"forced weights {forced_weights} != unforced {unforced_weights}",
+    )
+
+  def test_parity_default_block(self):
+    self._assert_parity(DummyConfig())
+
+  def test_parity_default_block_with_norm_topk_prob(self):
+    config = DummyConfig()
+    config.norm_topk_prob = True
+    self._assert_parity(config)
+
+  def test_parity_gemma4(self):
+    self._assert_parity(DummyConfig(decoder_block=ctypes.DecoderBlockType.GEMMA4))
+
+
+class RaggedSortGuardTest(unittest.TestCase):
+  """permute's standard (non-ragged) branch under forced routing.
+
+  The ragged branch is supported too; see
+  RaggedSortForcedRoutingEquivalenceTest for that one (tpu_only)."""
+
+  def _permute_config(self, use_ragged_sort, use_ring_of_experts):
+    """Builds a DummyConfig with the attributes permute() reads."""
+    config = DummyConfig()
+    config.load_balance_loss_weight = 0.0
+    config.routed_bias = False
+    config.routed_bias_update_rate = 0.0
+    config.num_experts = 3
+    config.use_ragged_sort = use_ragged_sort
+    config.use_ring_of_experts = use_ring_of_experts
+    config.moe_use_direct_token_gather = False
+    config.ragged_buffer_factor = 0.0
+    return config
+
+  def _make_model(self, config):
+    model = DummyRoutedMoE(config)
+    model.get_expert_parallelism_size = lambda: 1
+    model.should_update_load_balance = lambda: False
+    return model
+
+  def _run_permute(self, model, forced_routed_experts):
+    inputs = jnp.ones((1, 2, 4), dtype=jnp.float32)
+    gate_logits = jnp.array([[[1.0, 2.0, 0.5], [0.25, -1.0, 3.0]]])
+    return moe.RoutedMoE.permute(
+        model,
+        inputs,
+        gate_logits,
+        gate_logits,
+        forced_routed_experts=forced_routed_experts,
+    )
+
+  def test_forced_routing_without_ragged_sort_is_allowed(self):
+    model = self._make_model(self._permute_config(use_ragged_sort=False, use_ring_of_experts=True))
+    forced = jnp.array([[[0, 1], [2, -1]]], dtype=jnp.int32)
+    sorted_inputs = self._run_permute(model, forced)[0]
+    self.assertEqual(sorted_inputs.shape[-1], 4)
+
+
+class RaggedSortPaddingSentinelTest(unittest.TestCase):
+  """Documents the ring_ragged_sort contract the -1 -> num_experts remap needs.
+
+  NOTE: this asserts properties of the kernel expressions reproduced here; it
+  does NOT execute maxtext's remap. Only the tpu_only equivalence test does.
+
+  ring_ragged_sort orders slots with argsort but counts them with one_hot, and
+  derives each shard's [start, end) window from a cumsum of those counts. -1
+  satisfies only the counting half -- it sorts *before* expert 0 -- which
+  shifts every window by the number of padding slots. num_experts satisfies
+  both. These assertions mirror the kernel's own expressions
+  (kernels/ragged/ragged_sort.py) so they fail if it stops holding.
+  """
+
+  NUM_EXPERTS = 3
+
+  def _counts_and_order(self, flat_indices):
+    counts = jax.nn.one_hot(flat_indices, self.NUM_EXPERTS, dtype=jnp.int32).sum(axis=0)
+    return counts, jnp.argsort(flat_indices)
+
+  def test_num_experts_sentinel_is_excluded_from_counts_and_sorts_last(self):
+    real = jnp.array([0, 2, 1, 0], dtype=jnp.int32)
+    padded = jnp.array([0, -1, 2, 1, -1, 0], dtype=jnp.int32)
+    sentinel = jnp.where(padded < 0, self.NUM_EXPERTS, padded)
+
+    counts, order = self._counts_and_order(sentinel)
+    # Padding contributes nothing, so the counts equal the real-only counts.
+    self.assertEqual(counts.tolist(), self._counts_and_order(real)[0].tolist())
+
+    # Everything past group_offsets[num_experts] is padding, and nothing before
+    # it is -- so no shard window can reach a padded slot.
+    total_real = int(jnp.cumulative_sum(counts, include_initial=True)[self.NUM_EXPERTS])
+    self.assertEqual(total_real, int(jnp.sum(padded >= 0)))
+    reordered = padded[order]
+    self.assertTrue(bool(jnp.all(reordered[:total_real] >= 0)))
+    self.assertTrue(bool(jnp.all(reordered[total_real:] < 0)))
+
+  def test_raw_negative_sentinel_would_desynchronize_the_windows(self):
+    """Guards the reason for the remap: -1 breaks the offsets."""
+    padded = jnp.array([0, -1, 2, 1, -1, 0], dtype=jnp.int32)
+    counts, order = self._counts_and_order(padded)
+    total_real = int(jnp.cumulative_sum(counts, include_initial=True)[self.NUM_EXPERTS])
+    # The count is right, but padding sorts first, so the first `total_real`
+    # rows are not the real ones.
+    self.assertEqual(total_real, int(jnp.sum(padded >= 0)))
+    self.assertFalse(bool(jnp.all(padded[order][:total_real] >= 0)))
+
+
+class RaggedSortForcedRoutingEquivalenceTest(unittest.TestCase):
+  """Forced routing must give the same MoE output with and without the ragged
+  sort path. TPU-only: the ragged kernels require TPU, and use_ragged_sort
+  additionally requires expert parallelism > 1.
+
+  Mirrors moe_test.py::_run_ragged_sort_loss_and_grad, but drives both runs
+  with a forced routing that contains -1 padding -- the case that desynchronized
+  ring_ragged_sort's per-shard windows before the sentinel remap.
+  """
+
+  def _build_cfg(self, use_ragged_sort):
+    return pyconfig.initialize(
+        [None, get_test_config_path()],
+        run_name=f"router_replay_ragged_{use_ragged_sort}_test",
+        enable_checkpointing=False,
+        log_config=False,
+        skip_jax_distributed_system=True,
+        model_name="mixtral-8x7b",
+        override_model_config=True,
+        base_emb_dim=7168,  # multiple of 1024 so the kernel is fully used
+        base_mlp_dim=256,
+        base_moe_mlp_dim=256,
+        dtype="bfloat16",
+        megablox=True,
+        sparse_matmul=True,
+        per_device_batch_size=4,
+        ici_expert_parallelism=2,
+        use_ring_of_experts=True,
+        max_target_length=128,
+        float32_gate_logits=True,
+        use_ragged_sort=use_ragged_sort,
+        ragged_buffer_factor=-1.0,
+    )
+
+  @staticmethod
+  def _build_model(cfg, mesh):
+    return moe.get_routed_moe(
+        name="MoeBlock",
+        config=cfg,
+        num_experts=cfg.num_experts,
+        num_experts_per_tok=cfg.num_experts_per_tok,
+        mesh=mesh,
+        kernel_init=nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed", "mlp"),
+        intermediate_dim=cfg.mlp_dim,
+        dtype=cfg.dtype,
+    )
+
+  @pytest.mark.tpu_only
+  def test_ragged_sort_matches_non_ragged_under_forced_routing(self):
+    rng_model, rng_hidden = jax.random.split(jax.random.PRNGKey(2345))
+    device_count = jax.device_count()
+
+    cfg_ref = self._build_cfg(use_ragged_sort=False)
+    tokens = int(cfg_ref.per_device_batch_size) * device_count
+    hidden_states = jax.random.uniform(
+        rng_hidden,
+        (tokens, cfg_ref.max_target_length, cfg_ref.base_emb_dim),
+        dtype=cfg_ref.dtype,
+    )
+
+    # Replay a fixed routing, with the tail of every sequence marked unused so
+    # the -1 padding path is exercised on both sides.
+    top_k = cfg_ref.num_experts_per_tok
+    forced = jnp.zeros((tokens, cfg_ref.max_target_length, top_k), dtype=jnp.int32)
+    forced = forced.at[:, :, 0].set(1)
+    if top_k > 1:
+      forced = forced.at[:, :, 1].set(3)
+    forced = forced.at[:, -8:, :].set(-1)
+
+    def run(cfg, variables=None):
+      mesh = Mesh(maxtext_utils.create_device_mesh(cfg), cfg.mesh_axes)
+      model = self._build_model(cfg, mesh)
+      with jax.set_mesh(mesh), nn_partitioning.axis_rules(cfg.logical_axis_rules):
+        if variables is None:
+          variables = model.init(
+              {"params": rng_model, "dropout": rng_model},
+              hidden_states,
+              forced_routed_experts=forced,
+          )
+        out, _, _ = model.apply(
+            {"params": variables["params"]},
+            hidden_states,
+            forced_routed_experts=forced,
+        )
+      return out, variables
+
+    out_ref, variables = run(cfg_ref)
+    out_ragged, _ = run(self._build_cfg(use_ragged_sort=True), variables)
+
+    self.assertTrue(
+        jnp.allclose(out_ragged.astype(jnp.float32), out_ref.astype(jnp.float32), rtol=1e-2, atol=1e-2),
+        msg=(
+            "ragged sort output diverges from the non-ragged path under forced "
+            f"routing; max abs diff "
+            f"{float(jnp.max(jnp.abs(out_ragged.astype(jnp.float32) - out_ref.astype(jnp.float32))))}"
+        ),
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION


# Description

- In train.py loss_fn, extract forced_routed_experts from batch data and pass to model forward
- In RoutedMoE, override top_k_indices and route tokens with forced_routed_experts across sparse_matmul and dense_matmul
- In Decoder and NNXDecoder, plumb forced_routed_experts down across scanned/sequential decoder layers
- Plumbed forced_routed_experts across model implementations (Qwen3, Qwen3.5, DeepSeek, Gemma4, Mixtral)
- Added unit tests in tests/unit/forced_routing_test.py
- Added integration test in tests/test_trainer_router_replay.py verifying loss computation with forced routing


You can also provide a comma-separated list. If you don't want to close a bug but
simply to reference it, use BUGS, e.g.: 
BUGS: b/536114593

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

unit tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
