### PR TITLE
Add SFT vision COCO captions dataset and config support

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -736,6 +736,7 @@ train_data_columns: ['text'] # for DPO dataset containing "chosen" and "rejected
 train_image_column: 'image'
 eval_data_columns: ['text'] # for DPO dataset containing "chosen" and "rejected"
 eval_image_column: 'image'
+default_prompt: ''
 packing: true
 num_epoch: 1
 generate_padding_batch_train: false

--- a/src/maxtext/configs/post_train/sft-vision-coco-captions.yml
+++ b/src/maxtext/configs/post_train/sft-vision-coco-captions.yml
@@ -1,0 +1,41 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+base_config: "base.yml"
+
+use_sft: true
+use_tunix_gradient_accumulation: true
+use_multimodal: true
+# For vision captioning, prompt contains the image, model trains only on caption/completion tokens
+sft_train_on_completion_only: true
+packing: false  # multimodal packing is not supported yet
+freeze_vision_encoder_params: true
+learning_rate: 2.e-5
+
+# -------------- HF pipeline --------------
+dataset_type: hf
+hf_path: 'Fhrozen/coco-narratives'
+train_split: 'train'
+hf_eval_split: 'val'
+
+# Image column
+train_image_column: 'image'
+eval_image_column: 'image'
+
+# Text columns: ['prompt', 'captions']
+# 'prompt' is auto-injected as the user instruction (defaults to "", users can set it to their own prompt)
+# 'captions' uses the standard COCO ground truth captions
+train_data_columns: ['prompt', 'captions']
+eval_data_columns: ['prompt', 'captions']
+default_prompt: ""

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1403,6 +1403,10 @@ class DatasetGeneral(BaseModel):
   train_image_column: str | list[str] = Field("image", description="Column name(s) for images in the training data.")
   eval_data_columns: list[str] = Field(["text"], description="Column(s) to use from the evaluation data.")
   eval_image_column: str | list[str] = Field("image", description="Column name(s) for images in evaluation data.")
