### PR TITLE
Fix muon moe dimension numbers

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4257,6 +4257,10 @@ class MaxTextConfig(
         DecoderBlockType.DEEPSEEK,
         DecoderBlockType.DEEPSEEK4,
         DecoderBlockType.QWEN3,
+        DecoderBlockType.QWEN3_MOE,
+        DecoderBlockType.QWEN3_CUSTOM_MOE,
+        DecoderBlockType.QWEN3_NEXT,
+        DecoderBlockType.GPT_OSS,
         DecoderBlockType.GEMMA3,
         DecoderBlockType.LLAMA2,
     ]:

--- a/src/maxtext/utils/muon_utils.py
+++ b/src/maxtext/utils/muon_utils.py
@@ -78,6 +78,9 @@ def transform_logic(path: Tuple[str, ...]) -> Optional[mdn]:
   # "bias": scalar, common module
   # "hc_base": scalar, in mhc head
   # "post_beta", "pre_beta", "res_beta": scalar, in mhc
+  # "A_log": scalar / 1D per head, in gdn linear attention
+  # "conv1d": depthwise 1D convolution
+  # "shared_expert_gate": scalar projection (output_dim = 1)
   if any(
       any(
           x in segment
@@ -91,9 +94,12 @@ def transform_logic(path: Tuple[str, ...]) -> Optional[mdn]:
               "hc_base",
               "sinks",
               "tid2eid",
+              "A_log",
+              "conv1d",
+              "shared_expert_gate",
           )
       )
-      or segment == "bias"
+      or (segment.endswith("bias") and segment != "position_bias")
       for segment in path
   ):
     return None
@@ -101,15 +107,17 @@ def transform_logic(path: Tuple[str, ...]) -> Optional[mdn]:
   # 2 Special weights
   # 2.1 Special weights: MoE, [0, L, -2, -1]
   # L (optional) stands for layer when scan_layers=True
-  if "MoeBlock_0" in path:
+  if _is_path_contain_any(("MoeBlock_0", "routed_experts", "moe_block", "GptOssMlp"), path):
     # exclude gate
-    if _is_path_contain_any(("wi_0", "wi_1", "wo"), path):
+    if _is_path_contain_any(("wi", "wi_0", "wi_1", "wo"), path):
       return mdn((-2,), (-1,))
 
-  # 2.2 Special weights: Self attention
-  elif "self_attention" in path:
+  # 2.2 Special weights: Self attention / Attention
+  elif _is_path_contain_any(("self_attention", "GptOssAttention", "attention"), path):
     # Attention output projection: [0, L, -2, -1]
-    if "out" in path:
+    # For standard attention (e.g. self_attention, GptOssAttention), out projection reduces over (0, -2).
+    # Note: Qwen3-Next full attention flattens heads into a 2D projection, so it uses standard weights mdn((0,), (-1,)).
+    if "out" in path and _is_path_contain_any(("self_attention", "GptOssAttention"), path):
       return mdn((0, -2), (-1,))
     # Block-diagonal grouped linear layer: [n_groups, L, in_features_per_group, out_features_per_group]
     elif "o_a_proj" in path:

--- a/tests/unit/muon_utils_test.py
+++ b/tests/unit/muon_utils_test.py
@@ -53,6 +53,14 @@ class TestTransformLogic(unittest.TestCase):
   def test_bias_is_excluded(self):
     self.assertIsNone(muon_utils.transform_logic(("decoder", "dense", "bias")))
 
+  def test_bias_variant_is_excluded(self):
+    # Bias names (e.g., in MoE with mlp_bias=True) are excluded across all expert projections.
+    self.assertIsNone(muon_utils.transform_logic(("decoder", "moe_block", "wi_0_bias")))
+    self.assertIsNone(muon_utils.transform_logic(("decoder", "GptOssMlp", "wi_0_bias")))
+    self.assertIsNone(muon_utils.transform_logic(("decoder", "GptOssMlp", "wi_1_bias")))
+    self.assertIsNone(muon_utils.transform_logic(("decoder", "GptOssMlp", "wo_bias")))
+    self.assertIsNone(muon_utils.transform_logic(("decoder", "mlp", "mlp_bias")))
+
   def test_embedding_is_excluded(self):
     self.assertIsNone(muon_utils.transform_logic(("token_embedder", "embedding")))
 
