### PR TITLE
DSV4: Add mask hoisting, boolean splash masks, and thresholded indexer membership

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -457,6 +457,9 @@ o_lora_rank: 0 # Output LoRA rank for Compressed Attention.
 o_groups: 0 # Output groups for Compressed Attention.
 compress_ratios: [] # Per-layer compression ratios (0, 4, 128, etc).
 compressed_rope_max_timescale: 160_000 # If positive, used for Compressed Sparse/Heavy Attention.
+# Route COMPRESSED and LOCAL_SLIDING train attention to tokamax splash on TPU.
+# Requires use_tokamax_splash: true.
+compressed_use_dynamic_splash: false
 
 # QK-Clip (Muon Clip) Configuration
 use_qk_clip: false  # Enable QK-Clip (supported in MLA with DotProduct or Tokamax Splash)

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -460,6 +460,9 @@ compressed_rope_max_timescale: 160_000 # If positive, used for Compressed Sparse
 # Route COMPRESSED and LOCAL_SLIDING train attention to tokamax splash on TPU.
 # Requires use_tokamax_splash: true.
 compressed_use_dynamic_splash: false
+splash_bool_masks: false # Requires compressed_use_dynamic_splash: true.
+hoist_static_attention_masks: false
+indexer_threshold_membership: false
 
 # QK-Clip (Muon Clip) Configuration
 use_qk_clip: false  # Enable QK-Clip (supported in MLA with DotProduct or Tokamax Splash)

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -708,6 +708,11 @@ class CompressedAttention(BaseModel):
   compressed_rope_max_timescale: int = Field(
       160000, description="If positive, used for Compressed Sparse/Heavy Attention."
   )
+  compressed_use_dynamic_splash: bool = Field(
+      False,
+      description="Route COMPRESSED and LOCAL_SLIDING train attention to tokamax splash on TPU. Requires "
+      "use_tokamax_splash=true.",
+  )
 
 
 class AttentionIndexer(BaseModel):
@@ -3678,6 +3683,11 @@ class MaxTextConfig(
       raise ValueError("MoBA is only supported with dot_product attention.")
     if self.decoder_block == DecoderBlockType.DEEPSEEK4 and self.attention != "dot_product":
       raise ValueError("DeepSeek4 decoder block currently only supports dot_product attention.")
+    if self.compressed_use_dynamic_splash and not self.use_tokamax_splash:
+      raise ValueError(
+          "`compressed_use_dynamic_splash` requires `use_tokamax_splash=true`; without it the boolean mask "
+          "would be silently ignored by the non-tokamax splash branches."
+      )
     if self.mla_qk_head_chunk_size > 0:
       if self.mla_qk_head_chunk_size > self.num_query_heads or self.num_query_heads % self.mla_qk_head_chunk_size != 0:
         raise ValueError(

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -713,6 +713,23 @@ class CompressedAttention(BaseModel):
       description="Route COMPRESSED and LOCAL_SLIDING train attention to tokamax splash on TPU. Requires "
       "use_tokamax_splash=true.",
   )
+  splash_bool_masks: bool = Field(
+      False,
+      description="Keep DeepSeek-V4 compressed masks boolean end to end on the dynamic-splash train path "
+      "instead of building additive float masks and re-thresholding them. Requires "
+      "compressed_use_dynamic_splash=true.",
+  )
+  hoist_static_attention_masks: bool = Field(
+      False,
+      description="Build the layer-invariant DeepSeek-V4 mask tensors once per train step in the decoder and "
+      "pass them to the layers, instead of rebuilding them in every layer and remat pass.",
+  )
+  indexer_threshold_membership: bool = Field(
+      False,
+      description="Return the CSA indexer's selection as a boolean membership mask computed by thresholding "
+      "scores against the k-th top-k value, so the consumer skips the index one-hot expansion. Selects the "
+      "same window set as the top-k-indices path, including jax.lax.top_k's tie semantics.",
+  )
 
 
 class AttentionIndexer(BaseModel):
@@ -3688,6 +3705,17 @@ class MaxTextConfig(
           "`compressed_use_dynamic_splash` requires `use_tokamax_splash=true`; without it the boolean mask "
           "would be silently ignored by the non-tokamax splash branches."
       )
+    if self.splash_bool_masks and not self.compressed_use_dynamic_splash:
+      raise ValueError(
+          "`splash_bool_masks` requires `compressed_use_dynamic_splash=true`; only the dynamic-splash "
+          "path consumes boolean masks."
+      )
+    if (
+        self.hoist_static_attention_masks
+        and self.decoder_block == DecoderBlockType.DEEPSEEK4
+        and self.using_pipeline_parallelism
+    ):
+      raise ValueError("`hoist_static_attention_masks` does not support pipeline parallelism.")
     if self.mla_qk_head_chunk_size > 0:
       if self.mla_qk_head_chunk_size > self.num_query_heads or self.num_query_heads % self.mla_qk_head_chunk_size != 0:
         raise ValueError(

--- a/src/maxtext/layers/attention_compressed.py
+++ b/src/maxtext/layers/attention_compressed.py
@@ -37,6 +37,7 @@ from maxtext.common.common_types import (
 )
 
 from maxtext.layers import nnx_wrappers
+from maxtext.layers.attention_op import build_local_sliding_splash_mask
 from maxtext.layers.attentions import Attention
 from maxtext.layers.embeddings import DeepSeekV4RotaryEmbedding
 from maxtext.layers.initializers import nd_dense_init, NdInitializer, variable_to_logically_partitioned
@@ -406,6 +407,113 @@ def prime_prefill_cache_state(
       cache.overlap_gate.set_value(overlap_gate_to_write)
 
 
+def use_bool_compressed_masks(config: Any, mesh: Optional[Mesh], model_mode: str) -> bool:
+  """Returns whether compressed masks can remain boolean through attention."""
+  if not (config.splash_bool_masks and config.compressed_use_dynamic_splash):
+    return False
+  if model_mode != MODEL_MODE_TRAIN:
+    return False
+  return mesh is not None and mesh.devices.flat[0].platform == "tpu"
+
+
+def build_compressed_segment_mask(decoder_segment_ids: Array, compress_rate: int, emit_bool: bool = False) -> Array:
+  """Packing segment mask downsampled to the compressed kv columns, additive f32 or bool."""
+  segment_mask = decoder_segment_ids[:, :, None] == decoder_segment_ids[:, None, :]
+  if emit_bool:
+    return segment_mask[:, :, ::compress_rate]
+  segment_mask_additive = jnp.where(segment_mask, 0.0, DEFAULT_MASK_VALUE)
+  return segment_mask_additive[:, :, ::compress_rate]
+
+
+def build_hca_causal_mask(
+    position_ids: Array, compressed_len: int, compress_rate: int, dtype: DType, emit_bool: bool = False
+) -> Array:
+  """HCA causal mask over compressed windows: window w visible iff w < (pos + 1) // compress_rate."""
+  entry_indices = jnp.arange(compressed_len)
+  causal_threshold = (position_ids + 1) // compress_rate
+  future_mask = entry_indices[None, None, None, :] >= jnp.expand_dims(causal_threshold, axis=(1, 3))
+  if emit_bool:
+    return jnp.logical_not(future_mask)
+  return jnp.where(future_mask, DEFAULT_MASK_VALUE, 0.0).astype(dtype)
+
+
+def build_csa_indexer_causal(position_ids: Array, compressed_len: int, compress_rate: int) -> Array:
+  """CSA indexer future-window mask, `[batch, q_len, compressed_len]` bool (True = masked)."""
+  causal_threshold = (position_ids + 1) // compress_rate
+  entry_indices = jnp.arange(compressed_len)
+  return entry_indices[None, None, :] >= jnp.expand_dims(causal_threshold, axis=-1)
+
+
+def combine_compressed_and_segment_mask(compressed_mask: Array, compressed_segment_mask: Array) -> Array:
+  """Folds the packing segment mask into a compressed block mask (add if additive, AND if bool)."""
+  segment = jnp.expand_dims(compressed_segment_mask[:, :, : compressed_mask.shape[-1]], axis=1)
+  if compressed_mask.dtype == jnp.bool_:
+    return jnp.logical_and(compressed_mask, segment)
+  return compressed_mask + segment
+
+
+def topk_threshold_membership(index_scores: Array, k: int) -> Array:
+  """Returns a boolean top-k membership mask from the k-th score threshold."""
+  if k <= 0:
+    return jnp.zeros(index_scores.shape, dtype=jnp.bool_)
+  kth_value = jax.lax.top_k(index_scores, k)[0][..., k - 1 :]
+
+  # top_k orders +0.0 above -0.0 and breaks ties within each class by lower index.
+  score_negative = jnp.signbit(index_scores)
+  kth_negative = jnp.signbit(kth_value)
+  ieee_equal = index_scores == kth_value
+  greater = (index_scores > kth_value) | (ieee_equal & kth_negative & (~score_negative))
+  tie = ieee_equal & (score_negative == kth_negative)
+
+  num_greater = jnp.sum(greater.astype(jnp.int32), axis=-1, keepdims=True)
+  tie_rank = jnp.cumsum(tie.astype(jnp.int32), axis=-1)
+  return greater | (tie & (tie_rank <= (k - num_greater)))
+
+
+def build_deepseek4_hoisted_masks(
+    config: Any,
+    mesh: Optional[Mesh],
+    decoder_segment_ids: Optional[Array],
+    decoder_positions: Array,
+    model_mode: str,
+) -> Optional[dict[str, Array]]:
+  """Builds layer-invariant DeepSeek-V4 train masks before the layer scan."""
+  if not config.hoist_static_attention_masks or model_mode != MODEL_MODE_TRAIN:
+    return None
+  if decoder_positions is None:
+    return None
+  batch_size, seq_len = decoder_positions.shape
+  if seq_len <= 1:
+    return None
+
+  emit_bool = use_bool_compressed_masks(config, mesh, model_mode)
+  hoisted = {}
+
+  on_tpu = mesh is not None and mesh.devices.flat[0].platform == "tpu"
+  if config.compressed_use_dynamic_splash and on_tpu:
+    hoisted["prefix_bool"] = build_local_sliding_splash_mask(
+        batch_size, decoder_segment_ids, decoder_positions, seq_len, seq_len, config.sliding_window_size
+    )
+
+  for rate in sorted({int(r) for r in config.compress_ratios if r > 0}):
+    compressed_len = seq_len // rate
+    if compressed_len == 0:
+      continue
+    segment_mask = None
+    if decoder_segment_ids is not None:
+      segment_mask = build_compressed_segment_mask(decoder_segment_ids, rate, emit_bool)
+      hoisted[f"segment_mask_{rate}"] = segment_mask
+    if rate > 4:
+      hca_mask = build_hca_causal_mask(decoder_positions, compressed_len, rate, config.dtype, emit_bool)
+      if segment_mask is not None:
+        hca_mask = combine_compressed_and_segment_mask(hca_mask, segment_mask)
+      hoisted[f"hca_mask_{rate}"] = hca_mask
+    else:
+      hoisted[f"csa_future_mask_{rate}"] = build_csa_indexer_causal(decoder_positions, compressed_len, rate)
+
+  return hoisted or None
+
+
 class BaseDeepseekCompressor(nnx.Module):
   """Shared base class for DeepSeek-V4 long-range attention compressors.
 
@@ -537,7 +645,9 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
       position_ids: Array,
       model_mode: str,
       cache: Optional[Any] = None,
-  ) -> Tuple[Array, Array]:
+      emit_bool_mask: bool = False,
+      skip_mask: bool = False,
+  ) -> Tuple[Array, Optional[Array]]:
     """Forward pass for the HCA compressor.
 
     Args:
@@ -546,6 +656,8 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
       position_ids: Absolute token positions. Shape: `[batch, seq_len]`.
       model_mode: The execution mode (e.g. train, prefill, or autoregressive).
       cache: Optional KV cache instance used during inference.
+      emit_bool_mask: Return the causal mask boolean (True = attend) instead of additive.
+      skip_mask: Skip mask construction (the caller holds the hoisted equivalent); mask is None.
 
     Returns:
       compressed_kv: The pooled KV tensors. Shape: `[batch, n_windows, 1, head_dim]`.
@@ -579,7 +691,10 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
           mask_ndims=4,
       )
       compressed_kv = jnp.expand_dims(compressed, 2)  # [B, N, 1, D]
-      compressed_mask = jnp.where(is_valid, 0.0, DEFAULT_MASK_VALUE).astype(self.dtype)
+      if emit_bool_mask:
+        compressed_mask = is_valid
+      else:
+        compressed_mask = jnp.where(is_valid, 0.0, DEFAULT_MASK_VALUE).astype(self.dtype)
 
       return compressed_kv, compressed_mask
 
@@ -631,16 +746,19 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
           cache=cache,
       )
 
+    if skip_mask:
+      return compressed_kv, None
+
     # Skip causal mask generation during decoding (seq_len == 1) or if no blocks were pooled
     if seq_len == 1 or compressed_len == 0:
-      compressed_mask = jnp.zeros((batch_size, 1, seq_len, compressed_len), dtype=self.dtype)
+      mask_dtype = jnp.bool_ if emit_bool_mask else self.dtype
+      compressed_mask = jnp.zeros((batch_size, 1, seq_len, compressed_len), dtype=mask_dtype)
       return compressed_kv, compressed_mask
 
     # Construct a causal mask preventing early queries from attending to future compressed blocks
-    entry_indices = jnp.arange(compressed_len)
-    causal_threshold = (position_ids + 1) // self.compress_rate
-    future_mask = entry_indices[None, None, None, :] >= jnp.expand_dims(causal_threshold, axis=(1, 3))
-    compressed_causal_mask = jnp.where(future_mask, DEFAULT_MASK_VALUE, 0.0).astype(self.dtype)
+    compressed_causal_mask = build_hca_causal_mask(
+        position_ids, compressed_len, self.compress_rate, self.dtype, emit_bool_mask
+    )
 
     return compressed_kv, compressed_causal_mask
 
@@ -766,6 +884,7 @@ class DeepseekV4Indexer(nnx.Module):
       attention_mask: Optional[Array] = None,
       model_mode: str = MODEL_MODE_TRAIN,
       cache: Optional[Any] = None,
+      hoisted_masks: Optional[dict[str, Array]] = None,
   ) -> Array:
     """Forward pass for the DeepSeek-V4 Indexer.
 
@@ -773,12 +892,16 @@ class DeepseekV4Indexer(nnx.Module):
       hidden_states: Input token embeddings.
       q_latent: Latent query representation for index score computation.
       position_ids: Absolute token positions.
-      attention_mask: Optional attention mask.
+      attention_mask: Optional packing segment mask over the compressed windows, additive f32 or
+        bool under `splash_bool_masks`.
       model_mode: Execution mode (train, prefill, or autoregressive).
       cache: Optional Indexer KV cache instance for inference.
+      hoisted_masks: Optional `hoist_static_attention_masks` bundle with the precomputed causal mask.
 
     Returns:
-      Top-K selected indices for each query position.
+      `[batch, seq_len, k]` int32 top-k window indices with future selections invalidated to -1,
+      or `[batch, seq_len, n_windows]` bool membership of the same selected set under
+      `indexer_threshold_membership`.
     """
     batch_size, seq_len, _ = hidden_states.shape
     future_mask = None
