### PR TITLE
Enable Quantized All-Gather over FSDP for MoE embeddings

### DIFF
--- a/docs/reference/core_concepts/moe_configuration.md
+++ b/docs/reference/core_concepts/moe_configuration.md
@@ -121,7 +121,11 @@ MaxText implements an exact, paper-aligned version of DeepSeek V4's load balanci
 
 `moe_fsdp_use_two_stage_all_gather`: If enabled, split the All-Gather operation for MoE weights into two separate stages when using FSDP/FSDP-transpose sharding. This is preferred when 3D All-Gather support is unavailable.
 
-`shard_exp_on_fsdp`: If enabled, shard the expert dimension of the MLP weights on the FSDP axis, and recommended only when num_experts is a multiple of fsdp_parallelism.
+**MoE FSDP Sharding Strategies** (Note: At most one of the following three flags can be enabled at a time):
+
+- `shard_exp_on_fsdp`: If enabled, shard the expert dimension of the MLP weights on the FSDP axis. Works for both unquantized and quantized. When `quantization` and `weight_quantization_calibration_method` are fixed, it performs quantized weight all gather over fsdp before gmm. This is recommended only when `num_experts` is a multiple of `fsdp_parallelism`.
+- `use_2d_fsdp_sharding`: If enabled, use fsdp and fsdp_transpose axes for sharding the MoE weights.
+- `shard_embed_moe_on_fsdp`: If enabled, keep embed_moe sharded so we can manually QAG (Quantize-All-Gather) it over FSDP. Requires `quantization` to be specified and `weight_quantization_calibration_method` to be fixed.
 
 ## 3. Performance Tuning
 

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -286,6 +286,9 @@ moe_fsdp_use_two_stage_all_gather: false
 # Shard the expert dimension of the MLP weights on the FSDP axis.
 # This configuration is recommended only when num_experts is a multiple of fsdp_parallelism
 shard_exp_on_fsdp: false
+# Keep embed_moe sharded so we can manually QAG it over FSDP.
+# Requires quantization to be specified and weight_quantization_calibration_method to be fixed (static scaling mode).
+shard_embed_moe_on_fsdp: false
 # use fsdp and fsdp_transpose axes for sharding the moe weights
 use_2d_fsdp_sharding: false
 

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -952,6 +952,10 @@ class MoEGeneral(BaseModel):
       description="Shard the expert dimension of the MLP weights on the FSDP axis, "
       "and recommended only when num_experts is a multiple of fsdp_parallelism",
   )