@@ -69,9 +77,27 @@ class TestTransformLogic(unittest.TestCase):
   def test_moe_wo_uses_last_two_axes(self):
     self.assertEqual(muon_utils.transform_logic(("decoder", "MoeBlock_0", "wo")), mdn((-2,), (-1,)))
 
+  def test_moe_prefused_wi_uses_last_two_axes(self):
+    self.assertEqual(muon_utils.transform_logic(("decoder", "MoeBlock_0", "wi")), mdn((-2,), (-1,)))
+    self.assertEqual(muon_utils.transform_logic(("decoder", "routed_experts", "wi")), mdn((-2,), (-1,)))
+
+  def test_qwen3_next_moe_routed_experts(self):
+    self.assertEqual(muon_utils.transform_logic(("decoder", "mlp", "routed_experts", "wi_0")), mdn((-2,), (-1,)))
+    self.assertEqual(muon_utils.transform_logic(("decoder", "mlp", "routed_experts", "wi_1")), mdn((-2,), (-1,)))
+    self.assertEqual(muon_utils.transform_logic(("decoder", "mlp", "routed_experts", "wo")), mdn((-2,), (-1,)))
+
+  def test_qwen3_moe_block(self):
+    self.assertEqual(muon_utils.transform_logic(("decoder", "moe_block", "wi_0")), mdn((-2,), (-1,)))
+    self.assertEqual(muon_utils.transform_logic(("decoder", "moe_block", "wo")), mdn((-2,), (-1,)))
+
+  def test_gpt_oss_mlp_moe(self):
+    self.assertEqual(muon_utils.transform_logic(("decoder", "GptOssMlp", "wi_0")), mdn((-2,), (-1,)))
+    self.assertEqual(muon_utils.transform_logic(("decoder", "GptOssMlp", "wo")), mdn((-2,), (-1,)))
+
   def test_moe_gate_falls_through_to_standard(self):
-    # 'gate' is inside MoeBlock_0 but not one of (wi_0, wi_1, wo) → standard.
+    # 'gate' is inside MoeBlock_0 but not one of (wi, wi_0, wi_1, wo) → standard.
     self.assertEqual(muon_utils.transform_logic(("decoder", "MoeBlock_0", "gate", "kernel")), mdn((0,), (-1,)))
+    self.assertEqual(muon_utils.transform_logic(("decoder", "routed_experts", "gate", "kernel")), mdn((0,), (-1,)))
 
   # --- 2.2 Self-attention ---
   def test_self_attention_out_projection(self):
@@ -118,6 +144,18 @@ class TestTransformLogic(unittest.TestCase):
     # o_a_proj projects with reduction on in_features_per_group (-2)
     # and output on out_features_per_group (-1)
     self.assertEqual(muon_utils.transform_logic(("decoder", "self_attention", "o_a_proj")), mdn((-2,), (-1,)))
+
+  def test_deepseek_v4_position_bias_is_standard_weight(self):
+    # position_bias in DeepSeek V4 compressed attention is a 2D weight matrix (not a 1D bias vector),
+    # so it receives standard Muon dimension numbers mdn((0,), (-1,)).
+    self.assertEqual(
+        muon_utils.transform_logic(("decoder", "self_attention", "csa_compressor", "position_bias")),
+        mdn((0,), (-1,)),
+    )
+    self.assertEqual(
+        muon_utils.transform_logic(("decoder", "self_attention", "hca_compressor", "position_bias")),
+        mdn((0,), (-1,)),
+    )
 
 
 class TestGetTransformTree(unittest.TestCase):

