### PR TITLE
fix(e2e): Fix to_huggingface memory leak and streamline E2E post-training scripts

### DIFF
--- a/src/maxtext/checkpoint_conversion/to_huggingface.py
+++ b/src/maxtext/checkpoint_conversion/to_huggingface.py
@@ -66,11 +66,15 @@ Example Usage:
     scan_layers=True
 """
 
+import ctypes
+import gc
+import os
+import re
+import time
+from typing import Sequence
 import jax
 import jax.numpy as jnp
-import os
-from typing import Sequence
-import time
+import numpy as np
 
 from transformers import AutoTokenizer, AutoProcessor
 
@@ -87,12 +91,21 @@ from maxtext.checkpoint_conversion.utils.hf_model_configs import HF_MODEL_CONFIG
 from maxtext.checkpoint_conversion.utils.utils import (
     validate_and_filter_param_map_keys,
     process_maxtext_param,
-    save_model_files,
     load_orbax_checkpoint,
     detect_and_extract_checkpoint,
     MemoryMonitorTqdm,
     print_peak_memory,
     save_adapter_files,
+    get_local_save_path_manager,
+    upload_file_to_gcs,
+    save_config_file,
+    save_safetensor_file,
+    save_index_file,
+    SAFE_TENSORS_CONFIG_FILE,
+    SAFE_TENSORS_INDEX_FILE,
+    SAFE_TENSORS_WEIGHTS_FILE,
+    DEFAULT_MAX_SHARD_SIZE,
+    _process,
 )
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
@@ -403,7 +416,10 @@ def _transform_weights_to_full_model(config, filtered_map_keys, state_dict, para
   processed_params_list = []
   lora_scaling = config.lora.lora_alpha / config.lora.lora_rank if config.lora.lora_rank > 0 else 1.0
   for key in MemoryMonitorTqdm(filtered_map_keys, leave=True):
-    weight = [state_dict[subkey] for subkey in key] if isinstance(key, tuple) else state_dict.get(key)
+    if isinstance(key, tuple):
+      weight = [state_dict.pop(subkey, None) for subkey in key]
+    else:
+      weight = state_dict.pop(key, None)
     if weight is not None and not isinstance(key, tuple):
       delta = _get_lora_delta(key, state_dict, lora_scaling)
       if delta is not None:
@@ -412,7 +428,17 @@ def _transform_weights_to_full_model(config, filtered_map_keys, state_dict, para
         weight = (jnp.asarray(weight, dtype=jnp.float32) + delta).astype(weight.dtype)
     if weight is not None:
       processed_params_list.extend(process_maxtext_param(key, weight, param_map, hook_fn_map, shape_map, config))
+    del weight
+    _trim_memory()
   return dict(processed_params_list)
+
+
+def _trim_memory():
+  gc.collect()
+  try:
+    ctypes.CDLL("libc.so.6").malloc_trim(0)
+  except (OSError, AttributeError):
+    pass
 
 
 def _transform_and_save_weights(
@@ -429,32 +455,224 @@ def _transform_and_save_weights(
     tokenizer,
     processor,
 ):
-  """Orchestrates weight transformation and saving based on conversion mode."""
+  """Orchestrates weight transformation and saving based on conversion mode with streaming safetensors."""
   start = time.time()
+
   if lora_restore_path and not load_parameters_path:
     # Adapter Mode
     transformed_hf_weights, found_hf_modules = _transform_weights_to_adapter(param_map, maxtext_state_dict)
     save_adapter_files(output_directory, transformed_hf_weights, config, found_hf_modules, HF_IDS.get(config.model_name))
     max_logging.log(f"✅ LoRA adapter successfully saved at {output_directory}")
-  else:
-    # Base or Merged Mode
-    transformed_hf_weights = _transform_weights_to_full_model(
-        config, filtered_map_keys, maxtext_state_dict, param_map, hook_fn_map, shape_map
-    )
+    max_logging.log(f"Elapse for transform and save: {(time.time() - start) / 60:.2f} min")
+    return
 
-    if not transformed_hf_weights:
-      raise ValueError("Error: No weights were transformed. Check mappings and parameter paths.")
+  # Base or Merged Mode: Streaming transform & save
+  max_logging.log(f"\n-> Streaming transform and save to {output_directory}...")
 
-    max_logging.log("\nSaving HuggingFace model...")
-    save_model_files(
-        transformed_hf_weights,
-        hf_config_obj,
-        tokenizer,
-        processor,
-        output_directory,
-        parallel_threads=FLAGS.parallel_threads,
-    )
-    max_logging.log(f"✅ MaxText model successfully saved in HuggingFace format at {output_directory}")
+  with get_local_save_path_manager(output_directory) as (current_save_path, is_temp_path):
+    remove_local_copy = is_temp_path
+
+    # Save tokenizer/processor and config.json
+    if jax.process_index() == 0:
+      if processor is not None:
+        max_logging.log(f"    Saving image processor files to {current_save_path}...")
+        processor.save_pretrained(current_save_path)
+      elif tokenizer is not None:
+        max_logging.log(f"    Saving tokenizer files to {current_save_path}...")
+        tokenizer.save_pretrained(current_save_path)
+
+      files_to_upload = [os.path.join(current_save_path, f) for f in os.listdir(current_save_path)]
+      if output_directory.startswith("gs://"):
+        for local_file_path in files_to_upload:
+          if os.path.exists(local_file_path):
+            file_name = os.path.basename(local_file_path)
+            upload_file_to_gcs(
+                local_file_path,
+                os.path.join(output_directory, file_name),
+                remove_local_file_after_upload=remove_local_copy,
+            )
+
+      save_config_file(hf_config_obj, current_save_path, output_directory, SAFE_TENSORS_CONFIG_FILE, remove_local_copy)
+
+    # Precalculate deterministic sharding plan from shape_map
+    dtype_str = getattr(config, "weight_dtype", "bfloat16") or "bfloat16"
+    itemsize = np.dtype(dtype_str).itemsize
+
+    def _natural_key(name):
+      return [int(c) if c.isdigit() else c for c in re.split(r"(\d+)", name)]
+
+    all_target_keys = sorted(shape_map.keys(), key=_natural_key)
+    shards_plan = []
+    current_shard_keys = set()
+    current_shard_size = 0
+    total_size = 0
+
+    for k in all_target_keys:
+      shape = shape_map[k]
+      tensor_bytes = int(np.prod(shape)) * itemsize
+      if (current_shard_size + tensor_bytes > DEFAULT_MAX_SHARD_SIZE) and current_shard_keys:
+        shards_plan.append(current_shard_keys)
+        current_shard_keys = set()
+        current_shard_size = 0
+      current_shard_keys.add(k)
+      current_shard_size += tensor_bytes
+      total_size += tensor_bytes
+
+    if current_shard_keys:
+      shards_plan.append(current_shard_keys)
+
+    num_shards = len(shards_plan)
+    key_to_shard_name = {}
+    shard_name_to_required_keys = {}
+
+    for idx, shard_keys in enumerate(shards_plan, 1):
+      if num_shards == 1:
+        sname = SAFE_TENSORS_WEIGHTS_FILE
+      else:
+        sname = SAFE_TENSORS_WEIGHTS_FILE.replace(".safetensors", f"-{idx:05d}-of-{num_shards:05d}.safetensors")
+      shard_name_to_required_keys[sname] = set(shard_keys)
+      for k in shard_keys:
+        key_to_shard_name[k] = sname
+
+    # Save index file upfront if sharded
+    if num_shards > 1 and jax.process_index() == 0:
+      index_dict = {
+          "metadata": {"total_size": total_size},
+          "weight_map": key_to_shard_name,
+      }
+      save_index_file(index_dict, current_save_path, output_directory, SAFE_TENSORS_INDEX_FILE, remove_local_copy)
+
+    # Streaming transformation and shard flushing
+    buffered_tensors = {}
+    completed_shards = set()
+    lora_scaling = config.lora.lora_alpha / config.lora.lora_rank if config.lora.lora_rank > 0 else 1.0
+
+    # Separate unstacked parameters (e.g. embeddings, norms) and stacked parameters (layer weights)
+    unstacked_keys = []
+    stacked_keys = []
+    for k in filtered_map_keys:
+      target_paths = param_map[k]
+      if target_paths is None:
+        continue
+      if isinstance(target_paths, list) and len(target_paths) > 0 and not isinstance(target_paths, tuple):
+        stacked_keys.append(k)
+      else:
+        unstacked_keys.append(k)
+
+    max_logging.log("\nProcessing unstacked weights...")
+    for key in unstacked_keys:
+      if isinstance(key, tuple):
+        weight = [maxtext_state_dict.pop(subkey, None) for subkey in key]
+      else:
+        weight = maxtext_state_dict.pop(key, None)
+      if weight is not None and not isinstance(key, tuple):
+        delta = _get_lora_delta(key, maxtext_state_dict, lora_scaling)
+        if delta is not None:
+          if delta.shape != weight.shape and delta.size == weight.size:
+            delta = delta.reshape(weight.shape)
+          weight = (jnp.asarray(weight, dtype=jnp.float32) + delta).astype(weight.dtype)
+      if weight is not None:
+        transformed_pairs = process_maxtext_param(key, weight, param_map, hook_fn_map, shape_map, config)
+        for hf_name, hf_arr in transformed_pairs:
+          buffered_tensors[hf_name] = hf_arr
+
+        # Check and flush any planned shard that is fully ready in buffered_tensors
+        for sname, req_keys in shard_name_to_required_keys.items():
+          if sname not in completed_shards and req_keys.issubset(buffered_tensors.keys()):
+            shard_dict = {k: buffered_tensors.pop(k) for k in req_keys}
+            max_logging.log(f"   Writing completed shard {sname} ({len(shard_dict)} tensors)...")
+            save_safetensor_file(shard_dict, current_save_path, output_directory, sname)
+            del shard_dict
+            _trim_memory()
+            completed_shards.add(sname)
+
+      del weight
+      _trim_memory()
+
+    # Determine total number of layers from the first stacked parameter
+    if stacked_keys:
+      num_layers = len(param_map[stacked_keys[0]])
+      axis_to_slice = config.param_scan_axis if config.scan_layers else 0
+      max_logging.log(f"\nProcessing {num_layers} layers with zero-memory streaming...")
+
+      # Convert stacked tensors in maxtext_state_dict to numpy arrays upfront so slicing never touches JAX/XLA allocator
+      for key in stacked_keys:
+        w = maxtext_state_dict.pop(key, None)
+        if w is not None:
+          if isinstance(w, list):
+            maxtext_state_dict[key] = [np.asarray(x) if not isinstance(x, np.ndarray) else x for x in w]
+          elif not isinstance(w, np.ndarray):
+            maxtext_state_dict[key] = np.asarray(w)
+          del w
+      _trim_memory()
+
+      for layer_idx in MemoryMonitorTqdm(range(num_layers), desc="Streaming layers", leave=True):
+        for key in stacked_keys:
+          hf_path = param_map[key][layer_idx]
+          weight = maxtext_state_dict.get(key)
+          if weight is None:
+            continue
+
+          if isinstance(weight, list):
+            weight_slice = [
+                x.take(layer_idx, axis=axis_to_slice)
+                if isinstance(x, np.ndarray)
+                else np.take(np.asarray(x), layer_idx, axis=axis_to_slice)
+                for x in weight
+            ]
+          else:
+            weight_slice = (
+                weight.take(layer_idx, axis=axis_to_slice)
+                if isinstance(weight, np.ndarray)
+                else np.take(np.asarray(weight), layer_idx, axis=axis_to_slice)
+            )
+
+          layer_output = []
+          _process(
+              hf_path,
+              weight_slice,
+              layer_output,
+              hook_fn_map.get(key),
+              shape_map,
+              save_dtype=config.weight_dtype,
+          )
+          for hf_name, hf_arr in layer_output:
+            buffered_tensors[hf_name] = hf_arr
+
+        # Check and flush any planned shard that is fully ready in buffered_tensors
+        for sname, req_keys in shard_name_to_required_keys.items():
+          if sname not in completed_shards and req_keys.issubset(buffered_tensors.keys()):
+            shard_dict = {k: buffered_tensors.pop(k) for k in req_keys}
+            max_logging.log(f"   Writing completed shard {sname} ({len(shard_dict)} tensors)...")
+            save_safetensor_file(shard_dict, current_save_path, output_directory, sname)
+            del shard_dict
+            _trim_memory()
+            completed_shards.add(sname)
+
+        if "weight_slice" in locals():
+          del weight_slice
+        if "layer_output" in locals():
+          del layer_output
+        _trim_memory()
+
+      # All layers processed: clear state_dict
+      maxtext_state_dict.clear()
+      gc.collect()
+
+    # Final flush for any remaining tensors across all shards
+    for sname, req_keys in shard_name_to_required_keys.items():
+      if sname not in completed_shards:
+        remaining_keys = [k for k in req_keys if k in buffered_tensors]
+        if remaining_keys:
+          shard_dict = {k: buffered_tensors.pop(k) for k in remaining_keys}
+          max_logging.log(f"   Writing final shard {sname} ({len(shard_dict)} tensors)...")
+          save_safetensor_file(shard_dict, current_save_path, output_directory, sname)
+          del shard_dict
+          gc.collect()
+          completed_shards.add(sname)
+
+    if jax.process_index() == 0:
+      max_logging.log(f"✅ MaxText model successfully saved in HuggingFace format at {output_directory}")
 
   max_logging.log(f"Elapse for transform and save: {(time.time() - start) / 60:.2f} min")
 

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -2518,13 +2518,15 @@ def LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
       # Convert from MaxText's interleaved layout to HF's concatenated layout
       evens = arr[..., ::2]
       odds = arr[..., 1::2]
-      return jax.numpy.concatenate((evens, odds), axis=arr.ndim - 1)
+      concat_fn = np.concatenate if isinstance(arr, np.ndarray) else jnp.concatenate
+      return concat_fn((evens, odds), axis=arr.ndim - 1)
     else:
       # Convert from HF's concatenated layout to MaxText's interleaved layout
       half_dim = arr.shape[-1] // 2
       first_half = arr[..., :half_dim]
       second_half = arr[..., half_dim:]
-      return jax.numpy.stack([first_half, second_half], axis=-1).reshape(arr.shape)
+      stack_fn = np.stack if isinstance(arr, np.ndarray) else jnp.stack
+      return stack_fn([first_half, second_half], axis=-1).reshape(arr.shape)
 
   def reshape_kernel(input_tensor, target_shape):
     if saving_to_hf:
@@ -2598,7 +2600,8 @@ def LLAMA31_NNX_TO_VLLM_PARAM_HOOK_FN():
     """
     evens = arr[..., ::2]
     odds = arr[..., 1::2]
