### PR TITLE
WIP: fp8 inference init for large MoE models (MaxText fp8 is QT-only, saves no weight memory)

### DIFF
--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -347,9 +347,20 @@ class MaxTextForCausalLM(nnx.Module):
     if self.model is not None:
       return
 
+    # With `--load-format dummy` the weight values are already discarded, so fill
+    # parameters straight from the abstract model rather than running the real
+    # initializer. That keeps peak init memory at the final (post-quantization)
+    # parameter size instead of the full-precision size, which is what lets large
+    # quantized MoE models come up at all.
+    random_init = self.vllm_config.load_config.load_format == "dummy"
+
     with self.mesh, nn.logical_axis_rules(self.maxtext_config.logical_axis_rules):
       model = model_creation_utils.from_pretrained(
-          self.maxtext_config, mesh=self.mesh, model_mode=self.model_mode, rng_key=rng_key
+          self.maxtext_config,
+          mesh=self.mesh,
+          model_mode=self.model_mode,
+          rng_key=rng_key,
+          random_init=random_init,
       )
       if self.maxtext_config.lora.enable_lora:
         model = lora_utils.apply_lora_to_model(model, self.mesh, self.maxtext_config)

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1849,16 +1849,12 @@ class NNXDecoder(nnx.Module):
 
           graphdef, state = nnx.split(layer)
           if kv_caches is not None:
