### PR TITLE
Let splash attention exceed 524,288 tokens when packing is off

### DIFF
--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -1986,11 +1986,12 @@ class AttentionOp(nnx.Module):
         sinks,
         indexer_mask,
     ):
-      # Splash prefetches the segment ids into SMEM, and SMEM is 1 MB per core.
-      # This limits the segmented kernel to approximately 524,288 tokens. When
-      # packing is off there is one segment per example, so the segment ids are
-      # constant and the non-segmented kernel gives the same result. Drop the
-      # ids here, before any early return, so every path benefits.
+      # At 1,048,576 tokens the segmented kernel asks for a 2 MB SMEM prefetch
+      # against 1 MB per core and fails to compile. Which array that is has not
+      # been identified, and the failure has not reproduced on a second mesh.
+      # When packing is off there is one segment per example, so the segment ids
+      # are constant and the non-segmented kernel gives the same result. Drop
+      # the ids here, before any early return, so every path benefits.
       if not self.config.packing:
         decoder_segment_ids_q = None
         decoder_segment_ids_kv = None

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -2056,6 +2056,14 @@ class AttentionOp(nnx.Module):
               to_contiguous=True,
           )
 
+      # Splash prefetches the segment ids into SMEM, and SMEM is 1 MB per core.
+      # This limits the segmented kernel to approximately 524,288 tokens. When
+      # packing is off there is one segment per example, so the segment ids are
+      # constant and the non-segmented kernel gives the same result. Drop the
+      # ids in that case to remove the limit.
+      if not self.config.packing:
+        decoder_segment_ids_q = None
+
       if decoder_segment_ids_q is not None:
         if cp_size > 1 and load_balanced_context_parallel:
           decoder_segment_ids_tuple = splash_attention_kernel.SegmentIds(

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -1986,6 +1986,15 @@ class AttentionOp(nnx.Module):
         sinks,
         indexer_mask,
     ):
+      # Splash prefetches the segment ids into SMEM, and SMEM is 1 MB per core.
+      # This limits the segmented kernel to approximately 524,288 tokens. When
+      # packing is off there is one segment per example, so the segment ids are
+      # constant and the non-segmented kernel gives the same result. Drop the
+      # ids here, before any early return, so every path benefits.
+      if not self.config.packing:
+        decoder_segment_ids_q = None
+        decoder_segment_ids_kv = None
+
       if use_tokamax_ring:
         attention_output = tokamax_ring_attention.call_ring_attention(
             query,
@@ -2055,14 +2064,6 @@ class AttentionOp(nnx.Module):
               seq_dim=2,
               to_contiguous=True,
           )
-
-      # Splash prefetches the segment ids into SMEM, and SMEM is 1 MB per core.
-      # This limits the segmented kernel to approximately 524,288 tokens. When
-      # packing is off there is one segment per example, so the segment ids are
-      # constant and the non-segmented kernel gives the same result. Drop the
-      # ids in that case to remove the limit.
-      if not self.config.packing:
-        decoder_segment_ids_q = None
 
       if decoder_segment_ids_q is not None:
         if cp_size > 1 and load_balanced_context_parallel:


### PR DESCRIPTION
At `max_target_length=1048576` the segmented splash kernel fails to compile:

```
RESOURCE_EXHAUSTED: Allocation (size=2097152) would exceed memory (size=1048576)
:: #allocation3 [shape = 'u8[2097152]{0}', space=smem, size = 0x200000, scoped,
   tag = 'prefetched SMEM operand 0'] :: splash_mha_fwd_segmented_residuals.3
```

**I can't say which array that is.** `make_splash_mha` uses `num_scalar_prefetch = 3` and passes `fwd_mask_info.data_next`, `block_mask` and `mask_next` as the first three operands, so operand 0 is `data_next`. But 2,097,152 has several readings: `data_next` as `int16[1, 1024, 1024]` at block 1024, or a two-byte segment-id array at 1M tokens. I've stopped deriving it from the number.

Setting the segment ids to `None` when `packing` is off clears the failure. It's also correct on its own terms: with packing off there's one segment per example, the ids are constant, and that's what the non-segmented kernel assumes.

Four later runs on 64 v5p chips at 1M cross segment ids against splash block size. All four train, so I can't reproduce the failure above on that machine:

| segment ids | splash block | tokens/s/chip |
|---|---|---|
| dropped | 1024 | 513 |
| present | 1024 | 512 |
| dropped | 512 | 423 |
| present | 512 | 412 |

Treat the allocation dump as the report and the mechanism as open. Block 1024 is worth 21% at 1M.

## Effect

Measured on a v5p with a Qwen 3.5 hybrid model and context parallelism:

| Sequence | Before | After |
|---|---|---|
| 524,288 | compiles | compiles |
| 1,048,576 | kernel doesn't compile | trains end to end |

**The two halves of the 1M row are different machines.** "Before" is 16 chips at `ctx=16`, "after" is 64 chips at `ctx=64`, so per-device sequence went 65,536 to 16,384. SMEM scales with per-device sequence, so the shorter shard may be what cleared the allocation rather than the segment-id change. That confound is why this PR is a draft.

Set the splash block sizes to 1024 above 524,288 tokens.

## Scope

The change sets `decoder_segment_ids_q` and `decoder_segment_ids_kv` to `None` at the top of `wrap_flash_attention`, before the `use_tokamax_ring`, `use_ulysses` and `use_usp` returns, so every path gets it. It applies only when `packing` is false. Packed runs keep the segmented kernel and are unaffected.

## Tests

No unit test covers this path. I didn't add one, because the test needs a TPU and a sequence long enough to fill SMEM. Let me know where such a test should live and I'll write it.

cc @mmcsa


