### PR TITLE
fix(checkpointing): raise RuntimeError on fatal checkpointing errors

### DIFF
--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -893,8 +893,8 @@ def maybe_save_checkpoint(checkpoint_manager, state, config, data_iterator, step
     return
 
   def _checkpoint_error_handler(err):
-    """Handles checkpointing errors, when not in an elastic context."""
-    raise exceptions.StopTraining(f"Checkpointing failed. {str(err)}") from err
+    """Handles checkpointing errors."""
+    raise RuntimeError(f"Checkpointing failed. {str(err)}") from err
 
   with checkpoint_exception_guard(config, checkpoint_manager, _checkpoint_error_handler):
     checkpoint_saved = save_checkpoint(

--- a/tests/unit/checkpointing_test.py
+++ b/tests/unit/checkpointing_test.py
@@ -480,5 +480,37 @@ class GrainCheckpointableEquivalenceTest(parameterized.TestCase):
     self.assertEqual(iterators_restore_v1[1].state, 20)
 
 
+class CheckpointErrorHandlerTest(parameterized.TestCase):
+  """Tests for checkpoint error handling in maybe_save_checkpoint."""
+
+  def setUp(self):
+    super().setUp()
+    self.mock_manager = mock.MagicMock()
+    self.mock_manager.latest_step.return_value = None
+    self.mock_manager.reached_preemption.return_value = False
+    self.state = mock.Mock()
+
+  def test_error_handler_raises_runtime_error(self):
+    """Unexpected checkpointing errors should raise RuntimeError with original error chained."""
+    config = mock.Mock()
+    config.checkpoint_period = 1
+    config.pure_nnx = True
+    config.enable_diloco = False
+    config.async_checkpointing = False
+    config.enable_continuous_checkpointing = False
+    config.enable_emergency_checkpoint = False
+    config.enable_multi_tier_checkpointing = False
+    config.local_checkpoint_period = 0
+    config.enable_autocheckpoint = False
+    config.elastic_enabled = False
+
+    original_error = RuntimeError("GCS failure")
+    with mock.patch.object(checkpointing, "save_checkpoint", side_effect=original_error):
+      with self.assertRaises(RuntimeError) as cm:
+        checkpointing.maybe_save_checkpoint(self.mock_manager, self.state, config, data_iterator=None, step=1)
+      self.assertIn("Checkpointing failed. GCS failure", str(cm.exception))
+      self.assertIs(cm.exception.__cause__, original_error)
+
+
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
# Description
When checkpointing encounters an unexpected runtime or I/O failure, `_checkpoint_error_handler` previously converted the exception into `exceptions.StopTraining(...)`.

In `train.py`, all `StopTraining` exceptions are treated as graceful completions (`_job_completed_gracefully = True`), which causes the Python process to exit with status code `0` (success). This silently masks fatal checkpointing failures from upstream orchestration tools (such as Airflow DAGs, SLURM scripts, and CI runners), causing subsequent pipeline stages (like evaluation or decode) to fail cryptically with missing checkpoint errors.

### Fix
- Updated `_checkpoint_error_handler` in `src/maxtext/common/checkpointing.py` to raise `RuntimeError(f"Checkpointing failed. {str(err)}") from err` directly on unexpected errors.
- Elasticity signals (`JaxRuntimeError`, `ScaleUpSignalError`) continue to be bubbled up upstream via `checkpoint_exception_guard`.
- Fatal checkpoint errors now properly cause training to fail loudly with a non-zero exit code and full stack trace attached via `from err`.
- Added unit test coverage in `tests/unit/checkpointing_test.py` to verify `RuntimeError` raising and exception chaining (`__cause__`).

# Tests
- Pre-commit linters and formatters:
  - `codespell`, `pylint`, `pyink`, `mdformat`, `yamllint`, `actionlint` (all passed on diff files)
- Unit test suites:
  - `tests/unit/checkpointing_test.py` (13 tests passed)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