@@ -854,6 +977,8 @@ class DeepseekV4Indexer(nnx.Module):
         )
 
     if compressed_len == 0:
+      if self.config.indexer_threshold_membership:
+        return jnp.zeros((batch_size, seq_len, 0), dtype=jnp.bool_)
       return jnp.zeros((batch_size, seq_len, min(self.index_topk, compressed_len)), dtype=jnp.int32)
 
     # --- TOP-K ROUTING MATH (Executes in both Prefill and AR) ---
@@ -876,15 +1001,25 @@ class DeepseekV4Indexer(nnx.Module):
 
     # --- ONLY RUN MATHEMATICAL CAUSAL MASK IN PREFILL/TRAIN ---
     if future_mask is None:
-      causal_threshold = (position_ids + 1) // self.compress_rate
-      entry_indices_mask = jnp.arange(compressed_len)
-      future_mask = entry_indices_mask[None, None, :] >= jnp.expand_dims(causal_threshold, axis=-1)
+      hoisted = hoisted_masks or {}
+      future_key = f"csa_future_mask_{self.compress_rate}"
+      if future_key in hoisted:
+        future_mask = hoisted[future_key]
+      else:
+        future_mask = build_csa_indexer_causal(position_ids, compressed_len, self.compress_rate)
 
     # Apply the mask to the scores
     index_scores = jnp.where(future_mask, jnp.full_like(index_scores, -jnp.inf), index_scores)
 
     if attention_mask is not None:
-      index_scores += attention_mask[:, :, :compressed_len]
+      segment_mask = attention_mask[:, :, :compressed_len]
+      if segment_mask.dtype == jnp.bool_:
+        segment_mask = jnp.where(segment_mask, 0.0, DEFAULT_MASK_VALUE)
+      index_scores += segment_mask
+
+    if self.config.indexer_threshold_membership:
+      membership = topk_threshold_membership(index_scores, k)
+      return jnp.logical_and(membership, jnp.logical_not(future_mask))
 
     top_k_indices = jax.lax.top_k(index_scores, k)[1]
     invalid = jnp.take_along_axis(future_mask, top_k_indices, axis=-1)
@@ -959,6 +1094,8 @@ class DeepseekV4CSACompressor(BaseDeepseekCompressor):
       model_mode: str = MODEL_MODE_TRAIN,
       cache: Optional[Any] = None,
       indexer_cache: Optional[Any] = None,
+      emit_bool_mask: bool = False,
+      hoisted_masks: Optional[dict[str, Array]] = None,
   ) -> Tuple[Array, Array]:
     """Forward pass for the CSA compressor.
 
@@ -966,10 +1103,12 @@ class DeepseekV4CSACompressor(BaseDeepseekCompressor):
       hidden_states: Input token embeddings.
       q_latent: Latent query representation for index score computation.
       position_ids: Absolute token positions.
-      attention_mask: Optional attention mask.
+      attention_mask: Optional attention mask; forwarded to the indexer's scoring.
       model_mode: Execution mode (train, prefill, or autoregressive).
       cache: Optional CSA compressor KV cache instance for inference.
       indexer_cache: Optional Indexer KV cache instance for inference.
+      emit_bool_mask: Return the mask boolean (True = attend) instead of additive.
+      hoisted_masks: Optional `hoist_static_attention_masks` bundle, forwarded to the indexer.
 
     Returns:
       compressed_kv: The pooled KV tensors.
@@ -978,7 +1117,15 @@ class DeepseekV4CSACompressor(BaseDeepseekCompressor):
     batch_size, seq_len, _ = hidden_states.shape
 
     # 1. ALWAYS Run Indexer (It fetches its own history inside AR)
-    top_k_indices = self.indexer(hidden_states, q_latent, position_ids, attention_mask, model_mode, indexer_cache)
+    top_k_indices = self.indexer(
+        hidden_states,
+        q_latent,
+        position_ids,
+        attention_mask,
+        model_mode,
+        indexer_cache,
+        hoisted_masks=hoisted_masks,
+    )
 
     kv = self.kv_proj(hidden_states)
     gate = self.gate_proj(hidden_states)
@@ -1052,7 +1199,18 @@ class DeepseekV4CSACompressor(BaseDeepseekCompressor):
         )
 
     if compressed_len == 0:
-      return compressed_kv, jnp.zeros((batch_size, 1, seq_len, 0), dtype=self.dtype)
+      empty_dtype = jnp.bool_ if emit_bool_mask else self.dtype
+      return compressed_kv, jnp.zeros((batch_size, 1, seq_len, 0), dtype=empty_dtype)
+
+    if self.config.indexer_threshold_membership:
+      if top_k_indices.shape[-1] != compressed_len:
+        raise ValueError(
+            f"indexer membership window count {top_k_indices.shape[-1]} != compressor windows {compressed_len}"
+        )
+      is_selected = jnp.expand_dims(top_k_indices, axis=1)
+      if emit_bool_mask:
+        return compressed_kv, is_selected
+      return compressed_kv, jnp.where(is_selected, 0.0, DEFAULT_MASK_VALUE).astype(self.dtype)
 
     # 3. Apply Dynamic Masking Logic
     k = top_k_indices.shape[-1]
@@ -1065,7 +1223,12 @@ class DeepseekV4CSACompressor(BaseDeepseekCompressor):
       is_selected = jnp.any(is_valid_and_in_topk, axis=2)
       is_selected = jnp.expand_dims(is_selected, axis=1)
 
-      compressed_mask = jnp.where(is_selected, 0.0, DEFAULT_MASK_VALUE).astype(self.dtype)
+      if emit_bool_mask:
+        compressed_mask = is_selected
+      else:
+        compressed_mask = jnp.where(is_selected, 0.0, DEFAULT_MASK_VALUE).astype(self.dtype)
+    elif emit_bool_mask:
+      compressed_mask = jnp.zeros((batch_size, 1, seq_len, compressed_len), dtype=jnp.bool_)
     else:
       compressed_mask = jnp.full(
           (batch_size, 1, seq_len, compressed_len),
@@ -1501,20 +1664,30 @@ class CompressedAttention(Attention):
     compressed_kv = None
     compressed_mask = None
     compressed_segment_mask = None
+    hoisted = kwargs.get("hoisted_masks") or {}
+    emit_bool_mask = use_bool_compressed_masks(self.config, self.mesh, model_mode)
 
     if decoder_segment_ids is not None and self.compress_ratio > 0:
-      # Generate the standard segment mask
-      segment_mask = decoder_segment_ids[:, :, None] == decoder_segment_ids[:, None, :]
-      segment_mask_additive = jnp.where(segment_mask, 0.0, DEFAULT_MASK_VALUE)
-      # Downsample the kv dimension
-      compress_rate = self.compress_ratio
-      compressed_segment_mask = segment_mask_additive[:, :, ::compress_rate]
+      segment_key = f"segment_mask_{self.compress_ratio}"
+      if segment_key in hoisted:
+        compressed_segment_mask = hoisted[segment_key]
+      else:
+        compressed_segment_mask = build_compressed_segment_mask(decoder_segment_ids, self.compress_ratio, emit_bool_mask)
 
     # Route to the appropriate compressor depending on the layer's role in the architecture
+    segment_already_folded = False
     if self.compress_ratio > 4:
-      compressed_kv, compressed_mask = self.hca_compressor(
-          inputs_kv, q_normed, inputs_positions, model_mode, self.compressor_cache
-      )
+      hca_key = f"hca_mask_{self.compress_ratio}"
+      if hca_key in hoisted:
+        compressed_kv, _ = self.hca_compressor(
+            inputs_kv, q_normed, inputs_positions, model_mode, self.compressor_cache, skip_mask=True
+        )
+        compressed_mask = hoisted[hca_key]
+        segment_already_folded = True
+      else:
+        compressed_kv, compressed_mask = self.hca_compressor(
+            inputs_kv, q_normed, inputs_positions, model_mode, self.compressor_cache, emit_bool_mask=emit_bool_mask
+        )
     elif self.compress_ratio == 4:
       compressed_kv, compressed_mask = self.csa_compressor(
           inputs_kv,
@@ -1524,15 +1697,15 @@ class CompressedAttention(Attention):
           model_mode,
           self.compressor_cache,
           self.indexer_cache,
+          emit_bool_mask=emit_bool_mask,
+          hoisted_masks=kwargs.get("hoisted_masks"),
       )
 
     # Apply segment masking to the compressed blocks
-    if compressed_segment_mask is not None and compressed_mask is not None:
+    if compressed_segment_mask is not None and compressed_mask is not None and not segment_already_folded:
       # compressed_segment_mask is [batch, q_len, num_compressed_blocks]
       # compressed_mask is [batch, 1, q_len, num_compressed_blocks]
-      compressed_mask = compressed_mask + jnp.expand_dims(
-          compressed_segment_mask[:, :, : compressed_mask.shape[-1]], axis=1
-      )
+      compressed_mask = combine_compressed_and_segment_mask(compressed_mask, compressed_segment_mask)
 
     # Note: Unlike standard pre-attention concatenation (extending local KV tensors with compressed blocks),
     # compressed_kv is passed separately to attention_op to support custom kernels and decoding caching.
@@ -1558,6 +1731,7 @@ class CompressedAttention(Attention):
         compressed_mask=compressed_mask,
         compressed_kv=compressed_kv,
         cached_values=current_kv_cache,
+        hoisted_prefix_bool_mask=hoisted.get("prefix_bool"),
     )
 
     # Reverse RoPE on Values

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -170,20 +170,29 @@ def build_compressed_splash_mask(
     q_seq_len: int,
     kv_seq_len: int,
     sliding_window_size: int | None,
+    precomputed_uncompressed: Array | None = None,
 ) -> Array:
   """Builds the boolean COMPRESSED mask for dynamic splash attention.
 
