### PR TITLE
custom processor for omni poc

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -253,6 +253,7 @@ ModelName = Literal[
     "gemma4-31b",
     "gemma4-e2b",
     "gemma4-e4b",
+    "maxtext-omni-gemma3-qwen3",
     "qwen2.5-1.5b",
     "qwen2.5-7b",
     "qwen2.5-14b",
@@ -4003,6 +4004,7 @@ class MaxTextConfig(
           "qwen3-vl-30b-a3b",
           "qwen3.5-35b-a3b",
           "qwen3.5-397b-a17b",
+          "maxtext-omni-gemma3-qwen3",
       )
       if self.model_name not in valid_mm_models and self.model_name != "default":
         raise ValueError(f"Multimodal is only supported for {valid_mm_models}, not {self.model_name}")

--- a/src/maxtext/experimental/omni_poc/maxtext-omni-gemma3-qwen3.yml
+++ b/src/maxtext/experimental/omni_poc/maxtext-omni-gemma3-qwen3.yml
@@ -1,12 +1,15 @@
-# model config for omni-gemma3-qwen3
+# model config for maxtext-omni-gemma3-qwen3
 # Combines LLM backbone from Qwen 3 4B with Vision features from Gemma 3 4B
 
-# NOTE: model_name is set to "gemma3-4b" so encoders.py loads Gemma 3's Vision Tower without modification.
-# Meanwhile, decoders.py can build Qwen 3 LLM decoder directly from reading `decoder_block: "qwen3"` below.
-model_name: "gemma3-4b"
+# NOTE: vision_encoder_block is set to "gemma3" so encoders.py loads Gemma 3's Vision Tower without modification.
+# Meanwhile, decoders.py builds Qwen 3 LLM decoder directly from reading `decoder_block: "qwen3"` below.
+# base_config is currently a placeholder flag for future SFT runs.
+base_config: "base.yml"
+model_name: "maxtext-omni-gemma3-qwen3"
 use_multimodal: true
 
-# Multimodal config for vision model (from gemma3-4b.yml)
+# Vision encoder config (from gemma3-4b.yml)
+vision_encoder_block: "gemma3"
 image_size_for_vit: 896
 num_channels_for_vit: 3
 patch_size_for_vit: 14
@@ -15,7 +18,14 @@ hidden_size_for_vit: 1152
 intermediate_size_for_vit: 4304
 num_hidden_layers_for_vit: 27
 num_attention_heads_for_vit: 16
-image_placeholder: <start_of_image>
+image_placeholder: "<image>"
+
+# Vision projector config
+vision_projector_type: "customized_vision_projector"
+vision_connector_hidden_size: 4096
+vision_connector_num_layers: 3
+vision_connector_activation: "gelu"
+vision_connector_use_bias: true
 
 # LLM backbone config (from qwen3-4b.yml)
 base_emb_dim: 2560
@@ -34,6 +44,7 @@ logits_via_embedding: true
 normalize_embedding_logits: false
 enable_dropout: false
 tokenizer_type: "huggingface"
+tokenizer_path: "Qwen/Qwen3-4B"
 
 # Ensure no pretrained weights or checkpoints are loaded initially
 load_parameters_path: ""

--- a/src/maxtext/experimental/omni_poc/prepare_checkpoint.sh
+++ b/src/maxtext/experimental/omni_poc/prepare_checkpoint.sh
@@ -43,7 +43,7 @@ LLM_HF_REPO="Qwen/Qwen3-4B"
 
 # Automatically find maxtext package directory
 MAXTEXT_PKG_DIR=$(python3 -c "import os, maxtext; print(os.path.dirname(maxtext.__file__))")
-OMNI_CONFIG_PATH="${MAXTEXT_PKG_DIR}/experimental/omni_poc/omni-gemma3-qwen3.yml"
+OMNI_CONFIG_PATH="${MAXTEXT_PKG_DIR}/experimental/omni_poc/maxtext-omni-gemma3-qwen3.yml"
 
 VISION_CKPT_DIR="${BASE_OUTPUT_DIRECTORY}/${VISION_MAXTEXT_MODEL}_converted"
 LLM_CKPT_DIR="${BASE_OUTPUT_DIRECTORY}/${LLM_MAXTEXT_MODEL}_converted"

--- a/src/maxtext/experimental/omni_poc/tests/processor_maxtext_omni_test.py
+++ b/src/maxtext/experimental/omni_poc/tests/processor_maxtext_omni_test.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Omni multimodal processor."""
+
+from types import SimpleNamespace
+import unittest
+import numpy as np
+
+from maxtext.experimental.omni_poc.utils import processor_maxtext_omni as omni_processor
+
+
+class TestProcessorMaxtextOmni(unittest.TestCase):
+  """Concise test suite for processor_maxtext_omni."""
+
+  def test_constants_and_offsets(self):
+    self.assertEqual(omni_processor.DECODER_SPECIAL_TOKENS["qwen3"]["image_pad"], 151655)
+    self.assertEqual(omni_processor.VISION_TOKENS_PER_IMAGE["gemma3"], 256)
+    self.assertEqual(omni_processor.get_image_offsets_omni("gemma3", "qwen3", None), 255)
+    self.assertEqual(
+        omni_processor.get_image_offsets_omni("gemma3", "qwen3", SimpleNamespace(pixel_values=np.zeros((3, 1, 1, 3)))),
+        255 * 3,
+    )
+
+  def test_unsupported_combination_raises_error(self):
+    with self.assertRaises(ValueError):
+      omni_processor.get_image_offsets_omni("llama4", "qwen3", None)
+    with self.assertRaises(ValueError):
+      omni_processor.add_extra_tokens_for_omni([1, 2], "llama4", "qwen3")
+    with self.assertRaises(ValueError):
+      omni_processor.get_bidirectional_mask_vision_omni("llama4", "qwen3", np.array([1, 2]))
+
+  def test_add_extra_tokens_placeholder_expansion(self):
+    pad_id = omni_processor.DECODER_SPECIAL_TOKENS["qwen3"]["image_pad"]
+    # Expand single placeholder with custom count
+    tokens = [10, pad_id, 20]
+    out = omni_processor.add_extra_tokens_for_omni(tokens, "gemma3", "qwen3", num_tokens_per_image=3)
+    np.testing.assert_array_equal(out, [10, pad_id, pad_id, pad_id, 20])
+
+    # 2D array and dtype preservation
+    tokens_i64 = np.array([[pad_id], [99]], dtype=np.int64)
+    out_i64 = omni_processor.add_extra_tokens_for_omni(tokens_i64, "gemma3", "qwen3", num_tokens_per_image=2)
+    self.assertEqual(out_i64.dtype, np.int64)
+    np.testing.assert_array_equal(out_i64, [pad_id, pad_id, 99])
+
+  def test_add_extra_tokens_prepend_and_text_only(self):
+    # Prepend vision block when pixel values exist
+    proc_out = SimpleNamespace(pixel_values=np.zeros((1, 1, 1, 3)))
+    out = omni_processor.add_extra_tokens_for_omni(
+        [1, 2], "gemma3", "qwen3", processor_output=proc_out, num_tokens_per_image=2
+    )
+    tokens_cfg = omni_processor.DECODER_SPECIAL_TOKENS["qwen3"]
+    expected = [
+        tokens_cfg["vision_start"],
+        tokens_cfg["image_pad"],
+        tokens_cfg["image_pad"],
+        tokens_cfg["vision_end"],
+        1,
+        2,
+    ]
+    np.testing.assert_array_equal(out, expected)
+
+    # Text-only returns original
+    np.testing.assert_array_equal(omni_processor.add_extra_tokens_for_omni([1, 2], "gemma3", "qwen3"), [1, 2])
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/src/maxtext/experimental/omni_poc/tests/stitch_checkpoint_test.py
+++ b/src/maxtext/experimental/omni_poc/tests/stitch_checkpoint_test.py
@@ -52,12 +52,13 @@ from orbax import checkpoint as ocp
 
 from maxtext.configs import pyconfig
 from maxtext.experimental.omni_poc.utils import stitch_checkpoint
+from maxtext.layers import encoders
 from maxtext.layers.embeddings import Embed
 from maxtext.models import gemma3
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
 from maxtext.utils import model_creation_utils
-from maxtext.utils.globals import MAXTEXT_REPO_ROOT
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR, MAXTEXT_PKG_DIR
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -120,12 +121,10 @@ class TestOmniCheckpointStitcher(unittest.TestCase):
   def _create_config(self):
     """Creates a MaxText config from the Omni config file and defaults."""
     omni_config_path = os.path.join(
-        MAXTEXT_REPO_ROOT,
-        "src",
-        "maxtext",
+        MAXTEXT_PKG_DIR,
         "experimental",
         "omni_poc",
-        "omni-gemma3-qwen3.yml",
+        "maxtext-omni-gemma3-qwen3.yml",
     )
     custom_cfg = omegaconf.OmegaConf.to_container(omegaconf.OmegaConf.load(omni_config_path), resolve=True)
 
@@ -136,10 +135,12 @@ class TestOmniCheckpointStitcher(unittest.TestCase):
         "stitched_output_path",
         "vision_model_name",
         "llm_model_name",
+        "base_config",
+        "model_name",
     }
     yaml_overrides = {k: v for k, v in custom_cfg.items() if k not in omni_keys}
 
-    base_config_path = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "base.yml")
+    base_config_path = os.path.join(MAXTEXT_CONFIGS_DIR, "base.yml")
     config = pyconfig.initialize(
         ["", base_config_path],
         override_model_config=True,
@@ -151,6 +152,7 @@ class TestOmniCheckpointStitcher(unittest.TestCase):
         **yaml_overrides,
     )
     # Use object.__setattr__ to bypass the read-only check on _HyperParameters
+    object.__setattr__(config, "model_name", custom_cfg.get("model_name", "maxtext-omni-gemma3-qwen3"))
     object.__setattr__(config, "vision_model_name", "gemma3-4b")
     object.__setattr__(config, "llm_model_name", "qwen3-4b")
     object.__setattr__(config, "ici_context_autoregressive_parallelism", 1)
@@ -206,7 +208,11 @@ class TestOmniCheckpointStitcher(unittest.TestCase):
       stitched_inner = stitch_checkpoint._restore_subtrees_from_path(self.output_ckpt_dir, concrete_template, ckptr)
 
       # Load weights from the ORIGINAL Vision checkpoint
-      vision_abstract = concrete_template["vision_encoder"]
+      vision_abstract = {
+          k: v
+          for k, v in concrete_template["vision_encoder"].items()
+          if not ("projector" in k.lower() or "embedder" in k.lower())
+      }
       vision_restored = stitch_checkpoint._restore_subtrees_from_path(
           self.vision_ckpt_dir, {"vision_encoder": vision_abstract}, ckptr
       )
@@ -324,17 +330,13 @@ class TestOmniCheckpointStitcher(unittest.TestCase):
         stitched_inner["token_embedder"]["embedding"].reshape(-1)[:10],
     )
     print(
-        "orig vision projector weights first 10 values:",
-        vision_restored["vision_encoder"]["VisionEmbedder_0"]["mm_input_projection"]["w"].reshape(-1)[:10],
-    )
-    print(
         "stitched vision projector weights first 10 values:",
-        stitched_inner["vision_encoder"]["VisionEmbedder_0"]["mm_input_projection"]["w"].reshape(-1)[:10],
+        stitched_inner["vision_encoder"]["VisionEmbedder_0"]["custom_linear_0"]["kernel"].reshape(-1)[:10],
     )
 
     # Instantiate and update original vision & token embedder modules
     orig_vision_tower = gemma3.Gemma3VisionEncoderLayer(config, self.test_mesh, rngs=rngs)
-    orig_projector = gemma3.VisionEmbedder(config, self.test_mesh, rngs=rngs)
+    orig_projector = encoders.MultimodalMLPProjector(config, self.test_mesh, rngs=nnx.Rngs(1))
     # Manually define qwen3's token embedder to match MaxText's structures
     orig_token_embedder = Embed(
         num_embeddings=config.vocab_size,
@@ -349,17 +351,13 @@ class TestOmniCheckpointStitcher(unittest.TestCase):
         vision_restored["vision_encoder"]["Gemma3VisionEncoderLayer_0"],
     )
     nnx.update(
-        orig_projector,
-        vision_restored["vision_encoder"]["VisionEmbedder_0"],
-    )
-    nnx.update(
         orig_token_embedder,
         {"embedding": llm_restored["token_embedder"]["embedding"]},
     )
 
     # Instantiate and update stitched vision & token embedder modules
     stitched_vision_tower = gemma3.Gemma3VisionEncoderLayer(config, self.test_mesh, rngs=rngs)
-    stitched_projector = gemma3.VisionEmbedder(config, self.test_mesh, rngs=rngs)
+    stitched_projector = encoders.MultimodalMLPProjector(config, self.test_mesh, rngs=rngs)
     stitched_token_embedder = Embed(
         num_embeddings=config.vocab_size,
         num_features=config.emb_dim,

--- a/src/maxtext/experimental/omni_poc/utils/decode_omni.py
+++ b/src/maxtext/experimental/omni_poc/utils/decode_omni.py
@@ -1,0 +1,381 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Retrieve random examples from ChartQA dataset and evaluate the stitched model
+(pre-SFT and post-SFT) checkpoints to verify if:
+  1. the data flows end-to-end
+  2. the response is reasonable given the random vision projector
+ChartQA sample Q&A, ground truth and model responses are logged.
+
+Example usage:
+
+python src/maxtext/experimental/omni_poc/utils/decode_omni.py \
+  --checkpoint_path="gs://YOUR_BUCKET_NAME/omni_stitched_gemma3-4b_qwen3-4b/0/items" \
+  --num_samples=3 \
+  --max_new_tokens=128
+
+"""
+
+import maxtext
+# Eagerly initialize core MaxText C++ and model dependencies
+_ = (maxtext.Mesh, maxtext.pyconfig, maxtext.models, maxtext.model_creation_utils)
+
+import functools
+import os
+import random
+import sys
+from absl import app, flags
+import datasets
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh
+import numpy as np
+import omegaconf
+from transformers import AutoTokenizer
+
+from maxtext.common import checkpointing
+from maxtext.configs import pyconfig
+from maxtext.multimodal import processor as mm_processor
+from maxtext.utils import max_logging
+from maxtext.utils import max_utils
+from maxtext.utils import maxtext_utils
+from maxtext.utils import model_creation_utils
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
+
+FLAGS = flags.FLAGS
+
+
+def _define_flag(fn, name, default, help_str):
+  if name not in FLAGS:
+    fn(name, default, help_str)
+
+
+_define_flag(flags.DEFINE_string, "config_path", "", "Path to the config YAML file.")
+_define_flag(flags.DEFINE_string, "checkpoint_path", "", "Path to checkpoint parameters directory.")
+_define_flag(flags.DEFINE_integer, "num_samples", 5, "Number of random ChartQA validation samples to evaluate.")
+_define_flag(flags.DEFINE_string, "description", "Omni Model", "Description for evaluation logs.")
+_define_flag(flags.DEFINE_integer, "max_new_tokens", 128, "Maximum number of new tokens to generate.")
+
+
+def initialize_model_and_weights(config, checkpoint_path, mesh):
+  """Instantiates the Omni model and loads checkpoint.
+
+  Args:
+    config: The MaxText Omni configuration.
+    checkpoint_path: Path to the checkpoint parameters directory.
+    mesh: The JAX mesh for sharding.
+
+  Returns:
+    model: The stitched model.
+    params: The restored model parameters.
+  """
+  with jax.set_mesh(mesh):
+    model = model_creation_utils.from_config(config, mesh=mesh)
+
+    abstract_vars = maxtext_utils.get_abstract_param(model, config)
+    target_params_abstract = max_utils.unbox_logicallypartioned(abstract_vars["params"])
+
+    max_logging.log(f"Checkpoint parameters path: {checkpoint_path}")
+    restored = checkpointing.load_params_from_path(
+        checkpoint_path,
+        {"params": target_params_abstract},
+        config.checkpoint_storage_concurrent_gb,
+        use_ocdbt=config.checkpoint_storage_use_ocdbt,
+        use_zarr3=config.checkpoint_storage_use_zarr3,
+    )
+    return model, restored.get("params", restored)
+
+
+def load_omni_config(yaml_path, checkpoint_path):
+  """Loads custom omni config YAML and converts overrides onto base.yml."""
+  custom_cfg = omegaconf.OmegaConf.to_container(omegaconf.OmegaConf.load(yaml_path), resolve=True)
+  base_yml = os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")
+  num_devs = len(jax.devices())
+  per_dev_bs = 1.0 / num_devs
+  argv = [
+      sys.argv[0],
+      base_yml,
+      "override_model_config=True",
+      "skip_jax_distributed_system=True",
+      "ici_fsdp_parallelism=1",
+      "ici_data_parallelism=1",
+      "ici_autoregressive_parallelism=1",
+      "ici_tensor_parallelism=-1",
+      f"per_device_batch_size={per_dev_bs}",
+      "async_checkpointing=False",
+      f"load_parameters_path={checkpoint_path}",
+  ]
+
+  if "max_prefill_predict_length" not in custom_cfg:
+    argv.append("max_prefill_predict_length=1024")
+  if "max_target_length" not in custom_cfg:
+    argv.append("max_target_length=2048")
+
+  omni_skip_keys = {
+      # Custom omni YAML keys not in base.yml
+      "vision_load_path",
+      "llm_load_path",
+      "stitched_output_path",
+      "vision_model_name",
+      "llm_model_name",
+      "base_config",
+      "model_name",
+      # Batch and parallelism keys overridden for single-sample decoding
+      "per_device_batch_size",
+      "eval_per_device_batch_size",
+      "ici_fsdp_parallelism",
+      "ici_data_parallelism",
+      "ici_tensor_parallelism",
+      "ici_autoregressive_parallelism",
+      "ici_expert_parallelism",
+  }
+  for k, v in custom_cfg.items():
+    if k in omni_skip_keys:
+      continue
+    if isinstance(v, str):
+      argv.append(f"{k}='{v}'")
+    else:
+      argv.append(f"{k}={v}")
+
+  # Initialize config
+  config = pyconfig.initialize(
+      argv,
+      override_model_config=True,
+      skip_jax_distributed_system=True,
+      log_config=False,
+  )
+  # Explicitly set model_name and single-sample batch sizes on the frozen config
+  object.__setattr__(config, "model_name", "maxtext-omni-gemma3-qwen3")
+  object.__setattr__(config, "micro_batch_size_to_train_on", 1)
+  object.__setattr__(config, "global_batch_size_to_train_on", 1)
+  object.__setattr__(config, "per_device_batch_size", per_dev_bs)
+  return config
+
+
+@functools.partial(jax.jit, static_argnums=(0,))
+def _prefill_step(model, params, tokens, positions, segment_ids, images):
+  """Executes initial prefill pass and initializes the KV cache."""
+  logits, mutated_vars = model.apply(
+      {"params": params},
+      decoder_input_tokens=tokens,
+      decoder_positions=positions,
+      decoder_segment_ids=segment_ids,
+      encoder_images=images,
+      enable_dropout=False,
+      model_mode="prefill",
+      mutable=["cache"],
+  )
+  return logits, mutated_vars["cache"]
+
+
+@functools.partial(jax.jit, static_argnums=(0,))
+def _ar_step(model, params, cache, token, position):
+  """Executes a single-token autoregressive step reusing the KV cache."""
+  logits, mutated_vars = model.apply(
+      {"params": params, "cache": cache},
+      decoder_input_tokens=token,
+      decoder_positions=position,
+      decoder_segment_ids=None,
+      encoder_images=None,
+      enable_dropout=False,
+      model_mode="autoregressive",
+      mutable=["cache"],
+  )
+  return logits, mutated_vars["cache"]
+
+
+@functools.partial(jax.jit, static_argnums=(0, 5))
+def _generate_loop(model, params, cache, first_token, start_pos, num_steps: int):
+  """Executes the remaining autoregressive generation loop on TPU using jax.lax.scan without host syncs."""
+
+  def step_fn(carry, _):
+    current_cache, current_token, current_pos = carry
+    logits, mutated_vars = model.apply(
+        {"params": params, "cache": current_cache},
+        decoder_input_tokens=current_token,
+        decoder_positions=current_pos,
+        decoder_segment_ids=None,
+        encoder_images=None,
+        enable_dropout=False,
+        model_mode="autoregressive",
+        mutable=["cache"],
+    )
+    next_token = jnp.argmax(logits[:, 0:1, :], axis=-1).astype(jnp.int32)  # shape: [1, 1]
+    next_pos = current_pos + 1
+    new_cache = mutated_vars["cache"]
+    return (new_cache, next_token, next_pos), next_token
+
+  init_carry = (cache, first_token, start_pos)
+  _, generated_tokens_seq = jax.lax.scan(step_fn, init_carry, None, length=num_steps)
+  return generated_tokens_seq
+
+
+def decode_omni_sample(model, params, config, mesh, tokenizer, prompt_str, pil_image, max_new_tokens=128):
+  """Runs prefill and autoregressive decoding for a single multimodal sample with KV caching."""
+  # Preprocess image
+  image_np = np.array(pil_image.convert("RGB"), dtype=np.uint8)
+  processed_image = mm_processor.preprocess_image_for_training(image_np, config)
+  image_pixels = (
+      processed_image.pixel_values
+      if hasattr(processed_image, "pixel_values") and processed_image.pixel_values is not None
+      else processed_image
+  )
+  image_pixels = np.asarray(image_pixels)
+  if image_pixels.ndim == 4:
+    image_pixels = np.expand_dims(image_pixels, axis=0)
+  mock_image = jnp.array(image_pixels, dtype=jnp.bfloat16 if config.dtype == "bfloat16" else jnp.float32)
+
+  # Format prompt and expand image placeholder tokens
+  formatted_prompt = mm_processor.reformat_prompt(
+      prompt=prompt_str,
+      image_placeholder=config.image_placeholder,
+      model_name=config,
+      num_images=1,
+  )
+  initial_tokens = tokenizer.encode(formatted_prompt, add_special_tokens=False)
+  combined_tokens = mm_processor.prepare_text_for_image_fusion(
+      tokens=initial_tokens,
+      config=config,
+      processor_output=processed_image,
+  ).tolist()
+
+  # Pad token sequence to fixed config.max_prefill_predict_length
+  true_length = len(combined_tokens)
+  prefill_len = config.max_prefill_predict_length
+  if true_length > prefill_len:
+    raise ValueError(
+        f"The combined length of expanded prompt and vision tokens ({true_length}) "
+        f"exceeds config.max_prefill_predict_length ({prefill_len}). "
+        "Please increase max_prefill_predict_length in your model config."
+    )
+  pad_token = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
+  padded_tokens = combined_tokens + [pad_token] * (prefill_len - true_length)
+
+  tokens = np.array([padded_tokens[:prefill_len]], dtype=np.int32)
+  positions = np.tile(np.arange(prefill_len, dtype=np.int32), (1, 1))
+  segment_ids = np.zeros((1, prefill_len), dtype=np.int32)
+  segment_ids[:, :true_length] = 1
+
+  # Autoregressive decoding with KV cache
+  eos_token_id = tokenizer.eos_token_id
+  tokens_to_decode = []
+
+  with jax.set_mesh(mesh):
+    # Initial prefill pass (computes ViT embeddings and initializes KV cache)
+    logits, cache = _prefill_step(model, params, tokens, positions, segment_ids, mock_image)
+    first_token_id = int(jnp.argmax(logits[0, true_length - 1, :]))
+    tokens_to_decode.append(first_token_id)
+
+    # Autoregressive generation
+    if max_new_tokens > 1 and first_token_id != eos_token_id:
+      # Step 1 of AR: transitions cache metadata from cache_batch_prefill to cache_batch
+      first_token_arr = jnp.array([[first_token_id]], dtype=np.int32)
+      first_pos_arr = jnp.array([[true_length]], dtype=np.int32)
+      logits_1, ar_cache = _ar_step(model, params, cache, first_token_arr, first_pos_arr)
+      second_token_id = int(jnp.argmax(logits_1[0, 0, :]))
+      tokens_to_decode.append(second_token_id)
+
+      # Remaining AR steps inside jax.lax.scan (all steps use cache_batch metadata)
+      num_scan_steps = min(max_new_tokens - 2, config.max_target_length - config.max_prefill_predict_length - 2)
+      num_scan_steps = max(0, num_scan_steps)
+      if num_scan_steps > 0 and second_token_id != eos_token_id:
+        second_token_arr = jnp.array([[second_token_id]], dtype=np.int32)
+        second_pos_arr = jnp.array([[true_length + 1]], dtype=np.int32)
+        ar_tokens_seq = _generate_loop(model, params, ar_cache, second_token_arr, second_pos_arr, num_scan_steps)
+        for tok in np.array(ar_tokens_seq).reshape(-1).tolist():
+          if tok == eos_token_id:
+            break
+          tokens_to_decode.append(tok)
+
+  return tokenizer.decode(tokens_to_decode, skip_special_tokens=True).strip()
+
+
+def run_evaluation(checkpoint_path, config, num_samples=5, description="Omni Model", max_new_tokens=128):
+  """Runs evaluation on ChartQA random validation samples.
+  Args:
+    checkpoint_path: Path to the checkpoint parameters directory.
+    config: The MaxText Omni configuration.
+    num_samples: Number of random ChartQA validation samples to evaluate.
+    description: Description for evaluation logs.
+    max_new_tokens: Maximum number of new tokens to generate.
+  """
+  max_logging.log("=" * 60)
+  max_logging.log(f"Running Evaluation for {description}...")
+  max_logging.log(f"Loading checkpoint from: {checkpoint_path}")
+  max_logging.log("=" * 60)
+
+  # Load the dataset
+  try:
+    ds = datasets.load_dataset("HuggingFaceM4/ChartQA", split="val")
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    max_logging.log(f"Error loading ChartQA evaluation dataset: {e}")
+    return
+
+  # Initialize the model
+  if jax.local_devices()[0].platform == "cpu":
+    mesh = Mesh(np.array([jax.devices("cpu")[0]]), axis_names=("data",))
+  else:
+    mesh = maxtext_utils.get_mesh_from_config(config)
+
+  model, restored_params = initialize_model_and_weights(config, checkpoint_path, mesh)
+
+  tokenizer = AutoTokenizer.from_pretrained(config.tokenizer_path)
+
+  # Run decode on samples from the dataset
+  random.seed(42)
+  total_samples = len(ds)
+  sample_indices = random.sample(range(total_samples), min(num_samples, total_samples))
+
+  for idx, i in enumerate(sample_indices):
+    sample = ds[i]
+    model_response = decode_omni_sample(
+        model=model,
+        params=restored_params,
+        config=config,
+        mesh=mesh,
+        tokenizer=tokenizer,
+        prompt_str=f"<image> {sample['query']}",
+        pil_image=sample["image"],
+        max_new_tokens=max_new_tokens,
+    )
+
+    max_logging.log(
+        f"""
+Sample {idx+1}/{len(sample_indices)} (Index {i}):
+  Question: {sample['query']}
+  Ground Truth: {sample['label']}
+  Model Response: {model_response}
+"""
+    )
+
+
+def main(argv):
+  config_path = FLAGS.config_path or os.path.join(
+      MAXTEXT_PKG_DIR, "experimental", "omni_poc", "maxtext-omni-gemma3-qwen3.yml"
+  )
+  assert FLAGS.checkpoint_path, "Must specify --checkpoint_path"
+  config = load_omni_config(config_path, FLAGS.checkpoint_path)
+
+  run_evaluation(
+      checkpoint_path=FLAGS.checkpoint_path,
+      config=config,
+      num_samples=FLAGS.num_samples,
+      description=FLAGS.description,
+      max_new_tokens=FLAGS.max_new_tokens,
+  )
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/src/maxtext/experimental/omni_poc/utils/processor_maxtext_omni.py
+++ b/src/maxtext/experimental/omni_poc/utils/processor_maxtext_omni.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multimodal processor router for stitched / omni architectures in MaxText.
+
+Dispatches preprocessing, offset calculations, token expansions, and mask generations
+based on the specified vision encoder and text decoder combination.
+"""
+
+import numpy as np
+from maxtext.multimodal.processor_gemma3 import GEMMA_NUM_PLACEHOLDER_TOKENS_PER_IMAGE
+from maxtext.multimodal.processor_qwen3_omni import QWEN_SPECIAL_TOKEN_CONFIGS
+from maxtext.utils import max_logging
+
+# Vision encoder image token counts
+VISION_TOKENS_PER_IMAGE = {
+    "gemma3": GEMMA_NUM_PLACEHOLDER_TOKENS_PER_IMAGE,  # 256
+}
+
+# Text decoder token IDs for vision placeholders
+DECODER_SPECIAL_TOKENS = {
+    "qwen3": {
+        "vision_start": QWEN_SPECIAL_TOKEN_CONFIGS["qwen3-omni-30b-a3b"]["vision_start"],  # 151652
+        "vision_end": QWEN_SPECIAL_TOKEN_CONFIGS["qwen3-omni-30b-a3b"]["vision_end"],  # 151653
+        "image_pad": QWEN_SPECIAL_TOKEN_CONFIGS["qwen3-omni-30b-a3b"]["image_pad"],  # 151655
+    },
+}
+
+
+def get_image_offsets_omni(vision_block, decoder_block, processor_output=None):
+  """Calculate the increase in total token count after inserting visual token sequences."""
+  if vision_block not in VISION_TOKENS_PER_IMAGE or decoder_block not in DECODER_SPECIAL_TOKENS:
+    raise ValueError(f"Stitched model not supported for vision='{vision_block}', decoder='{decoder_block}'.")
+
+  num_tokens_per_image = VISION_TOKENS_PER_IMAGE[vision_block]
+  has_images = processor_output is not None and processor_output.pixel_values is not None
+  num_images = processor_output.pixel_values.shape[0] if has_images else 1
+  # +num_tokens_per_image for image_pad, -1 for original placeholder
+  return (num_tokens_per_image - 1) * num_images
+
+
+def add_extra_tokens_for_omni(
+    tokens,
+    vision_block,
+    decoder_block,
+    processor_output=None,
+    num_tokens_per_image=None,
+):
+  """Expands <|image_pad|> placeholders or prepends vision tokens if missing.
+
+  - If <|image_pad|> is present in `tokens`, expands each placeholder into `num_tokens_per_image` copies.
+  - If <|image_pad|> is absent but `processor_output` contains image data,
+    automatically prepends the vision sequence: [<|vision_start|>, <|image_pad|>*N, <|vision_end|>].
+  - Otherwise, returns the original tokens unchanged.
+  """
+  if vision_block not in VISION_TOKENS_PER_IMAGE or decoder_block not in DECODER_SPECIAL_TOKENS:
+    raise ValueError(f"Stitched model not supported for vision='{vision_block}', decoder='{decoder_block}'.")
+
+  if num_tokens_per_image is None:
+    num_tokens_per_image = VISION_TOKENS_PER_IMAGE[vision_block]
+
+  tokens_config = DECODER_SPECIAL_TOKENS[decoder_block]
+  image_pad_id = tokens_config["image_pad"]
+  vision_start_id = tokens_config["vision_start"]
+  vision_end_id = tokens_config["vision_end"]
+
+  dtype = tokens.dtype if isinstance(tokens, np.ndarray) else np.int32
+  token_list = np.asarray(tokens).flatten().tolist()
+
+  # Case 1: Prompt contains <|image_pad|> placeholders, expand them
+  if image_pad_id in token_list:
+    expanded_tokens = []
+    for token in token_list:
+      if token == image_pad_id:
+        expanded_tokens.extend([image_pad_id] * num_tokens_per_image)
+      else:
+        expanded_tokens.append(token)
+    return np.array(expanded_tokens, dtype=dtype)
+
+  # Case 2: No placeholder in text, but image data is present, prepend vision block
+  if processor_output is not None and processor_output.pixel_values is not None:
+    max_logging.warning(
+        "No visual placeholder (<|image_pad|>) found in prompt tokens, but image data is present. "
+        "Ensure prompts are formatted via reformat_prompt to avoid token offset discrepancies."
+    )
+    num_images = processor_output.pixel_values.shape[0]
+    vision_block_seq = []
+    for _ in range(num_images):
+      vision_block_seq.extend([vision_start_id] + [image_pad_id] * num_tokens_per_image + [vision_end_id])
+    return np.array(vision_block_seq + token_list, dtype=dtype)
+
+  # Case 3: Text-only sequence, return original tokens
+  return np.array(token_list, dtype=dtype)
+
+
+def get_bidirectional_mask_vision_omni(vision_block, decoder_block, decoder_input_tokens):
+  """Generates bidirectional attention mask for vision tokens in stitched models."""
+  if vision_block not in VISION_TOKENS_PER_IMAGE or decoder_block not in DECODER_SPECIAL_TOKENS:
+    raise ValueError(f"Stitched model not supported for vision='{vision_block}', decoder='{decoder_block}'.")
+
+  image_pad_id = DECODER_SPECIAL_TOKENS[decoder_block]["image_pad"]
+  return decoder_input_tokens == image_pad_id

--- a/src/maxtext/experimental/omni_poc/utils/stitch_checkpoint.py
+++ b/src/maxtext/experimental/omni_poc/utils/stitch_checkpoint.py
@@ -21,16 +21,21 @@ This script initializes a target multimodal model and restores subtrees from sep
 
 
 Example usage:
-python -m maxtext.experimental.omni_poc.utils.stitch_checkpoint \
+JAX_PLATFORMS=cpu python -m maxtext.experimental.omni_poc.utils.stitch_checkpoint \
+    src/maxtext/experimental/omni_poc/maxtext-omni-gemma3-qwen3.yml \
     --vision_load_path=gs://YOUR_BUCKET_NAME/checkpoints/gemma3-4b_converted/0/items \
     --llm_load_path=gs://YOUR_BUCKET_NAME/checkpoints/qwen3-4b_converted/0/items \
     --stitched_output_path=gs://YOUR_BUCKET_NAME/checkpoints/omni-gemma3-qwen3-4b/0/items
 """
 
+import maxtext
+# Eagerly initialize core MaxText C++ and model dependencies before train.py
+_ = (maxtext.Mesh, maxtext.pyconfig, maxtext.models, maxtext.model_creation_utils)
+
 import os
 from typing import Any, Dict
 
-from absl import app
+from absl import app, flags
 from etils import epath
 from flax import nnx
 import jax
@@ -45,6 +50,11 @@ from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
 from maxtext.utils import maxtext_utils_nnx
 from maxtext.utils import model_creation_utils
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string("vision_load_path", "", "Path to the vision model checkpoint.")
+flags.DEFINE_string("llm_load_path", "", "Path to the LLM checkpoint.")
+flags.DEFINE_string("stitched_output_path", "", "Path to save the stitched checkpoint.")
 
 
 def _unwrap_var(v):
@@ -139,13 +149,16 @@ def stitch_and_save_checkpoints(
   max_logging.log("=" * 60)
   max_logging.log("Starting Omni Multi-Directory Checkpoint Stitching...")
 
-  vision_model_name = getattr(config, "model_name", None)
+  vision_model_name = getattr(config, "vision_encoder_block", None)
   llm_model_name = getattr(config, "decoder_block", None)
-  assert vision_model_name, "model_name must be configured for vision component."
+  vision_projector_type = getattr(config, "vision_projector_type", None)
+  assert vision_model_name, "vision_encoder_block must be configured for vision component."
   assert llm_model_name, "decoder_block must be configured for LLM component."
+  assert vision_projector_type, "vision_projector_type must be configured for vision component."
 
   max_logging.log(f"  Vision (Model {vision_model_name}) Path: {vision_checkpoint_path}")
   max_logging.log(f"  LLM (Model {llm_model_name}) Path:    {llm_checkpoint_path}")
+  max_logging.log(f"  Projector Type:        {vision_projector_type}")
   max_logging.log(f"  Output Stitched Path:  {output_checkpoint_path}")
   max_logging.log("=" * 60)
 
@@ -206,11 +219,7 @@ def stitch_and_save_checkpoints(
 
   # 4. Assemble: Vision (Model A) + LLM (Model B) + Random Init Projector
   stitched_inner = {k: _assemble(k, v, stitched_subtrees) for k, v in inner_params.items()}
-  final_params = (
-      {"params": stitched_inner}
-      if "params" in params_dict and isinstance(params_dict["params"], dict)
-      else stitched_inner
-  )
+  final_params = {"params": stitched_inner}
 
   # 5. Save unified parameter tree to output_checkpoint_path
   max_logging.log(f"Saving stitched checkpoint to: {output_checkpoint_path}")
@@ -241,13 +250,21 @@ def _load_custom_yaml_overrides(yaml_path: str, omni_keys: set[str]):
 
 
 def main(argv):
-  # Extract omni stitching arguments directly from argv before passing to pyconfig.initialize
-  omni_keys = {"vision_load_path", "llm_load_path", "stitched_output_path", "vision_model_name", "llm_model_name"}
+  omni_keys = {
+      "vision_load_path",
+      "llm_load_path",
+      "stitched_output_path",
+      "vision_model_name",
+      "llm_model_name",
+      "base_config",
+      "model_name",
+  }
   omni_kwargs = {}
   cleaned_argv = []
   for arg in argv:
-    if "=" in arg and arg.split("=", 1)[0] in omni_keys:
-      k, v = arg.split("=", 1)
+    cleaned_arg = arg.lstrip("-")
+    if "=" in cleaned_arg and cleaned_arg.split("=", 1)[0] in omni_keys:
+      k, v = cleaned_arg.split("=", 1)
       omni_kwargs[k] = v
     else:
       cleaned_argv.append(arg)
@@ -275,12 +292,16 @@ def main(argv):
 
     cleaned_argv[1] = os.path.join(pyconfig_mod.MAXTEXT_CONFIGS_DIR, "base.yml")
 
+  if not any(arg.startswith("skip_jax_distributed_system=") for arg in cleaned_argv):
+    cleaned_argv.append("skip_jax_distributed_system=True")
+
   # Initialize MaxText config using standard train.initialize
   config, _ = initialize(cleaned_argv)
-  # Extract paths from command-line arguments
-  vision_path = omni_kwargs.get("vision_load_path")
-  llm_path = omni_kwargs.get("llm_load_path")
-  output_path = omni_kwargs.get("stitched_output_path")
+  object.__setattr__(config, "model_name", "maxtext-omni-gemma3-qwen3")
+  # Extract paths from command-line arguments or FLAGS
+  vision_path = FLAGS.vision_load_path or omni_kwargs.get("vision_load_path")
+  llm_path = FLAGS.llm_load_path or omni_kwargs.get("llm_load_path")
+  output_path = FLAGS.stitched_output_path or omni_kwargs.get("stitched_output_path")
   assert (
       vision_path and llm_path and output_path
   ), "Must specify vision_load_path, llm_load_path, and stitched_output_path"

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -723,6 +723,7 @@ class Decoder(nn.Module):
             "qwen3-vl-30b-a3b",
             "qwen3.5-35b-a3b",
             "qwen3.5-397b-a17b",
+            "maxtext-omni-gemma3-qwen3",
         ]:
           y = mm_utils.merge_mm_embeddings(
               text_embeddings=y,

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1361,6 +1361,7 @@ class NNXDecoder(nnx.Module):
             "qwen3-vl-30b-a3b",
             "qwen3.5-35b-a3b",
             "qwen3.5-397b-a17b",
+            "maxtext-omni-gemma3-qwen3",
         }:
           y = mm_utils.merge_mm_embeddings(
               text_embeddings=y,

--- a/src/maxtext/multimodal/processor.py
+++ b/src/maxtext/multimodal/processor.py
@@ -37,6 +37,8 @@ _MODEL_TO_BLOCKS = {
     "qwen3-vl-30b-a3b": ("qwen3_vl", "qwen3_moe"),
     "qwen3.5-35b-a3b": ("qwen3_5", "qwen3_5"),
     "qwen3.5-397b-a17b": ("qwen3_5", "qwen3_5"),
+    # Stitched model
+    "maxtext-omni-gemma3-qwen3": ("gemma3", "qwen3"),
 }
 
 
@@ -138,8 +140,13 @@ def preprocess_image_for_training(image, config):
 def get_image_offsets(config, processor_output: mm_utils.PreprocessorOutput | None):
   """Get the increase in total token count after inserting image token placeholders"""
   vision_block = _get_vision_block(config)
+  decoder_block = _get_decoder_block(config)
 
-  if vision_block in ["gemma3"]:
+  if "maxtext-omni" in getattr(config, "model_name", ""):
+    from maxtext.experimental.omni_poc.utils import processor_maxtext_omni  # pylint: disable=import-outside-toplevel
+
+    return processor_maxtext_omni.get_image_offsets_omni(vision_block, decoder_block, processor_output)
+  elif vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import get_image_offsets_gemma3  # pylint: disable=import-outside-toplevel
 
     return get_image_offsets_gemma3(processor_output)
@@ -220,7 +227,15 @@ def reformat_response(response, model_name):
 def prepare_text_for_image_fusion(tokens, config, processor_output=None):
   """Prepare text by adding extra tokens for image fusion based on the model."""
   vision_block = _get_vision_block(config)
-  if vision_block in ["gemma3"]:
+  decoder_block = _get_decoder_block(config)
+
+  if "maxtext-omni" in getattr(config, "model_name", ""):
+    from maxtext.experimental.omni_poc.utils import processor_maxtext_omni  # pylint: disable=import-outside-toplevel
+
+    return processor_maxtext_omni.add_extra_tokens_for_omni(
+        tokens, vision_block, decoder_block, processor_output=processor_output
+    )
+  elif vision_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import add_extra_tokens_for_images_gemma3  # pylint: disable=import-outside-toplevel
 
     return add_extra_tokens_for_images_gemma3(
@@ -296,7 +311,13 @@ def get_bidirectional_mask_vision(config, decoder_input_tokens, is_video: bool =
 
   decoder_block = _get_decoder_block(config)
 
-  if decoder_block in ["gemma3"]:
+  if "maxtext-omni" in getattr(config, "model_name", ""):
+    from maxtext.experimental.omni_poc.utils import processor_maxtext_omni  # pylint: disable=import-outside-toplevel
+
+    bidirectional_mask_vision = processor_maxtext_omni.get_bidirectional_mask_vision_omni(
+        vision_block, decoder_block, decoder_input_tokens
+    )
+  elif decoder_block in ["gemma3"]:
     from maxtext.multimodal.processor_gemma3 import GEMMA_TOKEN_PLACEHOLDER  # pylint: disable=import-outside-toplevel
 
     bidirectional_mask_vision = decoder_input_tokens == GEMMA_TOKEN_PLACEHOLDER

--- a/tests/unit/multimodal_utils_test.py
+++ b/tests/unit/multimodal_utils_test.py
@@ -500,6 +500,36 @@ class TestMultimodalProcessorRouting(unittest.TestCase):
     with self.assertRaises(ValueError):
       mm_processor.preprocess_image_for_training([dummy_image], config_text_only)
 
+  def test_omni_gemma3_qwen3_processor_routing(self):
+    # pylint: disable=protected-access,import-outside-toplevel
+    self.assertEqual(mm_processor._get_vision_block("maxtext-omni-gemma3-qwen3"), "gemma3")
+    self.assertEqual(mm_processor._get_decoder_block("maxtext-omni-gemma3-qwen3"), "qwen3")
+
+    omni_config = types.SimpleNamespace(
+        vision_encoder_block=VisionEncoderBlockType.GEMMA3,
+        decoder_block=DecoderBlockType.QWEN3,
+        model_name="maxtext-omni-gemma3-qwen3",
+    )
+    self.assertEqual(mm_processor.get_image_offsets(omni_config, None), 255)
+
+    from maxtext.experimental.omni_poc.utils import processor_maxtext_omni
+
+    qwen_image_pad = processor_maxtext_omni.DECODER_SPECIAL_TOKENS["qwen3"]["image_pad"]
+    tokens = [1, qwen_image_pad, 2]
+    fused = mm_processor.prepare_text_for_image_fusion(tokens, config=omni_config)
+    self.assertEqual(len(fused), 1 + 256 + 1)
+
+    mask = mm_processor.get_bidirectional_mask_vision(omni_config, np.array([[10, qwen_image_pad]]))
+    np.testing.assert_array_equal(mask, [[False, True]])
+
+    unsupported_omni = types.SimpleNamespace(
+        vision_encoder_block=VisionEncoderBlockType.LLAMA4,
+        decoder_block=DecoderBlockType.QWEN3,
+        model_name="maxtext-omni-unsupported",
+    )
+    with self.assertRaises(ValueError):
+      mm_processor.get_image_offsets(unsupported_omni, None)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
# Description

This PR introduces the implementations for hybrid multimodal processor in MaxText.

Specifically, it implements modular hybrid multimodal support in the preprocessing and fusion pipelines:
- **Text Prompt**: Formatted with the text decoder (Qwen 3) chat template and special vision tags (`<|vision_start|>`, `<|image_pad|>`, `<|vision_end|>`) and tokenized by the text decoder's tokenizer.
- **Image Inputs**: Preprocessed by the vision encoder (Gemma 3) processor.
- **Fusion Stage**: Handled by `processor_maxtext_omni.py`, which expands placeholder tokens into 256 copies of `<|image_pad|>`. This ensures the text decoder knows precisely where to inject the 256 projected visual embeddings within the token stream without corrupting text subword tokenization or array indexing.

This is Step 3 of a 5-step Proof-of-Concept for any-to-any multimodal alignment in MaxText. The overall goal is to align pretrained vision encoders with text-only LLMs by connecting the two with a dynamically configured adaptation layer (customized MLP connector), special tokenizer mapping for visual placeholder tokens, and training only the MLP using supervised fine tuning.

# Files

1. **Omni Multimodal Processor** 
   - `experimental/omni_poc/utils/processor_maxtext_omni.py`
     - Implemented modular visual placeholder token management (`<|vision_start|>`, `<|image_pad|>`, `<|vision_end|>`) combining Qwen 3's vocabulary with Gemma 3's visual token count (256 tokens per image).
     - Decoupled architectures via `VISION_TOKENS_PER_IMAGE` and `DECODER_SPECIAL_TOKENS` lookup tables.
     - Added functions for offset calculation, placeholder token expansion, and bidirectional mask generation (`get_image_offsets_omni`, `add_extra_tokens_for_omni`, `get_bidirectional_mask_vision_omni`) with validation for unsupported combinations.

2. **Name Registration & Routing** 
   - `multimodal/processor.py`, `layers/decoders.py`, and `layers/nnx_decoders.py`
     - Integrated stitched architecture routing into `processor.py` for models matching `"maxtext-omni"` in `model_name`.
     - Registered `maxtext-omni-gemma3-qwen3` model name across Flax/NNX decoders and multimodal registries.

3. **Preparation & Decoding Utilities** 
   - `experimental/omni_poc/prepare_checkpoint.sh`
     - Automated end-to-end HuggingFace download, conversion (`to_maxtext`), and stitching workflow.
   - `experimental/omni_poc/utils/decode_omni.py`
     - Added a decoding script to run prefill and autoregressive generation on ChartQA multimodal validation samples.
     - Update after review:
       - Replaced the repeated full-sequence forward loop with a decoupled prefill step and Flax KV-cached autoregressive decoding, reducing vision encoder passes from O(N x V_ViT) to O(1 x V_ViT) and attention complexity per generated token from quadratic O((L + i)^2) to linear O(L + i).
       - Replaced the Python step loop and host-device synchronization barriers with an XLA-compiled jax.lax.scan generation kernel, reducing CPU-TPU roundtrips from O(N) blocking calls to O(1) pure on-chip execution.
       - L = Prefill / Prompt length; N = Number of generated tokens; V_ViT = Cost of a full Gemma 3 Vision Transformer forward pass
       - In total, this reduced the decoding time from 3.3 minutes to 6 seconds in one example.
   - `experimental/omni_poc/utils/stitch_checkpoint.py`
     - Modified the checkpoint stitch script to be compatible with current codebase.

4. **Configuration** 
   - `experimental/omni_poc/maxtext-omni-gemma3-qwen3.yml`
     - Model configuration defining Gemma 3 vision tower parameters, Qwen 3 4B LLM backbone parameters, and custom projector.

5. **Unit Tests** 
   - `experimental/omni_poc/tests/processor_maxtext_omni_test.py`
     - Added unit tests for Omni visual token expansion, offset calculations, dtype preservation, and combination validation.
   - `experimental/omni_poc/tests/stitch_checkpoint_test.py`
     - Unit tests for checkpoint stitching compatibility.
   - `tests/unit/multimodal_utils_test.py`
     - Added unit tests for `maxtext-omni-gemma3-qwen3` routing, fusion masking, and exception handling in the multimodal processor.


# Tests

## 1. Checkpoint Stitching Generation
Generated a stitched Orbax checkpoint from converted Gemma 3 4B vision weights and Qwen 3 4B language weights:
```bash
JAX_PLATFORMS=cpu python -m maxtext.experimental.omni_poc.utils.stitch_checkpoint \
    src/maxtext/experimental/omni_poc/maxtext-omni-gemma3-qwen3.yml \
    --vision_load_path=gs://yuchenhou-maxtext-logs/omni_checkpoints/gemma3-4b_converted/0/items \
    --llm_load_path=gs://yuchenhou-maxtext-logs/omni_checkpoints/qwen3-4b_converted/0/items \
    --stitched_output_path=gs://yuchenhou-maxtext-logs/omni_checkpoints/omni_stitched_gemma3-4b_qwen3-4b/0/items
```

## 2. Checkpoint Stitching Unit Test
Verified that the stitched checkpoint accurately preserves original weights from both source models:
```bash
OMNI_TEST_BASE_DIR='gs://yuchenhou-maxtext-logs/omni_checkpoints' JAX_PLATFORMS=cpu \
    /home/yuchenhou_google_com/maxtext_env/bin/python -m unittest src/maxtext/experimental/omni_poc/tests/stitch_checkpoint_test.py
```
**Output:**
```
----------------------------------------------------------------------
Ran 2 tests in 135.804s

OK
```


## 3. Omni Processor Unit Test
Verified token ID mappings, sequence expansions, and offsets:
```bash
python -m unittest src/maxtext/experimental/omni_poc/tests/processor_maxtext_omni_test.py
```
**Output:**
```
----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK
```

## 4. Multimodal Processor Unit Tests
Verified hybrid multimodal routing and fusion:
```bash
JAX_PLATFORMS=cpu python3 -m pytest -v tests/unit/multimodal_utils_test.py tests/unit/qwen3_omni_layers_test.py
```
**Output:**
```
============================= 56 passed, 1 skipped in 192.32s =============================
```

## 5. End-to-End Multimodal Decoding
Ran end-to-end decoding on ChartQA validation samples using the stitched checkpoint:
```bash
JAX_PLATFORMS=tpu /home/yuchenhou_google_com/maxtext_env/bin/python src/maxtext/experimental/omni_poc/utils/decode_omni.py \
    --checkpoint_path="gs://yuchenhou-maxtext-logs/omni_checkpoints/omni_stitched_gemma3-4b_qwen3-4b/0/items" \
    --num_samples=2 \
    --max_new_tokens=64
```
**Output:**
```text
Sample 1 (Index 1309):
  Question: What was the average annual total income per household of those in the top decile group?
  Ground Truth: ['186600']
  Model Response: <think>
Okay, the user is asking about the average annual total income per household in the top decile group. First, I need to figure out what data they're referring to. The question is pretty general, so I should consider different sources where this information might be available.

Sample 2 (Index 228):
  Question: Which gender is represented by the red color line?
  Ground Truth: ['Male']
  Model Response: <think>
Okay, the user is asking about the gender represented by the red color line. But wait, the initial message they provided is a mix of different languages and some random characters. It seems like they might have pasted some text that's not properly formatted or maybe a mix of different scripts.

```

This ensures the data is flowing end to end. The response itself does not make sense due to the randomly initialized projector, as expected.



# Step-by-Step Objectives
- [PR 4485](https://github.com/google/maxtext/pull/4485) Multi-Directory Checkpoint Restoration: Implemented selective sub-tree parameter loading using Orbax such that we can initiaze a multimodal model with parameters from multiple checkpoints.
- [PR 4593](https://github.com/google/maxtext/pull/4593) Dynamic MLP Connector: Add omni modal adapter layer (MLP) to connect vision tower output to the LLM decoder
- [PR 4746](https://github.com/google/maxtext/pull/4746) and [PR 4839](https://github.com/google/maxtext/pull/4839) Special Tokenizer & Placeholder Masking: Add special token <|image|> to tokenizer and make sure the masking is correct in the decoder.
- [PR 4864](https://github.com/AI-Hypercomputer/maxtext/pull/4864) COCO-Narratives Data Pipeline Processing
- SFT Execution & Evaluation



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
