### PR TITLE
Add HCA Static Compilation for Splash Attention [Deepseek v4]

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4506,6 +4506,22 @@ class MaxTextConfig(
     context_parallel_size = getattr(self, f"ici_{self.context_sharding}_parallelism", 1) * getattr(
         self, f"dcn_{self.context_sharding}_parallelism", 1
     )
+    if self.attention_type == AttentionType.COMPRESSED.value:
+      # `compress_ratios` is per-layer and a ratio of 0 downgrades that layer to local sliding
+      # attention (see CompressedAttention.__init__), so context parallelism stays legal when no
+      # layer is actually compressed. `compress_ratios` defaults to [] for every other model.
+      if any(ratio > 0 for ratio in self.compress_ratios) and context_parallel_size > 1:
+        raise ValueError(
+            f"Context parallelism (context_parallel_size={context_parallel_size}) is not supported with "
+            "attention_type='compressed' and a non-zero compress_ratio. Set every entry of compress_ratios "
+            "to 0, or disable context parallelism."
+        )
+      # The Tokamax Splash backward kernel only accepts dq_reduction_steps of 3 or None; 0 means
+      # "unset" here and is mapped to the kernel default downstream.
+      if self.dq_reduction_steps not in (0, 3):
+        raise ValueError(
+            f"attention_type='compressed' requires dq_reduction_steps to be 0 or 3, got {self.dq_reduction_steps}."
+        )
     context_parallel_strategy = self.context_parallel_strategy.lower()
     if context_parallel_strategy not in ("all_gather", "ring", "ulysses", "usp"):
       raise ValueError("context_parallel_strategy must be one of 'all_gather', 'ring', 'ulysses', or 'usp'.")

--- a/src/maxtext/layers/attention_compressed.py
+++ b/src/maxtext/layers/attention_compressed.py
@@ -425,6 +425,38 @@ def prime_prefill_cache_state(
       cache.overlap_gate.set_value(overlap_gate_to_write)
 
 
+def compute_hca_padding(
+    q_len: int,
+    comp_len: int,
+    block_q: int = 128,
+    block_kv: int = 128,
+    kv_len: int | None = None,
+) -> tuple[int, int]:
+  """Computes (pad_q, pad_kv_total) for HCA Flash Attention.
+
+  Args:
+    q_len: Unpadded query sequence length.
+    comp_len: Number of compressed KV blocks appended after the local KV tokens.
+    block_q: Query tile size the kernel is compiled for.
+    block_kv: KV tile size the kernel is compiled for.
+    kv_len: Unpadded local KV sequence length. Defaults to `q_len`, which is the
+      self-attention case DeepSeek-V4 uses; pass it explicitly if the query and
+      KV sequences can differ.
+
+  Returns:
+    A (pad_q, pad_kv_total) tuple.
+  """
+  if kv_len is None:
+    kv_len = q_len
+  pad_q = (block_q - (q_len % block_q)) % block_q
+  total_kv_len = kv_len + comp_len
+  pad_kv_total = (block_kv - (total_kv_len % block_kv)) % block_kv
+  # Ensure padding KV columns exist whenever query padding is required
+  if pad_q > 0 and pad_kv_total == 0:
+    pad_kv_total = block_kv
+  return pad_q, pad_kv_total
+
+
 class BaseDeepseekCompressor(nnx.Module):
   """Shared base class for DeepSeek-V4 long-range attention compressors.
 
@@ -524,6 +556,7 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
       quant: Optional[Quant] = None,
       model_mode: str = MODEL_MODE_TRAIN,
       rngs: Optional[nnx.Rngs] = None,
+      attention_kernel: str = "dot_product",
   ):
     """Initializes the HCA Compressor.
 
@@ -537,6 +570,7 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
       quant: Optional quantization scheme.
       model_mode: The operational mode (e.g., "train", "prefill").
       rngs: An optional Rngs instance for stochastic initializations or dropout.
+      attention_kernel: Attention kernel name ("flash", "dot_product").
     """
     super().__init__(
         config,
@@ -548,6 +582,7 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
         model_mode,
         rngs,
     )
+    self.attention_kernel = attention_kernel
 
   def __call__(
       self,
@@ -648,8 +683,17 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
           cache=cache,
       )
 
-    # Skip causal mask generation during decoding (seq_len == 1) or if no blocks were pooled
-    if seq_len == 1 or compressed_len == 0:
+    # During decoding (seq_len == 1), dot-product attention requires a zero mask
+    if seq_len == 1:
+      compressed_mask = jnp.zeros((batch_size, 1, seq_len, compressed_len), dtype=self.dtype)
+      return compressed_kv, compressed_mask
+
+    # Skip dense causal mask generation when using static flash attention (HCAStaticMask)
+    if self.attention_kernel == "flash":
+      return compressed_kv, None
+
+    # Dot-product fallback when no blocks were pooled
+    if compressed_len == 0:
       compressed_mask = jnp.zeros((batch_size, 1, seq_len, compressed_len), dtype=self.dtype)
       return compressed_kv, compressed_mask
 
@@ -1297,6 +1341,7 @@ class CompressedAttention(Attention):
           quant=self.quant,
           model_mode=self.model_mode,
           rngs=self.rngs,
+          attention_kernel=self.attention_kernel,
       )
     elif self.compress_ratio == 4:
       self.csa_compressor = DeepseekV4CSACompressor(
@@ -1582,9 +1627,14 @@ class CompressedAttention(Attention):
     # Tokamax dynamic splash tile boundary alignment. Note: Tokamax kernel inside AttentionOp additionally
     # sets inner block size as min(block_kv, key_len) during kernel invocation.
     if self.attention_kernel == "flash":
-      total_kv_len = kv.shape[1] + (compressed_kv.shape[1] if compressed_kv is not None else 0)
-      block_size = self.config.sa_block_kv
-      pad_kv_total = (block_size - (total_kv_len % block_size)) % block_size
+      comp_len = compressed_kv.shape[1] if compressed_kv is not None else 0
+      _, pad_kv_total = compute_hca_padding(
+          q_len=inputs_q.shape[1],
+          comp_len=comp_len,
+          block_q=self.config.sa_block_q,
+          block_kv=self.config.sa_block_kv,
+          kv_len=kv.shape[1],
+      )
 
       if pad_kv_total > 0:
         if compressed_kv is not None:
@@ -1608,9 +1658,9 @@ class CompressedAttention(Attention):
     if self.query_pre_attn_scalar and self.query_pre_attn_scalar != 1.0:
       q = q * self.query_pre_attn_scalar
 
-    # Build indexer mask explicitly for tokamax splash kernel
+    # Build indexer mask explicitly for tokamax splash kernel (CSA dynamic path)
     indexer_mask = None
-    if self.attention_kernel == "flash" and compressed_mask is not None:
+    if self.attention_kernel == "flash" and compressed_mask is not None and self.compress_ratio == 4:
       indexer_mask = self.attention_op.generate_attention_mask(
           q,
           unpadded_kv,
@@ -1640,6 +1690,8 @@ class CompressedAttention(Attention):
         cached_values=current_kv_cache,
         indexer_mask=indexer_mask,
         decoder_segment_ids_kv=decoder_segment_ids_kv,
+        pad_kv_total=pad_kv_total,
+        compress_ratio=self.compress_ratio,
     )
 
     # Reverse RoPE on Values

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -86,6 +86,16 @@ from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_
 
 dynamic_vector_slice_in_dim = jax.vmap(lax.dynamic_slice_in_dim, in_axes=(None, 0, None, None))
 
+# Number of in-kernel dQ reduction steps used for AttentionType.COMPRESSED.
+#
+# The Tokamax Splash fused backward kernel only accepts `dq_reduction_steps` of 3 or None
+# (see SplashConfig.__post_init__); any other value raises at kernel config construction.
+# Selecting 3 enables a 3-slot circular ring buffer for dQ accumulation in SRAM instead of
+# writing one unreduced dQ tile per KV step to HBM, reducing unreduced dQ write traffic by a
+# factor of `kv_steps / 3`. For the DeepSeek-V4 HCA shapes benchmarked here (kv_steps = 128)
+# that is ~42x; the ratio is shape dependent, not a fixed kernel property.
+_COMPRESSED_DQ_REDUCTION_STEPS = 3
+
 
 def _resolve_attention_type(config: Config, attention_type: AttentionType | str | None) -> AttentionType:
   configured_attention_type = AttentionType(getattr(config, "attention_type", AttentionType.GLOBAL.value))
@@ -302,6 +312,126 @@ class BlockCausalMask(splash_attention_mask._ComputableMask):  # pylint: disable
             self.causal_block_size,
             self.q_sequence.tobytes() if self.q_sequence is not None else None,
         )
+    )
+
+
+class HCAStaticMask(splash_attention_mask.Mask):
+  """Static compile-time mask for DeepSeek-V4 Heavily Compressed Attention (HCA).
+
+  Defines coarse-block coordinates and deduplicated partial block patterns for
+  Splash Attention with pre-packed bitmasks loaded into VMEM/SMEM. Evaluates
+  analytical boolean slices on host CPU during compilation, eliminating runtime VPU
+  arithmetic overhead without materializing dense boolean mask arrays in HBM.
+
+  Attributes:
+    shape: (seq_len, aligned_kv_len) tuple.
+    local_kv_len: Unpadded local sequence length.
+    compressed_kv_len: Number of active compressed tokens.
+    pad_kv_total: Prepend tile padding tokens between local and compressed KV.
+    compress_ratio: Compression ratio for HCA (e.g. 128). Must be positive.
+    local_window: Local sliding-window size (e.g. 128).
+  """
+
+  def __init__(
+      self,
+      shape: tuple[int, int],
+      local_kv_len: Optional[int] = None,
+      compressed_kv_len: Optional[int] = None,
+      pad_kv_total: int = 0,
+      compress_ratio: int = 128,
+      local_window: Optional[int] = 128,
+      shard_count: int = 1,
+  ):
+    # shard_count is retained for Splash Attention Mask API compatibility;
+    # HCA static coordinates do not shard local window math across sequence axes.
+    del shard_count
+    if compress_ratio <= 0:
+      raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
+    self._shape = shape
+    self.local_kv_len = local_kv_len if local_kv_len is not None else shape[0]
+    if self._shape[0] > self.local_kv_len and pad_kv_total <= 0:
+      raise ValueError(
+          f"pad_kv_total must be > 0 when query sequence is padded (shape[0]={self._shape[0]} > local_kv_len={self.local_kv_len})."
+      )
+    self.compressed_kv_len = (
+        compressed_kv_len if compressed_kv_len is not None else max(0, self.local_kv_len // compress_ratio)
+    )
+    self.pad_kv_total = pad_kv_total
+    self.compress_ratio = compress_ratio
+    self.local_window = local_window
+
+  @property
+  def shape(self) -> tuple[int, int]:
+    return self._shape
+
+  def __getitem__(self, idx: tuple[slice, slice]) -> np.ndarray:
+    if len(idx) != 2:
+      raise NotImplementedError(f"Unsupported slice: {idx}")
+    q_slice, kv_slice = idx
+    if not isinstance(q_slice, slice) or not isinstance(kv_slice, slice):
+      raise NotImplementedError(f"Unsupported slice: {idx}")
+
+    q_slice = splash_attention_mask._fill_slice(q_slice, self.shape[0])
+    kv_slice = splash_attention_mask._fill_slice(kv_slice, self.shape[1])
+
+    rows = np.arange(q_slice.start, q_slice.stop, dtype=np.int32)[:, None]
+    cols = np.arange(kv_slice.start, kv_slice.stop, dtype=np.int32)[None, :]
+
+    if rows.size == 0 or cols.size == 0:
+      return np.empty((rows.shape[0], cols.shape[1]), dtype=np.bool_)
+
+    valid_row = rows < self.local_kv_len
+
+    diff = rows - cols
+    if self.local_window is None:
+      local_m = valid_row & (diff >= 0) & (cols < self.local_kv_len)
+    elif self.local_window > 0:
+      local_m = valid_row & (diff >= 0) & (diff < self.local_window) & (cols < self.local_kv_len)
+    else:
+      local_m = np.zeros((rows.shape[0], cols.shape[1]), dtype=np.bool_)
+
+    c_idx = cols - self.local_kv_len - self.pad_kv_total
+    c_thresh = (rows + 1) // self.compress_ratio
+    comp_m = valid_row & (c_idx >= 0) & (c_idx < c_thresh) & (c_idx < self.compressed_kv_len)
+
+    # Map each padded query row 1-to-1 to a distinct padding KV column (softmax denominator = 1.0, logsumexp = 0.0).
+    # This eliminates 0 * inf = NaN in backward dkv without cross-talk or gradient bleed into real tokens.
+    if self.pad_kv_total > 0:
+      pad_cols = self.local_kv_len + ((rows - self.local_kv_len) % self.pad_kv_total)
+      pad_m = (~valid_row) & (cols == pad_cols)
+    else:
+      pad_m = np.zeros((rows.shape[0], cols.shape[1]), dtype=np.bool_)
+
+    return local_m | comp_m | pad_m
+
+  def __eq__(self, other: object):
+    if not isinstance(other, type(self)):
+      return NotImplemented
+    return (
+        self.shape == other.shape
+        and self.local_kv_len == other.local_kv_len
+        and self.compressed_kv_len == other.compressed_kv_len
+        and self.pad_kv_total == other.pad_kv_total
+        and self.compress_ratio == other.compress_ratio
+        and self.local_window == other.local_window
+    )
+
+  def __hash__(self):
+    return hash(
+        (
+            type(self),
+            self.shape,
+            self.local_kv_len,
+            self.compressed_kv_len,
+            self.pad_kv_total,
+            self.compress_ratio,
+            self.local_window,
+        )
+    )
+
+  def __bool__(self) -> bool:
+    raise NotImplementedError(
+        "Conversion to bool is unsupported. Could be caused by using logical" " instead of bitwise operations on masks."
     )
 
 
@@ -1461,6 +1591,8 @@ class AttentionOp(nnx.Module):
       record_max_logits: bool = False,
   ) -> None:
     """Validates runtime constraints for the TPU Tokamax ring path."""
+    if self.attention_type == AttentionType.COMPRESSED:
+      raise ValueError("TPU Tokamax ring attention does not support AttentionType.COMPRESSED (DeepSeek-V4 HCA/CSA).")
     if getattr(self.config, "use_indexer", False) and indexer_mask is None:
       raise ValueError(
           "`indexer_mask` cannot be None when `use_indexer` is True. "
@@ -1489,6 +1621,11 @@ class AttentionOp(nnx.Module):
       record_max_logits: bool = False,
   ) -> None:
     """Validates runtime constraints for the TPU Ulysses path."""
+    if self.attention_type == AttentionType.COMPRESSED:
+      raise ValueError(
+          "TPU Ulysses attention does not support AttentionType.COMPRESSED (DeepSeek-V4 HCA/CSA) "
+          "due to MQA (num_kv_heads=1), asymmetric Q/KV sequence lengths, and dynamic/ragged masking."
+      )
     ulysses_attention.validate_ulysses_runtime(
         model_mode=model_mode,
         previous_chunk=previous_chunk,
@@ -1511,6 +1648,8 @@ class AttentionOp(nnx.Module):
       record_max_logits: bool = False,
   ) -> None:
     """Validates runtime constraints for the TPU USP path."""
+    if self.attention_type == AttentionType.COMPRESSED:
+      raise ValueError("TPU USP attention does not support AttentionType.COMPRESSED (DeepSeek-V4 HCA/CSA).")
     usp_attention.validate_usp_runtime(
         model_mode=model_mode,
         previous_chunk=previous_chunk,
@@ -1538,6 +1677,8 @@ class AttentionOp(nnx.Module):
       compressed_mask: Optional[Array] = None,
       record_max_logits: bool = False,
       decoder_segment_ids_kv: Optional[Array] = None,
+      pad_kv_total: int = 0,
+      compress_ratio: int = 0,
       *,
       qk_product_einsum: Callable[..., Array],
       wv_product_einsum: Callable[..., Array],
@@ -1546,6 +1687,9 @@ class AttentionOp(nnx.Module):
     self.check_attention_inputs(query, key, value)
     length = query.shape[-3]
     target_hardware = self.mesh.devices[(0,) * self.mesh.devices.ndim].platform
+    cp_size = self._context_parallel_size()
+    if self.attention_type == AttentionType.COMPRESSED and cp_size > 1:
+      raise ValueError(f"Context parallelism (cp_size={cp_size}) is not supported with AttentionType.COMPRESSED.")
     if (
         target_hardware == "tpu"
         and tokamax_ring_attention.is_context_parallel_ring_requested(self.config)
@@ -1633,6 +1777,8 @@ class AttentionOp(nnx.Module):
             use_ragged_attention=use_ragged_attention,
             record_max_logits=record_max_logits,
             decoder_segment_ids_kv=decoder_segment_ids_kv,
+            pad_kv_total=pad_kv_total,
+            compress_ratio=compress_ratio,
         )
         if max_logits is not None:
           self.max_logits = nnx.Intermediate(max_logits)
@@ -1814,6 +1960,8 @@ class AttentionOp(nnx.Module):
       use_ragged_attention: bool = False,
       record_max_logits: bool = False,
       decoder_segment_ids_kv: Array | None = None,
+      pad_kv_total: int = 0,
+      compress_ratio: int = 0,
   ) -> tuple[Array, Array]:
     """TPU Flash Attention."""
 
@@ -1857,6 +2005,28 @@ class AttentionOp(nnx.Module):
     query = jnp.transpose(query, axes=(0, 2, 1, 3))
     key = jnp.transpose(key, axes=(0, 2, 1, 3))
     value = jnp.transpose(value, axes=(0, 2, 1, 3))
+
+    orig_q_len = query.shape[2]
+    orig_kv_len = key.shape[2]
+    pad_q = 0
+    pad_kv = 0
+    decoder_segment_ids_kv_in = decoder_segment_ids_kv if decoder_segment_ids_kv is not None else decoder_segment_ids
+
+    # Pad sequences to block-sized boundaries upfront for AttentionType.COMPRESSED
+    if self.attention_type == AttentionType.COMPRESSED:
+      if query.shape[2] % self.block_q != 0:
+        pad_q = (self.block_q - (query.shape[2] % self.block_q)) % self.block_q
+        query = jnp.pad(query, ((0, 0), (0, 0), (0, pad_q), (0, 0)))
+        if decoder_segment_ids is not None:
+          decoder_segment_ids = jnp.pad(decoder_segment_ids, ((0, 0), (0, pad_q)), constant_values=-1)
+
+      if key.shape[2] % self.block_kv != 0:
+        pad_kv = (self.block_kv - (key.shape[2] % self.block_kv)) % self.block_kv
+        key = jnp.pad(key, ((0, 0), (0, 0), (0, pad_kv), (0, 0)))
+        value = jnp.pad(value, ((0, 0), (0, 0), (0, pad_kv), (0, 0)))
+        if decoder_segment_ids_kv_in is not None:
+          decoder_segment_ids_kv_in = jnp.pad(decoder_segment_ids_kv_in, ((0, 0), (0, pad_kv)), constant_values=-1)
+
     segment_axis_names_q = None
     segment_axis_names_kv = None
     sink_axis_names = self._logical_to_mesh_axes((HEAD,))
@@ -1951,7 +2121,14 @@ class AttentionOp(nnx.Module):
             )
             if config.cost_estimate_flops_bwd >= 0
             else None,
-            dq_reduction_steps=config.dq_reduction_steps if config.dq_reduction_steps > 0 else None,
+            # `dq_reduction_steps` of 0 means "unset" (see configs/base.yml); the Tokamax
+            # backward kernel accepts only 3 or None, so COMPRESSED opts into the ring buffer
+            # while every other attention type leaves the reduction unconstrained.
+            dq_reduction_steps=(
+                config.dq_reduction_steps
+                if config.dq_reduction_steps > 0
+                else (_COMPRESSED_DQ_REDUCTION_STEPS if self.attention_type == AttentionType.COMPRESSED else None)
+            ),
             use_experimental_scheduler=self.use_splash_scheduler,
         )
       else:
@@ -2013,24 +2190,40 @@ class AttentionOp(nnx.Module):
       splash_kernel = self._maybe_shard_with_pspec(splash_kernel, segment_axis_names_splash_kernel)
     else:
       sa_config = create_sa_config(self.config, query, key, attn_logits_soft_cap)
-      block_q = sa_config.block_q
-      block_kv = sa_config.block_kv
+      mask_shape = (query.shape[2], key.shape[2])  # (q_seq_len, kv_seq_len)
 
-      # Splash requires sequences to be padded to strict block-sized boundaries.
-      # If naturally divisible (condition false), it falls back to exact sequence lengths.
-      if self.attention_type == AttentionType.COMPRESSED and (
-          (query.shape[2] % block_q != 0) or (key.shape[2] % block_kv != 0)
-      ):
-        padded_q_len = ((query.shape[2] + block_q - 1) // block_q) * block_q
-        padded_kv_len = ((key.shape[2] + block_kv - 1) // block_kv) * block_kv
-        mask_shape = (padded_q_len, padded_kv_len)
-      else:
-        mask_shape = (query.shape[2], key.shape[2])  # (q_seq_len, kv_seq_len)
+      splash_q_seq_shards = cp_size
 
       mask_module = tokamax_splash_mask if self.config.use_tokamax_splash else splash_attention_mask
       use_load_balanced_cp = cp_size > 1 and load_balanced_context_parallel
       if self.attention_type == AttentionType.FULL:
         mask = mask_module.FullMask(mask_shape)
+      elif self.attention_type == AttentionType.COMPRESSED:
+        if not self.config.use_tokamax_splash:
+          raise ValueError("AttentionType.COMPRESSED flash attention requires use_tokamax_splash=True.")
+        if compress_ratio is None or compress_ratio <= 0:
+          raise ValueError("compress_ratio must be provided for AttentionType.COMPRESSED flash attention.")
+        if compress_ratio > 4:
+          local_kv_len = orig_q_len
+          compressed_kv_len = max(0, orig_kv_len - orig_q_len - pad_kv_total)
+          mask = HCAStaticMask(
+              shape=mask_shape,
+              local_kv_len=local_kv_len,
+              compressed_kv_len=compressed_kv_len,
+              pad_kv_total=pad_kv_total,
+              compress_ratio=compress_ratio,
+              local_window=self.sliding_window_size,
+              shard_count=splash_q_seq_shards,
+          )
+        elif compress_ratio == 4:
+          if indexer_mask is None:
+            raise ValueError("indexer_mask must be provided for CSA (compress_ratio == 4) dynamic splash attention.")
+          mask = None
+        else:
+          raise ValueError(
+              f"Unsupported compress_ratio={compress_ratio} for AttentionType.COMPRESSED. "
+              "Expected 4 for CSA (requires indexer_mask) or >4 for HCA (requires HCAStaticMask)."
+          )
       elif self.attention_type == AttentionType.BLOCK_DIFFUSION:
         mask_type = LoadBalancedBlockCausalMask if use_load_balanced_cp else BlockCausalMask
         mask_kwargs = {"cp_size": cp_size} if use_load_balanced_cp else {}
@@ -2045,6 +2238,7 @@ class AttentionOp(nnx.Module):
       if use_load_balanced_cp and self.attention_type not in (
           AttentionType.FULL,
           AttentionType.BLOCK_DIFFUSION,
+          AttentionType.COMPRESSED,
       ):
         mask = LoadBalancedCausalMask(shape=mask_shape, cp_size=cp_size)
 
@@ -2096,15 +2290,22 @@ class AttentionOp(nnx.Module):
           ],
       )
       def wrap_tokamax_splash_kernel(single_head_mask):
-        splash_kernel = tokamax_splash_kernel.make_splash_mha(
-            mask=single_head_mask,
-            config=sa_config,
-            q_seq_shards=cp_size,  # axis for sequence sharding,
-        )
+        if self.attention_type == AttentionType.COMPRESSED and self.num_kv_heads == 1:
+          splash_kernel = tokamax_splash_kernel.make_splash_mqa(
+              mask=single_head_mask,
+              config=sa_config,
+              q_seq_shards=splash_q_seq_shards,
+          )
+        else:
+          splash_kernel = tokamax_splash_kernel.make_splash_mha(
+              mask=single_head_mask,
+              config=sa_config,
+              q_seq_shards=splash_q_seq_shards,
+          )
         return splash_kernel
 
       segment_axis_names_splash_kernel = self._logical_to_mesh_axes((Q_LENGTH,))
-      if indexer_mask is None:
+      if indexer_mask is None and mask is not None:
         splash_kernel = wrap_tokamax_splash_kernel(single_head_mask)
         splash_kernel = self._maybe_shard_with_pspec(splash_kernel, segment_axis_names_splash_kernel)
       else:
@@ -2356,17 +2557,27 @@ class AttentionOp(nnx.Module):
 
           # Construct the splash kernel call with dynamic mask
           def dynamic_mask_splash_kernel(q, k, v, segment, sinks, indexer_mask):
-            splash_kernel = tokamax_splash_kernel.make_dynamic_splash_mha(
-                mask=indexer_mask,
-                config=sa_config,
-            )
+            if self.attention_type == AttentionType.COMPRESSED and self.num_kv_heads == 1:
+              splash_kernel = tokamax_splash_kernel.make_dynamic_splash_mqa(
+                  mask=indexer_mask,
+                  config=sa_config,
+              )
+              k_in = k[0]
+              v_in = v[0]
+            else:
+              splash_kernel = tokamax_splash_kernel.make_dynamic_splash_mha(
+                  mask=indexer_mask,
+                  config=sa_config,
+              )
+              k_in = k
+              v_in = v
             kernel = partial(splash_kernel, max_logit_value=max_logit_value)
 
             if record_max_logits:
-              out, stats = kernel(q, k, v, segment, sinks=sinks, save_residuals=True)
+              out, stats = kernel(q, k_in, v_in, segment, sinks=sinks, save_residuals=True)
               return out, stats["max_logits"]
             else:
-              return kernel(q, k, v, segment, sinks=sinks), None
+              return kernel(q, k_in, v_in, segment, sinks=sinks), None
 
           # Iterate over batch dimension for (query, key, value, segment, sinks, mask)
           attn_fn = jax.vmap(dynamic_mask_splash_kernel, (0, 0, 0, 0, None, 0))
@@ -2379,12 +2590,15 @@ class AttentionOp(nnx.Module):
             return attention_output, None
         else:
           kernel = partial(splash_kernel, max_logit_value=max_logit_value)
+          is_mqa_compressed = self.attention_type == AttentionType.COMPRESSED and self.num_kv_heads == 1
 
           if record_max_logits:
 
             def kernel_fn(q, k, v, d, s):
               # Pass save_residuals=True to force stats generation
-              out, stats = kernel(q, k, v, d, sinks=s, save_residuals=True)
+              k_in = k[0] if is_mqa_compressed else k
+              v_in = v[0] if is_mqa_compressed else v
+              out, stats = kernel(q, k_in, v_in, d, sinks=s, save_residuals=True)
               return out, stats["max_logits"]
 
             attention_output, max_logits = jax.vmap(kernel_fn, in_axes=(0, 0, 0, 0, None))(
@@ -2392,7 +2606,13 @@ class AttentionOp(nnx.Module):
             )
             return attention_output, max_logits
           else:
-            attention_output = jax.vmap(lambda q, k, v, d, s: kernel(q, k, v, d, sinks=s), in_axes=(0, 0, 0, 0, None))(
+
+            def call_kernel_fn(q, k, v, d, s):
+              k_in = k[0] if is_mqa_compressed else k
+              v_in = v[0] if is_mqa_compressed else v
+              return kernel(q, k_in, v_in, d, sinks=s)
+
+            attention_output = jax.vmap(call_kernel_fn, in_axes=(0, 0, 0, 0, None))(
                 query, key, value, decoder_segment_ids_tuple, sinks
             )
             return attention_output, None
@@ -2427,7 +2647,6 @@ class AttentionOp(nnx.Module):
     key = self._maybe_shard_with_pspec(key, axis_names_kv)
     value = self._maybe_shard_with_pspec(value, axis_names_kv)
     decoder_segment_ids_q = self._maybe_shard_with_pspec(decoder_segment_ids, segment_axis_names_q)
-    decoder_segment_ids_kv_in = decoder_segment_ids_kv if decoder_segment_ids_kv is not None else decoder_segment_ids
     decoder_segment_ids_kv = self._maybe_shard_with_pspec(decoder_segment_ids_kv_in, segment_axis_names_kv)
     sinks = self._maybe_shard_with_pspec(sinks, sink_axis_names)
     indexer_mask = self._maybe_shard_with_pspec(indexer_mask, indexer_mask_axis_names)
@@ -2448,6 +2667,11 @@ class AttentionOp(nnx.Module):
 
     x, max_logits = ret
     x = jnp.transpose(x, axes=(0, 2, 1, 3))
+    # Slice outputs back to unpadded sequence length for compressed attention
+    if self.attention_type == AttentionType.COMPRESSED and pad_q > 0:
+      x = x[:, :orig_q_len, :, :]
+      if record_max_logits:
+        max_logits = max_logits[:, :, :orig_q_len]
 
     if record_max_logits:
       # Max over sequence length (dim 2 of max_logits)
@@ -3048,6 +3272,8 @@ class AttentionOp(nnx.Module):
       slot: Optional[int] = None,
       record_max_logits: bool = False,
       decoder_segment_ids_kv: Optional[Array] = None,
+      pad_kv_total: int = 0,
+      compress_ratio: int = 0,
   ):
     if cached_values is None:
       prefill_kv_cache, ar_kv_cache = None, None
@@ -3095,6 +3321,8 @@ class AttentionOp(nnx.Module):
         qk_product_einsum=self.AqtEinsum_0,
         wv_product_einsum=self.AqtEinsum_1,
         decoder_segment_ids_kv=decoder_segment_ids_kv,
+        pad_kv_total=pad_kv_total,
+        compress_ratio=compress_ratio,
     )
 
     if ar_kv_cache is None:

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -46,6 +46,7 @@ from maxtext.common.common_types import (
     Q_LENGTH,
 )
 from maxtext.layers.attention_mla import MLA
+from maxtext.layers import attention_compressed
 from maxtext.layers.attention_compressed import CompressedAttention
 from maxtext.layers import attention_op
 from maxtext.layers.attention_op import (
@@ -467,6 +468,61 @@ class ChunkedCausalMaskTest(unittest.TestCase):
       _generate_chunk_attention_mask(mask_shape=(4, 4), chunk_size=0)
 
 
+def _create_mock_flash_op(
+    *,
+    attention_type=AttentionType.BLOCK_DIFFUSION,
+    context_parallel_size=1,
+    context_parallel_load_balance=False,
+    max_target_length=8,
+    block_size=4,
+    use_tokamax_splash=False,
+):
+  """Helper method to construct a mock AttentionOp for flash testing."""
+  config = types.SimpleNamespace(
+      causal_block_size=4,
+      context_parallel_strategy="all_gather",
+      context_parallel_load_balance=context_parallel_load_balance,
+      context_sharding="context",
+      sa_block_q=block_size,
+      sa_block_kv=block_size,
+      sa_block_kv_compute=block_size,
+      sa_block_q_dkv=block_size,
+      sa_block_kv_dkv=block_size,
+      sa_block_kv_dkv_compute=block_size,
+      sa_block_q_dq=block_size,
+      sa_block_kv_dq=block_size,
+      sa_use_fused_bwd_kernel=True,
+      sa_q_layout="HEAD_DIM_MINOR",
+      sa_k_layout="HEAD_DIM_MINOR",
+      sa_v_layout="HEAD_DIM_MINOR",
+      use_splash_scheduler=False,
+      sa_fuse_reciprocal=False,
+      sa_use_base2_exp=False,
+      use_tokamax_splash=use_tokamax_splash,
+      use_jax_splash=False,
+      cost_estimate_flops_fwd=-1,
+      cost_estimate_flops_bwd=-1,
+      dq_reduction_steps=-1,
+      use_max_logit_estimate=-1,
+      shard_mode="none",
+      debug_sharding=False,
+  )
+  device = types.SimpleNamespace(platform="cpu")
+  mesh = types.SimpleNamespace(
+      devices=np.asarray([device] * context_parallel_size, dtype=object),
+      shape={"context": context_parallel_size},
+  )
+  return AttentionOp(
+      config=config,
+      num_query_heads=1,
+      num_kv_heads=1,
+      max_target_length=max_target_length,
+      mesh=mesh,
+      attention_kernel="flash",
+      attention_type=attention_type,
+  )
+
+
 def _stub_mesh_axes(q_axis="context"):
   """Stands in for `AttentionOp._logical_to_mesh_axes` with no ambient rules bound.
 
@@ -816,6 +872,334 @@ class BlockCausalMaskTest(unittest.TestCase):
     )
     selected_mask = self._capture_splash_mask(op, jnp.zeros((1, 8, 1, 8)))
     self.assertIsInstance(selected_mask, splash_attention_mask.CausalMask)
+
+
+class HCAStaticMaskTest(unittest.TestCase):
+  """Tests the HCAStaticMask and its equivalence with the compressor mask."""
+
+  def _make_flash_op(self, **kwargs):
+    kwargs.setdefault("attention_type", AttentionType.COMPRESSED)
+    kwargs.setdefault("max_target_length", 512)
+    kwargs.setdefault("block_size", 128)
+    kwargs.setdefault("use_tokamax_splash", True)
+    return _create_mock_flash_op(**kwargs)
+
+  def _make_dot_product_op(self, max_target_length, sliding_window_size=128):
+    """Creates a mock dot_product AttentionOp instance with CPU mesh."""
+    devices = np.array(jax.devices()[:1]).reshape((1,))
+    mesh = jax.sharding.Mesh(devices, ("data",))
+    config = types.SimpleNamespace(
+        causal_block_size=4,
+        context_parallel_load_balance=False,
+        context_sharding="context",
+        shard_mode="none",
+        debug_sharding=False,
+    )
+    return AttentionOp(
+        config=config,
+        num_query_heads=1,
+        num_kv_heads=1,
+        max_target_length=max_target_length,
+        mesh=mesh,
+        attention_kernel="dot_product",
+        attention_type=AttentionType.COMPRESSED,
+        sliding_window_size=sliding_window_size,
+    )
+
+  def test_compute_hca_padding(self):
+    """Pins the padding arithmetic the layer and these tests both depend on."""
+    test_cases = [
+        # (q_len, comp_len, block_q, block_kv, expected_pad_q, expected_pad_kv_total)
+        (512, 4, 128, 128, 0, 124),  # aligned query, compressed blocks force KV padding
+        (489, 3, 128, 128, 23, 20),  # unaligned query and unaligned KV total
+        (512, 0, 128, 128, 0, 0),  # nothing to pad
+        (384, 128, 128, 128, 0, 0),  # KV total already a block multiple
+        (500, 12, 128, 128, 12, 128),  # KV aligned but query is not, so a full pad block is added
+    ]
+    for q_len, comp_len, block_q, block_kv, expected_pad_q, expected_pad_kv in test_cases:
+      with self.subTest(q_len=q_len, comp_len=comp_len):
+        pad_q, pad_kv_total = attention_compressed.compute_hca_padding(
+            q_len=q_len, comp_len=comp_len, block_q=block_q, block_kv=block_kv
+        )
+        self.assertEqual(pad_q, expected_pad_q)
+        self.assertEqual(pad_kv_total, expected_pad_kv)
+        self.assertEqual((q_len + pad_q) % block_q, 0)
+        self.assertEqual((q_len + comp_len + pad_kv_total) % block_kv, 0)
+
+  def test_hca_static_mask_matches_compressor_mask(self):
+    test_cases = [
+        # (seq_len, compress_ratio, local_window)
+        (512, 128, 128),
+        (1024, 128, 128),
+        (512, 128, None),  # full causal local attention
+        (384, 128, 128),
+        (489, 128, 128),  # unaligned S=489 (pad_q=23, pad_kv=20)
+        (1017, 128, 128),  # unaligned S=1017 (pad_q=7, pad_kv=121)
+    ]
+    block_q = 128
+    block_kv = 128
+
+    for seq_len, compress_ratio, local_window in test_cases:
+      with self.subTest(seq_len=seq_len, ratio=compress_ratio, window=local_window):
+        comp_len = max(0, seq_len // max(1, compress_ratio))
+        pad_q, pad_kv = attention_compressed.compute_hca_padding(
+            q_len=seq_len,
+            comp_len=comp_len,
+            block_q=block_q,
+            block_kv=block_kv,
+        )
+        padded_q_len = seq_len + pad_q
+        total_kv_len = seq_len + pad_kv + comp_len
+        shape = (padded_q_len, total_kv_len)
+
+        mask = attention_op.HCAStaticMask(
+            shape=shape,
+            local_kv_len=seq_len,
+            compressed_kv_len=comp_len,
+            pad_kv_total=pad_kv,
+            compress_ratio=compress_ratio,
+            local_window=local_window,
+        )
+
+        op = self._make_dot_product_op(seq_len, sliding_window_size=local_window)
+
+        position_ids = jnp.arange(seq_len)[None, :]
+        usable_len = comp_len * compress_ratio
+        if comp_len > 0:
+          block_positions = position_ids[:, :usable_len:compress_ratio]
+          future_mask = (block_positions[:, None, None, :] + compress_ratio) > (position_ids[:, None, :, None] + 1)
+          compressed_causal_mask = jnp.where(future_mask, DEFAULT_MASK_VALUE, 0.0)
+        else:
+          compressed_causal_mask = jnp.zeros((1, 1, seq_len, 0))
+
+        dummy_q = jnp.zeros((1, seq_len, 1, 128))
+        dummy_k = jnp.zeros((1, seq_len + comp_len, 1, 128))
+        ref_mask = op.generate_attention_mask(
+            dummy_q,
+            dummy_k,
+            decoder_segment_ids=None,
+            model_mode=MODEL_MODE_TRAIN,
+            compressed_mask=compressed_causal_mask,
+            pad_kv_total=pad_kv,
+        )
+        expected_mask = np.array(ref_mask[0, 0] == 0.0)
+
+        actual_mask = mask[:, :]
+        # Real query rows (0..seq_len) must match dot product reference mask
+        np.testing.assert_array_equal(actual_mask[:seq_len, :], expected_mask)
+
+        # Every row (including padded query rows) must have at least one active connection
+        self.assertTrue(
+            np.all(np.any(actual_mask, axis=-1)),
+            "Found an all-False softmax row in HCAStaticMask (would cause NaN in softmax).",
+        )
+
+  def test_hca_static_mask_raises_on_unpadded_kv_with_padded_query(self):
+    """Verifies that HCAStaticMask rejects configurations where query is padded but pad_kv_total <= 0."""
+    with self.assertRaises(ValueError):
+      attention_op.HCAStaticMask(
+          shape=(1024, 1017 + 7),
+          local_kv_len=1017,
+          pad_kv_total=0,
+          compress_ratio=128,
+      )
+
+  def test_hca_static_mask_padded_query_rows_mapping(self):
+    """Verifies that padded query rows map circularly to pad_cols without bleeding into real tokens."""
+    seq_len = 489
+    compress_ratio = 128
+    comp_len = seq_len // compress_ratio
+    pad_q, pad_kv = attention_compressed.compute_hca_padding(
+        q_len=seq_len,
+        comp_len=comp_len,
+        block_q=128,
+        block_kv=128,
+    )
+    pad_q_len = seq_len + pad_q
+    total_kv_len = seq_len + pad_kv + comp_len
+    mask = attention_op.HCAStaticMask(
+        shape=(pad_q_len, total_kv_len),
+        local_kv_len=seq_len,
+        compressed_kv_len=comp_len,
+        pad_kv_total=pad_kv,
+        compress_ratio=compress_ratio,
+        local_window=128,
+    )
+    actual_mask = mask[:, :]
+    for row in range(seq_len, pad_q_len):
+      expected_col = seq_len + ((row - seq_len) % pad_kv)
+      self.assertTrue(
+          actual_mask[row, expected_col],
+          f"Padded query row {row} must map to padding KV column {expected_col} in pad_m.",
+      )
+      self.assertEqual(np.sum(actual_mask[row]), 1)
+      self.assertFalse(
+          np.any(actual_mask[row, :seq_len]),
+          f"Padded query row {row} must not attend to real local KV tokens.",
+      )
+      self.assertFalse(
+          np.any(actual_mask[row, seq_len + pad_kv :]),
+          f"Padded query row {row} must not attend to compressed KV tokens.",
+      )
+
+  def test_hca_static_mask_equality_and_hash(self):
+    mask1 = attention_op.HCAStaticMask(
+        shape=(512, 640),
+        local_kv_len=512,
+        compressed_kv_len=4,
+        pad_kv_total=124,
+        compress_ratio=128,
+        local_window=128,
+    )
+    mask2 = attention_op.HCAStaticMask(
+        shape=(512, 640),
+        local_kv_len=512,
+        compressed_kv_len=4,
+        pad_kv_total=124,
+        compress_ratio=128,
+        local_window=128,
+    )
+    mask_diff_pad = attention_op.HCAStaticMask(
+        shape=(512, 640),
+        local_kv_len=512,
+        compressed_kv_len=4,
+        pad_kv_total=0,
+        compress_ratio=128,
+        local_window=128,
+    )
+
+    self.assertEqual(mask1, mask2)
+    self.assertEqual(hash(mask1), hash(mask2))
+    self.assertNotEqual(mask1, mask_diff_pad)
+    self.assertNotEqual(mask1, object())
+
+  def test_zero_division_guard(self):
+    with self.assertRaisesRegex(ValueError, "compress_ratio must be positive"):
+      attention_op.HCAStaticMask(
+          shape=(128, 128),
+          local_kv_len=128,
+          compressed_kv_len=1,
+          compress_ratio=0,
+          local_window=128,
+      )
+    with self.assertRaisesRegex(ValueError, "compress_ratio must be positive"):
+      attention_op.HCAStaticMask(
+          shape=(128, 128),
+          local_kv_len=128,
+          compressed_kv_len=1,
+          compress_ratio=-1,
+          local_window=128,
+      )
+
+  def test_csa_flash_requires_indexer_mask(self):
+    op = self._make_flash_op(
+        attention_type=AttentionType.COMPRESSED,
+        max_target_length=512,
+    )
+    query = jnp.zeros((1, 512, 1, 128))
+    key = jnp.zeros((1, 640, 1, 128))
+    with self.assertRaisesRegex(ValueError, "indexer_mask must be provided for CSA"):
+      op.tpu_flash_attention(query, key, key, decoder_segment_ids=None, compress_ratio=4)
+
+  def test_hca_flash_constructs_hcastaticmask(self):
+    op = self._make_flash_op(
+        attention_type=AttentionType.COMPRESSED,
+        max_target_length=512,
+        use_tokamax_splash=True,
+    )
+    query = jnp.zeros((1, 512, 1, 128))
+    key = jnp.zeros((1, 640, 1, 128))
+    with (
+        unittest.mock.patch.object(op, "_maybe_shard_with_pspec", side_effect=lambda x, p: x),
+        unittest.mock.patch.object(op, "_logical_to_mesh_axes", return_value=(None,)),
+        unittest.mock.patch.object(
+            jax, "shard_map", side_effect=lambda f, **kwargs: (lambda *args, **kw: (jnp.zeros_like(query), None))
+        ),
+        unittest.mock.patch.object(
+            attention_op,
+            "HCAStaticMask",
+            wraps=attention_op.HCAStaticMask,
+        ) as mock_mask,
+    ):
+      op.tpu_flash_attention(query, key, key, decoder_segment_ids=None, compress_ratio=128)
+      mock_mask.assert_called_once()
+      self.assertEqual(mock_mask.call_args.kwargs["compress_ratio"], 128)
+
+  def test_packed_positions_and_segment_ids_vs_generate_attention_mask(self):
+    """Verifies segment-id based document packing with positions on CPU ground truth generate_attention_mask."""
+    l1, l2 = 200, 312
+    total_len = l1 + l2
+    compress_ratio = 128
+    comp_len = total_len // compress_ratio  # 4
+    op = self._make_dot_product_op(total_len, sliding_window_size=128)
+
+    pos = jnp.concatenate([jnp.arange(l1, dtype=jnp.int32), jnp.arange(l2, dtype=jnp.int32)], axis=0)[None, :]
+    seg = jnp.concatenate([jnp.ones(l1, dtype=jnp.int32), jnp.full(l2, 2, dtype=jnp.int32)], axis=0)[None, :]
+
+    # Derive compressed segment IDs matching CompressedAttention runtime logic:
+    #   Block 0: 0..127   (Doc 1)          -> seg 1
+    #   Block 1: 128..255 (Doc 1 & Doc 2)  -> seg -1 (straddling block invalidated)
+    #   Block 2: 256..383 (Doc 2)          -> seg 2
+    #   Block 3: 384..511 (Doc 2)          -> seg 2
+    chunked_seg = seg.reshape((1, comp_len, compress_ratio))
+    min_seg = jnp.min(chunked_seg, axis=-1)
+    max_seg = jnp.max(chunked_seg, axis=-1)
+    comp_seg = jnp.where(min_seg == max_seg, min_seg, -1)
+    seg_kv = jnp.concatenate([seg, comp_seg], axis=1)
+
+    usable_len = comp_len * compress_ratio
+    block_positions = pos[:, :usable_len:compress_ratio]
+    future_mask = (block_positions[:, None, None, :] + compress_ratio) > (pos[:, None, :, None] + 1)
+    compressed_causal_mask = jnp.where(future_mask, DEFAULT_MASK_VALUE, 0.0)
+
+    dummy_q = jnp.zeros((1, total_len, 1, 128))
+    dummy_k = jnp.zeros((1, total_len + comp_len, 1, 128))
+
+    mask = op.generate_attention_mask(
+        dummy_q,
+        dummy_k,
+        decoder_segment_ids=seg,
+        decoder_segment_ids_kv=seg_kv,
+        segment_positions=pos,
+        model_mode=MODEL_MODE_TRAIN,
+        compressed_mask=compressed_causal_mask,
+        pad_kv_total=0,
+    )
+    mask_matrix = np.squeeze(np.array(mask == 0.0))
+
+    # 1. Uncompressed local token cross-document isolation
+    # Assert Doc 1 (rows 0..199) cannot attend to Doc 2 (cols 200..511)
+    self.assertFalse(np.any(mask_matrix[:l1, l1:total_len]))
+    # Assert Doc 2 (rows 200..511) cannot attend to Doc 1 (cols 0..199)
+    self.assertFalse(np.any(mask_matrix[l1:total_len, :l1]))
+
+    # 2. Compressed block cross-document isolation
+    # Doc 1 cannot attend to Block 1 (straddled) or Blocks 2, 3 (Doc 2)
+    self.assertFalse(np.any(mask_matrix[:l1, total_len + 1 :]))
+    # Doc 2 cannot attend to Block 0 (Doc 1) or Block 1 (straddled)
+    self.assertFalse(np.any(mask_matrix[l1:total_len, total_len : total_len + 2]))
+
+    # 3. Straddled boundary isolation: no query from any document may attend to Block 1
+    self.assertFalse(np.any(mask_matrix[:, total_len + 1]))
+
+    # 4. Valid compressed connections must remain reachable, so the assertions above are not
+    # vacuously satisfied by an all-masked matrix. With block_positions = [0, 128, 56, 184],
+    # the compressed causal mask admits Doc 1 rows 127..199 for Block 0 and Doc 2 rows
+    # 383..511 for Blocks 2, 3.
+    self.assertTrue(np.any(mask_matrix[:l1, total_len]))
+    self.assertTrue(np.any(mask_matrix[l1:total_len, total_len + 2 :]))
+
+  def test_compressed_flash_missing_or_invalid_compress_ratio_raises(self):
+    op = self._make_flash_op(
+        attention_type=AttentionType.COMPRESSED,
+        max_target_length=512,
+    )
+    query = jnp.zeros((1, 512, 1, 128))
+    key = jnp.zeros((1, 516, 1, 128))
+    with self.assertRaisesRegex(ValueError, "compress_ratio must be provided for AttentionType.COMPRESSED"):
+      op.tpu_flash_attention(query, key, key, decoder_segment_ids=None, compress_ratio=None)
+    with self.assertRaisesRegex(ValueError, "compress_ratio must be provided for AttentionType.COMPRESSED"):
+      op.tpu_flash_attention(query, key, key, decoder_segment_ids=None, compress_ratio=0)
 
 
 class AttentionTypeResolutionTest(unittest.TestCase):
@@ -5359,7 +5743,200 @@ class CompressedAttentionTest(parameterized.TestCase):
     out_flash = self._run_compressed_attention(compress_ratio, "flash")
     np.testing.assert_allclose(np.array(out_flash), np.array(out_dot), rtol=1e-2, atol=1e-2)
 
-  def _get_test_config(self, max_target_length, compress_ratio, attention_kernel):
+  @pytest.mark.tpu_only
+  def test_hca_flash_vs_dot_product_unaligned_grads(self):
+    """Verifies gradient numerical equivalence between dot_product and flash attention on unaligned sequences (S=489)."""
+    # --- Case 1: Unpacked single sequence S=489 ---
+    seq_len = 489
+    compress_ratio = 128
+    cfg_dot = self._get_test_config(max_target_length=seq_len)
+    cfg_flash = self._get_test_config(max_target_length=seq_len)
+
+    attn_dot = self._create_compressed_attention_layer(
+        cfg_dot, compress_ratio=compress_ratio, attention_kernel="dot_product"
+    )
+    attn_flash = self._create_compressed_attention_layer(
+        cfg_flash, compress_ratio=compress_ratio, attention_kernel="flash"
+    )
+
+    batch_size = cfg_dot.global_batch_size_to_train_on
+    x = jax.random.normal(jax.random.PRNGKey(0), (batch_size, seq_len, cfg_dot.base_emb_dim))
+    pos = jnp.arange(seq_len, dtype=jnp.int32)[None, :].repeat(batch_size, axis=0)
+    seg = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
+
+    def loss_dot(inp):
+      out, _ = attn_dot(
+          inp,
+          inp,
+          decoder_segment_ids=seg,
+          inputs_positions=pos,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.mean(out**2)
+
+    def loss_flash(inp):
+      out, _ = attn_flash(
+          inp,
+          inp,
+          decoder_segment_ids=seg,
+          inputs_positions=pos,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.mean(out**2)
+
+    out_dot, _ = attn_dot(
+        x, x, decoder_segment_ids=seg, inputs_positions=pos, deterministic=True, model_mode=MODEL_MODE_TRAIN
+    )
+    out_flash, _ = attn_flash(
+        x, x, decoder_segment_ids=seg, inputs_positions=pos, deterministic=True, model_mode=MODEL_MODE_TRAIN
+    )
+    np.testing.assert_allclose(np.array(out_flash), np.array(out_dot), rtol=1e-2, atol=1e-2)
+
+    grad_dot = jax.grad(loss_dot)(x)
+    grad_flash = jax.grad(loss_flash)(x)
+
+    self.assertTrue(np.all(np.isfinite(np.array(grad_dot))), "Dot grad contains NaN/Inf for unpacked S=489")
+    self.assertTrue(np.all(np.isfinite(np.array(grad_flash))), "Flash grad contains NaN/Inf for unpacked S=489")
+    np.testing.assert_allclose(np.array(grad_flash), np.array(grad_dot), rtol=1e-2, atol=1e-6)
+
+    # --- Case 2: Packed unaligned sequence L1=200, L2=289 (Total=489) ---
+    l1, l2 = 200, 289
+    total_len = l1 + l2
+    cfg_dot_packed = self._get_test_config(max_target_length=total_len)
+    cfg_flash_packed = self._get_test_config(max_target_length=total_len)
+
+    attn_dot_packed = self._create_compressed_attention_layer(
+        cfg_dot_packed, compress_ratio=compress_ratio, attention_kernel="dot_product"
+    )
+    attn_flash_packed = self._create_compressed_attention_layer(
+        cfg_flash_packed, compress_ratio=compress_ratio, attention_kernel="flash"
+    )
+
+    x_packed = jax.random.normal(jax.random.PRNGKey(42), (batch_size, total_len, cfg_dot_packed.base_emb_dim))
+    pos_packed = jnp.broadcast_to(
+        jnp.concatenate([jnp.arange(l1, dtype=jnp.int32), jnp.arange(l2, dtype=jnp.int32)], axis=0)[None, :],
+        (batch_size, total_len),
+    )
+    seg_packed = jnp.broadcast_to(
+        jnp.concatenate([jnp.ones(l1, dtype=jnp.int32), jnp.full(l2, 2, dtype=jnp.int32)], axis=0)[None, :],
+        (batch_size, total_len),
+    )
+
+    out_dot_p, _ = attn_dot_packed(
+        x_packed,
+        x_packed,
+        decoder_segment_ids=seg_packed,
+        inputs_positions=pos_packed,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    out_flash_p, _ = attn_flash_packed(
+        x_packed,
+        x_packed,
+        decoder_segment_ids=seg_packed,
+        inputs_positions=pos_packed,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    np.testing.assert_allclose(np.array(out_flash_p), np.array(out_dot_p), rtol=1e-2, atol=1e-2)
+
+    def loss_dot_packed(inp):
+      out, _ = attn_dot_packed(
+          inp,
+          inp,
+          decoder_segment_ids=seg_packed,
+          inputs_positions=pos_packed,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.mean(out**2)
+
+    def loss_flash_packed(inp):
+      out, _ = attn_flash_packed(
+          inp,
+          inp,
+          decoder_segment_ids=seg_packed,
+          inputs_positions=pos_packed,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.mean(out**2)
+
+    grad_dot_packed = jax.grad(loss_dot_packed)(x_packed)
+    grad_flash_packed = jax.grad(loss_flash_packed)(x_packed)
+
+    self.assertTrue(
+        np.all(np.isfinite(np.array(grad_dot_packed))), "Dot grad contains NaN/Inf for packed unaligned S=489"
+    )
+    self.assertTrue(
+        np.all(np.isfinite(np.array(grad_flash_packed))), "Flash grad contains NaN/Inf for packed unaligned S=489"
+    )
+    np.testing.assert_allclose(np.array(grad_flash_packed), np.array(grad_dot_packed), rtol=1e-2, atol=1e-6)
+
+  @pytest.mark.tpu_only
+  def test_hca_flash_vs_dot_product_packed_crossing_window(self):
+    """Verifies numerical equivalence between dot_product and flash attention on packed sequences crossing compression
+
+    windows.
+    """
+    l1, l2 = 200, 312
+    total_len = l1 + l2
+    compress_ratio = 128
+    cfg_dot = self._get_test_config(
+        max_target_length=total_len,
+    )
+    attn_dot = self._create_compressed_attention_layer(
+        cfg_dot, compress_ratio=compress_ratio, attention_kernel="dot_product"
+    )
+
+    cfg_flash = self._get_test_config(
+        max_target_length=total_len,
+    )
+    attn_flash = self._create_compressed_attention_layer(
+        cfg_flash, compress_ratio=compress_ratio, attention_kernel="flash"
+    )
+
+    batch_size = cfg_dot.global_batch_size_to_train_on
+
+    # Generate random inputs and packed metadata
+    x = jax.random.normal(jax.random.PRNGKey(42), (batch_size, total_len, cfg_dot.base_emb_dim))
+    pos = jnp.broadcast_to(
+        jnp.concatenate([jnp.arange(l1, dtype=jnp.int32), jnp.arange(l2, dtype=jnp.int32)], axis=0)[None, :],
+        (batch_size, total_len),
+    )
+    seg = jnp.broadcast_to(
+        jnp.concatenate([jnp.ones(l1, dtype=jnp.int32), jnp.full(l2, 2, dtype=jnp.int32)], axis=0)[None, :],
+        (batch_size, total_len),
+    )
+
+    out_dot, _ = attn_dot(
+        x,
+        x,
+        decoder_segment_ids=seg,
+        inputs_positions=pos,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    out_flash, _ = attn_flash(
+        x,
+        x,
+        decoder_segment_ids=seg,
+        inputs_positions=pos,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+
+    np.testing.assert_allclose(
+        np.array(out_flash),
+        np.array(out_dot),
+        rtol=1e-2,
+        atol=1e-2,
+        err_msg="Static flash attention does not match dot_product on packed sequence crossing compression window.",
+    )
+
+  def _get_test_config(self, max_target_length):
     """Initializes and returns a MaxTextConfig for document packing tests."""
     config_arguments = {
         "per_device_batch_size": 1.0,
@@ -5450,8 +6027,6 @@ class CompressedAttentionTest(parameterized.TestCase):
 
     cfg = self._get_test_config(
         max_target_length=total_len,
-        compress_ratio=compress_ratio,
-        attention_kernel=attention_kernel,
     )
     attn = self._create_compressed_attention_layer(cfg, compress_ratio=compress_ratio, attention_kernel=attention_kernel)
     batch_size = cfg.global_batch_size_to_train_on
@@ -5546,8 +6121,9 @@ class CompressedAttentionTest(parameterized.TestCase):
         err_msg="Adversarial corruption in Doc 1 leaked into Doc 2 in packed sequence.",
     )
 
-  def _run_compressed_attention(self, compress_ratio, attention_kernel):
+  def _run_compressed_attention(self, compress_ratio, attention_kernel, seq_len=None):
     """Runs CompressedAttention forward pass with specified compression ratio and kernel."""
+    target_length = seq_len if seq_len is not None else 512
     # Setup test config
     config_arguments = {
         "per_device_batch_size": 1.0,
@@ -5557,8 +6133,8 @@ class CompressedAttentionTest(parameterized.TestCase):
         "ici_data_parallelism": -1,
         "ici_tensor_parallelism": 1,
         "ici_autoregressive_parallelism": 1,
-        "max_target_length": 512,
-        "max_prefill_predict_length": 512,
+        "max_target_length": target_length,
+        "max_prefill_predict_length": target_length,
         "attention_type": AttentionType.COMPRESSED.value,
         "head_dim": 128,
         "q_lora_rank": 256,
@@ -5581,17 +6157,17 @@ class CompressedAttentionTest(parameterized.TestCase):
     mesh = Mesh(devices_array, cfg.mesh_axes)
 
     batch_size = cfg.global_batch_size_to_train_on
-    seq_len = cfg.max_target_length
+    cur_seq_len = cfg.max_target_length
     embed_dim = cfg.base_emb_dim
 
     # Inputs shape: [batch, seq_len, embed_dim]
     lnx = jax.random.normal(
         jax.random.PRNGKey(0),
-        shape=(batch_size, seq_len, embed_dim),
+        shape=(batch_size, cur_seq_len, embed_dim),
         dtype=jnp.float32,
     )
-    decoder_positions = jnp.stack([jnp.arange(seq_len, dtype=jnp.int32) for _ in range(batch_size)])
-    decoder_segment_ids = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
+    decoder_positions = jnp.stack([jnp.arange(cur_seq_len, dtype=jnp.int32) for _ in range(batch_size)])
+    decoder_segment_ids = jnp.ones((batch_size, cur_seq_len), dtype=jnp.int32)
 
     # Instantiate CompressedAttention
     attn = CompressedAttention(
@@ -5623,7 +6199,7 @@ class CompressedAttentionTest(parameterized.TestCase):
         model_mode=MODEL_MODE_TRAIN,
     )
 
-    self.assertEqual(output.shape, (batch_size, seq_len, embed_dim))
+    self.assertEqual(output.shape, (batch_size, cur_seq_len, embed_dim))
     return output
 
 

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -402,6 +402,72 @@ class ConfigTest(absltest.TestCase):
           with self.assertRaisesRegex((ValueError, pydantic.ValidationError), expected_regex):
             pyconfig.initialize(argv)
 
+  def test_compressed_attention_rejects_context_parallelism(self):
+    argv = [
+        "",
+        _BASE_CONFIG_PATH,
+        "run_name=test",
+        "attention=flash",
+        "attention_type=compressed",
+        "compress_ratios=[0, 128]",
+        "use_tokamax_splash=True",
+        "use_jax_splash=False",
+        "ici_context_parallelism=2",
+        "hardware=tpu",
+        "packing=False",
+        "dataset_type=synthetic",
+        "skip_jax_distributed_system=True",
+    ]
+    mock_devices = [unittest.mock.MagicMock(slice_index=0) for _ in range(8)]
+    with unittest.mock.patch("jax.devices", return_value=mock_devices):
+      with self.assertRaisesRegex(ValueError, "Context parallelism .* is not supported with attention_type='compressed'"):
+        pyconfig.initialize(argv)
+
+  def test_compressed_attention_allows_context_parallelism_when_all_ratios_are_zero(self):
+    """A compress_ratio of 0 downgrades the layer to local sliding, so CP stays legal."""
+    argv = [
+        "",
+        _BASE_CONFIG_PATH,
+        "run_name=test",
+        "attention=flash",
+        "attention_type=compressed",
+        "compress_ratios=[0, 0]",
+        "use_tokamax_splash=True",
+        "use_jax_splash=False",
+        "ici_context_parallelism=2",
+        "hardware=tpu",
+        "packing=False",
+        "dataset_type=synthetic",
+        "skip_jax_distributed_system=True",
+    ]
+    mock_devices = [unittest.mock.MagicMock(slice_index=0) for _ in range(8)]
+    with unittest.mock.patch("jax.devices", return_value=mock_devices):
+      config = pyconfig.initialize(argv)
+    self.assertEqual(config.attention_type, "compressed")
+
+  def test_compressed_attention_rejects_unsupported_dq_reduction_steps(self):
+    base_args = [
+        "",
+        _BASE_CONFIG_PATH,
+        "run_name=test",
+        "attention=flash",
+        "attention_type=compressed",
+        "use_tokamax_splash=True",
+        "use_jax_splash=False",
+        "hardware=tpu",
+        "packing=False",
+        "dataset_type=synthetic",
+        "skip_jax_distributed_system=True",
+    ]
+    mock_devices = [unittest.mock.MagicMock(slice_index=0) for _ in range(8)]
+    with unittest.mock.patch("jax.devices", return_value=mock_devices):
+      with self.assertRaisesRegex(ValueError, "requires dq_reduction_steps to be 0 or 3"):
+        pyconfig.initialize(base_args + ["dq_reduction_steps=2"])
+      # 0 (unset) and 3 both remain valid.
+      for valid in ("dq_reduction_steps=0", "dq_reduction_steps=3"):
+        with self.subTest(valid=valid):
+          pyconfig.initialize(base_args + [valid])
+
   def test_tpu_ulysses_config_validation_accepts_initial_config(self):
     argv = [
         "",


### PR DESCRIPTION
# Description
Add static Tokamax Splash Attention compilation for DeepSeek-V4 Heavily Compressed Attention (HCA).

Previously, both Compressed Sparse Attention (CSA, `compress_ratio == 4`) and HCA were dispatched through dynamic Splash Attention (`make_dynamic_splash_mqa`), requiring `DeepseekV4HCACompressor` to materialize dense `(B, 1, S, S_comp)` float mask arrays in HBM and build runtime indexer masks.

Because HCA attention patterns are strictly deterministic (local sliding window + completed preceding compression windows) and do not rely on the indexer (unlike CSA, which requires a top-k step), we can construct the block mask analytically on CPU during AOT tracing. This PR introduces `HCAStaticMask`, bypassing HBM mask allocation and dispatching directly to static Splash MQA kernels (`make_splash_mqa`).

Key changes:
- `HCAStaticMask`: Subclasses `splash_attention_mask.Mask` to evaluate coordinate-based block sparsity on CPU during tracing without runtime HBM mask materialization.
- Compressor bypass: `DeepseekV4HCACompressor` returns `None` for masks when `attention_kernel="flash"`. `generate_attention_mask` is now restricted strictly to CSA.
- MQA kernel dispatch: Routes compressed attention with `num_kv_heads == 1` to `make_splash_mqa`, stripping singleton KV head dimensions for 2D Tokamax input requirements.
- Backward ring buffer: Sets `dq_reduction_steps = 3` for `AttentionType.COMPRESSED` in `create_sa_config` to enable in-SRAM circular ring buffer accumulation for `dQ`. (Without this change, the backward pass is much slower than the dynamic path)
- Arbitrary sequence lengths & packing: Added ceiling division tile padding in `AttentionOp.tpu_flash_attention` for unaligned sequence lengths (e.g. $S=489$) and document packing boundary isolation with segment IDs.
- Validation guards: Added explicit `ValueError` checks blocking Context Parallelism (`cp_size > 1`) and Ulysses/USP when `AttentionType.COMPRESSED` is active, pending future asymmetric communication support.

### Details in b/537346777

# Performance
We conduct microbenchmarks (just on the attention layer) on a v5p TPU for DeepSeek-V4 Flash HCA.
- **Standard Context (S <= 8k)**: Static Flash and Dynamic Flash are on par across all batch sizes, delivering identical step latency while Static Flash avoids allocating dense boolean masks in device memory.
- **Long Context Speedups (S >= 16k)**: Static Flash becomes progressively faster than Dynamic Flash as sequence length increases—delivering a **1.09x** speedup at 16k, **1.20x** at 32k (with a **2.25x** speedup on the forward pass), and **1.48x** at 65k for batch size 1.
- **Memory Footprint**: By compiling mask coordinates analytically at trace-time rather than materializing dynamic boolean mask tensors on device, Static Flash eliminates the O(S^2) mask memory overhead, reducing peak HBM by up to **48%** at 65k. This allows us to scale up to 128k sequence length, where Dynamic Flash fails due to SMEM OOM.
- **Compilation Time Reduction**: When comparing against graph-captured masks, Static Flash drops JIT compilation time from **1.9 minutes to 1.7 seconds (68x reduction)** at 32k and from **7.6 minutes to 1.7 seconds (264x reduction)** at 65k. Under runtime dynamic masking, it eliminates host compiler memory spikes and SMEM lowering failures, compiling in under **5 seconds** across all sequence lengths up to 128k.

# Tests
Tested on Cloud TPU v5p:
```bash
# DeepSeek-V4 unit and reference parity tests
pytest tests/unit/deepseek_v4_vs_reference_test.py -v
# CompressedAttention compilation, numerical equivalence, and packing tests
pytest tests/unit/attention_test.py::CompressedAttentionTest -v
# Static mask bitwise parity, sliding window, and unaligned length tests
pytest tests/unit/attention_test.py::HCAStaticMaskTest -v
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).