-  The result has shape `[batch, q_seq_len, kv_seq_len]` and matches the dense path's
-  `apply_mask_to_logits` keep predicate.
+  `compressed_mask` may use the additive or boolean representation. The result has shape
+  `[batch, q_seq_len, kv_seq_len]`.
   """
   c_len = compressed_mask.shape[-1]
   s_len = kv_seq_len - c_len
   b = compressed_mask.shape[0]
 
-  uncompressed = build_local_sliding_splash_mask(
-      b, decoder_segment_ids, segment_positions, q_seq_len, s_len, sliding_window_size
-  )
-  compressed_keep = compressed_mask.reshape(b, q_seq_len, c_len) >= DEFAULT_MASK_VALUE * 0.5
+  if precomputed_uncompressed is not None:
+    if precomputed_uncompressed.shape != (b, q_seq_len, s_len):
+      raise ValueError(f"hoisted prefix mask shape {precomputed_uncompressed.shape} != expected {(b, q_seq_len, s_len)}")
+    uncompressed = precomputed_uncompressed
+  else:
+    uncompressed = build_local_sliding_splash_mask(
+        b, decoder_segment_ids, segment_positions, q_seq_len, s_len, sliding_window_size
+    )
+  if compressed_mask.dtype == jnp.bool_:
+    compressed_keep = compressed_mask.reshape(b, q_seq_len, c_len)
+  else:
+    compressed_keep = compressed_mask.reshape(b, q_seq_len, c_len) >= DEFAULT_MASK_VALUE * 0.5
   return jnp.concatenate([uncompressed, compressed_keep], axis=-1)
 
 
@@ -1003,6 +1012,8 @@ class AttentionOp(nnx.Module):
       [2] SARATHI: Efficient LLM Inference by Piggybacking Decodes with
           Chunked Prefills - ArXiv:2308.16369 (https://arxiv.org/abs/2308.16369)
     """
+    if compressed_mask is not None and compressed_mask.dtype == jnp.bool_:
+      raise ValueError("The dense attention path requires an additive compressed_mask.")
     mask = None
     if model_mode == MODEL_MODE_AUTOREGRESSIVE and decoder_segment_ids is not None:
       mask = decoder_segment_ids[:, None, None, None, :] == DECODING_ACTIVE_SEQUENCE_INDICATOR
@@ -1403,6 +1414,7 @@ class AttentionOp(nnx.Module):
       indexer_mask: Array | None = None,
       compressed_mask: Optional[Array] = None,
       record_max_logits: bool = False,
+      hoisted_prefix_bool_mask: Array | None = None,
       *,
       qk_product_einsum: Callable[..., Array],
       wv_product_einsum: Callable[..., Array],
@@ -1480,6 +1492,7 @@ class AttentionOp(nnx.Module):
           compressed_mask,
           sinks,
           record_max_logits,
+          hoisted_prefix_bool_mask=hoisted_prefix_bool_mask,
       )
 
     # 'vllm_rpa' uses the same dot-attention wrapper but routes to the vLLM
@@ -1702,6 +1715,7 @@ class AttentionOp(nnx.Module):
       compressed_mask: Array,
       sinks: Array | None,
       record_max_logits: bool = False,
