### PR TITLE
Add machinelearning_run to the decoupled mldiagnostics stub

### DIFF
--- a/src/maxtext/common/gcloud_stub.py
+++ b/src/maxtext/common/gcloud_stub.py
@@ -525,6 +525,9 @@ def _mldiagnostics_stub():  # pragma: no cover - simple placeholder
       """Return a stub context manager."""
       return _StubXprof()
 
+    def machinelearning_run(self, *a, **k):  # pylint: disable=unused-argument
+      """Do nothing: there is no run to register without the real package."""
+
   return _StubMldiag(), True
 
 


### PR DESCRIPTION
# Description

`ManagedMLDiagnostics.__init__` calls `mldiag.machinelearning_run(...)` whenever `config.managed_mldiagnostics` is set. When `google_cloud_mldiagnostics` is unavailable, either because `DECOUPLE_GCLOUD=TRUE` or because the import failed, `mldiagnostics_modules()`substitutes the stub built by `gcloud_stub._mldiagnostics_stub()`, and that stub only  implements `xprof`. The call therefore raises `AttributeError` instead of quietly doing nothing, which is what the rest of the stub layer does. This adds the missing no-op.

`tests/unit/managed_mldiagnostics_test.py` hits the same gap from the other side: all three of its tests `mock.patch.object(mldiag, "machinelearning_run")`, which fails on an object that has no such attribute.

This isn't visible in CI today because there is no decoupled run of these tests. The decoupled step inside `cpu-unit` runs `-m decoupled_target`, which only `checkpointing_test.py`, `param_mapping_test.py`, `correctness_tests_nnx_dispatch_test.py` and `grpo_nnx_test.py` carry, and the ordinary `cpu-unit` venv installs the real `google-cloud-mldiagnostics`, so the stub path is never exercised. It surfaced in a downstream fork that runs the full unit suite with `DECOUPLE_GCLOUD=TRUE`.

# Tests

In a decoupled environment (`DECOUPLE_GCLOUD=TRUE`, no `google_cloud_mldiagnostics` installed):

```
python -m pytest tests/unit/managed_mldiagnostics_test.py
```

Before: 3 failed with
`AttributeError: <...._StubMldiag object> does not have the attribute 'machinelearning_run'`.
After: 3 passed.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.