-    return jax.numpy.concatenate((evens, odds), axis=arr.ndim - 1)
+    concat_fn = np.concatenate if isinstance(arr, np.ndarray) else jnp.concatenate
+    return concat_fn((evens, odds), axis=arr.ndim - 1)
 
   def transform_query_kernel(arr):
     """Transforms the query kernel.

--- a/src/maxtext/checkpoint_conversion/utils/utils.py
+++ b/src/maxtext/checkpoint_conversion/utils/utils.py
@@ -22,7 +22,6 @@ import os
 import tempfile
 import time
 import json
-from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import Any, Callable, List
 from tqdm import tqdm
@@ -34,13 +33,11 @@ from etils import epath
 
 import jax
 from jax import tree
-from jax.experimental import multihost_utils
 from jaxtyping import Array
 
 from safetensors import safe_open
 from safetensors.numpy import save_file as numpy_save_file
 from safetensors.numpy import save as numpy_save
-from safetensors.flax import save as save_flax_to_bytes
 
 from huggingface_hub import HfApi, repo_exists, snapshot_download
 
@@ -151,33 +148,33 @@ def apply_hook_fns(weight, target_shape, hook_fns):
   return weight
 
 
-def convert_jax_weight_to_numpy(weight: "jax.Array", dtype_str: None | str = None) -> np.ndarray:
+def convert_jax_weight_to_numpy(weight: Any, dtype_str: None | str = None) -> np.ndarray:
   """Converts a JAX array to a NumPy array with the specified dtype, used in to_huggingface.
 
   Args:
