### PR TITLE
Add missing sa_bwd_dkv_megacore to a ring attention test config

### DIFF
--- a/tests/unit/tokamax_ring_attention_test.py
+++ b/tests/unit/tokamax_ring_attention_test.py
@@ -282,6 +282,7 @@ class TokamaxRingAttentionTest(absltest.TestCase):
         use_splash_scheduler=False,
         ring_scan_unroll=1,
         use_max_logit_estimate=-1,
+        sa_bwd_dkv_megacore=False,
     )
     devices = np.asarray(jax.devices()[:2]).reshape(1, 2)
     # The ring axis is deliberately not named "context" so that the string


### PR DESCRIPTION
# Description

`tokamax_ring_attention.build_splash_config` reads `config.sa_bwd_dkv_megacore`. Two of the three `SimpleNamespace` configs in `tests/unit/tokamax_ring_attention_test.py` were updated when that field was added; the third, in `test_residual_checkpoint_name_enables_context_remat_policy`, was missed, so that test raises `AttributeError: 'types.SimpleNamespace' object has no attribute 'sa_bwd_dkv_megacore'`.

No CI job surfaces this today. The test starts with

```python
if len(jax.devices()) < 2:
  self.skipTest("Requires at least 2 devices for a ring mesh.")
```

so it skips on `cpu-unit`'s single CPU device, and since it carries no explicit hardware marker conftest auto-marks it `cpu_only`, which the multi-device `tpu-unit` and `gpu-unit` jobs deselect. The test therefore never executes. It turned up on our downstream fork that runs `cpu_only` tests on a multi-device host.

# Tests

Reproduced and fixed without any accelerator, on plain CPU with two simulated devices:

```
JAX_PLATFORMS=cpu XLA_FLAGS=--xla_force_host_platform_device_count=2 \
  python -m unittest tests.unit.tokamax_ring_attention_test.TokamaxRingAttentionTest.test_residual_checkpoint_name_enables_context_remat_policy
```

Before: `AttributeError`. After: OK. The full file also passes on an 8-device host (10 passed).

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.