+  default_prompt: str = Field(
+      "",
+      description="Default prompt injected into the dataset when the prompt column is missing.",
+  )
   packing: bool = Field(
       True,
       description="Whether to pack multiple short examples into a single sequence.",

--- a/src/maxtext/input_pipeline/hf_data_processing.py
+++ b/src/maxtext/input_pipeline/hf_data_processing.py
@@ -93,6 +93,17 @@ def _get_training_objective_transform(
   return None
 
 
+def add_default_prompt_if_missing(dataset, text_columns, config):
+  """Inject default prompt if prompt column is missing in dataset (e.g. COCO captioning)."""
+  prompt_col = text_columns[0]
+  # Check if features is None (e.g. streaming IterableDataset) or prompt column is absent
+  features = getattr(dataset, "features", None) or getattr(dataset, "column_names", None)
+  # If so, populate each example with default_prompt
+  if features is None or prompt_col not in features:
+    dataset = dataset.map(lambda ex: {**ex, prompt_col: config.default_prompt})
+  return dataset
+
+
 def vision_sft_preprocessing_pipeline(
     dataset,
     config,
@@ -139,6 +150,8 @@ def vision_sft_preprocessing_pipeline(
         remove_columns=image_column,  # Drop the original image columns
     )
     image_column = "images"
+
+  dataset = add_default_prompt_if_missing(dataset, text_columns, config)
 
   dataset = dataset.select_columns(text_columns + [image_column])
   if image_column != "images":

--- a/tests/unit/hf_data_processing_test.py
+++ b/tests/unit/hf_data_processing_test.py
@@ -19,7 +19,9 @@ from types import SimpleNamespace
 import unittest
 from unittest import mock
 import os.path
+from unittest.mock import MagicMock
 
+import datasets
 import jax
 from jax.sharding import Mesh
 from jax.experimental import mesh_utils
@@ -125,6 +127,25 @@ class HfDataProcessingTest(unittest.TestCase):
     train_batch2 = get_first_batch(self.train_iter)
     self.assertTrue((train_batch1["inputs"] == train_batch2["inputs"]).all())  # pytype: disable=unsupported-operands
     self.assertTrue((train_batch1["targets"] == train_batch2["targets"]).all())  # pytype: disable=unsupported-operands
+
+  def test_add_default_prompt_if_missing(self):
+    config = MagicMock(default_prompt="")
+
+    # When prompt column is missing, default_prompt is added
+    ds = datasets.Dataset.from_dict({"image": [b"img"], "captions": ["a cat"]})
+    ds = hf_data_processing.add_default_prompt_if_missing(ds, ["prompt", "captions"], config)
+    self.assertEqual(ds[0]["prompt"], "")
+
+    # When prompt column already exists, existing prompt is preserved
+    ds_with_prompt = datasets.Dataset.from_dict({"prompt": ["Custom prompt"], "captions": ["a cat"]})
+    ds_with_prompt = hf_data_processing.add_default_prompt_if_missing(ds_with_prompt, ["prompt", "captions"], config)
+    self.assertEqual(ds_with_prompt[0]["prompt"], "Custom prompt")
+
+    # When streaming IterableDataset is used, default_prompt is added
+    iterable_ds = ds.to_iterable_dataset()
+    iterable_ds = hf_data_processing.add_default_prompt_if_missing(iterable_ds, ["prompt", "captions"], config)
+    first_item = next(iter(iterable_ds))
+    self.assertEqual(first_item["prompt"], "")
 
 
 class TrainingObjectiveTransformTest(unittest.TestCase):


### PR DESCRIPTION
# Description

This PR adds support for COCO-caption dataset for Supervised Fine-Tuning.

### Files and Changes
- `src/maxtext/input_pipeline/hf_data_processing.py`: Added `add_default_prompt_if_missing` to automatically inject `default_prompt` when the specified prompt column is missing in dataset features (e.g. COCO captioning).
- `src/maxtext/configs/base.yml` and `src/maxtext/configs/types.py`: Registered `default_prompt`.
- `src/maxtext/configs/post_train/sft-vision-coco-captions.yml`: Added configuration for COCO-caption dataset.
- `tests/unit/hf_data_processing_test.py`: Added `test_add_default_prompt_if_missing` unit test verifying prompt injection when missing and preservation when present.


# Tests

Tested end-to-end multimodal SFT and decode pipeline on Gemma 3 4B:

### 1. Pre-SFT Baseline Inference
```bash
python3 -m maxtext.inference.decode \
    src/maxtext/configs/base.yml \
    model_name=gemma3-4b \
    tokenizer_path=google/gemma-3-4b-it \
    tokenizer_type=huggingface \
    load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/gemma3-4b-processor/0/items \
    per_device_batch_size=1 \
    run_name=gemma3_4b_coco_pre_sft \
    max_prefill_predict_length=1024 \
    max_target_length=2048 \
    steps=1 \
    async_checkpointing=false \
    scan_layers=false \
    use_multimodal=true \
    prompt='Describe the image concisely' \
    image_path=tests/assets/test_image.jpg \
    attention=dot_product \
    skip_jax_distributed_system=true
```
**Output:**
```
Input `<start_of_turn>user
<start_of_image>Describe the image concisely<end_of_turn>
<start_of_turn>model
` -> `Here's a concise description of the image:

The image shows a panoramic view of Seattle, Washington. The iconic Space Needle dominates the skyline, with numerous other buildings visible. In the distance, snow-capped mountains are partially obscured by clouds.`
```

---

### 2. Vision SFT Training on COCO
```bash
python3 -m maxtext.trainers.post_train.sft.train_sft_native \
    src/maxtext/configs/post_train/sft-vision-coco-captions.yml \
    model_name=gemma3-4b \
    tokenizer_path=google/gemma-3-4b-it \
    tokenizer_type=huggingface \
    load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/gemma3-4b-processor/0/items \
    base_output_directory=gs://yuchenhou-maxtext-logs/gemma3-4b/multimodal/sft \
    run_name=gemma3_4b_sft_coco \
    per_device_batch_size=1 \
    max_prefill_predict_length=1024 \
    max_target_length=2048 \
    steps=101 \
    checkpoint_period=20 \
    scan_layers=false \
    async_checkpointing=false \
    save_checkpoint_on_completion=true \
    log_period=1 \
    eval_interval=10 \
    eval_steps=2 \
    gcs_metrics=true \
    float32_qk_product=true \
    float32_logits=true \
    attention=dot_product \
    sharding_tolerance=0.05 \
    checkpoint_storage_use_zarr3=false \
    checkpoint_storage_use_ocdbt=false \
    enable_single_controller=false \
    grain_worker_count=0
```

Verified locally that both train and val losses are decreasing and no errors detected.

---

### 3. Post-SFT Inference Verification
```bash
python3 -m maxtext.inference.decode \
    src/maxtext/configs/base.yml \
    model_name=gemma3-4b \
    tokenizer_path=google/gemma-3-4b-it \
    tokenizer_type=huggingface \
    load_parameters_path=gs://yuchenhou-maxtext-logs/gemma3-4b/multimodal/sft/gemma3_4b_sft_coco/checkpoints/100/items \
    per_device_batch_size=1 \
    run_name=gemma3_4b_coco_post_sft \
    max_prefill_predict_length=1024 \
    max_target_length=1600 \
    steps=1 \
    async_checkpointing=false \
    scan_layers=false \
    use_multimodal=true \
    prompt='Describe the image concisely.' \
    image_path=tests/assets/test_image.jpg \
    attention=dot_product \
    skip_jax_distributed_system=true
```
**Output:**
```
Input `<start_of_turn>user
<start_of_image>Describe the image concisely.<end_of_turn>
<start_of_turn>model
` -> `A city skyline with a snow covered mountain`
```

---

### 4. Unit Tests
```bash
JAX_PLATFORMS=cpu pytest tests/unit/hf_data_processing_test.py
```
**Output:**
```
=========================== 4 passed, 1 warning in 92.40s (0:01:32) ===========================
```

---

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