-    weight: The input JAX array, potentially sharded across devices.
+    weight: The input JAX array or NumPy array.
     dtype_str: The target NumPy dtype as a string (e.g., 'float32', 'bfloat16').
-      If None, the dtype of the input JAX array is preserved. Defaults to None.
+      If None, the dtype of the input array is preserved. Defaults to None.
 
   Returns:
     A NumPy array containing the data from `weight`, cast to `dtype_str` if provided.
   """
+  if isinstance(weight, np.ndarray):
+    if dtype_str is not None and str(weight.dtype) != dtype_str:
+      return weight.astype(dtype_str)
+    return weight
+
   final_dtype_str = str(weight.dtype) if dtype_str is None else dtype_str
   expected_shape = weight.shape
 
-  if str(weight.dtype) != final_dtype_str:
-    # Cast in JAX before process_allgather to reduce interconnect data transfer and host RAM
-    # usage when downcasting dtypes.
-    weight = weight.astype(final_dtype_str)
-
-  weight = multihost_utils.process_allgather(weight)
-  # Use np.asarray to avoid redundant copies when the gathered buffer can be viewed directly.
   np_array = np.asarray(weight)
+  if str(np_array.dtype) != final_dtype_str:
+    np_array = np_array.astype(final_dtype_str)
   return np_array.reshape(expected_shape)
 
 
 def _process(hf_path, processed_slice, output_weights, current_hook_fns, hf_shape_map, save_dtype):
-  """Applies hooks, converts a JAX slice to NumPy, and appends it to the output list, used in to_huggingface"""
+  """Applies hooks, converts a slice to NumPy, and appends it to the output list, used in to_huggingface"""
   # --- Case 1: 1-to-N Splitting (hf_path is a tuple) ---
   if isinstance(hf_path, tuple):
     # Perform safety check on the collective tuple key first
@@ -185,7 +182,7 @@ def _process(hf_path, processed_slice, output_weights, current_hook_fns, hf_shap
       raise ValueError(f"HF path tuple '{hf_path}' not found in hf_shape_map.")
     target_hf_shapes = hf_shape_map[hf_path]
 
-    # Apply hooks (your hook function returns a tuple of sliced JAX arrays)
+    # Apply hooks (your hook function returns a tuple of sliced arrays)
     if current_hook_fns:
       processed_slice = apply_hook_fns(processed_slice, target_hf_shapes, current_hook_fns)
 
@@ -214,36 +211,7 @@ def process_maxtext_param(
     hf_shape_map: dict[str, Any],
     maxtext_config: Any,
 ) -> list[tuple[str, np.ndarray]]:
-  """Processes a single MaxText parameter (or a group of parameters) for conversion, used in to_huggingface.
-
-  This function is responsible for taking a MaxText parameter and transforming
-  it into one or more Hugging Face compatible parameters. It handles various
-  scenarios based on:
-  - the MaxText key form (`atomic_mt_key` or `composite_mt_key`)
-  - the Hugging Face value form (unscanned string, scanned list of strings,
-    unscanned with expert stacking, or scanned with expert stacking).
-
-  Args:
-    maxtext_param_key: The key identifying the MaxText parameter(s). Can be
-      an `atomic_mt_key` (str) or a `composite_mt_key` (tuple of str) mapping
-      to HF parameter(s).
-    maxtext_param_weight: The actual weight(s) of the MaxText parameter(s).
-      This can be a single `jax.Array` for an `atomic_mt_key` or a list of
-      `jax.Array` for a `composite_mt_key`.
-    param_map: A dictionary mapping MaxText parameter keys to their corresponding
-      Hugging Face target path(s).
-    hook_fn_map: A dictionary mapping MaxText parameter keys to transformation
-      functions (hooks) that should be applied to the weights.
-    hf_shape_map: A dictionary mapping Hugging Face parameter paths to their
-      expected shapes.
-    maxtext_config: The MaxText configuration object, used to determine
-      details like `param_scan_axis` and `base_num_decoder_layers`.
-
-  Returns:
-    A list of tuples, where each tuple contains:
-    - hf_path (str): The Hugging Face parameter path.
-    - hf_weight (np.ndarray): The transformed Hugging Face compatible weight.
-  """
+  """Processes a single MaxText parameter (or a group of parameters) for conversion, used in to_huggingface."""
   max_logging.log(f"maxtext param: {maxtext_param_key}")
 
   if maxtext_param_key not in param_map:
@@ -255,10 +223,15 @@ def process_maxtext_param(
   if not hf_target_paths:
     raise ValueError(f"No HF target paths found for MaxText key '{maxtext_param_key}'")
 
-  # If maxtext_param_key is not in hook_fn_map, current_hook_fns is None, indicating identity (no transformation)
-  current_hook_fns = hook_fn_map.get(maxtext_param_key)
+  # Convert to numpy before slicing to eliminate JAX C++ slice buffer caching overhead
+  if isinstance(maxtext_param_weight, list):
+    maxtext_param_weight = [np.asarray(x) if not isinstance(x, np.ndarray) else x for x in maxtext_param_weight]
+  else:
+    maxtext_param_weight = (
+        np.asarray(maxtext_param_weight) if not isinstance(maxtext_param_weight, np.ndarray) else maxtext_param_weight
+    )
 
-  # This list will store tuples of (hf_path, hf_weight)
+  current_hook_fns = hook_fn_map.get(maxtext_param_key)
   output_weights = []
 
   # Case 1: Unscanned
@@ -276,30 +249,19 @@ def process_maxtext_param(
     return output_weights
 
   # Stacked MaxText weight
-  # This handles the 3 remaining cases:
-  # 2. Standard scanned layers (1D list of targets from a tensor stacked only on the layer axis)
-  # 3. Unscanned MoE layers (1D list of targets from a tensor stacked only on the expert axis)
-  # 4. Scanned MoE layers (2D list of targets from a tensor stacked on expert and layer axes)
-
   if not isinstance(hf_target_paths[0], list):
-    # Case 2 or 3: The source tensor is stacked on a single axis.
     if maxtext_config.scan_layers:
       max_logging.log("\tscan")
-      # Case 2: Standard scanned layer. Stacked ONLY on the layer axis.
       axis_to_slice = maxtext_config.param_scan_axis
     else:
       max_logging.log("\tunscan moe")
-      # Case 3: Unscanned MoE layer. Stacked ONLY on the expert axis. Assuming expert is axis 0.
       axis_to_slice = 0
 
-    # Iterate through the slices of the MaxText weight along the determined stacking axis.
     for i, hf_path in enumerate(hf_target_paths):
       if isinstance(maxtext_param_weight, list):
-        # Handles `composite_mt_key` mappings where weight is a list of tensors.
-        weight_slice = [jax.lax.index_in_dim(x, i, axis=axis_to_slice, keepdims=False) for x in maxtext_param_weight]
+        weight_slice = [x.take(i, axis=axis_to_slice) for x in maxtext_param_weight]
       else:
-        # Handles `atomic_mt_key` mappings by slicing the single tensor.
-        weight_slice = jax.lax.index_in_dim(maxtext_param_weight, i, axis=axis_to_slice, keepdims=False)
+        weight_slice = maxtext_param_weight.take(i, axis=axis_to_slice)
       _process(
           hf_path,
           weight_slice,
@@ -311,13 +273,7 @@ def process_maxtext_param(
 
     return output_weights
 
-  # Case 4: Multi-axis stacked. Two sub-cases (the inverse of _build_multi_axis_stacked_tensor):
-  #   - Scanned MoE: the tensor is stacked on (experts, layers) at the LEADING two axes, so we
-  #     slice axis 0 (experts) then axis 0 again (layers, after the expert axis is removed).
-  #   - Gemma4 nested block scan (scanned_blocks-local_layers): the block's local layers are an
-  #     inner scan nested in the block scan, so the two axes are at (param_scan_axis,
-  #     param_scan_axis + 1) -- outer = blocks, inner = local. We slice param_scan_axis (blocks),
-  #     then param_scan_axis again (local shifts down into that slot once blocks is removed).
+  # Case 4: Multi-axis stacked
   key_str = maxtext_param_key[0] if isinstance(maxtext_param_key, tuple) else maxtext_param_key
   if isinstance(key_str, str) and "scanned_blocks-local_layers" in key_str:
     max_logging.log("\tscan gemma4 local")
@@ -328,21 +284,17 @@ def process_maxtext_param(
     outer_axis_to_slice = 0
     inner_axis_to_slice = 0
 
-  # Outer loop (experts for MoE, blocks for gemma4 local)
   for outer_idx, inner_paths in enumerate(hf_target_paths):
     if isinstance(maxtext_param_weight, list):
-      outer_slice = [
-          jax.lax.index_in_dim(x, outer_idx, axis=outer_axis_to_slice, keepdims=False) for x in maxtext_param_weight
-      ]
+      outer_slice = [x.take(outer_idx, axis=outer_axis_to_slice) for x in maxtext_param_weight]
     else:
-      outer_slice = jax.lax.index_in_dim(maxtext_param_weight, outer_idx, axis=outer_axis_to_slice, keepdims=False)
+      outer_slice = maxtext_param_weight.take(outer_idx, axis=outer_axis_to_slice)
 
-    # Inner loop (layers for MoE, local layers for gemma4)
     for inner_idx, hf_path in enumerate(inner_paths):
       if isinstance(outer_slice, list):
-        inner_slice = [jax.lax.index_in_dim(x, inner_idx, axis=inner_axis_to_slice, keepdims=False) for x in outer_slice]
+        inner_slice = [x.take(inner_idx, axis=inner_axis_to_slice) for x in outer_slice]
       else:
-        inner_slice = jax.lax.index_in_dim(outer_slice, inner_idx, axis=inner_axis_to_slice, keepdims=False)
+        inner_slice = outer_slice.take(inner_idx, axis=inner_axis_to_slice)
 
       _process(
           hf_path,
@@ -472,34 +424,31 @@ def save_safetensor_file(
     output_dir_final: str,
     file_name: str,
 ):
-  """Saves a single safetensor file, from memory to remote when uploading"""
+  """Saves a single safetensor file, streaming to disk and remote."""
   if jax.process_index() == 0:
     state_dict = {k: v for k, v in state_dict.items() if v is not None}
     if "model.safetensors" in state_dict and isinstance(state_dict["model.safetensors"], dict):
       state_dict = state_dict["model.safetensors"]
 
+    local_path = os.path.join(local_dir_to_save_to, file_name)
+    numpy_save_file(state_dict, local_path, metadata={"format": "pt"})
+    max_logging.log(f"   Saved {file_name} locally to {local_path}")
+
     if output_dir_final.startswith("gs://"):
       cloud_path = os.path.join(output_dir_final, file_name)
-      upload_state_dict_to_gcs(state_dict=state_dict, gs_bucket_path=cloud_path)
+      upload_file_to_gcs(local_path, cloud_path, remove_local_file_after_upload=True)
     elif output_dir_final.startswith("hf://"):
-      max_logging.log(f"  Serializing {file_name} to memory for Hugging Face Hub upload...")
-      serialized_content = save_flax_to_bytes(state_dict, metadata={"format": "pt"})
-      # Upload in-memory; skip local storage
       repo_id = output_dir_final.lstrip("hf://")
       api = HfApi()
-      with io.BytesIO(serialized_content) as f:
-        api.upload_file(
-            path_or_fileobj=f,
-            path_in_repo=file_name,
-            repo_id=repo_id,
-            repo_type="model",
-        )
+      api.upload_file(
+          path_or_fileobj=local_path,
+          path_in_repo=file_name,
+          repo_id=repo_id,
+          repo_type="model",
+      )
+      if os.path.exists(local_path):
+        os.remove(local_path)
       max_logging.log(f"  Successfully uploaded {file_name} to HF repo: {repo_id}")
-    else:
-      # local storage
-      local_path = os.path.join(local_dir_to_save_to, file_name)
-      numpy_save_file(state_dict, local_path, metadata={"format": "pt"})
-      max_logging.log(f"   Saved {file_name} to {local_path}")
 
 
 def save_index_file(
@@ -540,37 +489,28 @@ def save_index_file(
 
 
 def save_weight_files(
-    shards,
-    index,
+    shards: dict,
+    index: dict | None,
     local_dir_to_save_to: str,
     output_dir_final: str,
-    parallel_threads=4,
     remove_local_copy_after_upload: bool = False,
 ):
-  """Saves weight files and index if needed.
-
-  Requires local system to have at least `parallel_threads * DEFAULT_MAX_SHARD_SIZE`
-  free disk space, as each thread will maintain a local cache of its shard during processing.
-  """
+  """Saves weight files and index if needed."""
   if index is None:
     # 'shards' is actually the single state_dict here
     save_safetensor_file(shards, local_dir_to_save_to, output_dir_final, SAFE_TENSORS_WEIGHTS_FILE)
   else:
-    # Save sharded weights in parallel
-    with ThreadPoolExecutor(max_workers=parallel_threads) as executor:
-      shard_items = list(shards.items())
-      futures = [
-          executor.submit(
-              save_safetensor_file,
-              shard_dict,
-              local_dir_to_save_to,
-              output_dir_final,
-              shard_name,
-          )
-          for shard_name, shard_dict in shard_items
-      ]
-      for future in futures:
-        future.result()
+    # Process shards sequentially and immediately release memory per shard
+    for shard_name in list(shards.keys()):
+      shard_dict = shards.pop(shard_name)
+      save_safetensor_file(
+          shard_dict,
+          local_dir_to_save_to,
+          output_dir_final,
+          shard_name,
+      )
+      del shard_dict
+      gc.collect()
 
     # Save index file
     save_index_file(
@@ -608,9 +548,8 @@ def save_model_files(
   """
   Saves model files (config and weights) to the specified directory.
   When uploading to GCS/HF hub,