+  shard_embed_moe_on_fsdp: bool = Field(
+      False,
+      description="Keep embed_moe sharded so we can manually QAG it over FSDP.",
+  )
   use_2d_fsdp_sharding: bool = Field(
       False,
       description="Use `fsdp` and `fsdp_transpose` axes for 2D FSDP sharding.",
@@ -983,6 +987,17 @@ class MoEGeneral(BaseModel):
   def validate_moe_chunks(self) -> "MoEGeneral":
     if self.num_moe_token_chunks > 1 and not self.use_ring_of_experts:
       raise ValueError("num_moe_token_chunks > 1 requires use_ring_of_experts=True.")
+    return self
+
+  @model_validator(mode="after")
+  def validate_moe_sharding_strategy(self) -> "MoEGeneral":
+    """Ensure that only one MoE FSDP sharding strategy is active at a time."""
+    active_sharding_flags = sum([self.shard_exp_on_fsdp, self.use_2d_fsdp_sharding, self.shard_embed_moe_on_fsdp])
+    if active_sharding_flags > 1:
+      raise ValueError(
+          "Only one of shard_exp_on_fsdp, use_2d_fsdp_sharding, or "
+          "shard_embed_moe_on_fsdp can be True at the same time."
+      )
     return self
 
 
@@ -3167,6 +3182,18 @@ class MaxTextConfig(
     # Explicitly setting encoding removes the need for the pylint disable comment
     with open(custom_mesh_path, "r", encoding="utf-8") as f:
       return yaml.safe_load(f) or {}
+
+  @model_validator(mode="after")
+  def validate_shard_embed_moe_on_fsdp(self) -> "MaxTextConfig":
+    """Raise ValueError if shard_embed_moe_on_fsdp is used without fixed weight quantization calibration."""
+    if self.shard_embed_moe_on_fsdp and (
+        self.quantization == "" or not self.weight_quantization_calibration_method.startswith("fixed")
+    ):
+      raise ValueError(
+          "shard_embed_moe_on_fsdp requires quantization to be specified and "
+          "weight_quantization_calibration_method to be fixed (static scaling mode)."
+      )
+    return self
 
   @model_validator(mode="after")
   def set_derived_and_validate_values(self) -> "MaxTextConfig":

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -1596,11 +1596,12 @@ class RoutedMoE(nnx.Module):
       # In the decoding case, the expert axis is instead replicated along the tensor's batch dimension.
       return input_activation.shape[0] > 1
 
-    def explicitly_weight_ag(shard_exp_on_fsdp):
-      if shard_exp_on_fsdp:
-        quantization_rule = qpl.get_current_rule("gmm")
-        if quantization_rule and quantization_rule.weight_calibration_method.startswith("fixed"):
-          return True
+    def explicitly_weight_ag():
+      if not (self.config.shard_exp_on_fsdp or self.config.shard_embed_moe_on_fsdp):
+        return False
+      quantization_rule = qpl.get_current_rule("gmm")
+      if quantization_rule and quantization_rule.weight_calibration_method.startswith("fixed"):
+        return True
       return False
 
     def maybe_aqt_partition(w0_kernel, w0_pspec, w1_kernel, w1_pspec, wo_kernel, wo_pspec):
@@ -1653,8 +1654,7 @@ class RoutedMoE(nnx.Module):
       # w0, w1, wo needs to be un sharded on fsdp / fsdp_transpose axis, so use
       # mlp_no_fsdp axis
       if self.config.shard_exp_on_fsdp:
-        quantization_rule = qpl.get_current_rule("gmm")
-        if quantization_rule and quantization_rule.weight_calibration_method.startswith("fixed"):
+        if explicitly_weight_ag():
           # special sharding when using static scaling for weights in quantization with shard_exp_on_fsdp
           w0_pspec = self._logical_to_mesh_axes(self.wi_kernel_axes)
           w1_pspec = self._logical_to_mesh_axes(self.wi_kernel_axes)
@@ -1668,8 +1668,13 @@ class RoutedMoE(nnx.Module):
         w0_pspec = self._logical_to_mesh_axes((None, "mlp_no_fsdp", None))
         w1_pspec = self._logical_to_mesh_axes((None, "mlp_no_fsdp", None))
         wo_pspec = self._logical_to_mesh_axes((None, "mlp_no_fsdp", None))
+      elif self.config.shard_embed_moe_on_fsdp and explicitly_weight_ag():
+        # Keep embed_moe sharded so we can manually QAG it over FSDP
+        w0_pspec = self._logical_to_mesh_axes(("exp", "embed_moe", "mlp_no_fsdp"))
+        w1_pspec = self._logical_to_mesh_axes(("exp", "embed_moe", "mlp_no_fsdp"))
+        wo_pspec = self._logical_to_mesh_axes(("exp", "mlp_no_fsdp", "embed_moe"))
       else:
-        # These are the main shardings used by default - they use funky rules to AG over FSDP.
+        # Tell XLA to automatically gather the D dimension (e.g. for dynamic absmax scaling)
         w0_pspec = self._logical_to_mesh_axes(("exp", None, "mlp_no_fsdp"))
         w1_pspec = self._logical_to_mesh_axes(("exp", None, "mlp_no_fsdp"))
         wo_pspec = self._logical_to_mesh_axes(("exp", "mlp_no_fsdp", None))
@@ -1692,7 +1697,7 @@ class RoutedMoE(nnx.Module):
       )
 
     is_batch_sharded_by_expert = is_batch_sharded_by_ep(inputs)
-    weight_gather = explicitly_weight_ag(self.config.shard_exp_on_fsdp)
+    weight_gather = explicitly_weight_ag()
     (
         batch_logical_axis,
         input_partition_pspec,
@@ -1908,8 +1913,14 @@ class RoutedMoE(nnx.Module):
     def get_wi_gmm_params():
       wi_gather_axes = []
       if weight_gather:
-        # wi [Experts, In, Hidden] -> Gather Exp(0) and Hidden(2)
-        wi_gather_axes.extend(get_active_sharding_axes(w0_pspec[0], 0))
+        # weight_gather implies either exp or embed_moe is sharded.
+        if self.config.shard_exp_on_fsdp:
+          # wi [Experts, In, Hidden] -> Gather Exp(0)
+          wi_gather_axes.extend(get_active_sharding_axes(w0_pspec[0], 0))
+        else:
+          # Gather In(1) where embed_moe is sharded.
+          wi_gather_axes.extend(get_active_sharding_axes(w0_pspec[1], 1))
+        # Gather Hidden(2)
         wi_gather_axes.extend(get_active_sharding_axes(w0_pspec[2], 2))
       wi_tile_size = (
           self.config.wi_tile_fwd_batch_seq,  # m (LHS batch)
@@ -1927,8 +1938,14 @@ class RoutedMoE(nnx.Module):
     def get_wo_gmm_params():
       wo_gather_axes = []
       if weight_gather:
-        # wo [Experts, Hidden, Out] -> Gather Exp(0) and Hidden(1)
-        wo_gather_axes.extend(get_active_sharding_axes(wo_pspec[0], 0))
+        # weight_gather implies either exp or embed_moe is sharded.
+        if self.config.shard_exp_on_fsdp:
+          # wo [Experts, Hidden, Out] -> Gather Exp(0)
+          wo_gather_axes.extend(get_active_sharding_axes(wo_pspec[0], 0))
+        else:
+          # Gather Out(2) where embed_moe is sharded.
+          wo_gather_axes.extend(get_active_sharding_axes(wo_pspec[2], 2))
+        # Gather Hidden(1)
         wo_gather_axes.extend(get_active_sharding_axes(wo_pspec[1], 1))
       wo_tile_size = (
           self.config.wo_tile_fwd_batch_seq,  # m (LHS batch)

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -452,6 +452,7 @@ def test_sparse_matmul_repairs_batch_specs_only_without_expert_parallelism(exper
       config=SimpleNamespace(
           shard_exp_on_fsdp=False,
           use_2d_fsdp_sharding=False,
+          shard_embed_moe_on_fsdp=False,
           model_name="qwen3.5-35b-a3b",
           check_vma=False,
           moe_fsdp_use_two_stage_all_gather=False,
@@ -1101,6 +1102,86 @@ class RoutedMoeTest(parameterized.TestCase):
       assert_moe_close(actual_output, expected_output, cfg.dtype)
 
   @pytest.mark.tpu_only
+  def test_shard_embed_moe_on_fsdp(self):
+    if jax.device_count() != 4:
+      self.skipTest("shard_embed_moe_on_fsdp test requires exactly 4 devices")
+
+    cfg = pyconfig.initialize(
+        [None, get_test_config_path()],
+        run_name="moe_block_shard_embed_test",
+        enable_checkpointing=False,
+        model_name="mixtral-8x7b",
+        dtype="bfloat16",
+        megablox=True,
+        sparse_matmul=True,
+        use_tokamax_gmm=True,
+        use_gmm_v2=True,
+        per_device_batch_size=4,
+        ici_fsdp_parallelism=4,
+        shard_embed_moe_on_fsdp=True,
+        max_target_length=128,
+        float32_gate_logits=True,
+        quantization="fp8_full",
+        use_qwix_quantization=True,
+        weight_quantization_calibration_method="fixed,-224,224",
+        act_quantization_calibration_method="fixed,-224,224",
+        bwd_quantization_calibration_method="absmax",
+    )
+
+    def get_fp8_full_qwix_rule_for_test(config):
+      return [
+          qwix.QtRule(
+              module_path=".*",
+              weight_qtype=jnp.float8_e4m3fn,
+              act_qtype=jnp.float8_e4m3fn,
+              bwd_qtype=jnp.float8_e5m2,
+              weight_calibration_method=config.weight_quantization_calibration_method,
+              act_calibration_method=config.act_quantization_calibration_method,
+              bwd_calibration_method=config.bwd_quantization_calibration_method,
+              op_names=("gmm", "ragged_dot"),
+          ),
+      ]
+
+    rng = jax.random.PRNGKey(2345)
+    rng_model, rng_hidden_states = jax.random.split(rng)
+    device_count = jax.device_count()
+    hidden_states = jax.random.uniform(
+        rng_hidden_states,
+        (int(cfg.per_device_batch_size) * device_count, cfg.max_target_length, cfg.base_emb_dim),
+        dtype=cfg.dtype,
+    )
+
+    devices_array = maxtext_utils.create_device_mesh(cfg)
+    mesh = Mesh(devices_array, cfg.mesh_axes)
+
+    # Instantiate QAG-quantized model with shard_embed_moe_on_fsdp
+    model_qag = moe.get_routed_moe(
+        name="MoeBlock",
+        config=cfg,
+        num_experts=cfg.num_experts,
+        num_experts_per_tok=cfg.num_experts_per_tok,
+        mesh=mesh,
+        kernel_init=nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed", "mlp"),
+        intermediate_dim=cfg.mlp_dim,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.dtype,
+    )
+    quantization_rule = get_fp8_full_qwix_rule_for_test(cfg)
+    quantization_provider = qwix.QtProvider(quantization_rule)
+    model_qag = qwix.quantize_model(model_qag, quantization_provider)
+
+    with nn_partitioning.axis_rules(cfg.logical_axis_rules):
+      # Initialize reference unfused model to get initial weights
+      _, expected_output = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
+
+      variables_qag = model_qag.init({"params": rng_model, "dropout": rng_model}, hidden_states.astype(jnp.float32))
+
+      output_qag, _, _ = jax.jit(model_qag.apply)(variables_qag, hidden_states.astype(jnp.float32))
+
+      self.assertEqual(output_qag.shape, expected_output.shape)
+
+  @pytest.mark.tpu_only
   def test_megablox_context_parallelism(self):
     cfg = pyconfig.initialize(
         [None, get_test_config_path()],
@@ -1542,26 +1623,36 @@ class RoutedMoeTest(parameterized.TestCase):
 
   @parameterized.named_parameters(
       {
-          "testcase_name": f"{base_name}_ep{ici_expert_parallelism}",
+          "testcase_name": f"{base_name}_ep{ici_expert_parallelism}" + ("_qag" if shard_embed_moe_on_fsdp else ""),
           "quantization": quantization,
           "use_tokamax_gmm": use_tokamax_gmm,
           "use_gmm_v2": use_gmm_v2,
           "wa_static": wa_static,
           "ici_expert_parallelism": ici_expert_parallelism,
+          "shard_embed_moe_on_fsdp": shard_embed_moe_on_fsdp,
       }
-      for base_name, quantization, use_tokamax_gmm, use_gmm_v2, wa_static, ici_expert_parallelism in [
-          ("megablox_bf16", "", False, False, False, 1),
-          ("megablox_fp8_dynamic", "fp8_full", False, False, False, 1),
-          ("megablox_fp8_static", "fp8_full", False, False, True, 1),
-          ("tokamax_v1_bf16", "", True, False, False, 1),
-          ("tokamax_v1_fp8_dynamic", "fp8_full", True, False, False, 1),
-          ("tokamax_v1_fp8_static", "fp8_full", True, False, True, 1),
-          ("tokamax_v2_bf16", "", True, True, False, 1),
-          ("tokamax_v2_fp8_dynamic", "fp8_full", True, True, False, 1),
-          ("tokamax_v2_fp8_static", "fp8_full", True, True, True, 1),
-          ("tokamax_v2_bf16", "", True, True, False, 4),
-          ("tokamax_v2_fp8_dynamic", "fp8_full", True, True, False, 4),
-          ("tokamax_v2_fp8_static", "fp8_full", True, True, True, 4),
+      for (
+          base_name,
+          quantization,
+          use_tokamax_gmm,
+          use_gmm_v2,
+          wa_static,
+          ici_expert_parallelism,
+          shard_embed_moe_on_fsdp,
+      ) in [
+          ("megablox_bf16", "", False, False, False, 1, False),
+          ("megablox_fp8_dynamic", "fp8_full", False, False, False, 1, False),
+          ("megablox_fp8_static", "fp8_full", False, False, True, 1, False),
+          ("tokamax_v1_bf16", "", True, False, False, 1, False),
+          ("tokamax_v1_fp8_dynamic", "fp8_full", True, False, False, 1, False),
+          ("tokamax_v1_fp8_static", "fp8_full", True, False, True, 1, False),
+          ("tokamax_v2_bf16", "", True, True, False, 1, False),
+          ("tokamax_v2_fp8_dynamic", "fp8_full", True, True, False, 1, False),
+          ("tokamax_v2_fp8_static", "fp8_full", True, True, True, 1, False),
+          ("tokamax_v2_bf16", "", True, True, False, 4, False),
+          ("tokamax_v2_fp8_dynamic", "fp8_full", True, True, False, 4, False),
+          ("tokamax_v2_fp8_static", "fp8_full", True, True, True, 4, False),
+          ("tokamax_v2_fp8_static", "fp8_full", True, True, True, 1, True),
       ]
   )
   @pytest.mark.skip_on_tpu7x  # TODO(b/543017989): Investigate correctness failures
@@ -1573,6 +1664,7 @@ class RoutedMoeTest(parameterized.TestCase):
       use_gmm_v2: bool,
       wa_static: bool,
       ici_expert_parallelism: int,
+      shard_embed_moe_on_fsdp: bool = False,
       **kwargs,
   ):
     megablox = True
@@ -1590,6 +1682,7 @@ class RoutedMoeTest(parameterized.TestCase):
         use_tokamax_gmm,
         use_gmm_v2,
         ici_expert_parallelism,
+        shard_embed_moe_on_fsdp,
     ):
       return pyconfig.initialize(
           [None, get_test_config_path()],
@@ -1606,6 +1699,7 @@ class RoutedMoeTest(parameterized.TestCase):
           megablox=megablox,
           use_tokamax_gmm=use_tokamax_gmm,
           use_gmm_v2=use_gmm_v2,
+          shard_embed_moe_on_fsdp=shard_embed_moe_on_fsdp,
           quantization=quantization,
           use_qwix_quantization=True,
           weight_quantization_calibration_method=weight_quantization_calibration_method,
@@ -1683,6 +1777,7 @@ class RoutedMoeTest(parameterized.TestCase):
         use_tokamax_gmm=False,
         use_gmm_v2=False,
         ici_expert_parallelism=1,
+        shard_embed_moe_on_fsdp=False,
     )
     # Use normal distribution to generate realistic variances and negative values
     # to guarantee the quantization scale != 1.0, which catches scale-dropping bugs.
@@ -1707,6 +1802,7 @@ class RoutedMoeTest(parameterized.TestCase):
         use_tokamax_gmm=use_tokamax_gmm,
         use_gmm_v2=use_gmm_v2,
         ici_expert_parallelism=ici_expert_parallelism,
+        shard_embed_moe_on_fsdp=shard_embed_moe_on_fsdp,
     )
     devices_array_tgt = maxtext_utils.create_device_mesh(cfg_tgt)
     mesh_tgt = Mesh(devices_array_tgt, cfg_tgt.mesh_axes)

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -429,6 +429,25 @@ assert train._TF_AVAILABLE is False
     self.assertEqual(_normalize_axes(["a", "b"]), ("a", "b"))
     self.assertEqual(_normalize_axes([]), ())
 
+  def test_moe_sharding_strategy_mutual_exclusivity(self):
+    """Ensure that shard_exp_on_fsdp, use_2d_fsdp_sharding, and shard_embed_moe_on_fsdp are mutually exclusive."""
+
+    def init_config(**kwargs):
+      pyconfig.initialize(
+          [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+          skip_jax_distributed_system=True,
+          **kwargs,
+      )
+
+    with self.assertRaisesRegex(ValueError, "Only one of shard_exp_on_fsdp"):
+      init_config(shard_exp_on_fsdp=True, use_2d_fsdp_sharding=True)
+
+    with self.assertRaisesRegex(ValueError, "Only one of shard_exp_on_fsdp"):
+      init_config(shard_exp_on_fsdp=True, shard_embed_moe_on_fsdp=True)
+
+    with self.assertRaisesRegex(ValueError, "Only one of shard_exp_on_fsdp"):
+      init_config(use_2d_fsdp_sharding=True, shard_embed_moe_on_fsdp=True)
+
   def test_ep_rank_1_raises_on_ep_flags(self):
     """When EP rank is 1 (no EP rules), setting EP-only flags must raise ValueError."""
     # No 'exp' rule -> infer_ep_axes returns () -> EP rank is 1.
@@ -470,6 +489,35 @@ assert train._TF_AVAILABLE is False
     ]
     self.assertEqual(infer_cp_axes(ep_as_cp_rules), ("expert",))
     self.assertEqual(infer_ep_axes(ep_as_cp_rules), ("expert",))
+
+  def test_shard_embed_moe_on_fsdp_requires_quantization(self):
+    """Verifies that a ValueError is raised when shard_embed_moe_on_fsdp
+    is used without fixed weight quantization calibration."""
+    with self.assertRaises(ValueError):
+      pyconfig.initialize(
+          [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+          skip_jax_distributed_system=True,
+          shard_embed_moe_on_fsdp=True,
+          quantization="",
+      )
+
+    with self.assertRaises(ValueError):
+      pyconfig.initialize(
+          [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+          skip_jax_distributed_system=True,
+          shard_embed_moe_on_fsdp=True,
+          quantization="int8",
+          weight_quantization_calibration_method="absmax",
+      )
+
+    # This should not raise
+    pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+        shard_embed_moe_on_fsdp=True,
+        quantization="int8",
+        weight_quantization_calibration_method="fixed,-1,1",
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This PR introduces the `shard_embed_moe_on_fsdp` configuration flag, allowing `embed_moe` to remain sharded so we can manually perform Quantize-All-Gather (QAG) over FSDP. 

Previously, MoE weights were automatically gathered by XLA for computations. By explicitly retaining the FSDP sharding on the `embed_moe` axis during manual QAG (when using `fixed` weight calibration), we significantly reduce communication overhead and improve throughput.

**Note:** This optimization only triggers when using static scales (fixed weight calibration).

### Key Changes
- Updated `moe.py` partition specs to support manual QAG when `shard_embed_moe_on_fsdp` is enabled.
- Added config validators to enforce mutual exclusivity across FSDP sharding flags, safely check quantization rules, and fallback to standard sharding if static quantization isn't configured.
- Updated the `moe_configuration.md` doc.

FIXES: b/544811065

# Tests

- Added unit tests in `moe_test.py` and `pyconfig_test.py`.
- Ran an E2E test which showed a ~7.3% improvement in throughput compared to the regular fp8 run. Full E2E workload and XProf results are attached in the bug comments.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).