### PR TITLE
fix: support heterogeneous attention layers and nested text config in Gemma 4 to_huggingface conversion

### DIFF
--- a/src/maxtext/checkpoint_conversion/to_huggingface.py
+++ b/src/maxtext/checkpoint_conversion/to_huggingface.py
@@ -246,6 +246,8 @@ def _validate_or_update_architecture(hf_config, max_config, override: bool):
       ("qk_rope_head_dim", "qk_rope_head_dim"),
       ("v_head_dim", "v_head_dim"),
       ("vocab_size", "vocab_size"),
+      ("global_head_dim", "global_head_dim"),
+      ("num_global_key_value_heads", "global_num_kv_heads"),
   ]
 
   if max_config.attention_type == "mla":
@@ -262,17 +264,19 @@ def _validate_or_update_architecture(hf_config, max_config, override: bool):
     attributes_to_check.append(("head_dim", "head_dim"))
 
   mismatches = []
+  target_cfg = getattr(hf_config, "text_config", hf_config) or hf_config
 
   for hf_attr, mt_attr in attributes_to_check:
-    # Skip checks if the HF config doesn't have this attribute (e.g. layer_norm_eps vs rms_norm_eps)
-    if not hasattr(hf_config, hf_attr):
-      continue
-
     # Skip checks if MaxText config doesn't have the attribute (shouldn't happen for valid configs)
     if not hasattr(max_config, mt_attr):
       continue
 
-    hf_value = getattr(hf_config, hf_attr)
+    # Skip checks if the HF config doesn't have this attribute or raises AmbiguousGlobalPerLayerAttributeError
+    try:
+      hf_value = getattr(target_cfg, hf_attr)
+    except (AttributeError, ValueError, RuntimeError):
+      continue
+
     mt_value = getattr(max_config, mt_attr)
 
     # Handle None values
@@ -307,7 +311,7 @@ def _validate_or_update_architecture(hf_config, max_config, override: bool):
     if not is_match:
       if override:
         max_logging.log(f"⚠️ Overwriting HF Config '{hf_attr}': {hf_value} -> {mt_value} (from MaxText '{mt_attr}')")
-        setattr(hf_config, hf_attr, mt_value)
+        setattr(target_cfg, hf_attr, mt_value)
       else:
         mismatches.append(f"{hf_attr} (HF={hf_value} vs MaxText={mt_value})")
 

--- a/src/maxtext/checkpoint_conversion/utils/hf_shape.py
+++ b/src/maxtext/checkpoint_conversion/utils/hf_shape.py
@@ -153,6 +153,39 @@ def GEMMA3_HF_WEIGHTS_TO_SHAPE(config):
   return shapes
 
 