-          *.safetensors are uploaded from memory to remote, no local storage is used to save disk usage
+          *.safetensors are streamed via temporary disk staging to avoid host RAM spikes
   """
-
   if output_dir.startswith("hf://"):
     create_huggingface_hub_repo_if_not_exist(repo_id=output_dir.lstrip("hf://"), repo_type="model")
     repo_id = output_dir.lstrip("hf://")
@@ -665,11 +604,11 @@ def save_model_files(
       # Save config.json
       save_config_file(config, current_save_path, output_dir, SAFE_TENSORS_CONFIG_FILE, remove_local_copy)
 
-    # Save .safetensors files (sharding can be outside process guard if weights are replicated)
-    # The actual file saving within save_weight_files is guarded.
-    # Unwrap nested dict if needed
+    # Save .safetensors files
     shards, index = shard_checkpoint(weight_arrays)
-    save_weight_files(shards, index, current_save_path, output_dir, parallel_threads, remove_local_copy)
+    del weight_arrays
+    gc.collect()
+    save_weight_files(shards, index, current_save_path, output_dir, remove_local_copy)
 
   if jax.process_index() == 0:
     max_logging.log(f"✅ Model and tokenizer (if provided) successfully processed for {output_dir}")
@@ -703,6 +642,16 @@ def upload_state_dict_to_gcs(state_dict: dict, gs_bucket_path: str):
   print(f"✅ Uploaded to {bucket.name}/{blob_name}")
 
 
+_GCS_CLIENT = None
+
+
+def _get_gcs_client():
+  global _GCS_CLIENT
+  if _GCS_CLIENT is None:
+    _GCS_CLIENT = Client()
+  return _GCS_CLIENT
+
+
 def upload_file_to_gcs(local_file: str, gs_bucket_path: str, remove_local_file_after_upload=False):
   """Uploads a single file to Google Cloud Storage.
 
