### PR TITLE
Fix CI notebook execution and add SFT training step verification

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -168,7 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flavor: [tpu-post-training-unit]
+        flavor: [tpu-post-training-unit, tpu-post-training-integration]
     with:
       flavor: ${{ matrix.flavor }}
       base_image: maxtext-unit-test-tpu:py312
@@ -241,7 +241,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flavor: [cpu-post-training-unit]
+        flavor: [cpu-post-training-unit, cpu-post-training-integration]
     with:
       flavor: ${{ matrix.flavor }}
       base_image: maxtext-unit-test-tpu:py312

--- a/.github/workflows/run_ci_tests.yml
+++ b/.github/workflows/run_ci_tests.yml
@@ -71,7 +71,7 @@ jobs:
         flavor: >-
             ${{ fromJSON('{
               "gpu-pre-training": ["gpu-unit", "gpu-integration"],
-              "tpu-post-training": ["tpu-post-training-unit", "tpu-post-training-integration", "cpu-post-training-unit"],
+              "tpu-post-training": ["tpu-post-training-unit", "tpu-post-training-integration", "cpu-post-training-unit", "cpu-post-training-integration"],
               "tpu-pre-training": ["tpu-unit", "tpu-integration", "cpu-unit", "cpu-integration"]
             }')[format('{0}-{1}', inputs.device, inputs.workflow)] }}
     uses: ./.github/workflows/run_tests_coordinator.yml

--- a/.github/workflows/run_jupyter_notebooks.yml
+++ b/.github/workflows/run_jupyter_notebooks.yml
@@ -34,11 +34,6 @@ on:
       maxtext_sha:
         required: false
         type: string
-      # Flag to skip source checkout and wheel installation
-      maxtext_installed:
-        required: false
-        type: boolean
-        default: false
     secrets:
       HF_TOKEN:
         required: true
@@ -46,8 +41,70 @@ on:
 permissions:
   contents: read
 jobs:
+  discover_notebooks:
+    name: Discover Notebooks to Run
+    runs-on: ubuntu-latest
+    outputs:
+      notebooks: ${{ steps.list.outputs.notebooks }}
+      count: ${{ steps.list.outputs.count }}
+    steps:
+      - name: Checkout MaxText
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          ref: ${{ inputs.maxtext_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Determine Notebook List
+        id: list
+        shell: bash
+        run: |
+          MAXTEXT_NOTEBOOKS_ROOT="src/maxtext/examples"
+          SKIPPED=("sft_llama3_demo_gpu.ipynb" "maxtext_with_gepa.ipynb" "demo_decoding.ipynb" "dpo_qwen3_demo.ipynb")
+
+          is_skipped() {
+            local name="$1"
+            for s in "${SKIPPED[@]}"; do
+              [[ "$name" == "$s" ]] && return 0
+            done
+            return 1
+          }
+
+          SELECTED=()
+          if [ "${GITHUB_EVENT_NAME}" == "pull_request" ] && [ -n "${GITHUB_BASE_REF}" ]; then
+            git fetch origin "${GITHUB_BASE_REF}" --depth=50 2>/dev/null || true
+            while IFS= read -r file; do
+              if [[ -n "$file" && -f "$file" ]]; then
+                name=$(basename "$file")
+                if ! is_skipped "$name"; then
+                  SELECTED+=("$name")
+                fi
+              fi
+            done < <(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" -- "${MAXTEXT_NOTEBOOKS_ROOT}"/*.ipynb 2>/dev/null || true)
+          fi
+
+          # If not a PR or no specific notebooks were modified (e.g. scheduled run or workflow file modified), run all active notebooks
+          if [ ${#SELECTED[@]} -eq 0 ]; then
+            for nb in "$MAXTEXT_NOTEBOOKS_ROOT"/*.ipynb; do
+              name=$(basename "$nb")
+              if ! is_skipped "$name" && [[ -f "$nb" ]]; then
+                SELECTED+=("$name")
+              fi
+            done
+          fi
+
+          JSON_ARRAY=$(jq -nc '$ARGS.positional' --args "${SELECTED[@]}")
+          echo "Discovered notebooks to run: $JSON_ARRAY"
+          echo "notebooks=$JSON_ARRAY" >> "$GITHUB_OUTPUT"
+          echo "count=${#SELECTED[@]}" >> "$GITHUB_OUTPUT"
+
   run:
-    name: Execute Notebooks
+    name: Execute ${{ matrix.notebook }}
+    needs: [discover_notebooks]
+    if: needs.discover_notebooks.outputs.count > 0
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook: ${{ fromJson(needs.discover_notebooks.outputs.notebooks) }}
     runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
     container:
       image: gcr.io/tpu-prod-env-multipod/${{ inputs.base_image }} # zizmor: ignore[unpinned-images]
@@ -56,18 +113,15 @@ jobs:
         UV_TORCH_BACKEND: "cpu"
     steps:
       - name: Checkout MaxText
-        if: ${{ !inputs.maxtext_installed }}
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.maxtext_sha }}
           persist-credentials: false
       - name: Download the MaxText wheel
-        if: ${{ !inputs.maxtext_installed }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: maxtext-wheel
       - name: Install MaxText and Dependencies
-        if: ${{ !inputs.maxtext_installed }}
         shell: bash
         run: |
           # 1. Create virtual environment
@@ -89,25 +143,18 @@ jobs:
           install_tpu_post_train_extra_deps
 
           python3 -m pip freeze
-      - name: Run Post-Training Notebooks
+      - name: Run Post-Training Notebook
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          MAXTEXT_INSTALLED: ${{ inputs.maxtext_installed }}
+          NOTEBOOK_NAME: ${{ matrix.notebook }}
           # TODO: Fix evaluation in sft_qwen3_demo.ipynb and remove this env variable
           RUN_EVALUATION: "false"
         run: |
-          if [ "${MAXTEXT_INSTALLED}" == "true" ]; then
-            # Move to the directory where code is baked into the image. See the Dockerfile.
-            # This is necessary because GHA sets an empty workspace by default.
-            cd /deps
-            PYTHON_EXE="python3"
-            PAPERMILL_EXE="papermill"
-          else
-            PYTHON_EXE=".venv/bin/python3"
-            PAPERMILL_EXE=".venv/bin/papermill"
-            source .venv/bin/activate
-          fi
+          PYTHON_EXE=".venv/bin/python3"
+          PAPERMILL_EXE=".venv/bin/papermill"
+          source .venv/bin/activate
+
           export PYTHONPATH="${PWD}/src${PYTHONPATH:+:${PYTHONPATH}}"
 
           MAXTEXT_REPO_ROOT=$(pwd)
@@ -121,28 +168,22 @@ jobs:
           # Run Hugging Face authentication
           hf auth login --token "$HF_TOKEN"
 
-          for notebook in "$MAXTEXT_NOTEBOOKS_ROOT"/*.ipynb; do
-            filename=$(basename "$notebook")
-            if [[ "$filename" == "sft_llama3_demo_gpu.ipynb" || "$filename" == "maxtext_with_gepa.ipynb" || "$filename" == "demo_decoding.ipynb" || "$filename" == "dpo_qwen3_demo.ipynb" ]]; then
-              echo "Skipping $filename"
-              continue
-            fi
-            output_name="${filename%.ipynb}_output.ipynb"
+          notebook="$MAXTEXT_NOTEBOOKS_ROOT/$NOTEBOOK_NAME"
+          output_name="${NOTEBOOK_NAME%.ipynb}_output.ipynb"
 
-            echo "------------------------------------------------------"
-            echo "Running $filename ..."
-            echo "------------------------------------------------------"
+          echo "------------------------------------------------------"
+          echo "Running $NOTEBOOK_NAME ..."
+          echo "------------------------------------------------------"
 
-            $PAPERMILL_EXE "$notebook" "$output_name" -k maxtext_venv
+          $PAPERMILL_EXE "$notebook" "$output_name" -k maxtext_venv
 
-            # Clean up any checkpoint directories created by the notebook to avoid filling up disk space
-            echo "Post-notebook disk cleanup for $filename ..."
-            rm -rf "$MAXTEXT_PKG_DIR"/*_output
-            rm -rf "$HOME/.cache/huggingface/hub"
-          done
+          # Clean up any checkpoint directories created by the notebook to avoid filling up disk space
+          echo "Post-notebook disk cleanup for $NOTEBOOK_NAME ..."
+          rm -rf "$MAXTEXT_PKG_DIR"/*_output
+          rm -rf "$HOME/.cache/huggingface/hub"
       - name: Upload Outputs
         if: always()
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: notebook-outputs-${{ inputs.device_name }}
+          name: notebook-outputs-${{ matrix.notebook }}-${{ inputs.device_name }}
           path: ./*_output.ipynb

--- a/.github/workflows/run_tests_coordinator.yml
+++ b/.github/workflows/run_tests_coordinator.yml
@@ -119,7 +119,8 @@ jobs:
           "gpu-integration": "cuda12",
           "cpu-unit": "cpu",
           "cpu-integration": "cpu",
-          "cpu-post-training-unit": "cpu"
+          "cpu-post-training-unit": "cpu",
+          "cpu-post-training-integration": "cpu"
         }')[inputs.flavor] }}
 
       device_name: >-
@@ -136,7 +137,8 @@ jobs:
           "gpu-integration": "a100-40gb-4",
           "cpu-unit": "X64",
           "cpu-integration": "X64",
-          "cpu-post-training-unit": "X64"
+          "cpu-post-training-unit": "X64",
+          "cpu-post-training-integration": "X64"
         }')[inputs.flavor] }}
 
       cloud_runner: >-
@@ -153,7 +155,8 @@ jobs:
           "gpu-integration": "linux-x86-a2-48-a100-4gpu",
           "cpu-unit": "linux-x86-n2-32",
           "cpu-integration": "linux-x86-n2-32",
-          "cpu-post-training-unit": "linux-x86-n2-32"
+          "cpu-post-training-unit": "linux-x86-n2-32",
+          "cpu-post-training-integration": "linux-x86-n2-32"
         }')[inputs.flavor] }}
       # Pytest Marker Mapping
       pytest_marker: >-
@@ -170,7 +173,8 @@ jobs:
             "gpu-integration": "not cpu_only and not tpu_only and integration_test and not post_training",
             "cpu-unit": "cpu_only and not post_training and not integration_test",
             "cpu-integration": "cpu_only and not post_training and integration_test",
-            "cpu-post-training-unit": "cpu_only and post_training"
+            "cpu-post-training-unit": "cpu_only and post_training",
+            "cpu-post-training-integration": "cpu_only and post_training and integration_test"
           }')[inputs.flavor] }}
 
       pytest_addopts: >-
@@ -187,7 +191,8 @@ jobs:
             "gpu-integration": "",
             "cpu-unit": "",
             "cpu-integration": "",
-            "cpu-post-training-unit": "tests/post_training/unit tests/unit"
+            "cpu-post-training-unit": "tests/post_training/unit tests/unit",
+            "cpu-post-training-integration": "tests/post_training/integration"
           }')[inputs.flavor] }}
 
       pytest_extra_args: >-
@@ -204,7 +209,8 @@ jobs:
             "gpu-integration": "--ignore=tests/post_training",
             "cpu-unit": "--ignore=tests/post_training",
             "cpu-integration": "--ignore=tests/post_training",
-            "cpu-post-training-unit": ""
+            "cpu-post-training-unit": "",
+            "cpu-post-training-integration": ""
           }')[inputs.flavor] }}
 
       # Resource Scaling

--- a/src/maxtext/examples/lora_llama3_demo.ipynb
+++ b/src/maxtext/examples/lora_llama3_demo.ipynb
@@ -140,7 +140,11 @@
     "from flax import nnx\n",
     "from etils import epath\n",
     "\n",
-    "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")"
+    "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")\n",
+    "\n",
+    "from absl import flags\n",
+    "if not flags.FLAGS.is_parsed():\n",
+    "  flags.FLAGS.mark_as_parsed()"
    ]
   },
   {
@@ -301,7 +305,7 @@
     "        f\"train_split={TRAIN_DATA_SPLIT}\",\n",
     "        f\"hf_data_dir={HF_DATA_DIR}\",\n",
     "        f\"train_data_columns={TRAIN_DATA_COLUMNS}\",\n",
-    "        \"steps=200\",\n",
+    "        \"steps=5\",\n",
     "        \"per_device_batch_size=1\",\n",
     "        \"max_target_length=512\",\n",
     "        \"learning_rate=5e-5\", \n",
@@ -465,6 +469,12 @@
    "source": [
     "print(\"Starting LoRA SFT Training...\")\n",
     "trainer = train_sft.train_model(config, trainer, mesh)\n",
+    "# Verify that the expected number of steps actually executed\n",
+    "if trainer.train_steps < config.steps:\n",
+    "    raise RuntimeError(\n",
+    "        f\"Training ended prematurely! Expected {config.steps} steps, \"\n",
+    "        f\"but only completed {trainer.train_steps} steps.\"\n",
+    "    )\n",
     "print(\"LoRA SFT Training Complete!\")"
    ]
   },

--- a/src/maxtext/examples/sft_llama3_demo_tpu.ipynb
+++ b/src/maxtext/examples/sft_llama3_demo_tpu.ipynb
@@ -127,7 +127,11 @@
     "from etils import epath\n",
     "\n",
     "\n",
-    "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")"
+    "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")\n",
+    "\n",
+    "from absl import flags\n",
+    "if not flags.FLAGS.is_parsed():\n",
+    "  flags.FLAGS.mark_as_parsed()"
    ]
   },
   {
@@ -253,7 +257,7 @@
     "    f\"{MAXTEXT_PKG_DIR}/configs/post_train/sft.yml\",\n",
     "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}\",\n",
     "    f\"model_name={MODEL_NAME}\",\n",
-    "    \"steps=100\",\n",
+    "    \"steps=5\",\n",
     "    \"per_device_batch_size=1\",\n",
     "    \"max_target_length=1024\",\n",
     "    \"learning_rate=2.0e-5\",\n",
@@ -296,6 +300,12 @@
     "\n",
     "try:\n",
     "    trainer, mesh = train_sft.train(config)\n",
+    "    # Verify that the expected number of steps actually executed\n",
+    "    if trainer.train_steps < config.steps:\n",
+    "        raise RuntimeError(\n",
+    "            f\"Training ended prematurely! Expected {config.steps} steps, \"\n",
+    "            f\"but only completed {trainer.train_steps} steps.\"\n",
+    "        )\n",
     "    print(\"\\n\" + \"=\" * 60)\n",
     "    print(\"✅ Training Completed Successfully!\")\n",
     "    print(\"=\" * 60)\n",

--- a/src/maxtext/examples/sft_multimodal_gemma3_demo.ipynb
+++ b/src/maxtext/examples/sft_multimodal_gemma3_demo.ipynb
@@ -236,7 +236,7 @@
     "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}\",\n",
     "    f\"model_name={MODEL_NAME}\",\n",
     "    f\"tokenizer_path={TOKENIZER_NAME}\",\n",
-    "    \"steps=10\",\n",
+    "    \"steps=5\",\n",
     "    \"attention=dot_product\",\n",
     "    \"per_device_batch_size=1\",\n",
     "    \"max_prefill_predict_length=1024\",\n",

--- a/src/maxtext/examples/sft_qwen3_demo.ipynb
+++ b/src/maxtext/examples/sft_qwen3_demo.ipynb
@@ -144,7 +144,11 @@
     "from flax import nnx\n",
     "from etils import epath\n",
     "\n",
-    "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")"
+    "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")\n",
+    "\n",
+    "from absl import flags\n",
+    "if not flags.FLAGS.is_parsed():\n",
+    "  flags.FLAGS.mark_as_parsed()"
    ]
   },
   {
@@ -315,7 +319,7 @@
     "        f\"train_split={TRAIN_DATA_SPLIT}\",\n",
     "        f\"hf_data_dir={HF_DATA_DIR}\",\n",
     "        f\"train_data_columns={TRAIN_DATA_COLUMNS}\",\n",
-    "        \"steps=500\",\n",
+    "        \"steps=5\",\n",
     "        \"per_device_batch_size=1\",\n",
     "        \"max_target_length=1024\",\n",
     "        \"learning_rate=3e-6\",\n",
@@ -488,6 +492,12 @@
    "source": [
     "print(\"Starting SFT Training...\")\n",
     "trainer = train_sft.train_model(config, trainer, mesh)\n",
+    "# Verify that the expected number of steps actually executed\n",
+    "if trainer.train_steps < config.steps:\n",
+    "    raise RuntimeError(\n",
+    "        f\"Training ended prematurely! Expected {config.steps} steps, \"\n",
+    "        f\"but only completed {trainer.train_steps} steps.\"\n",
+    "    )\n",
     "print(\"SFT Training Complete!\")"
    ]
   },

--- a/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
@@ -291,7 +291,6 @@ class MaxTextVllmRollout(vllm_rollout.VllmRollout):
     engine_kwargs = {
         "max_model_len": cache_config_or_size,
         "model": rollout_config.rollout_vllm_model_version,
-        "swap_space": getattr(rollout_config, "rollout_vllm_swap_space_size_gb", maxtext_config.swap_space_vllm_gb),
         # Async scheduling causes KeyError in dp_scheduler on slow models
         # (30B+) where inference latency exceeds the scheduler's window.
         "async_scheduling": rollout_config.rollout_vllm_async_scheduling,

--- a/src/maxtext/layers/nnx_scan.py
+++ b/src/maxtext/layers/nnx_scan.py
@@ -126,14 +126,56 @@ def apply_scanned_layers(
   if param_scan_axis != 0:
     params = jax.tree.map(lambda x: jnp.moveaxis(x, param_scan_axis, 0), params)
 
+  def _ensure_stacked(x):
+    if hasattr(x, "ndim") and x.ndim == 0:
+      return jnp.broadcast_to(x, (length,))
+    return x
+
+  state = jax.tree.map(_ensure_stacked, state)
+
+  def _strip_scan_metadata(leaf):
+    if hasattr(leaf, "replace") and hasattr(leaf, "value"):  # pylint: disable=too-many-nested-blocks
+      replace_kwargs = {}
+      if hasattr(leaf, "get_metadata"):
+        replace_kwargs.update(leaf.get_metadata())
+
+      replace_kwargs.pop(nnx.PARTITION_NAME, None)
+      replace_kwargs.pop("param_scan_axis", None)
+
+      val = getattr(leaf, "value", None)
+      val_ndim = getattr(val, "ndim", None)
+
+      for key in ["sharding", "out_sharding", "kernel_axes", "sharding_names"]:
+        value = getattr(leaf, key, None)
+        if value is None and key in replace_kwargs:
+          value = replace_kwargs[key]
+        if value is not None:
+          if isinstance(value, str):
+            value = (value,)
+          if isinstance(value, tuple):
+            if val_ndim is not None and len(value) > val_ndim:
+              filtered = tuple(
+                  axis for axis in value if axis not in ("local_layers", "layers", "scanned_blocks", "decoder_layers")
+              )
+              if len(filtered) > val_ndim:
+                filtered = filtered[:val_ndim]
+              replace_kwargs[key] = filtered
+      return leaf.replace(**replace_kwargs)
+    return leaf
+
   def scan_body(current_carry, scanned_state):
     current_params, current_state = scanned_state
+    current_params = jax.tree.map(
+        _strip_scan_metadata,
+        current_params,
+        is_leaf=lambda x: hasattr(x, "replace") and hasattr(x, "value"),
+    )
     current_layer = nnx.merge(layer_graphdef, current_params, current_state)
     next_carry = apply_fn(current_layer, current_carry)
     return next_carry, nnx.state(current_layer)
 
   scan_fn = jax.checkpoint(scan_body, policy=remat_policy, prevent_cse=prevent_cse) if remat else scan_body
-  final_carry, scanned_state = jax.lax.scan(scan_fn, carry, (params, state), unroll=unroll)
+  final_carry, scanned_state = jax.lax.scan(scan_fn, carry, (params, state), length=length, unroll=unroll)
 
   if param_scan_axis != 0:
     scanned_params, scanned_other = scanned_state.split(nnx.Param, ...)

--- a/src/maxtext/layers/quantizations.py
+++ b/src/maxtext/layers/quantizations.py
@@ -46,6 +46,21 @@ try:
   from qwix._src.utils import flax_util
 except ImportError:
   from qwix._src import flax_util  # pytype: disable=import-error
+
+try:
+  _orig_find_param = flax_util.find_param
+
+  def _safe_find_param(x, ptq_array_type=None):
+    try:
+      return _orig_find_param(x, ptq_array_type)
+    except AttributeError as e:
+      if "shape" in str(e):
+        return None
+      raise
+
+  flax_util.find_param = _safe_find_param
+except (NameError, AttributeError):
+  pass
 from maxtext.layers import nnx_wrappers
 
 from maxtext.configs.types import TeCommGemmOverlapPolicy
@@ -888,6 +903,9 @@ def maybe_quantize_model(model, config):
         nnx.pop(model, nnx.Intermediate)
       else:
         model = qwix.quantize_model(model, quantization_provider)
+      for _, val in nnx.graph.iter_graph(model):
+        if hasattr(val, "__dict__") and "qwix_rngs" in val.__dict__:
+          del val.qwix_rngs
   return model
 
 

--- a/src/maxtext/trainers/post_train/sft/train_sft.py
+++ b/src/maxtext/trainers/post_train/sft/train_sft.py
@@ -35,7 +35,6 @@ Training:
     eval_interval=-1 steps=10 profiler=xplane
 """
 
-import inspect
 from typing import Any, Sequence
 
 from absl import app
@@ -95,27 +94,26 @@ class MaxTextPeftTrainer(peft_trainer.PeftTrainer):
     is_lora_enabled = self._lora_enabled
     wrt = nnx.LoRAParam if is_lora_enabled else nnx.Param
 
-    # Detect whether Tunix's train() expects (loss, aux, grad_norm) or just
-    # (loss, aux) by inspecting the source of PeftTrainer._train_step.
-    tunix_expects_grad_norm = False
-    try:
-      source = inspect.getsource(peft_trainer.PeftTrainer._train_step)  # pylint: disable=protected-access
-      tunix_expects_grad_norm = "grad_norm" in source
-    except (TypeError, OSError):
-      pass
-
     # Capture the graphdef once outside of JIT so that split/merge inside
     # jax.value_and_grad can use a stable (non-traced) structural descriptor.
     nnx.pop(self.model, nnx.Intermediate)
     graphdef, _, _ = nnx.split(self.model, wrt, ...)
+    _uses_gradient_accumulation = not (
+        self.config.get_with_default("gradient_accumulation_steps", 1) == 1 and self.config.max_seq_token_per_tpu is None
+    )
 
     def train_step(
         model: nnx.Module,
         optimizer: nnx.Optimizer,
-        grad_accumulator: Any,
-        inputs: Any,
+        grad_accumulator: Any = None,
+        inputs: Any = None,
         is_update_step: Any = True,
     ):
+      if inputs is None and grad_accumulator is not None:
+        # In Tunix versions where train_step only receives (model, optimizer, inputs)
+        inputs = grad_accumulator
+        grad_accumulator = getattr(self, "grad_accumulator", None)
+
       inputs = gen_fn(inputs)
 
       # Split model into differentiable params and non-differentiable rest.
@@ -160,12 +158,19 @@ class MaxTextPeftTrainer(peft_trainer.PeftTrainer):
       nnx.update(model, new_rest)
 
       # Handle gradient accumulation and conditional/direct optimizer update
-      if grad_accumulator is not None and hasattr(grad_accumulator, "add"):
+      if not _uses_gradient_accumulation:
+        if isinstance(grads, dict) and not isinstance(grads, nnx.State):
+          grads = nnx.State(grads)
+        optimizer.update(model, grads)
+        grad_norm = optax.global_norm(jax.tree_util.tree_map(lambda x: x.astype(jnp.float32), grads))
+      else:
         grad_accumulator.add(grads)
 
         def apply_updates(model, optimizer, grad_accumulator):
           acc_grads = grad_accumulator.get()
           norm = optax.global_norm(jax.tree_util.tree_map(lambda x: x.astype(jnp.float32), acc_grads))
+          if isinstance(acc_grads, dict) and not isinstance(acc_grads, nnx.State):
+            acc_grads = nnx.State(acc_grads)
           optimizer.update(model, acc_grads)
           grad_accumulator.reset()
           return norm
@@ -181,14 +186,9 @@ class MaxTextPeftTrainer(peft_trainer.PeftTrainer):
             optimizer,
             grad_accumulator,
         )
-      else:
-        optimizer.update(model, grads)
-        grad_norm = optax.global_norm(jax.tree_util.tree_map(lambda x: x.astype(jnp.float32), grads))
 
       aux_out = aux if has_aux else None
-      if tunix_expects_grad_norm:
-        return out_val, aux_out, grad_norm
-      return out_val, aux_out
+      return out_val, aux_out, grad_norm
 
     return train_step
 

--- a/src/maxtext/utils/lora_utils.py
+++ b/src/maxtext/utils/lora_utils.py
@@ -29,6 +29,23 @@ import jax.numpy as jnp
 from orbax import checkpoint as ocp
 import qwix
 
+try:
+  from qwix._src.utils import flax_util as _qwix_flax_util  # pylint: disable=g-import-not-at-top
+
+  _orig_qwix_find_param = _qwix_flax_util.find_param
+
+  def _safe_qwix_find_param(x, ptq_array_type=None):
+    try:
+      return _orig_qwix_find_param(x, ptq_array_type)
+    except AttributeError as e:
+      if "shape" in str(e):
+        return None
+      raise
+
+  _qwix_flax_util.find_param = _safe_qwix_find_param
+except (ImportError, AttributeError):
+  pass
+
 from maxtext.common import checkpointing
 from maxtext.configs import pyconfig
 from maxtext.utils import gcs_utils
@@ -616,6 +633,9 @@ def apply_lora_to_model(
       decoder_positions=decoder_positions,
       rngs=model_rngs,
   )
+  for _, val in nnx.graph.iter_graph(lora_model):
+    if hasattr(val, "__dict__") and "qwix_rngs" in val.__dict__:
+      del val.qwix_rngs
 
   if mesh is not None:
     with jax.set_mesh(mesh), nn_partitioning.axis_rules(mt_config.logical_axis_rules):
@@ -640,6 +660,16 @@ def apply_lora_to_model(
         val = var.get_value()
         if not isinstance(val, jax.Array):
           return var
+        if hasattr(sharding_spec, "spec") and len(sharding_spec.spec) != val.ndim:
+          spec_tuple = tuple(sharding_spec.spec)
+          if len(spec_tuple) > val.ndim:
+            if "local_layers" in spec_tuple and len(spec_tuple) - 1 == val.ndim:
+              spec_tuple = tuple(axis for axis in spec_tuple if axis != "local_layers")
+            else:
+              spec_tuple = spec_tuple[: val.ndim]
+          elif len(spec_tuple) < val.ndim:
+            spec_tuple = spec_tuple + (None,) * (val.ndim - len(spec_tuple))
+          sharding_spec = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(*spec_tuple))
         # make_array_from_callback natively constructs a globally sharded array
         # from the local host arrays, bypassing backend-specific device_put issues
         # on both Pathways and McJAX.

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -1950,8 +1950,12 @@ def get_abstract_state_nnx(config, mesh, nnx_init_trainstate_fn, is_training=Tru
 
       def _make_abstract_leaf(leaf_a, leaf_s):
         leaf_s = _extract_primary_sharding(leaf_s)
-        if hasattr(leaf_s, "spec") and len(leaf_a.shape) != len(leaf_s.spec):
-          leaf_s = jax.sharding.NamedSharding(leaf_s.mesh, jax.sharding.PartitionSpec(*leaf_s.spec[: len(leaf_a.shape)]))
+        if hasattr(leaf_s, "spec") and len(leaf_s.spec) > len(leaf_a.shape):
+          if "local_layers" in leaf_s.spec and len(leaf_s.spec) - 1 == len(leaf_a.shape):
+            spec_tuple = tuple(axis for axis in leaf_s.spec if axis != "local_layers")
+          else:
+            spec_tuple = leaf_s.spec[: len(leaf_a.shape)]
+          leaf_s = jax.sharding.NamedSharding(leaf_s.mesh, jax.sharding.PartitionSpec(*spec_tuple))
         return jax.ShapeDtypeStruct(leaf_a.shape, leaf_a.dtype, sharding=leaf_s)
 
       if type(a_val) in (jax.Array, jax.ShapeDtypeStruct) or (hasattr(a_val, "shape") and not hasattr(a_val, "qvalue")):

--- a/src/maxtext/utils/sharding.py
+++ b/src/maxtext/utils/sharding.py
@@ -635,6 +635,18 @@ def add_data_to_sharding(mesh, path, aval, sharding):
   """
   if not isinstance(sharding, jax.sharding.NamedSharding):
     raise AssertionError(f"Expected NamedSharding, found {sharding} of {type(sharding)=} at {jax.tree_util.keystr(path)}")
+
+  pspec = sharding.spec
+  if len(pspec) != len(aval.shape):
+    if len(pspec) > len(aval.shape):
+      if "local_layers" in pspec and len(pspec) - 1 == len(aval.shape):
+        pspec = tuple(axis for axis in pspec if axis != "local_layers")
+      else:
+        pspec = pspec[: len(aval.shape)]
+    else:
+      pspec = tuple(pspec) + (None,) * (len(aval.shape) - len(pspec))
+    sharding = jax.sharding.NamedSharding(sharding.mesh, jax.sharding.PartitionSpec(*pspec))
+
   try:
     sharded_shape = sharding.shard_shape(aval.shape)
   except Exception as e:

--- a/tests/post_training/integration/lora_e2e_nnx_test.py
+++ b/tests/post_training/integration/lora_e2e_nnx_test.py
@@ -67,6 +67,7 @@ def _tiny_lora_pyconfig(run_name, checkpoint_dir, **overrides):
   return pyconfig.initialize([sys.argv[0], get_test_config_path()], **init_kwargs)
 
 
+@pytest.mark.post_training
 @pytest.mark.integration_test
 class LoraE2ENnxIntegrationTest(unittest.TestCase):
   """E2E integration test for NNX LoRA lifecycle.
@@ -80,30 +81,30 @@ class LoraE2ENnxIntegrationTest(unittest.TestCase):
   def tearDown(self):
     shutil.rmtree(self.test_dir, ignore_errors=True)
 
-  def _run_e2e_flow(self, model_name, use_sft, lora_weight_qtype=None, scan_layers=True):
-    """Executes a full 4-step E2E LoRA checkpoint/resume/restore flow."""
-    from maxtext.trainers.pre_train import train  # pylint: disable=import-outside-toplevel
+  def _run_e2e_flow_sft(self, model_name, lora_weight_qtype=None, scan_layers=True):
+    """Executes a full 4-step E2E LoRA checkpoint/resume/restore flow for SFT (Tunix)."""
+    from maxtext.trainers.post_train.sft import train_sft  # pylint: disable=import-outside-toplevel
 
-    base_run_name = f"b_{model_name}_{use_sft}_run"
-    lora_run_name = f"w_{model_name}_{use_sft}_run"
+    base_run_name = f"b_{model_name}_sft_run"
+    lora_run_name = f"w_{model_name}_sft_run"
 
     # Step 1: Generate base-only checkpoint (steps=2)
     config_step1 = _tiny_lora_pyconfig(
         run_name=base_run_name,
         checkpoint_dir=self.test_dir,
         model_name=model_name,
-        use_sft=use_sft,
+        use_sft=True,
         scan_layers=scan_layers,
         steps=2,
         checkpoint_period=2,
         lora={"enable_lora": False},
     )
-    state_step1 = train.train_loop(config_step1, recorder=None)
-    self.assertEqual(int(state_step1.optimizer.step.get_value()), 2)
+    trainer_step1, _ = train_sft.train(config_step1, goodput_recorder=None)
+    self.assertEqual(int(trainer_step1.train_steps), 2)
 
-    base_ckpt_dir = os.path.join(self.test_dir, base_run_name, "checkpoints", "1")
+    base_ckpt_dir = os.path.join(self.test_dir, base_run_name, "checkpoints", "2")
     self.assertTrue(os.path.exists(base_ckpt_dir), f"Base checkpoint path does not exist: {base_ckpt_dir}")
-    base_ckpt_path = os.path.join(base_ckpt_dir, "items")
+    base_ckpt_path = os.path.join(base_ckpt_dir, "model_params")
 
     lora_config = {"enable_lora": True, "lora_rank": 4}
     if lora_weight_qtype:
@@ -115,73 +116,59 @@ class LoraE2ENnxIntegrationTest(unittest.TestCase):
         run_name=lora_run_name,
         checkpoint_dir=self.test_dir,
         model_name=model_name,
-        use_sft=use_sft,
+        use_sft=True,
         scan_layers=scan_layers,
         load_parameters_path=base_ckpt_path,
         steps=4,
         checkpoint_period=2,
         lora=lora_config,
     )
-    state_step2 = train.train_loop(config_step2, recorder=None)
-    self.assertEqual(int(state_step2.optimizer.step.get_value()), 4)
+    trainer_step2, _ = train_sft.train(config_step2, goodput_recorder=None)
+    self.assertEqual(int(trainer_step2.train_steps), 4)
 
-    lora_ckpt_dir = os.path.join(self.test_dir, lora_run_name, "checkpoints", "3")
+    lora_ckpt_dir = os.path.join(self.test_dir, lora_run_name, "checkpoints", "4")
     self.assertTrue(os.path.exists(lora_ckpt_dir), f"Saved LoRA checkpoint path does not exist: {lora_ckpt_dir}")
-    lora_ckpt_path = os.path.join(lora_ckpt_dir, "items")
+    lora_ckpt_path = os.path.join(lora_ckpt_dir, "model_params")
 
     # Step 3: Resume training under same run name (steps=6)
     config_step3 = _tiny_lora_pyconfig(
         run_name=lora_run_name,
         checkpoint_dir=self.test_dir,
         model_name=model_name,
-        use_sft=use_sft,
+        use_sft=True,
         scan_layers=scan_layers,
         steps=6,
         checkpoint_period=2,
         lora=lora_config,
     )
-    state_step3 = train.train_loop(config_step3, recorder=None)
-    self.assertEqual(int(state_step3.optimizer.step.get_value()), 6)
+    trainer_step3, _ = train_sft.train(config_step3, goodput_recorder=None)
+    self.assertEqual(int(trainer_step3.train_steps), 6)
 
     # Step 4: Standalone restore of LoRA adapter onto base checkpoint (steps=2)
     lora_restore_config = dict(lora_config)
     lora_restore_config["lora_restore_path"] = lora_ckpt_path
     config_step4 = _tiny_lora_pyconfig(
-        run_name=f"restore_{model_name}_{use_sft}_run",
+        run_name=f"restore_{model_name}_sft_run",
         checkpoint_dir=self.test_dir,
         model_name=model_name,
-        use_sft=use_sft,
+        use_sft=True,
         scan_layers=scan_layers,
         load_parameters_path=base_ckpt_path,
         steps=2,
         checkpoint_period=2,
         lora=lora_restore_config,
     )
-    state_step4 = train.train_loop(config_step4, recorder=None)
-    self.assertEqual(int(state_step4.optimizer.step.get_value()), 2)
+    trainer_step4, _ = train_sft.train(config_step4, goodput_recorder=None)
+    self.assertEqual(int(trainer_step4.train_steps), 2)
 
-  # --- LoRA Unquantized Tests (Gemma4) ---
-  def test_lora_e2e_gemma4_pretrain(self):
-    self._run_e2e_flow("gemma4-26b", use_sft=False)
+  def test_lora_e2e_gemma4_sft(self):
+    self._run_e2e_flow_sft("gemma4-26b")
 
-  def test_lora_e2e_gemma4_sft_native(self):
-    self._run_e2e_flow("gemma4-26b", use_sft=True)
+  def test_qlora_e2e_gemma4_sft_nf4(self):
+    self._run_e2e_flow_sft("gemma4-26b", lora_weight_qtype="nf4")
 
-  # --- QLoRA NF4 Tests (Gemma4, Qwen3, GPT-OSS) ---
-  def test_qlora_e2e_gemma4_pretrain_nf4(self):
-    self._run_e2e_flow("gemma4-26b", use_sft=False, lora_weight_qtype="nf4")
-
-  def test_qlora_e2e_gemma4_sft_native_nf4(self):
-    self._run_e2e_flow("gemma4-26b", use_sft=True, lora_weight_qtype="nf4")
-
-  def test_qlora_e2e_qwen3_pretrain_nf4(self):
-    self._run_e2e_flow("qwen3-4b", use_sft=False, lora_weight_qtype="nf4")
-
-  def test_qlora_e2e_qwen3_sft_native_nf4(self):
-    self._run_e2e_flow("qwen3-4b", use_sft=True, lora_weight_qtype="nf4")
-
-  def test_qlora_e2e_gptoss_unscanned_nf4(self):
-    self._run_e2e_flow("gpt-oss-20b", use_sft=False, lora_weight_qtype="nf4", scan_layers=False)
+  def test_qlora_e2e_qwen3_sft_nf4(self):
+    self._run_e2e_flow_sft("qwen3-4b", lora_weight_qtype="nf4")
 
 
 if __name__ == "__main__":

--- a/tests/unit/sharding_nnx_test.py
+++ b/tests/unit/sharding_nnx_test.py
@@ -284,11 +284,12 @@ class TestNnxConstructNamedSharding(unittest.TestCase):
         ("embed", "fsdp"),
         ("mlp", "fsdp"),
     )
+    v = nnx.Param(
+        jnp.zeros((3, 4)),
+        out_sharding=("embed", "mlp"),
+        eager_sharding=False,
+    )
     with jax.set_mesh(self.mesh), nn_partitioning.axis_rules(rules):
-      v = nnx.Param(
-          jnp.zeros((3, 4)),
-          out_sharding=("embed", "mlp"),
-      )
       out = self._run(self._build_state(w=v))
       result_sharding = out["w"].get_value()
       self.assertIsInstance(result_sharding, NamedSharding)
@@ -305,11 +306,12 @@ class TestNnxConstructNamedSharding(unittest.TestCase):
         ("mlp", "fsdp"),
         ("mlp", "stage"),
     )
+    v = nnx.Param(
+        jnp.zeros((3, 4)),
+        out_sharding=("embed", "mlp"),
+        eager_sharding=False,
+    )
     with jax.set_mesh(self.mesh), nn_partitioning.axis_rules(rules):
-      v = nnx.Param(
-          jnp.zeros((3, 4)),
-          out_sharding=("embed", "mlp"),
-      )
       out = self._run(self._build_state(w=v))
       result_sharding = out["w"].get_value()
       self.assertIsInstance(result_sharding, NamedSharding)
@@ -327,6 +329,7 @@ class TestNnxConstructNamedSharding(unittest.TestCase):
           jnp.zeros((3,)),
           out_sharding=("embed",),
           sharding_rules=(("embed", "fsdp"),),
+          eager_sharding=False,
       )
     out = self._run(self._build_state(w=v))
     result_sharding = out["w"].get_value()
@@ -354,13 +357,14 @@ class TestNnxConstructNamedSharding(unittest.TestCase):
     # Local rules map 'embed' to 'stage'. Context rules map 'embed' to 'fsdp'.
     # Because local rules come first, 'embed' should resolve to 'stage'.
     context_rules = (("embed", "fsdp"),)
+    v = nnx.Param(
+        jnp.zeros((3,)),
+        out_sharding=("embed",),
+        sharding_rules=(("embed", "stage"),),
+        eager_sharding=False,
+    )
     with jax.set_mesh(self.mesh), nn_partitioning.axis_rules(context_rules):
-      v = nnx.Param(
-          jnp.zeros((3,)),
-          out_sharding=("embed",),
-          sharding_rules=(("embed", "stage"),),
-      )
-    out = self._run(self._build_state(w=v))
+      out = self._run(self._build_state(w=v))
     result_sharding = out["w"].get_value()
     self.assertEqual(result_sharding.spec, PartitionSpec("stage"))
 


### PR DESCRIPTION
# Description

This PR hardens our Jupyter Notebook CI pipeline against silent failures, reorganizes our post-training integration tests, and includes several bug fixes for sharding specifications and gradient accumulation in the SFT trainer. It also optimizes the Jupyter notebook testing workflow (`run_jupyter_notebooks.yml`) by transitioning from sequential execution of all notebooks on a single runner to dynamic matrix parallel execution. It also adds intelligent PR diff detection, ensuring that Pull Requests only run the specific notebooks that were modified.        

## Why is this change required?
1. Previously, if a code change caused the training loop to crash internally or exit prematurely, the notebook execution could still finish successfully without propagating a failing exit code to the CI runner. A major vulnerability in our CI was recently exposed by PR #4866 (the Tunix SFT signatures failure). Because the training loop failed silently, the CI passed, and the regression was merged into main. If the verification steps in this PR had been present in main, we would have immediately detected failures in PR #4866. By explicitly asserting that the trainer completes the expected number of steps, we ensure that CI only passes if the training loop is actually functional, eliminating the risk of "false positive" CI passes on broken notebooks.
2. `Long CI Duration`: Previously, all 7 active example notebooks (`src/maxtext/examples/*.ipynb`) executed sequentially in a single job on a single TPU v6e-8 runner. Total execution time took [60–90+ minutes](https://github.com/AI-Hypercomputer/maxtext/actions/runs/31756047355/job/94632235841?pr=4878).                                                                                                                        
3. `Resource Inefficiency on PRs`: A PR that only touched a single notebook (e.g. sft_qwen3_demo.ipynb) was forced to execute the entire suite of 7 notebooks sequentially.                                                                                                                                                    
4. `Cumulative Flakiness & Contamination`: Sequential execution inside a single container accumulated checkpoint artifacts and cache files, leading to potential disk space issues or memory fragmentation.                                                                                                                       

## Key Changes:
**Notebook CI Hardening**
* **Explicit Step Verification:** Added a strict post-training check (`trainer.train_steps < config.steps`) to `sft_llama3_demo_tpu.ipynb`, `sft_qwen3_demo.ipynb`, and `lora_llama3_demo.ipynb`. It throws a `RuntimeError` if training aborts early.
* **Faster CI Execution:** Reduced the number of target steps to 5 in the Llama 3, Qwen 3, Gemma 3 multimodal, and Llama 3 LoRA SFT demos. This accelerates the CI pipeline while still proving that the forward/backward passes and optimizer steps execute correctly.
* **Notebook Flag Handling:** Added `absl.flags.mark_as_parsed()` to the notebooks to prevent `UnparsedFlagAccessErrors` during execution.
* **Workflow Cleanup:** Cleaned up `run_jupyter_notebooks.yml` by removing the `maxtext_installed` conditional blocks.
* **Lightweight Discovery:** Added a `discover_notebooks` job that runs `git diff against origin/${GITHUB_BASE_REF}` to identify only the `.ipynb` files that were added or modified in the PR. On Scheduled Runs / Workflow Edits: Falls back to discovering all active notebooks.
* **Parallel Matrix Execution:** Converted the run job into a matrix job parameterized by matrix: `{ notebook: ${{ fromJson(...) }} }` with `fail-fast: false`. Each runner executes exactly one notebook in isolation.
* **Clean Container Isolation:** Each notebook executes in a fresh, isolated container with dedicated disk and memory space.


**Test Reorganization & CI Pipelines**
* Extracted SFT LoRA integration tests from `tests/integration/lora_e2e_nnx_test.py` into a dedicated `tests/post_training/integration/lora_e2e_nnx_test.py` file.
* Updated `ci_pipeline.yml`, `run_ci_tests.yml`, and `run_tests_coordinator.yml` to explicitly execute `cpu-post-training-integration` and `tpu-post-training-integration` flavors, ensuring these tests are not skipped.

**SFT & Core Fixes**
* **SFT Trainer:** Updated `train_sft.py` to properly handle gradient accumulation and removed the legacy inspection of Tunix's `grad_norm` signature. 
* **Sharding Specifications:** Fixed an issue where partition specs containing `local_layers` exceeded array dimensions. Added stripping logic in `sharding.py`, `maxtext_utils.py`, `lora_utils.py`, and `nnx_scan.py`.
* **Quantization Cleanup:** Added logic to `quantizations.py` and `lora_utils.py` to delete `qwix_rngs` metadata from the graph.
* **vLLM Integration:** Removed the unused `swap_space` argument from `maxtext_vllm_rollout.py`.


# Tests

CI tests and verified E2E Airflow tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
