### PR TITLE
Fix OOM in to_huggingface.py for Llama3.1-70B

### DIFF
--- a/src/maxtext/checkpoint_conversion/utils/utils.py
+++ b/src/maxtext/checkpoint_conversion/utils/utils.py
@@ -33,6 +33,7 @@ import pathlib
 from etils import epath
 
 import jax
+import jax.numpy as jnp
 from jax import tree
 from jax.experimental import multihost_utils
 from jaxtyping import Array
@@ -882,7 +883,20 @@ def load_orbax_checkpoint(config) -> dict:
   def create_restore_args(tree_metadata):
     """Create restore args for unsharded restoration."""
     if hasattr(tree_metadata, "shape"):
-      return ocp.ArrayRestoreArgs(sharding=jax.sharding.NamedSharding(single_device_mesh, jax.sharding.PartitionSpec()))
+      restore_dtype = None
+      if hasattr(tree_metadata, "dtype") and tree_metadata.dtype is not None:
+        try:
+          orig_dtype = jnp.dtype(tree_metadata.dtype)
+          if jnp.issubdtype(orig_dtype, jnp.floating) and getattr(config, "weight_dtype", None) is not None:
+            restore_dtype = jnp.dtype(config.weight_dtype)
+          else:
+            restore_dtype = orig_dtype
+        except (TypeError, ValueError):
+          restore_dtype = None
+      return ocp.ArrayRestoreArgs(
+          sharding=jax.sharding.NamedSharding(single_device_mesh, jax.sharding.PartitionSpec()),
+          dtype=restore_dtype,
+      )
     elif isinstance(tree_metadata, dict):
       return {k: create_restore_args(v) for k, v in tree_metadata.items()}
     else:

--- a/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh
+++ b/tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh
@@ -31,4 +31,6 @@ python3 -m maxtext.checkpoint_conversion.to_huggingface \
     scan_layers=$SCAN_LAYERS \
     weight_dtype=bfloat16 \
     checkpoint_storage_use_zarr3=False \
-    checkpoint_storage_use_ocdbt=False
+    checkpoint_storage_use_ocdbt=False \
+    checkpoint_storage_concurrent_gb=48 \
+    skip_jax_distributed_system=true


### PR DESCRIPTION
# Description

This PR fixes an issue where running `to_huggingface.py` on large models (such as Llama3.1-70B) exhausted host CPU memory and triggered the OOM.
                                                                                     
#### Root Causes                                                                                                                                                 

1. Unconstrained Tensor Restoration Dtype:
      • load_orbax_checkpoint constructed ocp.ArrayRestoreArgs without passing dtype.
      • For a 70B parameter model, arrays were restored in float32 by default (~280 GB RAM), exceeding standard host RAM limits.
  2. PRNG Key Array Type Mismatch:
      • Applying weight_dtype (bfloat16) unconditionally to all array leaves in the checkpoint tree caused uint32 PRNG keys (e.g., rngs) to be restored as bfloat16, failing JAX's key wrapping validation: `TypeError: JAX encountered invalid PRNG key data: expected key_data.dtype = uint32; got dtype=bfloat16`.

# Tests

https://cloudlogging.app.goo.gl/5UzJSZX7bo9JA42i6


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