+      hoisted_prefix_bool_mask: Array | None = None,
   ) -> tuple[Array, None, None]:
     """Runs COMPRESSED train attention with the tokamax dynamic splash kernel.
 
@@ -1726,7 +1740,13 @@ class AttentionOp(nnx.Module):
         )
 
     bool_mask = build_compressed_splash_mask(
-        compressed_mask, decoder_segment_ids, segment_positions, q_seq_len, kv_seq_len, self.sliding_window_size
+        compressed_mask,
+        decoder_segment_ids,
+        segment_positions,
+        q_seq_len,
+        kv_seq_len,
+        self.sliding_window_size,
+        precomputed_uncompressed=hoisted_prefix_bool_mask,
     )
 
     lcm = math.lcm(self.block_kv, self.block_kv_compute, self.block_kv_dkv, self.block_kv_dkv_compute)
@@ -2870,6 +2890,7 @@ class AttentionOp(nnx.Module):
       compressed_kv: Optional[Array] = None,
       slot: Optional[int] = None,
       record_max_logits: bool = False,
+      hoisted_prefix_bool_mask: Optional[Array] = None,
   ):
     if cached_values is None:
       prefill_kv_cache, ar_kv_cache = None, None
@@ -2908,6 +2929,7 @@ class AttentionOp(nnx.Module):
         indexer_mask=indexer_mask_prefill,
         compressed_mask=compressed_mask if pass_comp_to_prefill else None,
         record_max_logits=record_max_logits,
+        hoisted_prefix_bool_mask=hoisted_prefix_bool_mask,
         qk_product_einsum=self.AqtEinsum_0,
         wv_product_einsum=self.AqtEinsum_1,
     )

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -134,6 +134,59 @@ def apply_mask_to_logits(logits: Array, mask: Array):
   return jnp.where((mask >= DEFAULT_MASK_VALUE * 0.5), logits, DEFAULT_MASK_VALUE)
 
 
+def build_local_sliding_splash_mask(
+    batch: int,
+    decoder_segment_ids: Array | None,
+    segment_positions: Array | None,
+    q_seq_len: int,
+    kv_seq_len: int,
+    sliding_window_size: int | None,
+) -> Array:
+  """Builds the causal sliding mask for the uncompressed COMPRESSED prefix.
+
+  To match the dense path under packing, query positions may reset by segment while key
+  positions remain physical offsets.
+  """
+  if segment_positions is not None:
+    row_ids = segment_positions[:, :, None]
+  else:
+    row_ids = jnp.arange(q_seq_len)[None, :, None]
+  col_ids = jnp.arange(kv_seq_len)[None, None, :]
+  distance = row_ids - col_ids
+  mask = distance >= 0
+  if sliding_window_size is not None:
+    mask &= distance < sliding_window_size
+  mask = jnp.broadcast_to(mask, (batch, q_seq_len, kv_seq_len))
+  if decoder_segment_ids is not None:
+    segment = decoder_segment_ids[:, :, None] == decoder_segment_ids[:, None, :]
+    mask = jnp.logical_and(mask, segment[..., :kv_seq_len])
+  return mask
+
+
+def build_compressed_splash_mask(
+    compressed_mask: Array,
+    decoder_segment_ids: Array | None,
+    segment_positions: Array | None,
+    q_seq_len: int,
+    kv_seq_len: int,
+    sliding_window_size: int | None,
+) -> Array:
+  """Builds the boolean COMPRESSED mask for dynamic splash attention.
+
+  The result has shape `[batch, q_seq_len, kv_seq_len]` and matches the dense path's
+  `apply_mask_to_logits` keep predicate.
+  """
+  c_len = compressed_mask.shape[-1]
+  s_len = kv_seq_len - c_len
+  b = compressed_mask.shape[0]
+
+  uncompressed = build_local_sliding_splash_mask(
+      b, decoder_segment_ids, segment_positions, q_seq_len, s_len, sliding_window_size
+  )
+  compressed_keep = compressed_mask.reshape(b, q_seq_len, c_len) >= DEFAULT_MASK_VALUE * 0.5
+  return jnp.concatenate([uncompressed, compressed_keep], axis=-1)
+
+
 def validate_gpu_flash_attention(sinks: Array | None, record_max_logits: bool) -> None:
   """Helper function to check for unsupported features with flash attention on GPU."""
   if sinks is not None:
@@ -568,7 +621,8 @@ class AttentionOp(nnx.Module):
         raise ValueError("causal_block_size must be positive for block-diffusion attention")
       if self.attention_kernel not in ("autoselected", "dot_product", "flash"):
         raise ValueError("Block-diffusion attention is supported only by dot_product attention and TPU Splash attention.")
-    # Block sizes are only used by TPU splash attention kernels. Exclude non-splash kernels
+    # The opt-in COMPRESSED and LOCAL_SLIDING routes need splash block sizes despite using
+    # attention_kernel="dot_product".
     if self.attention_kernel not in (
         "dot_product",
         "paged",
@@ -576,6 +630,9 @@ class AttentionOp(nnx.Module):
         "vllm_batched_rpa",
         "cudnn_flash_te",
         "cudnn_flash_jax",
+    ) or (
+        self.attention_type in (AttentionType.COMPRESSED, AttentionType.LOCAL_SLIDING)
+        and self.config.compressed_use_dynamic_splash
     ):
       if self.attention_type == AttentionType.LOCAL_SLIDING:
         self.block_q = self.config.local_sa_block_q
@@ -1387,6 +1444,44 @@ class AttentionOp(nnx.Module):
         self.max_logits = nnx.Intermediate(local_max)
       return local_out, local_max, local_sum
 
+    # LOCAL_SLIDING has a static splash mask; COMPRESSED needs the dynamic mask from its
+    # compressor. Dense-only mask modifiers must continue through the dot-product path.
+    elif (
+        self.config.compressed_use_dynamic_splash
+        and model_mode == MODEL_MODE_TRAIN
+        and target_hardware == "tpu"
+        and previous_chunk is None
+        and bidirectional_mask is None
+        and (
+            self.attention_type == AttentionType.LOCAL_SLIDING
+            or (self.attention_type == AttentionType.COMPRESSED and compressed_mask is not None)
+        )
+    ):
+      if self.attention_type == AttentionType.LOCAL_SLIDING:
+        out, max_logits = self.tpu_flash_attention(
+            query,
+            key,
+            value,
+            decoder_segment_ids,
+            self.attn_logits_soft_cap,
+            sinks,
+            model_mode=model_mode,
+            record_max_logits=record_max_logits,
+        )
+        if max_logits is not None:
+          self.max_logits = nnx.Intermediate(max_logits)
+        return out, None, None
+      return self.dynamic_splash_attention(
+          query,
+          key,
+          value,
+          decoder_segment_ids,
+          segment_positions,
+          compressed_mask,
+          sinks,
+          record_max_logits,
+      )
+
     # 'vllm_rpa' uses the same dot-attention wrapper but routes to the vLLM
     # ragged paged attention kernel in `Attention.__call__`.
     elif (
@@ -1596,6 +1691,65 @@ class AttentionOp(nnx.Module):
         return ragged_gqa(query, key, value, lengths, block_size=block_size)
 
     return wrap_ragged_attention(query, key, value, lengths, block_size)
+
+  def dynamic_splash_attention(
+      self,
+      query: Array,
+      key: Array,
+      value: Array,
+      decoder_segment_ids: Array | None,
+      segment_positions: Array | None,
+      compressed_mask: Array,
+      sinks: Array | None,
+      record_max_logits: bool = False,
+  ) -> tuple[Array, None, None]:
+    """Runs COMPRESSED train attention with the tokamax dynamic splash kernel.
+
+    Packing is folded into the boolean mask because no segment ids exist for the compressed
+    KV columns. KV and mask columns are padded to satisfy all splash block sizes.
+    """
+    q_seq_len = query.shape[1]
+    kv_seq_len = key.shape[1]
+
+    if self.mesh.shape.get(self.config.context_sharding, 1) > 1:
+      raise NotImplementedError(
+          "compressed_use_dynamic_splash does not support context parallelism for COMPRESSED "
+          "attention (the dynamic-mask splash path has no load-balanced reorder for the "
+          "compressed kv concat). LOCAL_SLIDING layers take the static splash path and do."
+      )
+    for name, blk in (("block_q", self.block_q), ("block_q_dkv", self.block_q_dkv)):
+      eff = min(blk, q_seq_len)
+      if q_seq_len % eff:
+        raise ValueError(
+            f"compressed_use_dynamic_splash: query length {q_seq_len} must be a multiple of "
+            f"min({name}={blk}, q_len) = {eff}."
+        )
+
+    bool_mask = build_compressed_splash_mask(
+        compressed_mask, decoder_segment_ids, segment_positions, q_seq_len, kv_seq_len, self.sliding_window_size
+    )
+
+    lcm = math.lcm(self.block_kv, self.block_kv_compute, self.block_kv_dkv, self.block_kv_dkv_compute)
+    padded_kv_len = math.ceil(kv_seq_len / lcm) * lcm
+    if padded_kv_len != kv_seq_len:
+      pad = padded_kv_len - kv_seq_len
+      key = jnp.pad(key, ((0, 0), (0, pad), (0, 0), (0, 0)))
+      value = jnp.pad(value, ((0, 0), (0, pad), (0, 0), (0, 0)))
+      bool_mask = jnp.pad(bool_mask, ((0, 0), (0, 0), (0, pad)))
+
+    out, max_logits = self.tpu_flash_attention(
+        query,
+        key,
+        value,
+        decoder_segment_ids=None,
+        attn_logits_soft_cap=self.attn_logits_soft_cap,
+        sinks=sinks,
+        indexer_mask=bool_mask,
+        record_max_logits=record_max_logits,
+    )
+    if max_logits is not None:
+      self.max_logits = nnx.Intermediate(max_logits)
+    return out, None, None
 
   def tpu_flash_attention(
       self,
@@ -2068,8 +2222,9 @@ class AttentionOp(nnx.Module):
         decoder_segment_ids_tuple = None
 
       if self.config.use_tokamax_splash:
-        if self.config.use_indexer and indexer_mask is not None:
-          # Construct the splash kernel call with dynamic mask
+        if indexer_mask is not None:
+          # Pallas interpret mode does not propagate input_output_aliases across grid steps, so
+          # dynamic-splash GQA gradients must be checked on TPU.
           def dynamic_mask_splash_kernel(q, k, v, segment, sinks, indexer_mask):
             splash_kernel = tokamax_splash_kernel.make_dynamic_splash_mha(
                 mask=indexer_mask,
@@ -2083,9 +2238,9 @@ class AttentionOp(nnx.Module):
             else:
               return kernel(q, k, v, segment, sinks=sinks), None
 
-          # Iterate over batch dimension for (query, key, value, segment, sinks, mask)
           attn_fn = jax.vmap(dynamic_mask_splash_kernel, (0, 0, 0, 0, None, 0))
-          indexer_mask = jnp.isclose(indexer_mask, 0.0)
+          if indexer_mask.dtype != jnp.bool_:
+            indexer_mask = jnp.isclose(indexer_mask, 0.0)
 
           if record_max_logits:
             attention_output, max_logits = attn_fn(query, key, value, decoder_segment_ids_tuple, sinks, indexer_mask)

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -38,6 +38,7 @@ from maxtext.common.common_types import (
 )
 from maxtext.layers import initializers, linears, mhc, normalizations, quantizations
 from maxtext.layers import nnx_scan, nnx_wrappers
+from maxtext.layers.attention_compressed import build_deepseek4_hoisted_masks
 from maxtext.layers.attentions import Attention
 from maxtext.layers.embeddings import Embed, PositionalEmbedding, attend_on_embedding
 from maxtext.layers.normalizations import RMSNorm
@@ -1619,6 +1620,12 @@ class NNXDecoder(nnx.Module):
         "slot": slot,
         "previous_chunk": previous_chunk,
     }
+    hoisted_masks = None
+    if self.is_deepseek4 and not getattr(cfg, "using_pipeline_parallelism", False):
+      hoisted_masks = build_deepseek4_hoisted_masks(cfg, self.mesh, decoder_segment_ids, decoder_positions, model_mode)
+      if hoisted_masks is not None and not cfg.scan_layers:
+        layer_kwargs["hoisted_masks"] = hoisted_masks
+
     # Extract the bidirectional mask locally for layer configurations
     bidirectional_mask = None
     if multimodal_input is not None:
@@ -1844,6 +1851,7 @@ class NNXDecoder(nnx.Module):
               slot,
               previous_chunk,
               decoder_input_tokens,
+              hoisted_masks,
           )
         elif self.is_gemma3:
           y = self._apply_gemma3_scanned_blocks(
@@ -2023,6 +2031,7 @@ class NNXDecoder(nnx.Module):
       slot=None,
       previous_chunk=None,
       decoder_input_tokens=None,
+      hoisted_masks=None,
   ):
     """Applies DeepSeek V4 scanned decoder blocks: unrolled prefix hash layers followed by scanned full blocks."""
     cfg = self.config
@@ -2033,6 +2042,10 @@ class NNXDecoder(nnx.Module):
         "slot": slot,
         "decoder_input_tokens": decoder_input_tokens,
     }
+
+    # Keep these arrays closed over by the scan body rather than adding them to the scan carry.
+    if hoisted_masks is not None:
+      layer_call_kwargs["hoisted_masks"] = hoisted_masks
 
     # 1. Unrolled prefix layers (0, 1, 2)
     for layer_idx in range(num_hash_layers):

--- a/src/maxtext/models/deepseek.py
+++ b/src/maxtext/models/deepseek.py
@@ -214,8 +214,10 @@ class DeepSeekGenericLayer(nnx.Module):
       model_mode,
       previous_chunk=None,
       slot: None | int = None,
+      hoisted_masks=None,
   ):
     """Executes the attention layer."""
+    extra_attention_kwargs = {} if hoisted_masks is None else {"hoisted_masks": hoisted_masks}
     attention_result, _ = self.self_attention(
         x,
         x,
@@ -226,6 +228,7 @@ class DeepSeekGenericLayer(nnx.Module):
         out_sharding=self.out_sharding,
         previous_chunk=previous_chunk,
         slot=slot,
+        **extra_attention_kwargs,
     )
     return self.with_logical_constraint(attention_result)
 
@@ -274,8 +277,10 @@ class DeepSeekGenericLayer(nnx.Module):
       model_mode,
       previous_chunk=None,
       slot: None | int = None,
+      hoisted_masks=None,
   ):
     """self-attention with normalization"""
+    extra_attention_kwargs = {} if hoisted_masks is None else {"hoisted_masks": hoisted_masks}
     if self.is_mhc_enabled:
       intermediate_inputs, _ = self.mhc_attention(
           self.pre_attention_norm_op,
@@ -289,6 +294,7 @@ class DeepSeekGenericLayer(nnx.Module):
           out_sharding=self.out_sharding,
           previous_chunk=previous_chunk,
           slot=slot,
+          **extra_attention_kwargs,
       )
     else:
       lnx = self.pre_attention_norm_op(inputs)
@@ -300,6 +306,7 @@ class DeepSeekGenericLayer(nnx.Module):
           model_mode,
           previous_chunk,
           slot,
+          hoisted_masks=hoisted_masks,
       )
       intermediate_inputs = inputs + attention_lnx
     # Normalization

--- a/src/maxtext/models/deepseek4.py
+++ b/src/maxtext/models/deepseek4.py
@@ -139,6 +139,7 @@ class DeepSeek4DecoderLayer(deepseek.DeepSeekGenericLayer):
       kv_cache=None,
       attention_metadata=None,
       decoder_input_tokens=None,
+      hoisted_masks=None,
   ):
     if isinstance(inputs, tuple):
       inputs = inputs[0]
@@ -154,6 +155,7 @@ class DeepSeek4DecoderLayer(deepseek.DeepSeekGenericLayer):
         model_mode,
         previous_chunk,
         slot,
+        hoisted_masks=hoisted_masks,
     )
 
     layer_output, metadata = self.mhc_mlp(
@@ -227,6 +229,7 @@ class DeepSeek4ScannableBlock(nnx.Module):
       attention_metadata=None,
       kv_cache=None,
       decoder_input_tokens=None,
+      hoisted_masks=None,
   ):
     inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
     inputs = checkpoint_name(inputs, "decoder_layer_input")
@@ -243,6 +246,7 @@ class DeepSeek4ScannableBlock(nnx.Module):
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
         decoder_input_tokens=decoder_input_tokens,
+        hoisted_masks=hoisted_masks,
     )
 
     y, _ = self.layers_1(
@@ -256,6 +260,7 @@ class DeepSeek4ScannableBlock(nnx.Module):
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
         decoder_input_tokens=decoder_input_tokens,
+        hoisted_masks=hoisted_masks,
     )
 
     return y, None

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -391,6 +391,7 @@ class BlockCausalMaskTest(unittest.TestCase):
         sa_use_base2_exp=False,
         use_tokamax_splash=False,
         use_jax_splash=False,
+        compressed_use_dynamic_splash=False,
     )
     device = types.SimpleNamespace(platform="cpu")
     mesh = types.SimpleNamespace(
@@ -713,7 +714,9 @@ class LoadBalancedMaskTest(unittest.TestCase):
     np.testing.assert_array_equal(mask[:, :], expected)
 
   def test_dot_product_local_mask_uses_segment_positions(self):
-    config = types.SimpleNamespace(context_parallel_load_balance=True, context_sharding="context")
+    config = types.SimpleNamespace(
+        context_parallel_load_balance=True, context_sharding="context", compressed_use_dynamic_splash=False
+    )
     mesh = types.SimpleNamespace(shape={"context": 4})
     seq_len = 16
     sliding_window_size = 4

--- a/tests/unit/deepseek_v4_mask_flags_test.py
+++ b/tests/unit/deepseek_v4_mask_flags_test.py
@@ -1,0 +1,322 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the DeepSeek-V4 compressed-attention mask flags."""
+
+import sys
+import unittest
+from unittest import mock
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+
+from maxtext import pyconfig
+from maxtext.common.common_types import DEFAULT_MASK_VALUE
+from maxtext.layers import initializers
+from maxtext.layers.attention_compressed import (
+    DeepseekV4CSACompressor,
+    DeepseekV4HCACompressor,
+    build_compressed_segment_mask,
+    build_csa_indexer_causal,
+    build_deepseek4_hoisted_masks,
+    build_hca_causal_mask,
+    combine_compressed_and_segment_mask,
+    topk_threshold_membership,
+)
+from maxtext.layers.attention_op import AttentionOp, build_compressed_splash_mask, build_local_sliding_splash_mask
+from maxtext.layers.embeddings import DeepSeekV4RotaryEmbedding
+from maxtext.models.deepseek4 import DeepSeek4DecoderLayer, DeepSeek4ScannableBlock
+
+
+def make_config(**overrides):
+  config_arguments = {
+      "per_device_batch_size": 1.0,
+      "run_name": "test",
+      "enable_checkpointing": False,
+      "max_target_length": 128,
+      "base_emb_dim": 64,
+      "head_dim": 64,
+      "base_num_query_heads": 2,
+      "base_num_kv_heads": 1,
+      "dtype": "float32",
+      "weight_dtype": "float32",
+      "q_lora_rank": 16,
+      "indexer_n_heads": 2,
+      "indexer_head_dim": 64,
+      "indexer_topk": 8,
+      "sliding_window_size": 8,
+      "compress_ratios": [0, 0, 4, 128],
+  }
+  config_arguments.update(overrides)
+  argv = [sys.argv[0], "src/maxtext/configs/base.yml"]
+  return pyconfig.initialize(argv, **config_arguments)
+
+
+def make_compressor(config, cls, compress_rate, seed=0):
+  rotary = DeepSeekV4RotaryEmbedding(
+      head_dim=config.head_dim,
+      partial_rotary_factor=config.qk_rope_head_dim / config.head_dim,
+      rope_theta=config.compressed_rope_max_timescale,
+      fprop_dtype=config.dtype,
+  )
+  return cls(
+      config=config,
+      compress_ratio=compress_rate,
+      rotary_embedding=rotary,
+      kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+      rngs=nnx.Rngs(seed),
+  )
+
+
+def golden_membership(index_scores, k, future_mask):
+  """The pre-change op sequence: top_k indices -> invalidation -> one-hot -> any."""
+  top_k_indices = jax.lax.top_k(index_scores, k)[1]
+  invalid = jnp.take_along_axis(future_mask, top_k_indices, axis=-1)
+  top_k_indices = jnp.where(invalid, jnp.full_like(top_k_indices, -1), top_k_indices)
+  valid = top_k_indices >= 0
+  entry_indices = jnp.arange(index_scores.shape[-1])[None, None, :]
+  is_in_topk = jnp.expand_dims(top_k_indices, axis=-1) == entry_indices[None, ...]
+  return jnp.any(is_in_topk & jnp.expand_dims(valid, axis=-1), axis=2)
+
+
+class ThresholdMembershipTest(unittest.TestCase):
+  """Checks threshold membership against the index-based top-k path."""
+
+  BATCH, SEQ, WINDOWS, K = 2, 16, 16, 5
+
+  def _future_mask(self):
+    positions = jnp.broadcast_to(jnp.arange(self.SEQ)[None, :], (self.BATCH, self.SEQ))
+    return build_csa_indexer_causal(positions, self.WINDOWS, 1)
+
+  def _check(self, scores):
+    future_mask = self._future_mask()
+    masked = jnp.where(future_mask, jnp.full_like(scores, -jnp.inf), scores)
+    got = jnp.logical_and(topk_threshold_membership(masked, self.K), jnp.logical_not(future_mask))
+    want = golden_membership(masked, self.K, future_mask)
+    np.testing.assert_array_equal(np.array(got), np.array(want))
+
+  def test_continuous_scores(self):
+    rng = np.random.default_rng(0)
+    self._check(jnp.array(rng.normal(size=(self.BATCH, self.SEQ, self.WINDOWS)), dtype=jnp.float32))
+
+  def test_quantized_scores_force_ties(self):
+    rng = np.random.default_rng(1)
+    q = np.round(rng.normal(size=(self.BATCH, self.SEQ, self.WINDOWS)) * 2) / 2
+    self._check(jnp.array(q, dtype=jnp.float32))
+
+  def test_signed_zeros_at_boundary(self):
+    rng = np.random.default_rng(2)
+    z = np.where(rng.random((self.BATCH, self.SEQ, self.WINDOWS)) < 0.5, 0.0, -0.0)
+    self._check(jnp.array(z, dtype=jnp.float32))
+
+  def test_all_equal_rows(self):
+    self._check(jnp.ones((self.BATCH, self.SEQ, self.WINDOWS), dtype=jnp.float32))
+
+  def test_k_zero_and_k_full(self):
+    scores = jnp.ones((self.BATCH, self.SEQ, self.WINDOWS), dtype=jnp.float32)
+    self.assertFalse(bool(topk_threshold_membership(scores, 0).any()))
+    self.assertTrue(bool(topk_threshold_membership(scores, self.WINDOWS).all()))
+
+  def test_topk_tiebreak_semantics(self):
+    """Canary for the jax.lax.top_k semantics the threshold path depends on."""
+    row = jnp.array([[1.0, 2.0, 2.0, 0.0, 2.0]])
+    np.testing.assert_array_equal(np.array(jax.lax.top_k(row, 3)[1]), [[1, 2, 4]])
+    zeros = jnp.array([[0.0, -0.0, 0.0, -0.0]])
+    np.testing.assert_array_equal(np.array(jax.lax.top_k(zeros, 2)[1]), [[0, 2]])
+
+
+class IndexerMembershipModuleTest(unittest.TestCase):
+  """Checks indexer membership through the CSA compressor."""
+
+  BATCH, SEQ, RATE = 2, 64, 4
+
+  def _run(self, packed):
+    cfg_off = make_config()
+    cfg_on = make_config(indexer_threshold_membership=True)
+    comp_off = make_compressor(cfg_off, DeepseekV4CSACompressor, self.RATE)
+    comp_on = make_compressor(cfg_on, DeepseekV4CSACompressor, self.RATE)
+
+    rng = np.random.default_rng(0)
+    hidden = jnp.array(rng.normal(size=(self.BATCH, self.SEQ, cfg_off.emb_dim)), dtype=jnp.float32)
+    q_latent = jnp.array(rng.normal(size=(self.BATCH, self.SEQ, cfg_off.q_lora_rank)), dtype=jnp.float32)
+    positions = jnp.broadcast_to(jnp.arange(self.SEQ)[None, :], (self.BATCH, self.SEQ))
+    attention_mask = None
+    if packed:
+      ids = jnp.array(np.repeat([[1, 2]], self.SEQ // 2, axis=1).reshape(1, self.SEQ).repeat(self.BATCH, 0))
+      attention_mask = build_compressed_segment_mask(ids, self.RATE)
+
+    kv_off, mask_off = comp_off(hidden, q_latent, positions, attention_mask)
+    kv_on, mask_on = comp_on(hidden, q_latent, positions, attention_mask)
+    kv_bool, mask_bool = comp_on(hidden, q_latent, positions, attention_mask, emit_bool_mask=True)
+    np.testing.assert_array_equal(np.array(kv_off), np.array(kv_on))
+    np.testing.assert_array_equal(np.array(kv_on), np.array(kv_bool))
+    np.testing.assert_array_equal(np.array(mask_off), np.array(mask_on))
+    np.testing.assert_array_equal(np.array(mask_on == 0.0), np.array(mask_bool))
+
+  def test_unpacked(self):
+    self._run(packed=False)
+
+  def test_packed(self):
+    self._run(packed=True)
+
+
+class HoistedMasksTest(unittest.TestCase):
+  """Checks hoisted masks against the per-layer builders."""
+
+  BATCH, SEQ = 2, 64
+
+  def _inputs(self):
+    positions = jnp.broadcast_to(jnp.arange(self.SEQ)[None, :], (self.BATCH, self.SEQ))
+    ids = jnp.array(np.repeat([[1, 2]], self.SEQ // 2, axis=1).reshape(1, self.SEQ).repeat(self.BATCH, 0))
+    return positions, ids
+
+  def test_bundle_matches_per_layer_builders(self):
+    cfg = make_config(hoist_static_attention_masks=True, compress_ratios=[0, 0, 4, 8])
+    positions, ids = self._inputs()
+    hoisted = build_deepseek4_hoisted_masks(cfg, None, ids, positions, "train")
+
+    for rate in (4, 8):
+      np.testing.assert_array_equal(
+          np.array(hoisted[f"segment_mask_{rate}"]), np.array(build_compressed_segment_mask(ids, rate))
+      )
+    np.testing.assert_array_equal(
+        np.array(hoisted["csa_future_mask_4"]), np.array(build_csa_indexer_causal(positions, self.SEQ // 4, 4))
+    )
+    hca = build_hca_causal_mask(positions, self.SEQ // 8, 8, cfg.dtype)
+    hca = combine_compressed_and_segment_mask(hca, build_compressed_segment_mask(ids, 8))
+    np.testing.assert_array_equal(np.array(hoisted["hca_mask_8"]), np.array(hca))
+
+  def _check_model_forwarding(self, hoisted):
+    inputs = jnp.zeros((self.BATCH, self.SEQ, 4))
+    positions, ids = self._inputs()
+
+    decoder = mock.Mock()
+    decoder.with_logical_constraint.side_effect = lambda x: x
+    decoder.self_attention_with_norm_op.return_value = (inputs, inputs)
+    decoder.mhc_mlp.return_value = (inputs, {})
+    decoder.dropout_op.side_effect = lambda x, deterministic: x
+    decoder.post_process.return_value = (inputs, None)
+    DeepSeek4DecoderLayer.__call__(decoder, inputs, ids, positions, True, "train", hoisted_masks=hoisted)
+    self.assertIs(decoder.self_attention_with_norm_op.call_args.kwargs["hoisted_masks"], hoisted)
+
+    block = mock.Mock()
+    block.layers_0.side_effect = lambda x, *args, **kwargs: (x, None)
+    block.layers_1.side_effect = lambda x, *args, **kwargs: (x, None)
+    DeepSeek4ScannableBlock.__call__(block, inputs, ids, positions, True, "train", hoisted_masks=hoisted)
+    self.assertIs(block.layers_0.call_args.kwargs["hoisted_masks"], hoisted)
+    self.assertIs(block.layers_1.call_args.kwargs["hoisted_masks"], hoisted)
+
+  def test_gating_and_model_forwarding(self):
+    positions, ids = self._inputs()
+    self.assertIsNone(build_deepseek4_hoisted_masks(make_config(), None, ids, positions, "train"))
+    cfg_on = make_config(hoist_static_attention_masks=True)
+    self.assertIsNone(build_deepseek4_hoisted_masks(cfg_on, None, ids, positions, "autoregressive"))
+    self._check_model_forwarding({"csa_future_mask_4": jnp.zeros((self.BATCH, self.SEQ, self.SEQ // 4))})
+
+  def test_hca_compressor_with_hoisted_mask(self):
+    cfg = make_config()
+    comp = make_compressor(cfg, DeepseekV4HCACompressor, 8)
+    rng = np.random.default_rng(0)
+    hidden = jnp.array(rng.normal(size=(self.BATCH, self.SEQ, cfg.emb_dim)), dtype=jnp.float32)
+    positions, _ = self._inputs()
+
+    kv_default, mask_default = comp(hidden, None, positions, "train")
+    kv_bool, mask_bool = comp(hidden, None, positions, "train", emit_bool_mask=True)
+    kv_skip, mask_skip = comp(hidden, None, positions, "train", skip_mask=True)
+    self.assertIsNone(mask_skip)
+    np.testing.assert_array_equal(np.array(kv_default), np.array(kv_bool))
+    np.testing.assert_array_equal(np.array(kv_default), np.array(kv_skip))
+    np.testing.assert_array_equal(np.array(mask_default == 0.0), np.array(mask_bool))
+    hoisted_mask = build_hca_causal_mask(positions, self.SEQ // 8, 8, cfg.dtype)
+    np.testing.assert_array_equal(np.array(mask_default), np.array(hoisted_mask))
+
+  def test_indexer_with_hoisted_future_mask(self):
+    cfg = make_config()
+    comp = make_compressor(cfg, DeepseekV4CSACompressor, 4)
+    rng = np.random.default_rng(0)
+    hidden = jnp.array(rng.normal(size=(self.BATCH, self.SEQ, cfg.emb_dim)), dtype=jnp.float32)
+    q_latent = jnp.array(rng.normal(size=(self.BATCH, self.SEQ, cfg.q_lora_rank)), dtype=jnp.float32)
+    positions, _ = self._inputs()
+    hoisted = {"csa_future_mask_4": build_csa_indexer_causal(positions, self.SEQ // 4, 4)}
+
+    sel_default = comp.indexer(hidden, q_latent, positions, None)
+    sel_hoisted = comp.indexer(hidden, q_latent, positions, None, hoisted_masks=hoisted)
+    np.testing.assert_array_equal(np.array(sel_default), np.array(sel_hoisted))
+
+
+class BoolMaskTest(unittest.TestCase):
+  """Checks boolean compressed masks against additive masks."""
+
+  BATCH, SEQ = 2, 64
+
+  def test_builders_agree(self):
+    positions = jnp.broadcast_to(jnp.arange(self.SEQ)[None, :], (self.BATCH, self.SEQ))
+    ids = jnp.array(np.repeat([[1, 2]], self.SEQ // 2, axis=1).reshape(1, self.SEQ).repeat(self.BATCH, 0))
+
+    seg_add = build_compressed_segment_mask(ids, 4)
+    seg_bool = build_compressed_segment_mask(ids, 4, emit_bool=True)
+    np.testing.assert_array_equal(np.array(seg_add == 0.0), np.array(seg_bool))
+
+    hca_add = build_hca_causal_mask(positions, self.SEQ // 8, 8, jnp.float32)
+    hca_bool = build_hca_causal_mask(positions, self.SEQ // 8, 8, jnp.float32, emit_bool=True)
+    np.testing.assert_array_equal(np.array(hca_add == 0.0), np.array(hca_bool))
+
+    combined_add = combine_compressed_and_segment_mask(hca_add, seg_add[:, :, : self.SEQ // 8])
+    combined_bool = combine_compressed_and_segment_mask(hca_bool, seg_bool[:, :, : self.SEQ // 8])
+    np.testing.assert_array_equal(np.array(combined_add >= DEFAULT_MASK_VALUE * 0.5), np.array(combined_bool))
+
+    prefix = build_local_sliding_splash_mask(self.BATCH, ids, positions, self.SEQ, self.SEQ, 8)
+    additive_splash = build_compressed_splash_mask(
+        jnp.expand_dims(combined_add, axis=2), ids, positions, self.SEQ, self.SEQ + self.SEQ // 8, 8
+    )
+    bool_splash = build_compressed_splash_mask(
+        jnp.expand_dims(combined_bool, axis=2),
+        ids,
+        positions,
+        self.SEQ,
+        self.SEQ + self.SEQ // 8,
+        8,
+        precomputed_uncompressed=prefix,
+    )
+    np.testing.assert_array_equal(np.array(additive_splash), np.array(bool_splash))
+
+  def test_indexer_selection_same_under_bool_segment_mask(self):
+    cfg = make_config()
+    comp = make_compressor(cfg, DeepseekV4CSACompressor, 4)
+    rng = np.random.default_rng(0)
+    hidden = jnp.array(rng.normal(size=(self.BATCH, self.SEQ, cfg.emb_dim)), dtype=jnp.float32)
+    q_latent = jnp.array(rng.normal(size=(self.BATCH, self.SEQ, cfg.q_lora_rank)), dtype=jnp.float32)
+    positions = jnp.broadcast_to(jnp.arange(self.SEQ)[None, :], (self.BATCH, self.SEQ))
+    ids = jnp.array(np.repeat([[1, 2]], self.SEQ // 2, axis=1).reshape(1, self.SEQ).repeat(self.BATCH, 0))
+
+    sel_add = comp.indexer(hidden, q_latent, positions, build_compressed_segment_mask(ids, 4))
+    sel_bool = comp.indexer(hidden, q_latent, positions, build_compressed_segment_mask(ids, 4, emit_bool=True))
+    np.testing.assert_array_equal(np.array(sel_add), np.array(sel_bool))
+
+  def test_dense_path_rejects_bool_mask(self):
+    with self.assertRaises(ValueError):
+      AttentionOp.generate_attention_mask(
+          None,
+          query=jnp.zeros((1, 4, 1, 8)),
+          key=jnp.zeros((1, 4, 1, 8)),
+          decoder_segment_ids=None,
+          model_mode="train",
+          compressed_mask=jnp.zeros((1, 1, 4, 4), dtype=jnp.bool_),
+      )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/dynamic_splash_mask_test.py
+++ b/tests/unit/dynamic_splash_mask_test.py
@@ -1,0 +1,436 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the COMPRESSED / LOCAL_SLIDING dynamic-splash boolean masks."""
+
+import math
+import types
+import unittest
+from unittest import mock
+
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from maxtext.common.common_types import (
+    AttentionType,
+    DEFAULT_MASK_VALUE,
+    MODEL_MODE_AUTOREGRESSIVE,
+    MODEL_MODE_PREFILL,
+    MODEL_MODE_TRAIN,
+)
+from maxtext.layers.attention_op import (
+    AttentionOp,
+    build_compressed_splash_mask,
+    build_local_sliding_splash_mask,
+)
+
+
+def _stub_config(compressed_use_dynamic_splash=False, block=8):
+  """A minimal stand-in for the dynamic-splash configuration."""
+  kernel_fields = {
+      f"sa_block_{n}": block for n in ("q", "kv", "kv_compute", "q_dkv", "kv_dkv", "kv_dkv_compute", "q_dq", "kv_dq")
+  }
+  kernel_fields.update({f"sa_{n}_layout": "HEAD_DIM_MINOR" for n in ("q", "k", "v")})
+  kernel_fields.update(sa_use_fused_bwd_kernel=True, sa_fuse_reciprocal=False, sa_use_base2_exp=False)
+  kernel_fields["use_splash_scheduler"] = False
+  kernel_fields.update({f"local_{name}": value for name, value in kernel_fields.items()})
+  return types.SimpleNamespace(
+      compressed_use_dynamic_splash=compressed_use_dynamic_splash,
+      context_parallel_load_balance=False,
+      context_parallel_strategy="all_gather",
+      context_sharding="context",
+      **kernel_fields,
+  )
+
+
+def _make_op(attention_type, sliding_window_size, *, config=None, platform="cpu", context_parallel_size=1):
+  """Builds an AttentionOp whose only job is mask generation / dispatch."""
+  device = types.SimpleNamespace(platform=platform)
+  mesh = types.SimpleNamespace(
+      devices=np.asarray([device], dtype=object),
+      shape={"context": context_parallel_size},
+  )
+  return AttentionOp(
+      config=config if config is not None else _stub_config(),
+      num_query_heads=1,
+      num_kv_heads=1,
+      max_target_length=32,
+      mesh=mesh,
+      attention_kernel="dot_product",
+      attention_type=attention_type,
+      sliding_window_size=sliding_window_size,
+  )
+
+
+def _dense_keep_set(additive_mask):
+  """Converts a dense additive mask to its keep set."""
+  return np.asarray(additive_mask)[:, 0, 0, :, :] >= DEFAULT_MASK_VALUE * 0.5
+
+
+def _packing(seq_len, batch, packed):
+  """Returns segment ids and per-segment positions, which reset under packing."""
+  if not packed:
+    return None, jnp.asarray(np.arange(seq_len)[None, :]).repeat(batch, axis=0)
+  segment_len = seq_len // 2
+  segment_ids = jnp.asarray(np.arange(seq_len)[None, :] // segment_len + 1).repeat(batch, axis=0)
+  reset_positions = jnp.asarray((np.arange(seq_len) % segment_len)[None, :]).repeat(batch, axis=0)
+  return segment_ids, reset_positions
+
+
+def _additive_lattice(rng, shape):
+  """Builds a compressed-block mask, including the keep predicate's boundary."""
+  choices = np.asarray([0.0, DEFAULT_MASK_VALUE * 0.5, DEFAULT_MASK_VALUE, -np.inf], dtype=np.float32)
+  return jnp.asarray(choices[rng.integers(0, len(choices), size=shape)])
+
+
+class DynamicSplashMaskParityTest(parameterized.TestCase):
+  """The boolean splash mask must keep exactly what the dense additive mask keeps."""
+
+  @pytest.mark.cpu_only
+  @parameterized.product(
+      seq_len=(16, 32),
+      sliding_window_size=(4, 16),
+      packed=(False, True),
+  )
+  def test_local_sliding_mask_matches_dense(self, seq_len, sliding_window_size, packed):
+    batch = 2
+    segment_ids, _ = _packing(seq_len, batch, packed)
+    op = _make_op(AttentionType.LOCAL_SLIDING, sliding_window_size)
+    dense = op.generate_attention_mask(
+        jnp.zeros((batch, seq_len, 1, 1)),
+        jnp.zeros((batch, seq_len, 1, 1)),
+        segment_ids,
+        MODEL_MODE_TRAIN,
+    )
+    expected = np.broadcast_to(_dense_keep_set(dense), (batch, seq_len, seq_len))
+    actual = build_local_sliding_splash_mask(batch, segment_ids, None, seq_len, seq_len, sliding_window_size)
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+  @pytest.mark.cpu_only
+  @parameterized.product(
+      seq_len=(16, 32),
+      sliding_window_size=(4, 16, None),
+      packed=(False, True),
+      compress_ratio=(4, 8),
+      positions=("none", "physical", "reset"),
+  )
+  def test_compressed_mask_matches_dense(self, seq_len, sliding_window_size, packed, compress_ratio, positions):
+    batch = 2
+    compressed_len = seq_len // compress_ratio
+    kv_seq_len = seq_len + compressed_len
+    segment_ids, reset_positions = _packing(seq_len, batch, packed)
+    segment_positions = {
+        "none": None,
+        "physical": jnp.asarray(np.arange(seq_len)[None, :]).repeat(batch, axis=0),
+        "reset": reset_positions,
+    }[positions]
+    compressed_mask = _additive_lattice(np.random.default_rng(0), (batch, 1, 1, seq_len, compressed_len))
+    op = _make_op(AttentionType.COMPRESSED, sliding_window_size)
+    dense = op.generate_attention_mask(
+        jnp.zeros((batch, seq_len, 1, 1)),
+        jnp.zeros((batch, kv_seq_len, 1, 1)),
+        segment_ids,
+        MODEL_MODE_TRAIN,
+        compressed_mask=compressed_mask,
+        segment_positions=segment_positions,
+    )
+    expected = np.broadcast_to(_dense_keep_set(dense), (batch, seq_len, kv_seq_len))
+    actual = build_compressed_splash_mask(
+        compressed_mask, segment_ids, segment_positions, seq_len, kv_seq_len, sliding_window_size
+    )
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+  @pytest.mark.cpu_only
+  def test_packed_reset_positions_retain_no_uncompressed_columns(self):
+    """Pins the dense path's reset-query/physical-key asymmetry under packing."""
+    batch, seq_len, window, compressed_len = 1, 16, 4, 4
+    kv_seq_len = seq_len + compressed_len
+    segment_ids, reset_positions = _packing(seq_len, batch, packed=True)
+    compressed_mask = jnp.zeros((batch, 1, 1, seq_len, compressed_len), dtype=jnp.float32)
+    op = _make_op(AttentionType.COMPRESSED, window)
+    dense = op.generate_attention_mask(
+        jnp.zeros((batch, seq_len, 1, 1)),
+        jnp.zeros((batch, kv_seq_len, 1, 1)),
+        segment_ids,
+        MODEL_MODE_TRAIN,
+        compressed_mask=compressed_mask,
+        segment_positions=reset_positions,
+    )
+    keep = np.broadcast_to(_dense_keep_set(dense), (batch, seq_len, kv_seq_len))
+    self.assertEqual(keep[:, seq_len // 2 :, :seq_len].sum(), 0)
+    self.assertEqual(keep[:, : seq_len // 2, :seq_len].sum(), 26)
+    actual = build_compressed_splash_mask(compressed_mask, segment_ids, reset_positions, seq_len, kv_seq_len, window)
+    np.testing.assert_array_equal(np.asarray(actual), keep)
+
+
+class DynamicSplashAttentionTest(unittest.TestCase):
+  """Checks what dynamic_splash_attention hands to the kernel, without running the kernel."""
+
+  def _capture(self, op, batch, q_seq_len, kv_seq_len, compressed_mask, decoder_segment_ids=None, segment_positions=None):
+    """Runs dynamic_splash_attention with a stubbed kernel and returns the captured call kwargs."""
+    captured = {}
+
+    def fake_tpu_flash_attention(query, key, value, **kwargs):
+      captured.update(kwargs, key=key, value=value)
+      return jnp.zeros_like(query), None
+
+    with mock.patch.object(op, "tpu_flash_attention", fake_tpu_flash_attention):
+      out, exp_max, exp_sum = op.dynamic_splash_attention(
+          jnp.zeros((batch, q_seq_len, 1, 4)),
+          jnp.zeros((batch, kv_seq_len, 1, 4)),
+          jnp.zeros((batch, kv_seq_len, 1, 4)),
+          decoder_segment_ids,
+          segment_positions,
+          compressed_mask,
+          None,
+      )
+    self.assertIsNone(exp_max)
+    self.assertIsNone(exp_sum)
+    self.assertEqual(out.shape, (batch, q_seq_len, 1, 4))
+    return captured
+
+  @pytest.mark.cpu_only
+  def test_kernel_call_pads_kv_folds_packing_into_the_mask_and_guards_its_assumptions(self):
+    batch, seq_len, compressed_len, block = 2, 32, 8, 16
+    kv_seq_len = seq_len + compressed_len
+    segment_ids, reset_positions = _packing(seq_len, batch, packed=True)
+    op = _make_op(AttentionType.COMPRESSED, 4, config=_stub_config(True, block=block))
+    compressed_mask = _additive_lattice(np.random.default_rng(1), (batch, 1, 1, seq_len, compressed_len))
+    captured = self._capture(op, batch, seq_len, kv_seq_len, compressed_mask, segment_ids, reset_positions)
+
+    self.assertIsNone(captured["decoder_segment_ids"])
+    padded_kv_len = math.ceil(kv_seq_len / block) * block
+    self.assertGreater(padded_kv_len, kv_seq_len)
+    mask = np.asarray(captured["indexer_mask"])
+    self.assertEqual(mask.dtype, np.bool_)
+    self.assertEqual(mask.shape, (batch, seq_len, padded_kv_len))
+    self.assertEqual(captured["key"].shape[1], padded_kv_len)
+    self.assertEqual(captured["value"].shape[1], padded_kv_len)
+    self.assertFalse(mask[:, :, kv_seq_len:].any())
+    unpadded = build_compressed_splash_mask(compressed_mask, segment_ids, reset_positions, seq_len, kv_seq_len, 4)
+    np.testing.assert_array_equal(mask[:, :, :kv_seq_len], np.asarray(unpadded))
+
+    small = _additive_lattice(np.random.default_rng(2), (1, 1, 1, 24, compressed_len))
+    with self.assertRaisesRegex(ValueError, "must be a multiple of"):
+      self._capture(op, 1, 24, 24 + compressed_len, small)
+    cp_op = _make_op(AttentionType.COMPRESSED, 4, config=_stub_config(True, block=block), context_parallel_size=2)
+    with self.assertRaisesRegex(NotImplementedError, "context parallelism"):
+      self._capture(cp_op, batch, seq_len, kv_seq_len, compressed_mask)
+
+
+class DynamicSplashRoutingTest(parameterized.TestCase):
+  """Tests dynamic, static, and dense routing."""
+
+  def _dispatch(
+      self,
+      *,
+      flag,
+      model_mode,
+      platform,
+      attention_type,
+      compressed_mask,
+      previous_chunk=None,
+      bidirectional_mask=None,
+  ):
+    """Returns 'dynamic' (dynamic-mask splash), 'static' (static splash) or 'dot' (dense path)."""
+    op = _make_op(attention_type, 4, config=_stub_config(flag), platform=platform)
+    with (
+        mock.patch.object(op, "dynamic_splash_attention", return_value=(None, None, None)) as dynamic,
+        mock.patch.object(op, "tpu_flash_attention", return_value=(None, None)) as static,
+        mock.patch.object(op, "apply_attention_dot", return_value=(None, None, None)) as dot,
+    ):
+      op.apply_attention(
+          jnp.zeros((1, 32, 1, 4)),
+          jnp.zeros((1, 32, 1, 4)),
+          jnp.zeros((1, 32, 1, 4)),
+          None,
+          None,
+          None,
+          model_mode,
+          previous_chunk=previous_chunk,
+          bidirectional_mask=bidirectional_mask,
+          compressed_mask=compressed_mask,
+          qk_product_einsum=jnp.einsum,
+          wv_product_einsum=jnp.einsum,
+      )
+    self.assertEqual(dynamic.called + static.called + dot.called, 1)
+    if dynamic.called:
+      return "dynamic"
+    return "static" if static.called else "dot"
+
+  @pytest.mark.cpu_only
+  @parameterized.named_parameters(
+      ("compressed", AttentionType.COMPRESSED, "dynamic"),
+      ("local_sliding", AttentionType.LOCAL_SLIDING, "static"),
+  )
+  def test_gate(self, attention_type, enabled_target):
+    compressed_mask = jnp.zeros((1, 1, 1, 32, 8)) if attention_type == AttentionType.COMPRESSED else None
+    kwargs = {"attention_type": attention_type, "compressed_mask": compressed_mask}
+    on_tpu_train = {"flag": True, "model_mode": MODEL_MODE_TRAIN, "platform": "tpu", **kwargs}
+    self.assertEqual(self._dispatch(**on_tpu_train), enabled_target)
+    self.assertEqual(self._dispatch(flag=False, model_mode=MODEL_MODE_TRAIN, platform="tpu", **kwargs), "dot")
+    self.assertEqual(self._dispatch(flag=True, model_mode=MODEL_MODE_PREFILL, platform="tpu", **kwargs), "dot")
+    self.assertEqual(self._dispatch(flag=True, model_mode=MODEL_MODE_AUTOREGRESSIVE, platform="tpu", **kwargs), "dot")
+    self.assertEqual(self._dispatch(flag=True, model_mode=MODEL_MODE_TRAIN, platform="cpu", **kwargs), "dot")
+    self.assertEqual(self._dispatch(previous_chunk=object(), **on_tpu_train), "dot")
+    self.assertEqual(self._dispatch(bidirectional_mask=jnp.ones((1, 32), dtype=bool), **on_tpu_train), "dot")
+
+
+def _v4_test_config(compressed_use_dynamic_splash, *extra_overrides):
+  """A deepseek4 config small enough to instantiate in a test, with the flag set either way."""
+  from maxtext.configs.pyconfig import initialize  # pylint: disable=import-outside-toplevel
+  from tests.utils.test_helpers import get_test_config_path  # pylint: disable=import-outside-toplevel
+
+  overrides = (
+      "model_name=deepseek4-284b attention=dot_product qk_rope_head_dim=16 v_head_dim=16 qk_nope_head_dim=16 "
+      "use_tokamax_splash=True override_model_config=True "
+      f"compressed_use_dynamic_splash={compressed_use_dynamic_splash}"
+  ).split()
+  return initialize([None, get_test_config_path(), *overrides, *extra_overrides])
+
+
+class DynamicSplashEndToEndTest(parameterized.TestCase):
+  """Dense-vs-splash parity for a whole compressed attention layer (needs the Pallas TPU kernel)."""
+
+  def _layer_output(self, compressed_use_dynamic_splash, compress_ratio, packed):
+    """Runs one CompressedAttention layer with the flag set either way and returns its output."""
+    from flax import nnx  # pylint: disable=import-outside-toplevel
+    from jax.sharding import Mesh  # pylint: disable=import-outside-toplevel
+    from maxtext.layers.attention_compressed import CompressedAttention  # pylint: disable=import-outside-toplevel
+
+    seq_len = 128
+    layer = CompressedAttention(
+        config=_v4_test_config(compressed_use_dynamic_splash),
+        num_query_heads=4,
+        num_kv_heads=1,
+        head_dim=512,
+        max_target_length=seq_len,
+        mesh=Mesh(np.array(jax.devices()[:1]), ("data",)),
+        attention_kernel="dot_product",
+        inputs_q_shape=(1, seq_len, 4096),
+        inputs_kv_shape=(1, seq_len, 4096),
+        compress_ratio=compress_ratio,
+        sliding_window_size=seq_len // 2,
+        q_lora_rank=1024,
+        rngs=nnx.Rngs(0),
+    )
+    inputs = jax.random.normal(jax.random.PRNGKey(1), (1, seq_len, 4096), dtype=jnp.float32)
+    segment_ids = jnp.ones((1, seq_len), dtype=jnp.int32)
+    positions = jnp.arange(seq_len)[None, :]
+    if packed:
+      segment_ids = segment_ids.at[:, seq_len // 2 :].set(2)
+      positions = positions % (seq_len // 2)
+    return layer(inputs, inputs, segment_ids, positions, deterministic=True)[0]
+
+  @pytest.mark.tpu_only
+  @parameterized.product(
+      compress_ratio=(0, 4, 128),
+      packed=(False, True),
+  )
+  def test_dense_and_dynamic_splash_agree(self, compress_ratio, packed):
+    dense = self._layer_output(False, compress_ratio, packed)
+    splash = self._layer_output(True, compress_ratio, packed)
+    np.testing.assert_allclose(np.asarray(splash), np.asarray(dense), rtol=2e-2, atol=2e-2)
+
+
+class DynamicSplashBackwardParityTest(unittest.TestCase):
+  """Tests COMPRESSED GQA gradients on TPU.
+
+  Pallas interpret mode does not propagate the kernel's aliased gradient accumulators.
+  """
+
+  def _forward_and_grads(self, compressed_use_dynamic_splash, q, k, v, compressed_mask, decoder_segment_ids, cotangent):
+    """Returns (out, dq, dk, dv) for one COMPRESSED AttentionOp with the flag set either way."""
+    from jax.sharding import Mesh  # pylint: disable=import-outside-toplevel
+
+    blocks = [f"sa_block_{n}=128" for n in ("q", "kv", "kv_compute", "q_dkv", "kv_dkv", "kv_dkv_compute")]
+    op = AttentionOp(
+        config=_v4_test_config(compressed_use_dynamic_splash, *blocks),
+        mesh=Mesh(np.array(jax.devices()[:1]), ("data",)),
+        attention_kernel="dot_product",
+        max_target_length=q.shape[1],
+        num_query_heads=q.shape[2],
+        num_kv_heads=k.shape[2],
+        attention_type=AttentionType.COMPRESSED,
+        sliding_window_size=64,
+    )
+
+    def loss_fn(q, k, v):
+      out, _, exp_sum = op.apply_attention(
+          q,
+          k,
+          v,
+          decoder_segment_ids,
+          None,
+          None,
+          MODEL_MODE_TRAIN,
+          compressed_mask=compressed_mask,
+          qk_product_einsum=jnp.einsum,
+          wv_product_einsum=jnp.einsum,
+      )
+      if exp_sum is not None:
+        out = out / exp_sum
+      return jnp.sum(out * cotangent), out
+
+    (_, out), grads = jax.value_and_grad(loss_fn, argnums=(0, 1, 2), has_aux=True)(q, k, v)
+    return (out, *grads)
+
+  @pytest.mark.tpu_only
+  def test_gradients_match_the_dense_path(self):
+    batch, q_seq_len, compressed_len, heads, kv_heads, head_dim = 1, 128, 32, 4, 1, 128
+    kv_seq_len = q_seq_len + compressed_len
+    keys = jax.random.split(jax.random.PRNGKey(0), 4)
+    q = jax.random.normal(keys[0], (batch, q_seq_len, heads, head_dim), dtype=jnp.float32)
+    k = jax.random.normal(keys[1], (batch, kv_seq_len, kv_heads, head_dim), dtype=jnp.float32)
+    v = jax.random.normal(keys[2], (batch, kv_seq_len, kv_heads, head_dim), dtype=jnp.float32)
+    cotangent = jax.random.normal(keys[3], (batch, q_seq_len, heads, head_dim), dtype=jnp.float32)
+    block_of = jnp.arange(compressed_len) * (q_seq_len // compressed_len)
+    keep = block_of[None, :] <= jnp.arange(q_seq_len)[:, None]
+    compressed_mask = jnp.where(keep, 0.0, DEFAULT_MASK_VALUE)[None, None, None, :, :]
+    segment_ids = jnp.ones((batch, q_seq_len), dtype=jnp.int32)
+
+    args = (q, k, v, compressed_mask, segment_ids, cotangent)
+    dense = self._forward_and_grads(False, *args)
+    splash = self._forward_and_grads(True, *args)
+    for name, got, want in zip(("out", "dq", "dk", "dv"), splash, dense):
+      got = np.asarray(got, dtype=np.float64).ravel()
+      want = np.asarray(want, dtype=np.float64).ravel()
+      rel_l2 = np.linalg.norm(got - want) / np.linalg.norm(want)
+      cosine = np.dot(got, want) / (np.linalg.norm(got) * np.linalg.norm(want))
+      self.assertLess(rel_l2, 5e-2, f"{name}: relative L2 distance {rel_l2:.3e}")
+      self.assertGreater(cosine, 0.999, f"{name}: cosine similarity {cosine:.6f}")
+
+
+class DynamicSplashConfigValidatorTest(unittest.TestCase):
+  """compressed_use_dynamic_splash without use_tokamax_splash must be rejected at config time."""
+
+  @pytest.mark.cpu_only
+  def test_flag_requires_tokamax_splash(self):
+    from maxtext.configs.pyconfig import initialize  # pylint: disable=import-outside-toplevel
+    from tests.utils.test_helpers import get_test_config_path  # pylint: disable=import-outside-toplevel
+
+    with self.assertRaisesRegex(Exception, "use_tokamax_splash"):
+      initialize(
+          [None, get_test_config_path()],
+          enable_checkpointing=False,
+          compressed_use_dynamic_splash=True,
+          use_tokamax_splash=False,
+      )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description
Stacked on #4908 (the splash attention PR); the diff includes its commit until it merges. Review the top commit.

Adds three opt-in DeepSeek-V4 mask optimizations for the dynamic-splash training path. Static causal, segment, and uncompressed prefix masks are built before the layer scan and reused by compressed-attention layers and rematerialized calls.

Adds boolean compressed masks from the HCA and CSA compressors through splash mask construction, and lets the CSA indexer return threshold-based membership without the one-hot expansion. The threshold path follows `jax.lax.top_k` ordering at boundary ties, including lower-index and signed-zero ordering.

# Performance
Step time improved from 9.98 to 8.75 s/step (1.14x) with `hoist_static_attention_masks`, `splash_bool_masks`, and `indexer_threshold_membership` toggled on.

Reproduction setup: v6e-128, DeepSeek-V4-Flash 284B, LoRA fine-tuning, `ici_expert_parallelism=16`, `ici_tensor_parallelism=8`, `ici_fsdp_parallelism=1`, `max_target_length=16384`, `per_device_batch_size=0.125` (global batch 16), `LIBTPU_INIT_ARGS=--xla_tpu_scoped_vmem_limit_kib=98304`, with the dynamic-splash attention path enabled and the three flags toggled off versus on.

# Tests
- `PYTHONPATH=$PWD/src JAX_PLATFORMS=cpu /home/jeremy/git/maxtext-16kmem/.venv/bin/python3 -m pytest -q tests/unit/deepseek_v4_mask_flags_test.py` — 15 passed.
- The tie canary pins `jax.lax.top_k` lower-index and signed-zero ordering, while the parity tests compare hoisted, boolean, and threshold-membership masks with their default-path forms.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
