### PR TITLE
add zxhe-sean to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,12 +10,12 @@ src/maxtext/models @parambole @shuningjin @RissyRan @jiangjy1982 @gobbleturk @bv
 # Features
 src/maxtext/experimental/rl @A9isha @khatwanimohit @xuefgu @gagika @richjames0 @shralex @darisoy @shuwenf @igorts-git
 src/maxtext/input_pipeline @aireenmei @SurbhiJainUSC @richjames0 @shralex @darisoy @shuwenf @igorts-git
-src/maxtext/kernels/megablox @RissyRan @michelle-yooh @gagika @richjames0 @shralex @jesselu-google @darisoy @shuwenf @igorts-git @shuningjin
+src/maxtext/kernels/megablox @RissyRan @michelle-yooh @gagika @richjames0 @shralex @jesselu-google @darisoy @shuwenf @igorts-git @shuningjin @zxhe-sean
 src/maxtext/kernels/ragged_attention.py @patemotter @vipannalla @richjames0 @shralex @darisoy @shuwenf @igorts-git
 src/maxtext/layers/pipeline.py @gobbleturk @richjames0 @shralex @NuojCheng @darisoy @shuwenf @igorts-git
-src/maxtext/layers/moe.py @RissyRan @michelle-yooh @gagika @richjames0 @shralex @jesselu-google @darisoy @shuwenf @igorts-git @shuningjin
-src/maxtext/layers/multi_token_prediction.py @parambole @RissyRan @gagika @richjames0 @shralex @darisoy @shuwenf @igorts-git @shuningjin
-src/maxtext/layers/quantizations.py @khatwanimohit @shuningjin @jshin1394 @liudangyi @richjames0 @shralex @darisoy @shuwenf @igorts-git
+src/maxtext/layers/moe.py @RissyRan @michelle-yooh @gagika @richjames0 @shralex @jesselu-google @darisoy @shuwenf @igorts-git @shuningjin @zxhe-sean
+src/maxtext/layers/multi_token_prediction.py @parambole @RissyRan @gagika @richjames0 @shralex @darisoy @shuwenf @igorts-git @shuningjin @zxhe-sean
+src/maxtext/layers/quantizations.py @khatwanimohit @shuningjin @jshin1394 @liudangyi @richjames0 @shralex @darisoy @shuwenf @igorts-git @zxhe-sean
 
 # vLLM eval framework
 src/maxtext/eval/ @dipannita08 @hengtaoguo @igorts-git


### PR DESCRIPTION
# Description

Add zxhe-sean to owners of `src/maxtext/kernels/megablox`, `src/maxtext/layers/moe.py`, `src/maxtext/layers/multi_token_prediction.py` and `src/maxtext/layers/quantizations.py`

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