+def _get_gemma4_layer_attention_dims(text_cfg: dict, layer_idx: int, is_global: bool):
+  """Extracts (q_dim, kv_dim, norm_dim) for a Gemma 4 layer accounting for per_layer_config overrides."""
+  num_attention_heads = text_cfg["num_attention_heads"]
+  num_key_value_heads = text_cfg["num_key_value_heads"]
+  head_dim = text_cfg["head_dim"]
+  global_head_dim = text_cfg.get("global_head_dim") or head_dim
+  num_global_key_value_heads = text_cfg.get("num_global_key_value_heads") or num_key_value_heads
+
+  per_layer_config = text_cfg.get("per_layer_config") or {}
+  if isinstance(per_layer_config, list):
+    layer_override = (
+        per_layer_config[layer_idx]
+        if layer_idx < len(per_layer_config) and isinstance(per_layer_config[layer_idx], dict)
+        else {}
+    )
+  elif isinstance(per_layer_config, dict):
+    layer_override = (
+        per_layer_config.get(layer_idx)
+        or per_layer_config.get(str(layer_idx))
+        or per_layer_config.get(f"{layer_idx:02d}")
+        or {}
+    )
+  else:
+    layer_override = {}
+
+  l_heads = layer_override.get("num_attention_heads") or num_attention_heads
+  l_kv_heads = layer_override.get("num_key_value_heads") or (
+      num_global_key_value_heads if is_global else num_key_value_heads
+  )
+  l_head_dim = layer_override.get("head_dim") or (global_head_dim if is_global else head_dim)
+  return l_heads * l_head_dim, l_kv_heads * l_head_dim, l_head_dim
+
+
 def GEMMA4_HF_WEIGHTS_TO_SHAPE(config):
   """Generates shape mapping for Hugging Face Gemma4 parameters.
 
@@ -179,33 +212,22 @@ def GEMMA4_HF_WEIGHTS_TO_SHAPE(config):
   hidden_size = text_cfg["hidden_size"]
   intermediate_size = text_cfg["intermediate_size"]
   num_hidden_layers = text_cfg["num_hidden_layers"]
-  num_attention_heads = text_cfg["num_attention_heads"]
-  num_key_value_heads = text_cfg["num_key_value_heads"]
-  num_global_key_value_heads = text_cfg.get("num_global_key_value_heads", num_key_value_heads)
-  head_dim = text_cfg["head_dim"]
-  global_head_dim = text_cfg.get("global_head_dim", head_dim)
   vocab_size = text_cfg["vocab_size"]
 
   num_experts = text_cfg.get("num_experts")
   num_experts = num_experts if num_experts is not None else 1
   # "moe_intermediate_size" is the canonical key in Gemma4 config; fall back to "expert_intermediate_size"
   expert_intermediate_size = text_cfg.get("moe_intermediate_size") or text_cfg.get("expert_intermediate_size")
+  layer_types = text_cfg.get("layer_types", [])
 
   shapes[f"{text_base}.embed_tokens.weight"] = [vocab_size, hidden_size]
   shapes[f"{text_base}.norm.weight"] = [hidden_size]
 
   for i in range(num_hidden_layers):
     hf_prefix = f"{text_base}.layers.{i}"
-    is_global = (i % 6) == 5
+    is_global = (i < len(layer_types) and layer_types[i] == "full_attention") if layer_types else (i % 6) == 5
 
-    if is_global:
-      q_dim = num_attention_heads * global_head_dim
-      kv_dim = num_global_key_value_heads * global_head_dim
-      norm_dim = global_head_dim
-    else:
-      q_dim = num_attention_heads * head_dim
-      kv_dim = num_key_value_heads * head_dim
-      norm_dim = head_dim
+    q_dim, kv_dim, norm_dim = _get_gemma4_layer_attention_dims(text_cfg, i, is_global)
 
     shapes[f"{hf_prefix}.self_attn.q_proj.weight"] = [q_dim, hidden_size]
     shapes[f"{hf_prefix}.self_attn.k_proj.weight"] = [kv_dim, hidden_size]
@@ -291,7 +313,7 @@ def GEMMA4_SMALL_HF_WEIGHTS_TO_SHAPE(config):
     * derives global-vs-sliding from the per-model ``layer_types`` list
       (E2B has period-5, E4B has period-6),
     * emits the Per-Layer-Embedding parameters when ``hidden_size_per_layer_input`` > 0,
-    * omits k_proj/v_proj/k_norm/v_norm shapes on KV-shared layers, and
+      * omits k_proj/v_proj/k_norm/v_norm shapes on KV-shared layers, and
     * doubles ``intermediate_size`` on shared layers when ``use_double_wide_mlp``
       is set (E2B).
   """
@@ -304,11 +326,6 @@ def GEMMA4_SMALL_HF_WEIGHTS_TO_SHAPE(config):
   hidden_size = text_cfg["hidden_size"]
   intermediate_size = text_cfg["intermediate_size"]
   num_hidden_layers = text_cfg["num_hidden_layers"]
-  num_attention_heads = text_cfg["num_attention_heads"]
-  num_key_value_heads = text_cfg["num_key_value_heads"]
-  num_global_key_value_heads = text_cfg.get("num_global_key_value_heads") or num_key_value_heads
-  head_dim = text_cfg["head_dim"]
-  global_head_dim = text_cfg.get("global_head_dim", head_dim)
   vocab_size = text_cfg["vocab_size"]
   layer_types = text_cfg.get("layer_types", [])
 