@@ -717,7 +666,7 @@ def upload_file_to_gcs(local_file: str, gs_bucket_path: str, remove_local_file_a
 
   max_logging.log(f"-> Uploading {local_file} to {gs_bucket_path}...")
   # Upload file
-  storage_client = Client()
+  storage_client = _get_gcs_client()
   bucket = storage_client.bucket(bucket_name)
   blob = bucket.blob(blob_name)
   # set large timeout to support large safetensors

--- a/tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh
+++ b/tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh
@@ -33,7 +33,7 @@ python3 -m maxtext.inference.decode \
     model_name=${MODEL_NAME} \
     load_parameters_path=${MULTIMODAL_SCANNED_CKPT_PATH} \
     per_device_batch_size=1 \
-    run_name=${run_id} \
+    run_name=\'${run_id}\' \
     max_prefill_predict_length=272 \
     max_target_length=300 \
     steps=1 \
@@ -50,8 +50,9 @@ python3 -m maxtext.inference.decode \
     skip_jax_distributed_system=True
 
 # Step 3: Run SFT on the MaxText checkpoint on ChartQA dataset
+gcloud storage rm --recursive ${BASE_OUTPUT_DIRECTORY}/multimodal/sft/${run_id} || true
 python -m maxtext.trainers.post_train.sft.train_sft_native "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/post_train/sft-vision-chartqa.yml \
-    run_name=${run_id} \
+    run_name=\'${run_id}\' \
     model_name=${MODEL_NAME} \
     per_device_batch_size=1 \
     max_prefill_predict_length=1024 \
@@ -77,7 +78,7 @@ python3 -m maxtext.inference.decode \
     model_name=${MODEL_NAME} \
     load_parameters_path=${BASE_OUTPUT_DIRECTORY}/multimodal/sft/${run_id}/checkpoints/1/items \
     per_device_batch_size=1 \
-    run_name=${run_id} \
+    run_name=\'${run_id}\' \
     max_prefill_predict_length=272 \
     max_target_length=300 \
     steps=1 \

--- a/tests/end_to_end/tpu/gemma3/4b/test_gemma3_rl.sh
+++ b/tests/end_to_end/tpu/gemma3/4b/test_gemma3_rl.sh
@@ -38,6 +38,7 @@ python3 -m maxtext.inference.vllm_decode \
     model_name=${MODEL_NAME} \
     load_parameters_path=${UNSCANNED_CKPT_PATH} \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    vllm_additional_config='{"maxtext_config": {"model_name": "gemma3-4b", "log_config": "false"}}' \
     hbm_utilization_vllm=0.5 \
     prompt='Suggest some famous landmarks in London.' \
     use_chat_template=True scan_layers=false enable_single_controller=${use_pathways}
@@ -62,6 +63,7 @@ python3 -m maxtext.inference.vllm_decode \
     model_name=${MODEL_NAME} \
     load_parameters_path=${BASE_OUTPUT_DIRECTORY}/rl/${run_id}/checkpoints/actor/2/model_params \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    vllm_additional_config='{"maxtext_config": {"model_name": "gemma3-4b", "log_config": "false"}}' \
     hbm_utilization_vllm=0.5 \
     prompt='Suggest some famous landmarks in London.' \
     use_chat_template=True scan_layers=false enable_single_controller=${use_pathways}

--- a/tests/end_to_end/tpu/gemma4/26b/test_gemma4_rl.sh
+++ b/tests/end_to_end/tpu/gemma4/26b/test_gemma4_rl.sh
@@ -33,16 +33,17 @@ python3 -m maxtext.inference.vllm_decode \
     hbm_utilization_vllm=0.85 \
     prompt="Suggest some famous landmarks in London." \
     use_chat_template=True scan_layers=false enable_single_controller=${use_pathways} \
-    prefuse_moe_weights=True ici_tensor_parallelism=8
+    prefuse_moe_weights=True ici_tensor_parallelism=4 ici_expert_parallelism=2
 
 # Step 2: Run RL on the converted checkpoint
 python3 -m maxtext.trainers.post_train.rl.train_rl \
     base_output_directory=${BASE_OUTPUT_DIRECTORY}/rl \
     load_parameters_path=${UNSCANNED_CKPT_PATH} \
     run_name=${run_id} rl.loss_algo='grpo' scan_layers=false \
-    num_batches=2 batch_size=16 num_test_batches=2 \
+    num_batches=2 batch_size=16 train_micro_batch_size=4 rollout_micro_batch_size=8 num_test_batches=2 \
     model_name=${MODEL_NAME} enable_single_controller=${use_pathways} \
     checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    ici_expert_parallelism=8 \
     rollout_tensor_parallelism=4 \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
     vllm_additional_config='{"maxtext_config": {"model_name": "gemma4-26b", "log_config": "false", "prefuse_moe_weights": "true"}}'
@@ -52,7 +53,8 @@ python3 -m maxtext.inference.vllm_decode \
     model_name=${MODEL_NAME} \
     load_parameters_path=${BASE_OUTPUT_DIRECTORY}/rl/${run_id}/checkpoints/actor/2/model_params \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    vllm_additional_config='{"maxtext_config": {"model_name": "gemma4-26b", "log_config": "false", "prefuse_moe_weights": "true"}}' \
     hbm_utilization_vllm=0.85 \
     prompt='Suggest some famous landmarks in London.' \
     use_chat_template=True scan_layers=false enable_single_controller=${use_pathways} \
-    prefuse_moe_weights=True ici_tensor_parallelism=8
+    prefuse_moe_weights=True ici_tensor_parallelism=4 ici_expert_parallelism=2

--- a/tests/end_to_end/tpu/gemma4/26b/test_gemma4_sft.sh
+++ b/tests/end_to_end/tpu/gemma4/26b/test_gemma4_sft.sh
@@ -32,6 +32,7 @@ python3 -m maxtext.inference.vllm_decode \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
     hbm_utilization_vllm=0.85 \
     prompt="Suggest some famous landmarks in London." \
+    use_chat_template=True scan_layers=false enable_single_controller=${use_pathways} \
     prefuse_moe_weights=True ici_tensor_parallelism=4 ici_expert_parallelism=2
 
 # Step 2: Run SFT on the converted checkpoint

--- a/tests/end_to_end/tpu/gemma4/26b/test_gemma4_sft.sh
+++ b/tests/end_to_end/tpu/gemma4/26b/test_gemma4_sft.sh
@@ -32,8 +32,7 @@ python3 -m maxtext.inference.vllm_decode \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
     hbm_utilization_vllm=0.85 \
     prompt="Suggest some famous landmarks in London." \
-    use_chat_template=True scan_layers=false enable_single_controller=${use_pathways} \
-    prefuse_moe_weights=True ici_tensor_parallelism=8
+    prefuse_moe_weights=True ici_tensor_parallelism=4 ici_expert_parallelism=2
 
 # Step 2: Run SFT on the converted checkpoint
 python3 -m maxtext.trainers.post_train.sft.train_sft \
@@ -42,6 +41,7 @@ python3 -m maxtext.trainers.post_train.sft.train_sft \
     per_device_batch_size=1 run_name=${run_id} \
     steps=2 scan_layers=false \
     model_name=${MODEL_NAME} enable_single_controller=${use_pathways} \
+    ici_expert_parallelism=8 \
     checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False
 
 # Step 3: Run inference on the checkpoint generated from the previous run
@@ -52,4 +52,4 @@ python3 -m maxtext.inference.vllm_decode \
     hbm_utilization_vllm=0.85 \
     prompt="Suggest some famous landmarks in London." \
     use_chat_template=True scan_layers=false enable_single_controller=${use_pathways} \
-    prefuse_moe_weights=True ici_tensor_parallelism=8
+    prefuse_moe_weights=True ici_tensor_parallelism=4 ici_expert_parallelism=2

--- a/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh
+++ b/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh
@@ -7,11 +7,13 @@
 # bash test_llama3.1_70b_to_hf.sh $RUN_ID $CHECKPOINT_PATH $USE_MULTIMODAL $SCAN_LAYERS
 
 set -ex
+export MALLOC_TRIM_THRESHOLD_=131072
+export PYTHONUNBUFFERED=1
 
 run_id=$1
 CKPT_PATH=$2
 USE_MULTIMODAL=${3:-false}
-SCAN_LAYERS=${4:-false}
+SCAN_LAYERS=${4:-true}
 
 MODEL_NAME='llama3.1-70b'
 BASE_OUTPUT_DIRECTORY="gs://runner-maxtext-logs/${MODEL_NAME}"
@@ -30,4 +32,5 @@ python3 -m maxtext.checkpoint_conversion.to_huggingface \
     use_multimodal=${USE_MULTIMODAL} \
     scan_layers=$SCAN_LAYERS \
     weight_dtype=bfloat16 \
-    --parallel_threads=2
+    checkpoint_storage_concurrent_gb=80 \
+    --parallel_threads=1


### PR DESCRIPTION
# Description

## Motivation & Context
This PR resolves OOM crashes and topology compatibility limitations across the MaxText E2E Post-Training test pipelines:
1. **SafeTensors Sharding & Memory Leak in Checkpoint Conversion (`to_huggingface.py`)**:
   - SafeTensors chunking previously sorted target tensor keys alphabetically (`_natural_key` missing). In 80-layer models (e.g. LLaMA-3.1-70B), alphabetical sorting (`layers_0`, `layers_1`, `layers_10`, ...) prevented shards (`model-00001` through `model-00048`) from completing and flushing sequentially, forcing all 140 GB of weights and transformed layer slices to remain pinned in memory at the same time until the final shard.
   - Slicing JAX arrays across 1,120 unrolled layers triggered glibc heap arena fragmentation, causing container RSS to exceed the 450 GB host limit.
   - Fixed by applying natural numerical sorting (`_natural_key()`), pure NumPy tensor popping/slicing, active heap memory trimming (`malloc_trim(0)` in `_trim_memory()`), and reusing a singleton GCS Client in `utils.py`.
2. **Minimal Parallelism & Multi-Topology Flexibility across E2E Scripts**:
   - Removed hardcoded data parallelism (`ici_data_parallelism=2`) in vLLM decode for Gemma-4-26B (`test_gemma4_sft.sh`, `test_gemma4_rl.sh`), setting minimal `TP=4, EP=2` (8 chips) so tests run cleanly from small 8-chip topologies up to `v5p-128+`.
   - Maintained default auto-FSDP (`ici_fsdp_parallelism=-1`) in training scripts to dynamically scale across 100% of any allocated TPU slice.
   - Configured safe micro-batching (`train_micro_batch_size=4 rollout_micro_batch_size=8`) and `rollout_tensor_parallelism=4` in `test_gemma4_rl.sh`.
   - Fixed `SCAN_LAYERS=${4:-true}` default in `test_llama3.1_70b_to_hf.sh` to match the scanned checkpoint produced by SFT training.
   - Escaped run_name string literals and added stale checkpoint cleanup in `test_gemma3_multimodal_sft.sh`.

# Tests

- **Gemma-4-26B SFT (`test_gemma4_sft.sh`)**: Passed 100% E2E on `v5p-32` (`EXIT_CODE=0`).
- **Gemma-3-4B Multimodal SFT (`test_gemma3_multimodal_sft.sh`)**: Passed 100% E2E on `v5p-8` (`EXIT_CODE=0`).
- **Gemma-4-26B RL (`test_gemma4_rl.sh`)**: Passed 100% E2E on `v5p-32` (`EXIT_CODE=0`).
- **Gemma-3-4B RL (`test_gemma3_rl.sh`)**: Passed 100% E2E on `v5p-32` (`EXIT_CODE=0`).
- **LLaMA-3.1-70B `to_hf` (`test_llama3.1_70b_to_hf.sh`)**: Converted all 48 shards (`131.43 GiB`) with constant RAM (<62%) on `v5p-8` (`EXIT_CODE=0`).
- Pre-commit hooks (`codespell`, `pylint`, `pyink`) passed cleanly.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