-            if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
-              if (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
-                kv_cache = (
-                    kv_caches["key_cache"][lyr],
-                    kv_caches["value_cache"][lyr],
-                )
-              else:
-                kv_cache = None
-            else:
-              kv_cache = kv_caches[lyr]
+            # vLLM/tpu-inference hands us a flat per-layer list, one entry per
+            # decoder layer. For hybrid QWEN3_NEXT / QWEN3_5 stacks that includes
+            # the GDN (linear-attention) layers, whose recurrent state lives in
+            # their own entry -- Qwen3_5DecoderLayer forwards kv_cache to the
+            # GatedDeltaNet branch too, so they must not be handed None.
+            kv_cache = kv_caches[lyr]
           else:
             kv_cache = None
 
@@ -1881,12 +1877,11 @@ class NNXDecoder(nnx.Module):
             nnx.update(layer, new_state)
 
           if kv_caches is not None and kv_cache is not None:
-            if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
-              if (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
-                kv_caches["key_cache"][lyr] = kv_cache[0]
-                kv_caches["value_cache"][lyr] = kv_cache[1]
-            else:
-              kv_caches[lyr] = kv_cache
+            # Mirror of the read side above: write the layer's updated cache back
+            # into the flat per-layer list vLLM/tpu-inference handed us. This
+            # covers both the full-attention layers and the GDN layers, whose
+            # entry carries the (conv_state, recurrent_state) pair.
+            kv_caches[lyr] = kv_cache
 
           if deepstack_visual_embeds is not None and lyr < len(deepstack_visual_embeds):
             visual_embeds = deepstack_visual_embeds[lyr]

--- a/src/maxtext/layers/quantizations.py
+++ b/src/maxtext/layers/quantizations.py
@@ -846,6 +846,15 @@ def get_qt_provider(config):
   """Get quantization rules based on the config."""
   match config.quantization:
     case "int4" | "int8" | "fp4" | "fp4_e2m1" | "fp8" | "fp8_e5m2" | "fp8_e4m3" | "fp8_full":
+      # QtProvider is Quantized *Training*: it keeps full-precision master
+      # weights and only simulates quantization inside the ops, so it saves no
+      # parameter memory. For inference that is pure cost -- a 397B model still
+      # needs its bf16 footprint and cannot be served on a host sized for fp8.
+      # PtqProvider stores genuinely quantized weights instead; combined with an
+      # abstract (eval_shape) init, the full-precision weights are never
+      # materialized. See qwix PtqProvider's docstring.
+      if getattr(config, "model_call_mode", "") == "inference":
+        return qwix.PtqProvider(get_quantization_rule(config))
       return qwix.QtProvider(get_quantization_rule(config))
     case "fp8_gpu":
       return NvidaFp8Provider(get_quantization_rule(config))

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -658,8 +658,24 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       # vLLM PAGED STATE PATH: use tpu_inference fused conv + ragged delta-rule.
       # =========================================================================
       try:
-        from tpu_inference.layers.common.gdn_attention import GdnAttentionConfig, run_jax_gdn_attention  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
-        from tpu_inference.layers.common.ragged_gated_delta_rule_wrapper import RaggedGatedDeltaRuleImpl  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
+        from tpu_inference.layers.common.gdn_attention import run_jax_gdn_attention  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
+
+        # `GdnAttentionConfig` / the `layers.common.ragged_gated_delta_rule_wrapper`
+        # module only exist in newer tpu-inference revisions. Against releases that
+        # predate them, fall back to calling run_jax_gdn_attention without a config
+        # and let it pick its own default delta-rule implementation.
+        try:
+          from tpu_inference.layers.common.gdn_attention import GdnAttentionConfig  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
+        except ImportError:
+          GdnAttentionConfig = None
+        try:
+          from tpu_inference.layers.common.ragged_gated_delta_rule_wrapper import RaggedGatedDeltaRuleImpl  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
+        except ImportError:
+          try:
+            from tpu_inference.kernels.gdn.reference.ragged_gated_delta_rule_wrapper import RaggedGatedDeltaRuleImpl  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
+          except ImportError:
+            RaggedGatedDeltaRuleImpl = None
+
         from tpu_inference.layers.common.sharding import ShardingAxisName  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
         from tpu_inference.layers.common.utils import reorder_concatenated_tensor_for_sharding  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
         from tpu_inference.utils import get_mesh_shape_product  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
@@ -704,7 +720,10 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       conv_state_paged, recurrent_state_paged = kv_cache
 
       # Use REF impl (pure JAX) to avoid Mosaic kernel compilation issues.
-      gdn_config = GdnAttentionConfig(ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.REF)
+      if GdnAttentionConfig is not None and RaggedGatedDeltaRuleImpl is not None:
+        extra_gdn_kwargs = {"config": GdnAttentionConfig(ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.REF)}
+      else:
+        extra_gdn_kwargs = {}
 
       (new_conv_state_paged, new_recurrent_state_paged), gdn_output = run_jax_gdn_attention(
           mixed_qkv,
@@ -726,7 +745,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
           self.head_v_dim,
           cfg.gdn_conv_kernel_dim,
           mesh=self.mesh,
-          config=gdn_config,
+          **extra_gdn_kwargs,
       )
 
       # Reshape GDN output and apply gated norm + out projection.

--- a/src/maxtext/utils/maxtext_utils_nnx.py
+++ b/src/maxtext/utils/maxtext_utils_nnx.py
@@ -180,6 +180,86 @@ def create_nnx_sharded_model(
   return nnx.merge(graphdef, sharded_state)
 
 
+def create_nnx_random_sharded_model(
+    abstract_model: nnx.Module,
+    rng_key: jax.Array | None = None,
+    mesh: Mesh | None = None,
+    named_sharding: nnx.State | None = None,
+) -> nnx.Module:
+  """
+  Create a model with random weights, allocated directly at the abstract dtype.
+
+  This is the memory-lean counterpart to `create_nnx_sharded_model`, intended
+  for performance benchmarking where weight *values* are irrelevant.
+
+  `create_nnx_sharded_model` runs the real `init_fn()` inside the JIT, which
+  materializes every parameter at `weight_dtype` (e.g. bfloat16) and only then
+  applies `maybe_quantize_model`. Peak init memory is therefore bf16-sized even
+  when `quantization=fp8_e4m3`, which OOMs large MoE models: qwen3.5-397b-a17b
+  needs ~157-165GiB of HLO temporaries per chip against 94.74GiB of HBM.
+
+  The abstract model produced by `create_nnx_abstract_model` has already been
+  traced through `maybe_quantize_model`, so its leaves carry the *final* dtypes
+  (fp8 qvalue + scale when quantization is enabled). Filling those leaves
+  directly skips the full-precision stage entirely: peak memory equals the final
+  parameter size, and the model graph is never executed.
+
+  Args:
+    abstract_model: the abstract model, from `create_nnx_abstract_model`
+    rng_key: the Rng key used to draw the random weights
+    mesh: the device mesh
+    named_sharding: the given sharding
+
+  Returns:
+    The initialized sharded model, with random weights
+  """
+  graphdef, abstract_state = nnx.split(abstract_model)
+  if named_sharding is None:
+    named_sharding = nnx_extract_named_sharding(abstract_state)
+
+  if mesh is None:
+    mesh = abstract_model.mesh  # pyrefly: ignore[missing-attribute]
+
+  if rng_key is None:
+    rng_key = jax.random.PRNGKey(0)
+
+  leaves, treedef = jax.tree.flatten(abstract_state)
+
+  # Dtypes jax.random can emit natively. Anything else (notably fp8) must be
+  # filled with a constant: drawing at a wider dtype and casting down would
+  # allocate a temporary several times the size of the leaf itself, which is
+  # exactly the blowup this function exists to avoid. Empirically, casting fp8
+  # leaves down from float32 costs 164.90GiB of HLO temporaries per chip.
+  _NATIVE_RANDOM_DTYPES = (jnp.float32, jnp.bfloat16, jnp.float16)
+
+  def _random_leaf(key, leaf):
+    # Integer leaves (e.g. token counters) get zeros; drawing garbage indices
+    # could push downstream gathers out of bounds.
+    if not jnp.issubdtype(leaf.dtype, jnp.floating):
+      return jnp.zeros(leaf.shape, leaf.dtype)
+    if any(leaf.dtype == d for d in _NATIVE_RANDOM_DTYPES):
+      # Small values keep activations finite through deep stacks; the magnitude
+      # is arbitrary since only throughput is being measured.
+      return jax.random.normal(key, leaf.shape, leaf.dtype) * 0.02
+    # Narrow float (fp8): allocate straight at the target dtype. Non-zero so
+    # quantization scale leaves stay well-formed.
+    return jnp.full(leaf.shape, 0.02, leaf.dtype)
+
+  @partial(jax.jit, out_shardings=named_sharding)
+  def create_random_state():
+    keys = jax.random.split(rng_key, len(leaves))
+    state = jax.tree.unflatten(treedef, [_random_leaf(k, leaf) for k, leaf in zip(keys, leaves)])
+    # Constrain *inside* the JIT, as create_nnx_sharded_model does. With only
+    # out_shardings, XLA is free to build each leaf at its full global shape and
+    # shard just before returning, so the unsharded tensors show up as HLO
+    # temporaries and defeat the point of this function.
+    return jax.lax.with_sharding_constraint(state, named_sharding)
+
+  with jax.set_mesh(mesh):
+    sharded_state = create_random_state()
+  return nnx.merge(graphdef, sharded_state)
+
+
 def nnx_ensure_scan_leading_axis(tree, length):
   """Broadcasts scalar-like variables to have a leading scan axis."""
 

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -846,12 +846,19 @@ def from_pretrained(
     tokenizer_pad_id=None,
     *,
     quant_mode_str: str = "train",
+    random_init: bool = False,
 ):
   """Creates a NNX model with sharded parameters, possibly loading from a checkpoint.
 
   `quant_mode_str` is forwarded to model construction. Pass `"serve"` when
   loading a pre-quantized checkpoint so AQT layers materialize the on-disk
   scale factors instead of full-precision kernels.
+
+  `random_init` fills parameters directly at their abstract (post-quantization)
+  dtypes instead of running the real initializer, avoiding the full-precision
+  materialization that OOMs large quantized MoE models. Weight values are
+  meaningless, so this is for performance benchmarking only. Requires
+  `config.pure_nnx`, and skips checkpoint loading entirely.
   """
   original_mesh = mesh
   if config.convert_checkpoint_if_possible and not config.load_parameters_path:
@@ -927,7 +934,15 @@ def from_pretrained(
   _, _abs_state_for_specs = nnx.split(abstract_model)
   specs = nnx.get_partition_spec(_abs_state_for_specs)
 
-  if config.pure_nnx:
+  if random_init:
+    if not config.pure_nnx:
+      raise ValueError("random_init requires config.pure_nnx; the hybrid path has no abstract-model seam.")
+    max_logging.log(
+        "random_init: filling parameters from the abstract model. Weights are random and the model output is"
+        " meaningless -- performance benchmarking only."
+    )
+    model = maxtext_utils_nnx.create_nnx_random_sharded_model(abstract_model, rng_key=rng_key, mesh=mesh)
+  elif config.pure_nnx:
     model = maxtext_utils_nnx.create_nnx_sharded_model(abstract_model, _create_model, mesh=mesh)
     # TODO: print debug_sharding info
   else:
@@ -939,7 +954,7 @@ def from_pretrained(
     mesh = model.mesh  # pyrefly: ignore[missing-attribute]
 
   with mesh:
-    if config.load_parameters_path:
+    if config.load_parameters_path and not random_init:
       ckptr = ocp.Checkpointer(
           ocp.PyTreeCheckpointHandler(
               restore_concurrent_gb=config.checkpoint_storage_concurrent_gb,


### PR DESCRIPTION
## Status: draft, does not work yet

Opening this for visibility on a finding, not as a working fix. It contains a starting point plus the measurements that located the real blocker.

## Problem

Serving `qwen3.5-397b-a17b` in fp8 OOMs during model initialization. `create_sharded_state` requires ~157-165GiB of HLO temporaries per chip against 94.74GiB of HBM, and **the quantization setting makes no difference**.

## Root cause

MaxText's qwix integration is quantized-*training* only:

```python
# layers/quantizations.py, get_qt_provider
case "int4" | "int8" | ... | "fp8_e4m3" | "fp8_full":
    return qwix.QtProvider(get_quantization_rule(config))
```

`QtProvider` is *"Quantization provider for Quantized Training (QT)"* — it keeps full-precision master weights and only simulates quantization inside the ops. So `quantization=fp8_e4m3` + `use_qwix_quantization=true` saves **zero** parameter memory.

`qwix.PtqProvider`, the inference provider that stores genuinely quantized weights, **is not referenced anywhere in MaxText** (`grep -rn PtqProvider src/` → no hits).

The practical consequence is broader than one model: MaxText appears unable to serve any model with a compressed fp8 weight footprint.

## Measurements

8 chips x 94.74GiB, `qwen3.5-397b-a17b`, TP=8, `--load-format dummy`:

| config | HLO temporaries |
|---|---|
| bf16 baseline | 164.80G |
| + `quantization=fp8_e4m3` (QtProvider) | 164.80G — no effect |
| + random init from abstract model | 164.88G |
| + inner `with_sharding_constraint` | 164.88G |
| + `PtqProvider` | 163.56G |
| **available** | **94.74G** |

## What's here

- **`create_nnx_random_sharded_model`** (`utils/maxtext_utils_nnx.py`) — fills parameters directly from the abstract model rather than running the real initializer, so peak init memory is the final parameter size, not the full-precision size. Never upcasts: dtypes `jax.random` cannot emit (fp8) are constant-filled, because drawing wider and casting down reintroduces the very temporary this avoids. This is the `eval_shape` trick `PtqProvider`'s own docstring recommends.
- **`from_pretrained(random_init=...)`** — selects it, skips checkpoint restore, requires `pure_nnx`.
- **`adapter.py`** — sets `random_init` when vLLM passes `--load-format dummy`.
- **`get_qt_provider`** — uses `PtqProvider` when `model_call_mode == "inference"`. Training paths untouched.

Values are random and outputs meaningless; this path is for throughput benchmarking only.

## What's still blocking

`PtqProvider` *"still initialize[s] the original weights when the model is initialized"* and substitutes quantized weights when ops are called. So the **abstract** parameter shapes stay bf16, and the abstract-fill path has nothing smaller to allocate. Making the quantized shapes visible at trace time is the remaining work, and wants someone who knows qwix's PTQ interception.

## Repro

```
vllm serve Qwen/Qwen3.5-397B-A17B-FP8 \
  --tensor-parallel-size=8 --max-model-len=65536 --max-num-seqs=256 \
  --load-format dummy --kv-cache-dtype=fp8 --enable-expert-parallel \
  --hf-overrides '{"architectures": ["MaxTextForCausalLM"]}' \
  --additional-config '{"maxtext_config": {"model_name": "qwen3.5-397b-a17b",
    "scan_layers": false, "weight_dtype": "bfloat16",
    "quantization": "fp8_e4m3", "use_qwix_quantization": true,
    "model_call_mode": "inference", "attention": "vllm_rpa",
    "enable_nnx": true, "pure_nnx_decoder": true,
    "allow_split_physical_axes": true, "prefuse_moe_weights": true}}'
```

## Unrelated note

`use_random_routing: true` is rejected on the `vllm_rpa` path (`use_random_routing must be False`), because top-k happens inside tpu-inference's `fused_moe_func`. Uniform routing there has to come from `FORCE_MOE_RANDOM_ROUTING=1`. Correct behavior, but the error gives no hint of the alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
