### PR TITLE
Zero-initialize the ragged all-to-all combine buffer when ragged_buffer_factor > 0

### DIFF
--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -120,6 +120,13 @@ def _truncate_matrix(all_shards_group_sizes: jax.Array, buffer_size: int) -> jax
   return jnp.diff(clamped_cumsum_extended, axis=0)
 
 
+def _ragged_all_to_all_output_buffer(shape, dtype, zero_init: bool) -> jax.Array:
+  """Creates a zeroed or uninitialized ragged all-to-all output buffer."""
+  if zero_init:
+    return jnp.zeros(shape, dtype=dtype)
+  return jax.lax.empty(shape, dtype=dtype)
+
+
 def _sort_activations(
     inputs: jax.Array,
     sort_indices: jax.Array,
@@ -2247,12 +2254,13 @@ class RoutedMoE(nnx.Module):
         original_inputs_first_dim = batch_size * sequence_length * self.config.num_experts_per_tok
         if routing.sorted_selected_experts.shape[0] != original_inputs_first_dim:
           raise ValueError("original_inputs_first_dim does not match the original tensor" " shape!")
-        output_shape = jax.lax.empty(
+        output_shape = _ragged_all_to_all_output_buffer(
             (
                 original_inputs_first_dim,
                 self.moe_expert_input_dim // self.get_tensor_parallelism_size(),
             ),
-            dtype=intermediate_output.dtype,
+            intermediate_output.dtype,
+            zero_init=is_batch_sharded_by_expert and self.config.ragged_buffer_factor > 0.0,
         )
 
         intermediate_output = unsort_output_and_ra2a(

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -1493,6 +1493,66 @@ class RoutedMoeTest(parameterized.TestCase):
     )
     self.assertEqual(expected_ragged_buffer, actual_ragged_buffer)
 
+  # Rows are batch shards and columns are expert shards; each batch shard sends eight assignments.
+  _TRAFFIC_MATRIX = np.array([[4, 1, 2, 1], [3, 2, 1, 2], [1, 2, 2, 3], [2, 1, 0, 5]], dtype=np.int32)
+
+  def test_ragged_all_to_all_output_buffer_zero_init(self):
+    """The all-to-all destination buffer is zeroed only when requested."""
+    # pylint: disable=protected-access
+    shape = (6, 4)
+
+    def emitted_primitives(zero_init):
+      jaxpr = jax.make_jaxpr(lambda: moe._ragged_all_to_all_output_buffer(shape, jnp.bfloat16, zero_init=zero_init))()
+      return [str(eqn.primitive) for eqn in jaxpr.jaxpr.eqns]
+
+    # Empty buffers may read as zero, so the emitted primitive distinguishes the allocation paths.
+    self.assertNotIn("empty", emitted_primitives(zero_init=True))
+    self.assertIn("empty", emitted_primitives(zero_init=False))
+
+    zeroed = moe._ragged_all_to_all_output_buffer(shape, jnp.bfloat16, zero_init=True)
+    self.assertEqual((zeroed.shape, zeroed.dtype), (shape, jnp.bfloat16))
+    np.testing.assert_array_equal(np.asarray(zeroed, dtype=np.float32), np.zeros(shape, np.float32))
+
+  def test_truncated_combine_leaves_dropped_assignments_unwritten(self):
+    """A dropped assignment contributes zero to the combined token."""
+    # pylint: disable=protected-access
+    num_ep, buffer_size, emb, top_k = 4, 6, 2, 2
+    sizes = self._TRAFFIC_MATRIX
+    origin = 1
+    rows = int(sizes[origin].sum())
+    marker = np.broadcast_to((np.arange(rows, dtype=np.float32) + 1)[:, None], (rows, emb))
+
+    def replay_combine(destination):
+      """Replays combine's row copies because ragged all-to-all has no CPU lowering."""
+      destination = np.array(destination, dtype=np.float32)
+      for expert_shard in range(num_ep):
+        _, send_sz, out_off, _ = moe.RoutedMoE.get_all_to_all_params(
+            jnp.asarray(sizes),
+            expert_shard,
+            num_ep,
+            ragged_buffer_factor=1.0,
+            buffer_size=buffer_size,
+            is_dispatch=False,
+        )
+        start = int(np.asarray(out_off)[origin])
+        end = start + int(np.asarray(send_sz)[origin])
+        destination[start:end] = marker[start:end]
+      return destination
+
+    def weighted_unpermute(combined):
+      """Applies the reshape and weighted sum from `RoutedMoE.unpermute`."""
+      return np.einsum("BKE,BK->BE", combined.reshape(-1, top_k, emb), np.full((rows // top_k, top_k), 0.5, np.float32))
+
+    dropped = np.flatnonzero(~replay_combine(np.zeros((rows, emb))).any(axis=1))
+    np.testing.assert_array_equal(dropped, [2])
+
+    poisoned = weighted_unpermute(replay_combine(np.full((rows, emb), np.nan, np.float32)))
+    self.assertTrue(np.isnan(poisoned[int(dropped[0]) // top_k]).all())
+
+    combined = replay_combine(moe._ragged_all_to_all_output_buffer((rows, emb), jnp.float32, zero_init=True))
+    np.testing.assert_array_equal(combined[dropped], 0.0)
+    np.testing.assert_array_equal(weighted_unpermute(combined)[int(dropped[0]) // top_k], 0.5 * marker[3])
+
   @parameterized.named_parameters(
       {
           "testcase_name": f"{base_name}_ep{ici_expert_parallelism}",


### PR DESCRIPTION
# Description

Since [#4397](https://github.com/AI-Hypercomputer/maxtext/pull/4397), `ragged_buffer_factor > 0` truncates overflow but combine all-to-all writes the truncated sizes at the original offsets, leaving unwritten interior rows in a `lax.empty` buffer. Weighted combine reads those rows at full router weight, introducing uninitialized values into activations and gradients on TPU/GPU; `lax.empty` reads as zero on CPU, hiding the bug from CPU CI. This breaks [#3541](https://github.com/AI-Hypercomputer/maxtext/pull/3541)'s invariant that every `lax.empty` row is overwritten.

The combine buffer is now zero-initialized only when truncation is enabled; the default `ragged_buffer_factor=-1` path remains byte-identical. Dispatch still uses `lax.empty` because receives form a packed prefix and unwritten rows are never read.

# Tests

Added two CPU tests: one checks the emitted allocation primitive (`zeros` vs `empty`, since `empty` reads as zero on CPU), and one replays combine row copies to verify a dropped row reads zero.

- `pytest tests/unit/moe_test.py` — 22 passed, 38 skipped (`origin/main`: 20 passed; this PR adds 2).
- `pyink --check --pyink-indentation=2 --line-length=122 src/maxtext/layers/moe.py tests/unit/moe_test.py` — passed.
- Mutation check: forcing the combine allocation back to `lax.empty` fails the emitted-primitive regression test.

End-to-end: ran 24 DeepSeek-V4 training steps on v6e-128 with `ragged_buffer_factor=1.015625` and smooth monotonic loss; the private reservation has no workload link.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
