### PR TITLE
fix: force `dot_product` attention in E2E test to support long context

### DIFF
--- a/tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh
+++ b/tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh
@@ -91,6 +91,7 @@ if [ "${USE_MULTIMODAL}" = "false" ]; then
         --hf_model_path=${HF_GOLDEN_MODEL} \
         --max_kl_div=0.03 \
         --run_hf_model=true \
+        attention=dot_product \
         hardware=cpu \
         skip_jax_distributed_system=True
 fi

--- a/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_mt.sh
+++ b/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_mt.sh
@@ -68,5 +68,6 @@ if [ "${USE_MULTIMODAL}" = "false" ]; then
         --hf_model_path=${HF_GOLDEN_MODEL} \
         --max_kl_div=0.03 \
         --run_hf_model=true \
+        attention=dot_product \
         hardware=cpu skip_jax_distributed_system=True
 fi

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh
@@ -58,4 +58,5 @@ python3 -m tests.utils.forward_pass_logit_checker \
     --hf_model_path=${HF_GOLDEN_MODEL} \
     --max_kl_div=0.03 \
     --run_hf_model=true \
+    attention=dot_product \
     hardware=cpu skip_jax_distributed_system=True


### PR DESCRIPTION
## Description

This PR resolves a persistent crash in the Gemma3-4b, Llama3.1-70b, Qwen3-30b checkpoint conversion E2E validation script. 
When the `forward_pass_logit_checker` evaluates the on-the-fly HF model on a TPU node, it fails with `ValueError: bkv_compute must be a multiple of 128`, which actively breaks the automated pipeline.

## Root Cause

1. **Long Context Addition:** A recent update introduced a long MRoPE regression prompt to the checker. For the Gemma3 tokenizer, this text tokenizes to exactly **464 tokens**.
2. **Loss of Fallback:** Previously, very short prompts (<128 tokens) gracefully fell back to standard `dot_product` attention. The new 464-token sequence bypasses this automatic safety net.
3. **Hardware Constraint:** Because when the test executes, `maxtext` defaults to the highly optimized Pallas Splash Attention (`flash_attention`). Splash Attention strictly mandates that sequence chunks (`bkv_compute`) must be an exact multiple of 128. A length of 464 crashes instantly out of mathematical compliance.

## Solution

Appended `attention=dot_product` to the `forward_pass_logit_checker` execution command inside the E2E script.

# Tests

```bash
xpk workload create \
  --cluster=mlperf-v5p \
  --workload=convert-to-maxtext-v5p-gemma3-4b-1 \
  --device-type=v5p-8 \
  --num-slices=1 \
  --docker-image=[gcr.io/tpu-prod-env-multipod/fix-logit:latest](http://gcr.io/tpu-prod-env-multipod/fix-logit:latest) \
  --project=cloud-tpu-multipod-dev \
  --zone=europe-west4 \
  --priority=very-high \
  --env GCS_OUTPUT=gs://ml-auto-solutions/output/unowned/convert-to-maxtext-v5p-8-2026-08-12-01-46-39/ \
  --skip-validation \
  --command="set -xue; export HF_HOME=\"/dev/shm/hf_cache\"; export LIBTPU_INIT_ARGS=\"--xla_tpu_scoped_vmem_limit_kib=20480\"; bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh post-20260812"
```
Log:https://cloudlogging.app.goo.gl/fDkkxCXkRiZWgb3r7

```bash
xpk workload create \
  --cluster=mlperf-v5p \
  --workload=convert-to-maxtext-v5p-llama70-1 \
  --device-type=v5p-8 \
  --num-slices=1 \
  --docker-image=[gcr.io/tpu-prod-env-multipod/fix-logit](http://gcr.io/tpu-prod-env-multipod/maxtext_post_training_nightly:31550029519):latest \
  --project=cloud-tpu-multipod-dev \
  --zone=europe-west4 \
  --priority=very-high \
  --env GCS_OUTPUT=gs://ml-auto-solutions/output/unowned/convert-to-maxtext-v5p-8-2026-08-12-01-46-39/ \
  --skip-validation \
  --command="set -xue; export HF_HOME=\"/dev/shm/hf_cache\"; export LIBTPU_INIT_ARGS=\"--xla_tpu_scoped_vmem_limit_kib=20480\"; bash tests/end_to_end/tpu/llama3.1/70b/[test_llama3.1_70b_to_mt.sh](http://test_llama3.1_70b_to_mt.sh/) pre-20260812"
```
Log: https://cloudlogging.app.goo.gl/4gMhqn9Zh5FsEXG39

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
