### PR TITLE
Fix Qwen text-only model padding check in PadOrTrimToMaxLength

### DIFF
--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -795,7 +795,11 @@ class PadOrTrimToMaxLength(grain.MapTransform):
 
     vision_block = mm_processor._get_vision_block(self.config)  # pylint: disable=protected-access
     model_name = getattr(self.config, "model_name", None)
-    if vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]:
+    if (
+        vision_block is None
+        or not getattr(self.config, "use_multimodal", False)
+        or vision_block in ["qwen3_omni", "qwen3_vl", "qwen3_5"]
+    ):
       return preprocessed_image
     elif model_name and model_name.startswith("qwen"):
       raise ValueError(

--- a/tests/unit/input_pipeline_utils_test.py
+++ b/tests/unit/input_pipeline_utils_test.py
@@ -211,15 +211,27 @@ class PadOrTrimToMaxLengthMultimodalTest(unittest.TestCase):
 
     # Registered Qwen vision models bypass image padding
     for vb in ["qwen3_vl", "qwen3_omni", "qwen3_5"]:
-      transform = PadOrTrimToMaxLength(max_length=128, pad_id=0, config=SimpleNamespace(vision_encoder_block=vb))
+      transform = PadOrTrimToMaxLength(
+          max_length=128, pad_id=0, config=SimpleNamespace(vision_encoder_block=vb, use_multimodal=True)
+      )
       self.assertIs(transform._pad_image_and_mask(dummy_output), dummy_output)  # pylint: disable=protected-access
 
-    # Unregistered Qwen model raises ValueError
+    # Unregistered Qwen model raises ValueError when use_multimodal=True
     unreg_transform = PadOrTrimToMaxLength(
-        max_length=128, pad_id=0, config=SimpleNamespace(vision_encoder_block="unregistered", model_name="qwen3-future")
+        max_length=128,
+        pad_id=0,
+        config=SimpleNamespace(vision_encoder_block="unregistered", model_name="qwen3-future", use_multimodal=True),
     )
     with self.assertRaisesRegex(ValueError, "registered in `PadOrTrimToMaxLength`"):
       unreg_transform._pad_image_and_mask(dummy_output)  # pylint: disable=protected-access
+
+    # Text-only Qwen model (use_multimodal=False) bypasses error and returns preprocessed_image
+    text_transform = PadOrTrimToMaxLength(
+        max_length=128,
+        pad_id=0,
+        config=SimpleNamespace(vision_encoder_block=None, model_name="qwen3-0.6b", use_multimodal=False),
+    )
+    self.assertIs(text_transform._pad_image_and_mask(dummy_output), dummy_output)  # pylint: disable=protected-access
 
     # None pixel_values raises ValueError
     with self.assertRaisesRegex(ValueError, "must have pixel_values"):


### PR DESCRIPTION
# Description

## Problem
PadOrTrimToMaxLength is a shared Grain transform used across all models and datasets. In PadOrTrimToMaxLength.map(), any dataset example containing an "images" key (e.g., from multimodal datasets, shared test suites, or mock batches) will evoke `_pad_image_and_mask` *regardless of the model is text-only or not*.

Previously, PR #4897 added an image padding bypass for Qwen multimodal models (qwen3_vl, qwen3_omni, qwen3_5) with an unregistered model fallback:

```python
elif model_name and model_name.startswith("qwen"):
  raise ValueError(...)
```

Because if a dictionary has an "images" key, it calls `_pad_image_and_mask()` unconditionally. Therefore, `_pad_image_and_mask` itself must properly handle text-only models (vision_block is None or use_multimodal=False). Otherwise, a text-only models that has no vision encoder will fail the bypass check and hit the elif branch, incorrectly raising a ValueError: Qwen multimodal model 'qwen3-0.6b' with vision_block 'None' was not registered

## Fix
In `input_pipeline_utils.py`, allow text-only models (vision_block is None or use_multimodal=False) to bypass image padding without error. Ensure the unregistered Qwen model validation only triggers when the model is actually configured for multimodal training (use_multimodal=True).


## Tests

```
python -m unittest tests/unit/input_pipeline_utils_test.py

----------------------------------------------------------------------
Ran 13 tests in 0.004s

OK
```

```
python -m unittest tests/unit/train_compile_test.py -k 'test_qwen3'

----------------------------------------------------------------------
Ran 3 tests in 174.657s

OK
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
