### PR TITLE
Optimize MoE routing for Gemma4

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -236,6 +236,7 @@ moe_dispatch_no_expert_sharding: false
 use_ragged_sort: false # whether to use the Pallas ragged-sort kernels in the MoE permute path; valid both with and
                        # without `use_ring_of_experts` (with EP > 1). When `use_ring_of_experts=True` the kernels run
                        # inside `permute`/`unpermute`; otherwise they run inside `local_permute`/local-unpermute.
+moe_use_direct_token_gather: false # whether to gather tokens directly in expert order instead of materializing Top-K copies
 use_gather_mosaic_kernel: false # whether to use a custom mosaic kernel for token gather ops
 ragged_gather_fallback: false # when true, unconditionally use the JAX reference implementation instead of the
                               # ragged gather SparseCore kernel. When false (default), use the SparseCore kernel.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -899,6 +899,10 @@ class MoEGeneral(BaseModel):
       False,
       description="Whether to run ragged sort kernels on 1 SparseCore instead of all SparseCores.",
   )
+  moe_use_direct_token_gather: bool = Field(
+      False,
+      description="Whether to gather tokens directly in expert order instead of materializing Top-K copies.",
+  )
   use_gather_mosaic_kernel: bool = Field(
       False,
       description="Whether to use a custom mosaic kernel for token gather ops.",
@@ -3790,6 +3794,8 @@ class MaxTextConfig(
             f"Engram vocab size mismatch: expected {self.engram_max_ngram_size - 1} (max_ngram_size - 1), "
             f"but got {self.engram_vocab_bases}."
         )
+    if self.moe_use_direct_token_gather and self.use_gather_mosaic_kernel:
+      raise ValueError("`moe_use_direct_token_gather=True` currently requires `use_gather_mosaic_kernel=False`.")
     if self.num_experts > 1:
       if self.moe_mlp_dim <= 0:
         raise ValueError("moe_mlp_dim must be positive for MoE models (num_experts > 1)")

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -33,6 +33,7 @@ from jax.sharding import PartitionSpec as P
 from maxtext.common import common_types as ctypes
 from maxtext.common.common_types import ShardMode
 from maxtext.kernels import megablox as mblx
+from maxtext.kernels import sort_activations
 from maxtext.layers import attentions, linears, nnx_wrappers, quantizations
 from maxtext.layers.initializers import NdInitializer, default_bias_init, nd_dense_init, variable_to_logically_partitioned
 from maxtext.kernels.ragged.ragged_sort import a2a_ragged_sort
@@ -149,6 +150,16 @@ def _sort_activations(
     if use_custom_vjp:
       return _sort_activations_custom(inputs, sort_indices)
     return inputs[sort_indices, ...]
+
+
+def _route_activations(inputs: jax.Array, selected_experts: jax.Array) -> jax.Array:
+  """Groups token activations by expert without materializing Top-K copies."""
+  selected_experts = selected_experts.reshape((inputs.shape[0], -1))
+  # When use_gather_mosaic_kernel=False, use the general JAX backward, which
+  # gathers and sums gradients from all expert copies of each token. The
+  # optimized Mosaic gather-reduce kernel currently requires exactly 8 selected
+  # experts per token and is enabled only by the specialized batch-split path.
+  return sort_activations.route(inputs, selected_experts, use_gather_mosaic_kernel=False)
 
 
 @jax.custom_vjp
@@ -952,11 +963,13 @@ class RoutedMoE(nnx.Module):
       if roll_to_expert_id is not None:
         flatten_selected_experts = (flatten_selected_experts - roll_to_expert_id) % self.num_experts
       sorted_selected_experts = jnp.argsort(flatten_selected_experts)
-      # sort inputs for number of selected experts
-      replicated_inputs_2d = jnp.repeat(inputs_2d, self.num_experts_per_tok, axis=0)
-      sorted_inputs = _sort_activations(replicated_inputs_2d, sorted_selected_experts, use_custom_sort_vjp).astype(
-          self.dtype
-      )
+      if self.config.moe_use_direct_token_gather:
+        sorted_inputs = _route_activations(inputs_2d, flatten_selected_experts).astype(self.dtype)
+      else:
+        replicated_inputs_2d = jnp.repeat(inputs_2d, self.num_experts_per_tok, axis=0)
+        sorted_inputs = _sort_activations(replicated_inputs_2d, sorted_selected_experts, use_custom_sort_vjp).astype(
+            self.dtype
+        )
       group_size = jnp.bincount(flatten_selected_experts, length=self.num_experts)
 
     num_tokens = bsz_times_seq_len * self.num_experts_per_tok

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -504,6 +504,53 @@ def test_sparse_matmul_repairs_batch_specs_only_without_expert_parallelism(exper
 class RoutedMoeTest(parameterized.TestCase):
   """Routed Mixture of Experts test."""
 
+  @parameterized.parameters(False, True)
+  def test_permute_direct_token_gather_matches_repeat_and_sort(self, compute_gradient):
+    inputs = jnp.arange(24, dtype=jnp.float32).reshape(2, 3, 4)
+    selected_experts = jnp.array(
+        [
+            [[3, 1], [0, 2], [1, 3]],
+            [[2, 0], [3, 2], [0, 1]],
+        ],
+        dtype=jnp.int32,
+    )
+    weights = jnp.arange(12, dtype=jnp.float32).reshape(2, 3, 2)
+    gate_logits = jnp.zeros((2, 3, 4), dtype=jnp.float32)
+
+    def permute(x, use_direct_token_gather):
+      routed_moe = SimpleNamespace(
+          config=SimpleNamespace(
+              decoder_block=None,
+              load_balance_loss_weight=0.0,
+              moe_use_direct_token_gather=use_direct_token_gather,
+              num_experts=4,
+              use_ragged_sort=False,
+              use_ring_of_experts=False,
+          ),
+          dtype=jnp.float32,
+          is_hash_routing=False,
+          num_experts=4,
+          num_experts_per_tok=2,
+          get_expert_parallelism_size=lambda: 1,
+          get_topk=lambda *_args, **_kwargs: (weights, selected_experts),
+          should_update_load_balance=lambda: False,
+      )
+      return moe.RoutedMoE.permute(routed_moe, x, gate_logits, gate_logits)
+
+    if compute_gradient:
+      cotangent = jnp.arange(48, dtype=jnp.float32).reshape(12, 4)
+      expected = jax.grad(lambda x: jnp.sum(permute(x, False)[0] * cotangent))(inputs)
+      result = jax.grad(lambda x: jnp.sum(permute(x, True)[0] * cotangent))(inputs)
+      np.testing.assert_array_equal(result, expected)
+    else:
+      expected = permute(inputs, False)
+      result = permute(inputs, True)
+      for actual_value, expected_value in zip(result, expected):
+        if expected_value is None:
+          self.assertIsNone(actual_value)
+        else:
+          np.testing.assert_array_equal(actual_value, expected_value)
+
   def get_expected_output(self, rng, hidden_states, cfg, mesh):
     """Retrieve expected output from Routed Mixture of Experts."""
     model = get_moe_loop(


### PR DESCRIPTION
# Description

Add an optional direct-token-gather path for sparse MoE routing. It gathers input tokens directly in expert order instead of materializing Top-K copies with jnp.repeat before sorting.

For Gemma4-26B, this removes the large Top-8 activation expansion while preserving expert-ID rotation and correct gradient accumulation.

The optimization is controlled by moe_use_direct_token_gather, which defaults to false and is currently enabled only for Gemma4-26B. Its performance improvement has only been validated on that model; other MoE configurations retain the existing repeat-and-sort path until they are benchmarked.


# Tests

Add unit test for numerical equivalence.

XProf confirms that the direct-gather path removes the broadcast_bitcast_fusion associated with the repeated activation, and improved end-to-end step time.
Before: [xprof](https://xprof.corp.google.com/trace_viewer/aireenmei-13534665124925283610?view_start=11352.617&view_end=11358.416), [screenshot](https://screenshot-v2.corp.google.com/40jao38emg6eo), step time: 10.5 s
Before: [xprof](https://xprof.corp.google.com/trace_viewer/aireenmei-6309662714480977089?view_start=11644.359&view_end=11652.992), [screenshot](https://screenshot-v2.corp.google.com/718p0f3ruv7uo), step time: 10.39 s



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
