### PR TITLE
fix(qwen3): support homogeneous scanned layer unrolling and fix 30B E2E scripts

### DIFF
--- a/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
@@ -118,21 +118,25 @@ def _find_scanned_layer_idx(key_tuple, container_names=("layers", "scanned_block
 
 
 def _find_qwen_scanned_layer_idx(key_tuple):
-  """Finds a Qwen heterogeneous scanned block path like `layers.layer_0`."""
+  """Finds a Qwen scanned block path like `layers.layer_0` or `layers.moe_block`."""
   for i in range(len(key_tuple) - 1):
     if key_tuple[i] != "layers" or not isinstance(key_tuple[i + 1], str):
       continue
+    if key_tuple[i + 1].startswith("layers_"):
+      continue
     match = re.fullmatch(r"layer_(\d+)", key_tuple[i + 1])
     if match:
-      return i, int(match.group(1))
-  return -1, -1
+      return i, int(match.group(1)), 2
+    return i, 0, 1
+  return -1, -1, 0
 
 
 def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Optional[int] = None):
-  """Unroll Qwen's heterogeneous scanned blocks for an unscanned MaxText target.
+  """Unroll Qwen's heterogeneous or homogeneous scanned blocks for an unscanned MaxText target.
 
   Qwen 3 Next/3.5 training stores a repeating layer cycle as
   `decoder.layers.layer_{slot}`, with repetitions stacked on `scan_axis`.
+  Qwen 3 base training stores homogeneous layers as `decoder.layers.*` stacked on `scan_axis`.
   The inference model stores every layer as a direct decoder attribute named
   `layers_{global_index}`. Tunix's generic direct-sync mapper cannot bridge
   these two structures and otherwise silently leaves all destination layers at
@@ -159,12 +163,12 @@ def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Opt
   slot_indices = set()
   scan_lengths = set()
   for key, value in flat_w.items():
-    container_idx, slot_idx = _find_qwen_scanned_layer_idx(key)
+    container_idx, slot_idx, consumed = _find_qwen_scanned_layer_idx(key)
     if container_idx == -1 or "dropout" in key or "rngs" in key:
       continue
     if not hasattr(value, "shape") or len(value.shape) <= scan_axis:
       raise ValueError(f"Qwen scanned parameter {'.'.join(map(str, key))} has no scan axis {scan_axis}: {value!r}")
-    scanned_keys.append((key, value, container_idx, slot_idx))
+    scanned_keys.append((key, value, container_idx, slot_idx, consumed))
     slot_indices.add(slot_idx)
     scan_lengths.add(value.shape[scan_axis])
 
@@ -184,12 +188,12 @@ def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Opt
     raise ValueError(f"Qwen scanned parameters disagree on scan length: {sorted(scan_lengths)}")
 
   scan_length = scan_lengths.pop()
-  scanned_key_paths = {key for key, _, _, _ in scanned_keys}
+  scanned_key_paths = {key for key, _, _, _, _ in scanned_keys}
   new_flat_w = {key: value for key, value in flat_w.items() if key not in scanned_key_paths}
 
-  for key, value, container_idx, slot_idx in scanned_keys:
+  for key, value, container_idx, slot_idx, consumed in scanned_keys:
     prefix = key[:container_idx]
-    suffix = key[container_idx + 2 :]
+    suffix = key[container_idx + consumed :]
     for repetition in range(scan_length):
       global_idx = repetition * pattern_length + slot_idx
       new_key = prefix + (f"layers_{global_idx}",) + suffix
@@ -197,7 +201,7 @@ def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Opt
 
   logging.info(
       "MaxTextVllmSampler: unrolled %d Qwen tensor components across %d layers for direct MaxText weight sync.",
-      len(scanned_keys),
+      len(scanned_key_paths),
       scan_length * pattern_length,
   )
   return unflatten_dict(new_flat_w)

--- a/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_rl.sh
+++ b/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_rl.sh
@@ -21,7 +21,8 @@ use_pathways=${2:-false}
 MODEL_NAME='llama3.1-70b'
 
 # Non-Googlers please remember to point `BASE_OUTPUT_DIRECTORY` to the GCS paths where you have the scanned and unscanned checkpoints stored
-BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
+BASE_OUTPUT_DIRECTORY=${BASE_OUTPUT_DIRECTORY:-gs://runner-maxtext-logs/${MODEL_NAME}}
+OUTPUT_DIR=${GCS_OUTPUT:-${BASE_OUTPUT_DIRECTORY}}
 UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned/${run_id}/0/items
 SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned/${run_id}/0/items
 
@@ -38,7 +39,7 @@ python3 -m maxtext.inference.vllm_decode \
 
 # Step 2: Run RL on the converted checkpoint
 python3 -m maxtext.trainers.post_train.rl.train_rl \
-    base_output_directory=${BASE_OUTPUT_DIRECTORY}/rl \
+    base_output_directory=${OUTPUT_DIR}/rl \
     load_parameters_path=${SCANNED_CKPT_PATH} \
     run_name=${run_id} rl.loss_algo='grpo' scan_layers=true \
     num_batches=5 batch_size=1 num_test_batches=5 \
@@ -54,7 +55,7 @@ python3 -m maxtext.trainers.post_train.rl.train_rl \
 # Step 3: Run inference on the checkpoint generated from the previous run
 python3 -m maxtext.inference.vllm_decode \
     model_name=${MODEL_NAME} \
-    load_parameters_path=${BASE_OUTPUT_DIRECTORY}/rl/${run_id}/checkpoints/actor/5/model_params \
+    load_parameters_path=${OUTPUT_DIR}/rl/${run_id}/checkpoints/actor/5/model_params \
     tokenizer_path='meta-llama/Llama-3.1-70B-Instruct' \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
     hbm_utilization_vllm=0.6 \

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh
@@ -49,7 +49,7 @@ python3 -m maxtext.trainers.pre_train.train \
     dataset_path=${DATASET_PATH} \
     tokenizer_type="huggingface" \
     load_parameters_path=${SCANNED_CKPT_PATH} \
-    per_device_batch_size=0.25 \
+    per_device_batch_size=1 \
     run_name=${run_id} \
     max_target_length=64 \
     steps=5 \

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3_sft.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3_sft.sh
@@ -43,7 +43,7 @@ python3 -m maxtext.inference.vllm_decode \
 python3 -m maxtext.trainers.post_train.sft.train_sft \
     base_output_directory=${BASE_OUTPUT_DIRECTORY}/sft \
     load_parameters_path=${SCANNED_CKPT_PATH} \
-    per_device_batch_size=0.25 \
+    per_device_batch_size=1 \
     run_name=${run_id} \
     steps=5 \
     scan_layers=true \

--- a/tests/post_training/unit/vllm_rollout_unroll_test.py
+++ b/tests/post_training/unit/vllm_rollout_unroll_test.py
@@ -225,6 +225,47 @@ class QwenScannedWeightsUnrollTest(unittest.TestCase):
     self.assertEqual(validate_direct_sync_layer_coverage(unrolled, target), 4)
 
   @pytest.mark.cpu_only
+  def test_correctly_unrolls_homogeneous_scanned_weights(self):
+    """Verify homogeneous scanned layers (LLaMA, Qwen Base) unroll to layers_{global_idx}."""
+    # 4 layers stacked on scan_axis=1 (feature_dim=2, num_layers=4, hidden=1)
+    probe_arr = np.zeros((2, 4, 1), dtype=np.float32)
+    for i in range(4):
+      probe_arr[:, i, :] = i
+    weights = MockWeights(
+        {
+            "base": {
+                "decoder": {
+                    "layers": {
+                        "self_attention": {"probe": probe_arr},
+                        "dropout": {"rngs": {"key": np.ones(2, dtype=np.uint32)}},
+                    },
+                    "decoder_norm": {"scale": np.ones(2)},
+                }
+            }
+        }
+    )
+
+    unrolled = unroll_qwen_scanned_weights(weights)
+
+    decoder = unrolled["base"]["decoder"]
+    for layer_idx in range(4):
+      self.assertIn(f"layers_{layer_idx}", decoder)
+      np.testing.assert_array_equal(
+          decoder[f"layers_{layer_idx}"]["self_attention"]["probe"],
+          np.full((2, 1), layer_idx, dtype=np.float32),
+      )
+    np.testing.assert_array_equal(decoder["decoder_norm"]["scale"], np.ones(2))
+    target = {
+        "model": {
+            "decoder": {
+                f"layers_{layer_idx}": {"self_attention": {"probe": np.zeros((2, 1), dtype=np.float32)}}
+                for layer_idx in range(4)
+            }
+        }
+    }
+    self.assertEqual(validate_direct_sync_layer_coverage(unrolled, target), 4)
+
+  @pytest.mark.cpu_only
   def test_rejects_inconsistent_scan_lengths(self):
     weights = MockWeights(
         {


### PR DESCRIPTION
# Description

This PR fixes Qwen 3 MoE direct weight synchronization during vLLM rollout and updates the batch size for Qwen3-30B end-to-end tests:

1. **Qwen 3 MoE Scanned Weight Unrolling (`maxtext_vllm_rollout.py`)**:
   - `unroll_qwen_scanned_weights` previously only looked for heterogeneous repeating layer cycle patterns (`layers.layer_{slot}`).
   - Qwen 3 base models stack homogeneous scanned layers directly under `decoder.layers.<module>` with shape `(num_layers, ...)`.
   - Updated `_find_qwen_scanned_layer_idx` and `unroll_qwen_scanned_weights` to dynamically handle both homogeneous and cyclic layer structures, ensuring 100% of the 48 transformer layers unroll to `decoder.layers_{global_idx}.<module>` to match the vLLM rollout sampler keys.

2. **Batch Size Fixes for 30B E2E Tests (`test_qwen3.sh`, `test_qwen3_sft.sh`)**:
   - Updated `per_device_batch_size=1` in `test_qwen3.sh` and `test_qwen3_sft.sh` to prevent fractional batch sizes on TPU slices.

# Tests

Verified end-to-end on TPU `v5p-32` (`mlperf-v5p` cluster):
- `tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh` -> **PASSED** (`EXIT_CODE=0`)
- `tests/end_to_end/tpu/qwen3/30b/test_qwen3_sft.sh` -> **PASSED** (`EXIT_CODE=0`)
- `tests/end_to_end/tpu/qwen3/30b/test_qwen3_rl.sh` -> **PASSED** (`EXIT_CODE=0`)

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