@@ -330,15 +347,7 @@ def GEMMA4_SMALL_HF_WEIGHTS_TO_SHAPE(config):
     hf_prefix = f"{text_base}.layers.{i}"
     is_global = i < len(layer_types) and layer_types[i] == "full_attention"
     is_shared = num_kv_shared > 0 and i >= first_shared
-
-    if is_global:
-      q_dim = num_attention_heads * global_head_dim
-      kv_dim = num_global_key_value_heads * global_head_dim
-      norm_dim = global_head_dim
-    else:
-      q_dim = num_attention_heads * head_dim
-      kv_dim = num_key_value_heads * head_dim
-      norm_dim = head_dim
+    q_dim, kv_dim, norm_dim = _get_gemma4_layer_attention_dims(text_cfg, i, is_global)
 
     shapes[f"{hf_prefix}.self_attn.q_proj.weight"] = [q_dim, hidden_size]
     shapes[f"{hf_prefix}.self_attn.o_proj.weight"] = [hidden_size, q_dim]

--- a/tests/unit/hf_checkpoint_conversion_test.py
+++ b/tests/unit/hf_checkpoint_conversion_test.py
@@ -25,10 +25,15 @@ from maxtext.checkpoint_conversion.to_huggingface import (
     _get_lora_delta,
     _transform_weights_to_adapter,
     _transform_weights_to_full_model,
+    _validate_or_update_architecture,
 )
 from maxtext.checkpoint_conversion.to_maxtext import (
     convert_hf_lora_key_to_maxtext,
     _process_and_stack_weights,
+)
+from maxtext.checkpoint_conversion.utils.hf_shape import (
+    GEMMA4_HF_WEIGHTS_TO_SHAPE,
+    _get_gemma4_layer_attention_dims,
 )
 from maxtext.checkpoint_conversion.utils.utils import (
     _recursive_update,
@@ -550,6 +555,95 @@ class Gemma3And4CheckpointConversionTest(unittest.TestCase):
     self.assertEqual(delta.shape, (2, 16, 32))
     # Math: einsum("lir,lro->lio", A, B) * 2.0 -> 0.25 * 4 * 2.0 = 2.0
     self.assertTrue(np.allclose(delta, 2.0))
+
+  def test_validate_architecture_multimodal_nested_text_config(self):
+    class MockTextConfig:
+      """Mock TextConfig for testing."""
+
+      def __init__(self):
+        self.hidden_size = 2816
+        self.intermediate_size = 2112
+        self.num_hidden_layers = 30
+        self.num_attention_heads = 16
+        self.vocab_size = 262144
+        self.global_head_dim = 512
+        self.num_global_key_value_heads = 2
+
+      @property
+      def head_dim(self):
+        raise RuntimeError("Ambiguous per-layer attribute")
+
+      @property
+      def num_key_value_heads(self):
+        raise RuntimeError("Ambiguous per-layer attribute")
+
+    text_cfg = MockTextConfig()
+    hf_config = SimpleNamespace(text_config=text_cfg)
+    max_config = SimpleNamespace(
+        emb_dim=2816,
+        mlp_dim=2112,
+        num_decoder_layers=30,
+        num_query_heads=16,
+        global_num_kv_heads=2,
+        global_head_dim=512,
+        vocab_size=262144,
+        attention_type="dot_product",
+        model_name="gemma4-26b",
+    )
+
+    # Should validate nested text_config without error
+    _validate_or_update_architecture(hf_config, max_config, override=False)
+
+  def test_gemma4_shape_mapping_per_layer_config(self):
+    cfg = {
+        "text_config": {
+            "hidden_size": 2816,
+            "intermediate_size": 2112,
+            "num_hidden_layers": 6,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 8,
+            "head_dim": 256,
+            "global_head_dim": 512,
+            "num_global_key_value_heads": 2,
+            "vocab_size": 262144,
+            "num_experts": 128,
+            "moe_intermediate_size": 704,
+            "per_layer_config": {
+                "05": {"head_dim": 512, "num_key_value_heads": 2},
+            },
+        }
+    }
+    shapes = GEMMA4_HF_WEIGHTS_TO_SHAPE(cfg)
+    # Layer 0: sliding window attention
+    self.assertEqual(shapes["model.layers.0.self_attn.q_proj.weight"], [4096, 2816])
+    self.assertEqual(shapes["model.layers.0.self_attn.k_proj.weight"], [2048, 2816])
+    # Layer 5: global full attention from per_layer_config
+    self.assertEqual(shapes["model.layers.5.self_attn.q_proj.weight"], [8192, 2816])
+    self.assertEqual(shapes["model.layers.5.self_attn.k_proj.weight"], [1024, 2816])
+    self.assertEqual(shapes["model.layers.5.self_attn.q_norm.weight"], [512])
+
+  def test_get_gemma4_layer_attention_dims(self):
+    text_cfg = {
+        "num_attention_heads": 16,
+        "num_key_value_heads": 8,
+        "head_dim": 256,
+        "global_head_dim": 512,
+        "num_global_key_value_heads": 2,
+        "per_layer_config": {
+            "05": {"head_dim": 512, "num_key_value_heads": 2},
+        },
+    }
+    # Sliding layer (layer 0)
+    q, kv, norm = _get_gemma4_layer_attention_dims(text_cfg, 0, is_global=False)
+    self.assertEqual(q, 16 * 256)
+    self.assertEqual(kv, 8 * 256)
+    self.assertEqual(norm, 256)
+
+    # Global layer with per_layer_config override (layer 5)
+    q, kv, norm = _get_gemma4_layer_attention_dims(text_cfg, 5, is_global=True)
+    self.assertEqual(q, 16 * 512)
+    self.assertEqual(kv, 2 * 512)
+    self.assertEqual(norm, 512)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

In `transformers >= 5.15.0`, Hugging Face introduced official `Gemma4Config` / `Gemma4TextConfig` with heterogeneous attention layers managed via `text_config.per_layer_config` (where global attention layers store overrides like `{head_dim: 512, num_key_value_heads: 2/4}`).

Previously, converting MaxText Gemma 4 checkpoints to Hugging Face encountered two blocking issues:
1. `_validate_or_update_architecture` only inspected top-level `hf_config`, silently missing language model hyperparameters residing under `hf_config.text_config` on multimodal models, while querying heterogeneous attributes like `num_key_value_heads` raised `AmbiguousGlobalPerLayerAttributeError`.
2. `hf_shape.py` did not dynamically parse `text_cfg.per_layer_config` for layer-specific attention projection shapes (`head_dim`, `num_key_value_heads`, and `num_attention_heads`), leading to tensor shape mismatch errors when reshaping query / key / value projection kernels on global full-attention layers.

### Solution:
1. In `_validate_or_update_architecture`, resolve `target_cfg = getattr(hf_config, "text_config", hf_config)` so composite/multimodal configs (e.g. Gemma 4, Gemma 3) validate and update text hyperparameters on the actual `text_config` object, while safely catching `(AttributeError, ValueError)` (covering `AmbiguousGlobalPerLayerAttributeError`) on heterogeneous layer attributes.
2. In `hf_shape.py`, add `_get_gemma4_layer_attention_dims` to dynamically extract per-layer attention dimensions (`head_dim`, `num_key_value_heads`, and `num_attention_heads`) from `per_layer_config` (supporting dict and list serialization) for both 26B/31B and small E2B/E4B variants without hardcoded numbers.
3. Added unit tests for multimodal nested `text_config` validation, `per_layer_config` shape mapping, and `_get_gemma4_layer_attention_dims`.

# Tests

1. **Unit Tests**:
   ```bash
   pytest tests/unit/hf_checkpoint_conversion_test.py
   pytest tests/unit/gemma4_small_test.py
   ```
   All 17 checkpoint conversion tests and 14 model architecture tests passed.

2. **Cluster E2E Checkpoint Conversion**:
   Ran `test_gemma4_to_hf.sh` on TPU cluster `mlperf-v5p` via XPK:
   ```bash
   bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh pre-20260814T192047 gs://runner-maxtext-logs/gemma4-26b/train/pre-20260814T192047/checkpoints/4/items
   ```
   **Result**: All 657 parameter tensors transformed and all 38 safetensors shards uploaded to GCS successfully (`EXIT_CODE=0`).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