--- a/tests/unit/optimizers_test.py
+++ b/tests/unit/optimizers_test.py
@@ -219,6 +219,177 @@ QWEN3_DIMENSION_NUMBER = {
 }
 
 
+# qwen3 MoE (e.g. qwen3-30b-a3b)
+QWEN3_MOE_DIMENSION_NUMBER = {
+    "params": {
+        "decoder": {
+            "decoder_norm": {"scale": None},
+            "layers": {
+                "moe_block": {
+                    "gate": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+                    "wi_0": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+                    "wi_1": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+                    "wo": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+                },
+                "post_self_attention_layer_norm": {"scale": None},
+                "pre_self_attention_layer_norm": {"scale": None},
+                "self_attention": {
+                    "query": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "key": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "value": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "out": {"kernel": mdn(reduction_axis=(0, -2), output_axis=(-1,))},
+                    "key_norm": {"scale": None},
+                    "query_norm": {"scale": None},
+                },
+            },
+            "logits_dense": {"kernel": None},
+        },
+        "token_embedder": {"embedding": None},
+    }
+}
+
+
+# qwen3 custom MoE (e.g. qwen3-custom-30b-a3b)
+QWEN3_CUSTOM_MOE_DIMENSION_NUMBER = {
+    "params": {
+        "decoder": {
+            "decoder_norm": {"scale": None},
+            "layers": {
+                "latent_norm": {"scale": None},
+                "layer_up_projection": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+                "moe_block": {
+                    "gate": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+                    "wi_0": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+                    "wi_1": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+                    "wo": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+                },
+                "post_self_attention_layer_norm": {"scale": None},
+                "pre_self_attention_layer_norm": {"scale": None},
+                "self_attention": {
+                    "query": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "key": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "value": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "out": {"kernel": mdn(reduction_axis=(0, -2), output_axis=(-1,))},
+                    "key_norm": {"scale": None},
+                    "query_norm": {"scale": None},
+                },
+            },
+            "logits_dense": {"kernel": None},
+        },
+        "token_embedder": {"embedding": None},
+    }
+}
+
+
+# qwen3-next (e.g. qwen3-next-80b-a3b)
+_QWEN3_NEXT_MLP = {
+    "routed_experts": {
+        "gate": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+        "wi_0": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+        "wi_1": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+        "wo": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+    },
+    "shared_expert": {
+        "wi_0": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+        "wi_1": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+        "wo": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+    },
+    "shared_expert_gate": {"kernel": None},
+}
+
+_QWEN3_NEXT_GDN_ATTENTION = {
+    "A_log": None,
+    "conv1d": {"kernel": None},
+    "dt_bias": None,
+    "in_proj_ba": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+    "in_proj_qkvz": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+    "norm": {"rms_norm": {"scale": None}},
+    "out_proj": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+}
+
+_QWEN3_NEXT_FULL_ATTENTION = {
+    "attention": {
+        "query": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+        "key": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+        "value": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+        "out": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+        "key_norm": {"scale": None},
+        "query_norm": {"scale": None},
+    },
+}
+
+_QWEN3_NEXT_GDN_LAYER = {
+    "attention": _QWEN3_NEXT_GDN_ATTENTION,
+    "input_layernorm": {"scale": None},
+    "mlp": _QWEN3_NEXT_MLP,
+    "post_attention_layernorm": {"scale": None},
+}
+
+_QWEN3_NEXT_FULL_ATTN_LAYER = {
+    "attention": _QWEN3_NEXT_FULL_ATTENTION,
+    "input_layernorm": {"scale": None},
+    "mlp": _QWEN3_NEXT_MLP,
+    "post_attention_layernorm": {"scale": None},
+}
+
+QWEN3_NEXT_DIMENSION_NUMBER = {
+    "params": {
+        "decoder": {
+            "decoder_norm": {"scale": None},
+            "layers": {
+                "layer_0": _QWEN3_NEXT_GDN_LAYER,
+                "layer_1": _QWEN3_NEXT_GDN_LAYER,
+                "layer_2": _QWEN3_NEXT_GDN_LAYER,
+                "layer_3": _QWEN3_NEXT_FULL_ATTN_LAYER,
+            },
+            "logits_dense": {"kernel": None},
+        },
+        "token_embedder": {"embedding": None},
+    }
+}
+
+
+# gpt-oss (e.g. gpt-oss-20b)
+_GPT_OSS_ATTENTION = {
+    "query": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1)), "bias": None},
+    "key": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1)), "bias": None},
+    "value": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1)), "bias": None},
+    "out": {"kernel": mdn(reduction_axis=(0, -2), output_axis=(-1,)), "bias": None},
+    "sinks": None,
+}
+
+_GPT_OSS_MLP = {
+    "gate": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,)), "bias": None},
+    "wi_0": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+    "wi_0_bias": None,
+    "wi_1": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+    "wi_1_bias": None,
+    "wo": mdn(reduction_axis=(-2,), output_axis=(-1,)),
+    "wo_bias": None,
+}
+
+_GPT_OSS_LAYER = {
+    "GptOssAttention": _GPT_OSS_ATTENTION,
+    "GptOssMlp": _GPT_OSS_MLP,
+    "post_self_attention_layer_norm": {"scale": None},
+    "pre_self_attention_layer_norm": {"scale": None},
+}
+
+GPT_OSS_DIMENSION_NUMBER = {
+    "params": {
+        "decoder": {
+            "decoder_norm": {"scale": None},
+            "layers": {
+                "layers_0": _GPT_OSS_LAYER,
+                "layers_1": _GPT_OSS_LAYER,
+            },
+            "logits_dense": {"kernel": None},
+        },
+        "token_embedder": {"embedding": None},
+    }
+}
+
+
 # deepseek4 building blocks
 _DEEPSEEK4_MHC_ATTENTION = {
     "mhc_norm": {"scale": None},
@@ -392,6 +563,10 @@ class MuonDimensionTest(parameterized.TestCase):
       ("llama3.3-70b", "llama3.3-70b", LLAMA2_DIMENSION_NUMBER),
       ("gemma3-4b", "gemma3-4b", GEMMA3_DIMENSION_NUMBER),
       ("qwen3-0.6b", "qwen3-0.6b", QWEN3_DIMENSION_NUMBER),
+      ("qwen3-30b-a3b", "qwen3-30b-a3b", QWEN3_MOE_DIMENSION_NUMBER),
+      ("qwen3-custom-30b-a3b", "qwen3-custom-30b-a3b", QWEN3_CUSTOM_MOE_DIMENSION_NUMBER),
+      ("qwen3-next-80b-a3b", "qwen3-next-80b-a3b", QWEN3_NEXT_DIMENSION_NUMBER),
+      ("gpt-oss-20b", "gpt-oss-20b", GPT_OSS_DIMENSION_NUMBER),
   )
   @pytest.mark.tpu_only
   def test_model_integration(self, model_name, expected_output):
