### PR TITLE
Fix Qwen-VL SFT image padding registration in PadOrTrimToMaxLength

### DIFF
--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -793,8 +793,16 @@ class PadOrTrimToMaxLength(grain.MapTransform):
     if preprocessed_image.pixel_values is None:
       raise ValueError("Input preprocessed_image must have pixel_values to pad images.")
 
-    if self.config.model_name and self.config.model_name.startswith("qwen3-omni"):  # pyrefly: ignore[missing-attribute]
+    vision_block = mm_processor._get_vision_block(self.config)  # pylint: disable=protected-access
+    model_name = getattr(self.config, "model_name", None)
+    if vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
       return preprocessed_image
+    elif model_name and model_name.startswith("qwen"):
+      raise ValueError(
+          f"Qwen multimodal model '{model_name}' with vision_block '{vision_block}' was not "
+          f"registered in `PadOrTrimToMaxLength`. Qwen models use native dynamic grids and must be "
+          f"registered to bypass image padding."
+      )
 
     # Determine the maximum number of images/masks allowed.
     image_offsets = mm_processor.get_image_offsets(self.config, preprocessed_image)

--- a/tests/unit/input_pipeline_utils_test.py
+++ b/tests/unit/input_pipeline_utils_test.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 import numpy as np
 
 from maxtext.input_pipeline.input_pipeline_utils import BlockDiffusionCorruption, compute_file_sharding, PadOrTrimToMaxLength
+from maxtext.multimodal import utils as mm_utils
 
 
 class BlockDiffusionPaddingTest(unittest.TestCase):
@@ -200,6 +201,29 @@ class ComputeFileShardingUndersizedCaseTest(unittest.TestCase):
     # 2 files, 3 hosts: file 1 has only one reader (host 1) → no row split needed
     _, _, row_shard = compute_file_sharding(2, host_index=1, host_count=3)
     self.assertIsNone(row_shard)
+
+
+class PadOrTrimToMaxLengthMultimodalTest(unittest.TestCase):
+  """Unit tests for PadOrTrimToMaxLength image padding behaviors."""
+
+  def test_qwen_vision_padding_bypass_and_validation(self):
+    dummy_output = mm_utils.PreprocessorOutput(pixel_values=np.zeros((1, 3, 224, 224)), num_images=1)
+
+    # Registered Qwen vision models bypass image padding
+    for vb in ["qwen3_vl", "qwen3_omni", "qwen3_5"]:
+      transform = PadOrTrimToMaxLength(max_length=128, pad_id=0, config=SimpleNamespace(vision_encoder_block=vb))
+      self.assertIs(transform._pad_image_and_mask(dummy_output), dummy_output)  # pylint: disable=protected-access
+
+    # Unregistered Qwen model raises ValueError
+    unreg_transform = PadOrTrimToMaxLength(
+        max_length=128, pad_id=0, config=SimpleNamespace(vision_encoder_block="unregistered", model_name="qwen3-future")
+    )
+    with self.assertRaisesRegex(ValueError, "registered in `PadOrTrimToMaxLength`"):
+      unreg_transform._pad_image_and_mask(dummy_output)  # pylint: disable=protected-access
+
+    # None pixel_values raises ValueError
+    with self.assertRaisesRegex(ValueError, "must have pixel_values"):
+      unreg_transform._pad_image_and_mask(mm_utils.PreprocessorOutput(pixel_values=None))  # pylint: disable=protected-access
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

## Problem
Qwen 3 models need to bypass image padding In `PadOrTrimToMaxLength` from `input_pipeline_utils.py`. However, the previous bypass for Qwen 3 models only checked `self.config.model_name.startswith("qwen3-omni")`. This ignores `qwen3-vl-2b` and `qwen3-vl-4b`, which are both vision-language models, to erroneously fell through to tile-based _pad_image_and_mask. This corrupted SFT training representations.

*This is a silent bug that won't be visible without a meaningful amount of training steps.*

FIXES: b/546726345 

## Fix
- Updated `PadOrTrimToMaxLength` to check vision_block via `mm_processor._get_vision_block()` to cover all Qwen dynamic vision architectures (qwen3_omni, qwen3_vl, qwen3_5).
- Added an explicit ValueError if a Qwen multimodal model with an unregistered vision block is encountered, preventing silent fallthroughs in future model additions.




# Tests

## Unit tests

```
python3 -m unittest tests/unit/input_pipeline_utils_test.py

----------------------------------------------------------------------
Ran 13 tests in 0.004s

OK
```

## SFT training

Doing SFT using Qwen3-vl-2b for 100 steps.

```bash
python3 -m maxtext.trainers.post_train.sft.train_sft_native \
    src/maxtext/configs/post_train/sft-vision-coco-captions.yml \
    model_name=qwen3-vl-2b \
    load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/qwen3-vl-2b-processor/0/items \
    base_output_directory=gs://yuchenhou-maxtext-logs/qwen3-vl-2b/multimodal/sft \
    run_name=qwen3_vl_sft_coco_tp4 \
    ici_tensor_parallelism=4 \
    per_device_batch_size=1 \
    max_prefill_predict_length=1024 \
    max_target_length=1600 \
    steps=101 \
    remat_policy=full \
    scan_layers=false \
    save_checkpoint_on_start=false \
    save_checkpoint_on_completion=true

```

```bash
python3 -m maxtext.inference.decode \
    src/maxtext/configs/base.yml \
    model_name=qwen3-vl-2b \
    load_parameters_path=gs://yuchenhou-maxtext-logs/qwen3-vl-2b/multimodal/sft/qwen3_vl_sft_coco_tp4/checkpoints/100/items \
    per_device_batch_size=1 \
    run_name=qwen3_vl_coco_post_sft \
    max_prefill_predict_length=1024 \
    max_target_length=1600 \
    steps=1 \
    async_checkpointing=false \
    scan_layers=false \
    use_multimodal=true \
    tokenizer_type=huggingface \
    prompt='Describe the image concisely.' \
    image_path=tests/assets/test_image.jpg \
    attention=dot_product \
    skip_jax_distributed_system=true
```

Reference image:

<img src="https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/assets/test_image.jpg?raw=true" width="400" alt="Test Image" />


Before fix
```
Input `<|im_start|>user
<|vision_start|><|image_pad|><|vision_end|>Describe the image concisely.<|im_end|>
<|im_start|>assistant
` -> `A man standing on a tennis court holding a racquet.
```

After fix
```
Input `<|im_start|>user
<|vision_start|><|image_pad|><|vision_end|>Describe the image concisely.<|im_end|>
<|im_start|>assistant
` -> `A city with a tall building and a snow covered mountain.
```

(This is expected using COCO with empty default prompt for a small amount of steps. I got similar results using Gemma 3 4B)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
