### PR TITLE
Parallelize Jupyter notebook CI workflow using dynamic matrix

### DIFF
--- a/.github/workflows/run_jupyter_notebooks.yml
+++ b/.github/workflows/run_jupyter_notebooks.yml
@@ -34,11 +34,6 @@ on:
       maxtext_sha:
         required: false
         type: string
-      # Flag to skip source checkout and wheel installation
-      maxtext_installed:
-        required: false
-        type: boolean
-        default: false
     secrets:
       HF_TOKEN:
         required: true
@@ -46,8 +41,70 @@ on:
 permissions:
   contents: read
 jobs:
+  discover_notebooks:
+    name: Discover Notebooks to Run
+    runs-on: ubuntu-latest
+    outputs:
+      notebooks: ${{ steps.list.outputs.notebooks }}
+      count: ${{ steps.list.outputs.count }}
+    steps:
+      - name: Checkout MaxText
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          ref: ${{ inputs.maxtext_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Determine Notebook List
+        id: list
+        shell: bash
+        run: |
+          MAXTEXT_NOTEBOOKS_ROOT="src/maxtext/examples"
+          SKIPPED=("sft_llama3_demo_gpu.ipynb" "maxtext_with_gepa.ipynb" "demo_decoding.ipynb" "dpo_qwen3_demo.ipynb")
+
+          is_skipped() {
+            local name="$1"
+            for s in "${SKIPPED[@]}"; do
+              [[ "$name" == "$s" ]] && return 0
+            done
+            return 1
+          }
+
+          SELECTED=()
+          if [ "${GITHUB_EVENT_NAME}" == "pull_request" ] && [ -n "${GITHUB_BASE_REF}" ]; then
+            git fetch origin "${GITHUB_BASE_REF}" --depth=50 2>/dev/null || true
+            while IFS= read -r file; do
+              if [[ -n "$file" && -f "$file" ]]; then
+                name=$(basename "$file")
+                if ! is_skipped "$name"; then
+                  SELECTED+=("$name")
+                fi
+              fi
+            done < <(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" -- "${MAXTEXT_NOTEBOOKS_ROOT}"/*.ipynb 2>/dev/null || true)
+          fi
+
+          # If not a PR or no specific notebooks were modified (e.g. scheduled run or workflow file modified), run all active notebooks
+          if [ ${#SELECTED[@]} -eq 0 ]; then
+            for nb in "$MAXTEXT_NOTEBOOKS_ROOT"/*.ipynb; do
+              name=$(basename "$nb")
+              if ! is_skipped "$name" && [[ -f "$nb" ]]; then
+                SELECTED+=("$name")
+              fi
+            done
+          fi
+
+          JSON_ARRAY=$(jq -nc '$ARGS.positional' --args "${SELECTED[@]}")
+          echo "Discovered notebooks to run: $JSON_ARRAY"
+          echo "notebooks=$JSON_ARRAY" >> "$GITHUB_OUTPUT"
+          echo "count=${#SELECTED[@]}" >> "$GITHUB_OUTPUT"
+
   run:
-    name: Execute Notebooks
+    name: Execute ${{ matrix.notebook }}
+    needs: [discover_notebooks]
+    if: needs.discover_notebooks.outputs.count > 0
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook: ${{ fromJson(needs.discover_notebooks.outputs.notebooks) }}
     runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
     container:
       image: gcr.io/tpu-prod-env-multipod/${{ inputs.base_image }} # zizmor: ignore[unpinned-images]
@@ -56,18 +113,15 @@ jobs:
         UV_TORCH_BACKEND: "cpu"
     steps:
       - name: Checkout MaxText
-        if: ${{ !inputs.maxtext_installed }}
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.maxtext_sha }}
           persist-credentials: false
       - name: Download the MaxText wheel
-        if: ${{ !inputs.maxtext_installed }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: maxtext-wheel
       - name: Install MaxText and Dependencies
-        if: ${{ !inputs.maxtext_installed }}
         shell: bash
         run: |
           # 1. Create virtual environment
@@ -89,25 +143,18 @@ jobs:
           install_tpu_post_train_extra_deps
 
           python3 -m pip freeze
-      - name: Run Post-Training Notebooks
+      - name: Run Post-Training Notebook
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          MAXTEXT_INSTALLED: ${{ inputs.maxtext_installed }}
+          NOTEBOOK_NAME: ${{ matrix.notebook }}
           # TODO: Fix evaluation in sft_qwen3_demo.ipynb and remove this env variable
           RUN_EVALUATION: "false"
         run: |
-          if [ "${MAXTEXT_INSTALLED}" == "true" ]; then
-            # Move to the directory where code is baked into the image. See the Dockerfile.
-            # This is necessary because GHA sets an empty workspace by default.
-            cd /deps
-            PYTHON_EXE="python3"
-            PAPERMILL_EXE="papermill"
-          else
-            PYTHON_EXE=".venv/bin/python3"
-            PAPERMILL_EXE=".venv/bin/papermill"
-            source .venv/bin/activate
-          fi
+          PYTHON_EXE=".venv/bin/python3"
+          PAPERMILL_EXE=".venv/bin/papermill"
+          source .venv/bin/activate
+
           export PYTHONPATH="${PWD}/src${PYTHONPATH:+:${PYTHONPATH}}"
 
           MAXTEXT_REPO_ROOT=$(pwd)
@@ -121,28 +168,22 @@ jobs:
           # Run Hugging Face authentication
           hf auth login --token "$HF_TOKEN"
 
-          for notebook in "$MAXTEXT_NOTEBOOKS_ROOT"/*.ipynb; do
-            filename=$(basename "$notebook")
-            if [[ "$filename" == "sft_llama3_demo_gpu.ipynb" || "$filename" == "maxtext_with_gepa.ipynb" || "$filename" == "demo_decoding.ipynb" || "$filename" == "dpo_qwen3_demo.ipynb" ]]; then
-              echo "Skipping $filename"
-              continue
-            fi
-            output_name="${filename%.ipynb}_output.ipynb"
+          notebook="$MAXTEXT_NOTEBOOKS_ROOT/$NOTEBOOK_NAME"
+          output_name="${NOTEBOOK_NAME%.ipynb}_output.ipynb"
 
-            echo "------------------------------------------------------"
-            echo "Running $filename ..."
-            echo "------------------------------------------------------"
+          echo "------------------------------------------------------"
+          echo "Running $NOTEBOOK_NAME ..."
+          echo "------------------------------------------------------"
 
-            $PAPERMILL_EXE "$notebook" "$output_name" -k maxtext_venv
+          $PAPERMILL_EXE "$notebook" "$output_name" -k maxtext_venv
 
-            # Clean up any checkpoint directories created by the notebook to avoid filling up disk space
-            echo "Post-notebook disk cleanup for $filename ..."
-            rm -rf "$MAXTEXT_PKG_DIR"/*_output
-            rm -rf "$HOME/.cache/huggingface/hub"
-          done
+          # Clean up any checkpoint directories created by the notebook to avoid filling up disk space
+          echo "Post-notebook disk cleanup for $NOTEBOOK_NAME ..."
+          rm -rf "$MAXTEXT_PKG_DIR"/*_output
+          rm -rf "$HOME/.cache/huggingface/hub"
       - name: Upload Outputs
         if: always()
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: notebook-outputs-${{ inputs.device_name }}
+          name: notebook-outputs-${{ matrix.notebook }}-${{ inputs.device_name }}
           path: ./*_output.ipynb


### PR DESCRIPTION
# Description

This PR optimizes the Jupyter notebook testing workflow (`run_jupyter_notebooks.yml`) by transitioning from sequential execution of all notebooks on a single runner to dynamic matrix parallel execution. It also adds intelligent PR diff detection, ensuring that Pull Requests only run the specific notebooks that were modified.                                      
                                                                                                                                                       
## Problem & Motivation                                                                                                                                         

1. `Long CI Duration`: Previously, all 7 active example notebooks (`src/maxtext/examples/*.ipynb`) executed sequentially in a single job on a single TPU v6e-8 runner. Total execution time took [60–90+ minutes](https://github.com/AI-Hypercomputer/maxtext/actions/runs/31756047355/job/94632235841?pr=4878).                                                                                                                        
2. `Resource Inefficiency on PRs`: A PR that only touched a single notebook (e.g. sft_qwen3_demo.ipynb) was forced to execute the entire suite of 7 notebooks sequentially.                                                                                                                                                    
3. `Cumulative Flakiness & Contamination`: Sequential execution inside a single container accumulated checkpoint artifacts and cache files, leading to potential disk space issues or memory fragmentation.                                                                                                                       
4. Coarse Feedback: If the 5th notebook failed, subsequent notebooks never run.

## Key Changes                                                                                                                                                  
1. `discover_notebooks Pre-job (Lightweight Discovery)`:
      • Added a `discover_notebooks` job that runs `git diff against origin/${GITHUB_BASE_REF}` to identify only the `.ipynb` files that were added or modified in the PR.
      • On Scheduled Runs / Workflow Edits: Falls back to discovering all active notebooks.
      • Emits a dynamic JSON array output (e.g. ["sft_qwen3_demo.ipynb", "lora_llama3_demo.ipynb"]) consumed by the matrix strategy.
2. Parallel Matrix Execution:
      • Converted the run job into a matrix job parameterized by matrix: `{ notebook: ${{ fromJson(...) }} }` with `fail-fast: false`.
      • Each runner executes exactly one notebook in isolation.
      • Uploads dedicated output artifacts named `notebook-outputs-${{ matrix.notebook }}-${{ inputs.device_name }}`.
  3. Clean Container Isolation:
      • Each notebook executes in a fresh, isolated container with dedicated disk and memory space.

# Tests
 
CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