@@ -694,6 +869,7 @@ class TestMuonLogic(unittest.TestCase):
     self.assertIsNone(muon_utils.transform_logic(("layer_0", "bias")))
     self.assertIsNone(muon_utils.transform_logic(("layer_0", "scale")))
     self.assertIsNone(muon_utils.transform_logic(("embedding", "kernel")))
+    self.assertIsNone(muon_utils.transform_logic(("layer_0", "attention", "A_log")))
 
   def test_transform_logic_moe(self):
     path = ("layers_0", "MoeBlock_0", "wi_0")
@@ -707,6 +883,18 @@ class TestMuonLogic(unittest.TestCase):
 
     path_q = ("layers_0", "self_attention", "query", "kernel")
     self.assertEqual(muon_utils.transform_logic(path_q), mdn((0,), (-2, -1)))
+
+    path_gpt_out = ("layers_0", "GptOssAttention", "out", "kernel")
+    self.assertEqual(muon_utils.transform_logic(path_gpt_out), mdn((0, -2), (-1,)))
+
+    path_gpt_q = ("layers_0", "GptOssAttention", "query", "kernel")
+    self.assertEqual(muon_utils.transform_logic(path_gpt_q), mdn((0,), (-2, -1)))
+
+    path_qwen3_next_q = ("layers_0", "attention", "attention", "query", "kernel")
+    self.assertEqual(muon_utils.transform_logic(path_qwen3_next_q), mdn((0,), (-2, -1)))
+
+    path_qwen3_next_out = ("layers_0", "attention", "attention", "out", "kernel")
+    self.assertEqual(muon_utils.transform_logic(path_qwen3_next_out), mdn((0,), (-1,)))
 
   def test_get_transform_tree(self):
     fake_tree = {"params": {"layer_0": {"kernel": "leaf", "bias": "leaf"}, "MoeBlock_0": {"wi_0": "leaf"}}}


