### PR TITLE
Fix duplicate XLA compilation of jit(train_step)

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -959,7 +959,10 @@ def train_loop(config, recorder, state=None):
       params_shardings,
   )
 
-  with jax.set_mesh(mesh), mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
+  # Do not enter the legacy `mesh` context manager here: the training loop calls
+  # p_train_step without it, and the mismatch in jit's tracing-cache key would
+  # cause train_step to be traced and compiled a second time on the first step.
+  with jax.set_mesh(mesh), nn_partitioning.axis_rules(config.logical_axis_rules):
     data_sharding = sharding.get_input_data_sharding(config, mesh)
     shaped_batch = maxtext_utils.get_shaped_batch(config, batch_sharding=data_sharding)
     if config.shard_optimizer_over_data and isinstance(model, nn.Module):
@@ -973,7 +976,12 @@ def train_loop(config, recorder, state=None):
     else:
       lower_args = (state, shaped_batch)
     maxtext_utils.maybe_dump_jaxpr(config, p_train_step, lower_args)
-    if config.compiled_trainstep_file == "":  # compile only when there is no pre-compiled file loaded
+    if config.compiled_trainstep_file == "" and not jax.config.jax_enable_pgle:
+      # Compile only when there is no pre-compiled file loaded. With AutoPGLE, an
+      # ahead-of-time compiled executable can never be reused by the dispatch path
+      # (the active PGLE profiler is part of JAX's executable cache key), so this
+      # compile would only add a third full compilation on top of the profiling
+      # compile and the FDO recompile; skip it and its memory stats.
       compiler_options = max_utils.parse_libtpu_flags_to_dict(config.compile_xla_flags)
       compiled = p_train_step.lower(*lower_args).compile(compiler_options=compiler_options)
       compiled_stats = compiled.memory_analysis()

--- a/tests/unit/compile_cache_test.py
+++ b/tests/unit/compile_cache_test.py
@@ -80,6 +80,7 @@ def test_train_step_cache_hit():
     env["JAX_PLATFORMS"] = "cpu"
     env["JAX_ENABLE_COMPILATION_CACHE"] = "true"
     env["JAX_COMPILATION_CACHE_DIR"] = temp_dir
+    env["JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS"] = "0.0"
     env["JAX_LOG_COMPILES"] = "1"
 
     print("Running CPU training subprocess:", " ".join(cmd))
@@ -112,6 +113,16 @@ def test_train_step_cache_hit():
         "This indicates a cache miss where AOT compilation and runtime execution generated different keys, "
         "causing train_step to be compiled twice (double-compilation regression)."
     )
+
+    print("Running second CPU training subprocess:", " ".join(cmd))
+    result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=True)
+
+    captured_logs = result.stderr
+
+    # Print captured logs for debugging (will be shown by pytest if assert fails)
+    print("=== Captured Subprocess Stderr ===")
+    print(captured_logs)
+    print("===================================")
 
     assert "Persistent compilation cache hit for 'jit_train_step'" in captured_logs, (
         "Did not find 'Persistent compilation cache hit for 'jit_train_step'' in logs. "


### PR DESCRIPTION
# Description

The AoT compilation used to extract memory stats previously caused a redundant compilation due to mismatched context managers. Skip the memory stats entirely when AutoPGLE is enabled as there is no nice way of getting the statistics up-front without causing redundant compilation.

# Tests

With https://docs.jax.dev/en/latest/config_options.html#jax_log_compiles this can be seen to reduce the number of training step compilations from 2 to 1 without AutoPGLE, or from 3 to 2 with AutoPGLE.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
