### PR TITLE
fix(qwen3-vl): avoid scatter crash on TPU by vectorizing multimodal embedding merge and casting dtype

### DIFF
--- a/src/maxtext/multimodal/utils.py
+++ b/src/maxtext/multimodal/utils.py
@@ -190,27 +190,20 @@ def _merge_mm_embeddings_inner(
 ) -> jnp.ndarray:
   """`merge_mm_embeddings` without batch dimension."""
 
+  multimodal_embeddings = multimodal_embeddings.astype(text_embeddings.dtype)
+
   if token_mask is not None:
     # This logic packs valid multimodal tokens to the front of the array.
     # It correctly handles cases where some multimodal tokens are just padding.
     sort_indices = jnp.argsort(-token_mask)  # Sorts descending, putting 1s first
     multimodal_embeddings = multimodal_embeddings[sort_indices]
 
-  # Find positions in the text sequence to place the multimodal embeddings.
-  # The `size` argument ensures a fixed shape for JIT compilation.
-  target_pos = jnp.nonzero(mask, size=multimodal_embeddings.shape[0])  # pyrefly: ignore[bad-argument-type]
-  target_pos = target_pos[0]  # jnp.nonzero returns a tuple of arrays
-
-  # Save the embedding at the first position.
-  first_pos_embedding = text_embeddings[0]
-
-  # Perform the insertion.
-  merged = text_embeddings.at[target_pos, :].set(multimodal_embeddings)
-
-  # Restore the first position's embedding, in case it was overwritten.
-  merged = merged.at[0].set(first_pos_embedding)
-
-  return merged
+  cumsum_mask = jnp.cumsum(mask != 0)
+  mask_bool = (mask != 0) & (cumsum_mask <= multimodal_embeddings.shape[0])
+  mask_expanded = mask_bool[:, jnp.newaxis]
+  mm_token_idx = jnp.clip(cumsum_mask - 1, 0, multimodal_embeddings.shape[0] - 1)
+  mm_aligned = multimodal_embeddings[mm_token_idx, :]
+  return jnp.where(mask_expanded, mm_aligned, text_embeddings)
 
 
 # Following audio functions derived from the HuggingFace implementation


### PR DESCRIPTION
# Description

Fixes a TPU core halt during SFT training with Qwen3-VL models (`test_qwen3_multimodal_sft.sh`).

### Root Cause
1. In `_merge_mm_embeddings_inner` (`src/maxtext/multimodal/utils.py`), multimodal embeddings (`float32`) were inserted into text hidden states (`bfloat16`) via JAX `.at[target_pos, :].set(multimodal_embeddings)`.
2. Under JAX 0.11.0 with strict type promotion, the backward pass lowered this mixed-type in-place scatter into an XLA `scatter_custom_fusion` on TPU, triggering a fatal `RuntimeUnexpectedCoreHalt` sequencer halt at Step 0.

### Fix
- Cast `multimodal_embeddings` explicitly to `text_embeddings.dtype`.
- Vectorized the insertion using `jnp.where(mask_expanded, mm_aligned, text_embeddings)` with a cumulative sum mask constraint (`cumsum_mask <= multimodal_embeddings.shape[0]`), eliminating the XLA scatter operation.

# Verification
- **Unit Tests**: All 23 unit tests in `multimodal_utils_test.py` pass.
- **End-to-End TPU Verification (`mlperf-v5p` v5p-8)**:
  - Step 1 (JetStream installation): Succeeded.
  - Step 2 (Base checkpoint decode): Succeeded.
  - Step 3 (SFT native training on ChartQA, 2 steps): Completed steps 0 & 1 and successfully saved `checkpoints/1/items`.
  - Step 4 (Trained checkpoint decode): Succeeded loading `checkpoints/1/items` and generated expected predictions.
  - Full run exited with `EXIT_CODE=0`.