### PR DESCRIPTION
# Description

This PR updates `maxtext.utils.muon_utils.transform_logic` to assign `MuonDimensionNumbers` to MoE expert weights across (Qwen 3, Qwen 3-next, and GPT-OSS) and ensures all bias variants are correctly excluded from Muon orthogonalization.

### Problem
1. **Missing MoE block names**: `transform_logic` previously checked `if "MoeBlock_0" in path:` to detect expert weights. However, newer MoE architectures use different module names:
   - `routed_experts` (Qwen3-next in `qwen3.py`)
   - `moe_block` (Qwen3 MoE in `qwen3.py` / `qwen3_custom.py`)
   - `GptOssMlp` (GPT-OSS in `gpt_oss.py`)
   Because these module names did not contain `"MoeBlock_0"`, their expert weight tensors fell through to the default mapping `mdn((0,), (-1,))` instead of `mdn((-2,), (-1,))`, leading to incorrect orthogonalization across the expert axis.
2. **Prefused MoE kernels**: When `prefuse_moe_weights=True`, the fused gate+up kernel is named `wi`, which was missing from the recognized expert weight kernels `("wi_0", "wi_1", "wo")`.
3. **Bias variants**: `transform_logic` checked `segment == "bias"`, which missed compound bias names such as `wi_0_bias`, `wo_bias` (used in GPT-OSS with `mlp_bias=True`), and `mlp_bias`.

### Solution
- Expanded MoE block container matching in `transform_logic` to recognize `("MoeBlock_0", "routed_experts", "moe_block", "GptOssMlp")`.
- Added `"wi"` to the expert weight kernel tuple `("wi", "wi_0", "wi_1", "wo")` returning `mdn((-2,), (-1,))`.
- Added `"bias"` to the substring exclusion tuple so all bias variations (`wi_0_bias`, `wo_bias`, etc.) return `None` and fall back to AdamW as intended.

FIXES: #4798

# Tests

Added unit test coverage in `tests/unit/muon_utils_test.py`:
- `test_bias_variant_is_excluded`: Verifies `wi_0_bias`, `wo_bias`, and `mlp_bias` return `None`.
- `test_qwen3_next_moe_routed_experts`: Verifies `routed_experts` expert kernels (`wi_0`, `wi_1`, `wo`) return `mdn((-2,), (-1,))`.
- `test_qwen3_moe_block`: Verifies `moe_block` expert kernels return `mdn((-2,), (-1,))`.
- `test_gpt_oss_mlp_moe`: Verifies `GptOssMlp` expert kernels return `mdn((-2,), (-1,))`.
- `test_moe_prefused_wi_uses_last_two_axes`: Verifies prefused `wi` kernels return `mdn((-2,), (-1,))`.
- `test_moe_gate_falls_through_to_standard`: Verifies gate routing kernels fall through to standard mapping.

Ran test suite locally:
```bash
python3 -m unittest tests/unit/muon_utils_test.py
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

