### PR TITLE
Fix pylint E0611 by using direct import path

### DIFF
--- a/src/maxtext/checkpoint_conversion/inspect_checkpoint.py
+++ b/src/maxtext/checkpoint_conversion/inspect_checkpoint.py
@@ -61,15 +61,17 @@ Optional Flags:
 """
 
 import argparse
-import sys
 import os
-import re
 import pathlib
+import re
+import sys
+
 import absl
-from maxtext.inference.inference_utils import str2bool
-from maxtext.checkpoint_conversion.utils.utils import print_peak_memory
-from maxtext.utils.model_creation_utils import create_nnx_abstract_model
 from flax import nnx
+
+from maxtext.checkpoint_conversion.utils.utils import print_peak_memory
+from maxtext.inference.inference_utils import str2bool
+from maxtext.utils.model_creation_utils import create_nnx_abstract_model
 
 
 def natural_sort_key(s: str):
@@ -216,12 +218,12 @@ def inspect_maxtext(args, remaining_args):
   """
   # Defer imports to avoid overhead when running in other modes.
   import jax
-  from maxtext.utils import max_utils, maxtext_utils
+  from maxtext.checkpoint_conversion.utils.utils import param_key_parts_from_path
   from maxtext.configs import pyconfig
-  from maxtext.utils.globals import MAXTEXT_PKG_DIR
   from maxtext.layers import quantizations
   from maxtext.models import models
-  from maxtext.checkpoint_conversion.utils.utils import param_key_parts_from_path
+  from maxtext.utils import max_utils, maxtext_utils
+  from maxtext.utils.globals import MAXTEXT_PKG_DIR
 
   Transformer = models.transformer_as_linen
 

--- a/src/maxtext/checkpoint_conversion/inspect_checkpoint.py
+++ b/src/maxtext/checkpoint_conversion/inspect_checkpoint.py
@@ -217,7 +217,7 @@ def inspect_maxtext(args, remaining_args):
   # Defer imports to avoid overhead when running in other modes.
   import jax
   from maxtext.utils import max_utils, maxtext_utils
-  from maxtext import pyconfig
+  from maxtext.configs import pyconfig
   from maxtext.utils.globals import MAXTEXT_PKG_DIR
   from maxtext.layers import quantizations
   from maxtext.models import models


### PR DESCRIPTION
# Description

Yesterday I changed `__init__.py` to use lazy imports to solve some Google-internal problems.
Unfortunately, pylint does not understand lazy imports, we need to use full import paths to keep pylint happy.

# Tests

Ran pre-commit

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
