### PR TITLE
[Fix] Qwen3.5 vLLM OOT align with upstream API

### DIFF
--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1849,16 +1849,12 @@ class NNXDecoder(nnx.Module):
 
           graphdef, state = nnx.split(layer)
           if kv_caches is not None:
-            if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
-              if (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
-                kv_cache = (
-                    kv_caches["key_cache"][lyr],
-                    kv_caches["value_cache"][lyr],
-                )
-              else:
-                kv_cache = None
-            else:
-              kv_cache = kv_caches[lyr]
+            # vLLM/tpu-inference hands us a flat per-layer list, one entry per
+            # decoder layer. For hybrid QWEN3_NEXT / QWEN3_5 stacks that includes
+            # the GDN (linear-attention) layers, whose recurrent state lives in
+            # their own entry -- Qwen3_5DecoderLayer forwards kv_cache to the
+            # GatedDeltaNet branch too, so they must not be handed None.
+            kv_cache = kv_caches[lyr]
           else:
             kv_cache = None
 
@@ -1881,12 +1877,11 @@ class NNXDecoder(nnx.Module):
             nnx.update(layer, new_state)
 
           if kv_caches is not None and kv_cache is not None:
-            if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
-              if (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
-                kv_caches["key_cache"][lyr] = kv_cache[0]
-                kv_caches["value_cache"][lyr] = kv_cache[1]
-            else:
-              kv_caches[lyr] = kv_cache
+            # Mirror of the read side above: write the layer's updated cache back
+            # into the flat per-layer list vLLM/tpu-inference handed us. This
+            # covers both the full-attention layers and the GDN layers, whose
+            # entry carries the (conv_state, recurrent_state) pair.
+            kv_caches[lyr] = kv_cache
 
           if deepstack_visual_embeds is not None and lyr < len(deepstack_visual_embeds):
             visual_embeds = deepstack_visual_embeds[lyr]

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1849,11 +1849,6 @@ class NNXDecoder(nnx.Module):
 
           graphdef, state = nnx.split(layer)
           if kv_caches is not None:
-            # vLLM/tpu-inference hands us a flat per-layer list, one entry per
-            # decoder layer. For hybrid QWEN3_NEXT / QWEN3_5 stacks that includes
-            # the GDN (linear-attention) layers, whose recurrent state lives in
-            # their own entry -- Qwen3_5DecoderLayer forwards kv_cache to the
-            # GatedDeltaNet branch too, so they must not be handed None.
             kv_cache = kv_caches[lyr]
           else:
             kv_cache = None
@@ -1877,10 +1872,6 @@ class NNXDecoder(nnx.Module):
             nnx.update(layer, new_state)
 
           if kv_caches is not None and kv_cache is not None:
-            # Mirror of the read side above: write the layer's updated cache back
-            # into the flat per-layer list vLLM/tpu-inference handed us. This
-            # covers both the full-attention layers and the GDN layers, whose
-            # entry carries the (conv_state, recurrent_state) pair.
             kv_caches[lyr] = kv_cache
 
           if deepstack_visual_embeds is not None and lyr < len(deepstack_visual_embeds):

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -658,8 +658,24 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       # vLLM PAGED STATE PATH: use tpu_inference fused conv + ragged delta-rule.
       # =========================================================================
       try:
-        from tpu_inference.layers.common.gdn_attention import GdnAttentionConfig, run_jax_gdn_attention  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
-        from tpu_inference.layers.common.ragged_gated_delta_rule_wrapper import RaggedGatedDeltaRuleImpl  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
+        from tpu_inference.layers.common.gdn_attention import run_jax_gdn_attention  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
+
+        # `GdnAttentionConfig` / the `layers.common.ragged_gated_delta_rule_wrapper`
+        # module only exist in newer tpu-inference revisions. Against releases that
+        # predate them, fall back to calling run_jax_gdn_attention without a config
+        # and let it pick its own default delta-rule implementation.
+        try:
+          from tpu_inference.layers.common.gdn_attention import GdnAttentionConfig  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
+        except ImportError:
+          GdnAttentionConfig = None
+        try:
+          from tpu_inference.layers.common.ragged_gated_delta_rule_wrapper import RaggedGatedDeltaRuleImpl  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
+        except ImportError:
+          try:
+            from tpu_inference.kernels.gdn.reference.ragged_gated_delta_rule_wrapper import RaggedGatedDeltaRuleImpl  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
+          except ImportError:
+            RaggedGatedDeltaRuleImpl = None
+
         from tpu_inference.layers.common.sharding import ShardingAxisName  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
         from tpu_inference.layers.common.utils import reorder_concatenated_tensor_for_sharding  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
         from tpu_inference.utils import get_mesh_shape_product  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
@@ -704,7 +720,10 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       conv_state_paged, recurrent_state_paged = kv_cache
 
       # Use REF impl (pure JAX) to avoid Mosaic kernel compilation issues.
-      gdn_config = GdnAttentionConfig(ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.REF)
+      if GdnAttentionConfig is not None and RaggedGatedDeltaRuleImpl is not None:
+        extra_gdn_kwargs = {"config": GdnAttentionConfig(ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.REF)}
+      else:
+        extra_gdn_kwargs = {}
 
       (new_conv_state_paged, new_recurrent_state_paged), gdn_output = run_jax_gdn_attention(
           mixed_qkv,
@@ -726,7 +745,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
           self.head_v_dim,
           cfg.gdn_conv_kernel_dim,
           mesh=self.mesh,
-          config=gdn_config,
+          **extra_gdn_kwargs,
       )
 
       # Reshape GDN output and apply gated norm + out projection.

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -659,23 +659,6 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       # =========================================================================
       try:
         from tpu_inference.layers.common.gdn_attention import run_jax_gdn_attention  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
-
-        # `GdnAttentionConfig` / the `layers.common.ragged_gated_delta_rule_wrapper`
-        # module only exist in newer tpu-inference revisions. Against releases that
-        # predate them, fall back to calling run_jax_gdn_attention without a config
-        # and let it pick its own default delta-rule implementation.
-        try:
-          from tpu_inference.layers.common.gdn_attention import GdnAttentionConfig  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
-        except ImportError:
-          GdnAttentionConfig = None
-        try:
-          from tpu_inference.layers.common.ragged_gated_delta_rule_wrapper import RaggedGatedDeltaRuleImpl  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
-        except ImportError:
-          try:
-            from tpu_inference.kernels.gdn.reference.ragged_gated_delta_rule_wrapper import RaggedGatedDeltaRuleImpl  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
-          except ImportError:
-            RaggedGatedDeltaRuleImpl = None
-
         from tpu_inference.layers.common.sharding import ShardingAxisName  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
         from tpu_inference.layers.common.utils import reorder_concatenated_tensor_for_sharding  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
         from tpu_inference.utils import get_mesh_shape_product  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
@@ -719,12 +702,6 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
 
       conv_state_paged, recurrent_state_paged = kv_cache
 
-      # Use REF impl (pure JAX) to avoid Mosaic kernel compilation issues.
-      if GdnAttentionConfig is not None and RaggedGatedDeltaRuleImpl is not None:
-        extra_gdn_kwargs = {"config": GdnAttentionConfig(ragged_gated_delta_rule_impl=RaggedGatedDeltaRuleImpl.REF)}
-      else:
-        extra_gdn_kwargs = {}
-
       (new_conv_state_paged, new_recurrent_state_paged), gdn_output = run_jax_gdn_attention(
           mixed_qkv,
           b_flat,
@@ -745,7 +722,6 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
           self.head_v_dim,
           cfg.gdn_conv_kernel_dim,
           mesh=self.mesh,
-          **extra_gdn_kwargs,
       )
 
       # Reshape GDN output and apply gated norm + out projection.


### PR DESCRIPTION
MaxText `main` cannot serve Qwen3.5 (hybrid GDN / linear-attention MoE) through the vLLM out-of-tree path against tpu-inference `main`. Two fixes, verified against tpu-inference `ae3238f83`.

**`qwen3.py` — GDN config API no longer exists.** tpu-inference [#3016](https://github.com/vllm-project/tpu-inference/pull/3016) (`53d202394`, 2026-06-29) deleted `GdnAttentionConfig`, moved `ragged_gated_delta_rule_wrapper` to `kernels/gdn/reference/`, and dropped the `config` parameter from `run_jax_gdn_attention`. MaxText still imports those symbols and passes `config=`, so the path has been broken since that date. Fix: import only what exists and call without `config`.

**`nnx_decoders.py` — kv_cache plumbing for hybrid stacks.** The loop gave a cache entry only to full-attention layers and `None` to every GDN layer. tpu-inference passes a flat per-layer list that includes them (`runner/kv_cache_manager.py:906` appends `tuple(mamba_states)`), and `Qwen3_5DecoderLayer` forwards `kv_cache` into the GatedDeltaNet branch. Fix: index `kv_caches[lyr]` uniformly on read and write-back.

**Validation.** Served `Qwen3.5-35B-A3B` via `MaxTextForCausalLM` against tpu-inference `main`, 8 chips, TP=8 / `attn_dp_size=4`, fp8 weights via in-flight qwix quantization. Agentic trace replay: 480/480 turns at 16 streams and 240/240 at 8 streams, 100% success. `tests/unit/nnx_decoders_test.py` passes (46 passed, 2 skipped).

Separately, `--kv-cache-dtype=fp8` does not work on this path: the RPA kernel requires `kv_cache.dtype == k.dtype == v.dtype` (`kernels/ragged_paged_attention/v3/kernel.py:1408`) and MaxText's attention emits bf16 k/v without the `quantize_kv` step tpu-inference's own attention layer performs. Out of scope here.
