### PR TITLE
allow grain to read tfds config

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4302,17 +4302,34 @@ class MaxTextConfig(
         raise ValueError("Only supports <= 1 for now, more workers results in duplicated data")
     elif self.dataset_type == DatasetType.GRAIN:
       use_hf_parquet = self.hf_path and self.grain_file_type == "parquet"
+      use_tfds_tfrecord_train = (
+          self.grain_file_type == "tfrecord" and self.dataset_path and self.dataset_name and self.train_split
+      )
+      use_tfds_tfrecord_eval = (
+          self.grain_file_type == "tfrecord" and self.dataset_path and self.eval_dataset_name and self.eval_split
+      )
 
-      if not self.grain_train_files and not self.grain_train_mixture_config_path and not use_hf_parquet:
+      if (
+          not self.grain_train_files
+          and not self.grain_train_mixture_config_path
+          and not use_hf_parquet
+          and not use_tfds_tfrecord_train
+      ):
         raise ValueError(
             "When dataset_type=grain, set grain_train_files, "
-            "grain_train_mixture_config_path, or use hf_path with grain_file_type=parquet."
+            "grain_train_mixture_config_path, use hf_path with grain_file_type=parquet, or use dataset_path, "
+            "dataset_name, and train_split with grain_file_type=tfrecord."
         )
-      if self.eval_interval > 0 and not self.grain_eval_files and not use_hf_parquet:
-        raise ValueError("Please specify grain_eval_files (or hf_path with parquet) or set eval_interval to <=0.")
+      if self.eval_interval > 0 and not self.grain_eval_files and not use_hf_parquet and not use_tfds_tfrecord_eval:
+        raise ValueError(
+            "Please specify grain_eval_files, use hf_path with grain_file_type=parquet, or use dataset_path, "
+            "eval_dataset_name, and eval_split with grain_file_type=tfrecord; otherwise set eval_interval to <=0."
+        )
     elif self.dataset_type == DatasetType.TFDS:
       logger.warning(
-          "tfds pipeline is deprecated. Use dataset_type=grain, grain_file_type=tfrecord, and provide grain_train_files."
+          "tfds pipeline is deprecated. Use dataset_type=grain and grain_file_type=tfrecord. You can keep the same "
+          "dataset_path, dataset_name, train_split, eval_dataset_name, and eval_split settings to automatically construct "
+          "the file paths. Alternatively, provide grain_train_files or grain_eval_files for custom file paths."
       )
       if self.use_dpo:
         raise ValueError(

--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -66,6 +66,14 @@ def construct_hf_dataset_path(hf_path: str, hf_train_files: str | None = None, s
   return full_path
 
 
+def construct_tfds_tfrecord_path(dataset_path: str, dataset_name: str, split: str) -> str:
+  """Constructs a glob for TFRecords in the standard TFDS prepared-data layout."""
+  dataset_dir = dataset_name.strip().strip("/").replace(":", "/")
+  path = f"{dataset_path.strip().rstrip('/')}/{dataset_dir}/*-{split}.tfrecord-*"
+  max_logging.log(f"Automatically constructed Grain TFRecord path from TFDS configuration: {path}")
+  return path
+
+
 def find_data_files(data_file_pattern, hf_access_token=None):
   """Find data files matching the pattern."""
   if data_file_pattern.startswith("gs://"):
@@ -481,8 +489,22 @@ def make_grain_train_iterator(
   pipeline_fn = _get_pipeline_fn(config)
 
   grain_train_files = config.grain_train_files
-  if not grain_train_files and not config.grain_train_mixture_config_path and config.hf_path:
+  if (
+      not grain_train_files
+      and not config.grain_train_mixture_config_path
+      and config.grain_file_type == "parquet"
+      and config.hf_path
+  ):
     grain_train_files = construct_hf_dataset_path(config.hf_path, split="train")
+  elif (
+      not grain_train_files
+      and not config.grain_train_mixture_config_path
+      and config.grain_file_type == "tfrecord"
+      and config.dataset_path
+      and config.dataset_name
+      and config.train_split
+  ):
+    grain_train_files = construct_tfds_tfrecord_path(config.dataset_path, config.dataset_name, config.train_split)
 
   get_ds_fn = functools.partial(
       get_datasets,
@@ -588,9 +610,17 @@ def make_grain_eval_iterator(
   pipeline_fn = _get_pipeline_fn(config)
 
   grain_eval_files = config.grain_eval_files
-  if not grain_eval_files and getattr(config, "hf_path", None):
+  if not grain_eval_files and config.grain_file_type == "parquet" and getattr(config, "hf_path", None):
     split = getattr(config, "hf_eval_split", None) or "validation"
     grain_eval_files = construct_hf_dataset_path(config.hf_path, split=split)
+  elif (
+      not grain_eval_files
+      and config.grain_file_type == "tfrecord"
+      and config.dataset_path
+      and config.eval_dataset_name
+      and config.eval_split
+  ):
+    grain_eval_files = construct_tfds_tfrecord_path(config.dataset_path, config.eval_dataset_name, config.eval_split)
 
   get_ds_fn = functools.partial(
       get_datasets,

--- a/src/maxtext/input_pipeline/tfds_data_processing.py
+++ b/src/maxtext/input_pipeline/tfds_data_processing.py
@@ -24,7 +24,12 @@ try:
   import tensorflow_datasets as tfds
 except ImportError as error:
   raise ImportError(
-      "TensorFlow and tensorflow-datasets are required. Run `pip install tensorflow tensorflow-datasets`"
+      "The deprecated TFDS pipeline requires TensorFlow and tensorflow-datasets.\n\n"
+      "Recommended: migrate to Grain by setting dataset_type=grain and grain_file_type=tfrecord. Existing "
+      "dataset_path, dataset_name, train_split, eval_dataset_name, and eval_split settings will be used to "
+      "automatically construct file paths when grain_train_files or grain_eval_files are not provided. Set the "
+      "grain_train_files or grain_eval_files explicitly for a custom path.\n\n"
+      "To continue using the deprecated TFDS pipeline, run: `pip install tensorflow tensorflow-datasets`."
   ) from error
 
 import jax

--- a/tests/unit/grain_data_processing_test.py
+++ b/tests/unit/grain_data_processing_test.py
@@ -24,6 +24,7 @@ import numpy as np
 
 import jax
 import pytest
+from unittest.mock import patch
 from jax.sharding import Mesh
 from jax.experimental import mesh_utils
 
@@ -33,6 +34,27 @@ from maxtext.input_pipeline import input_pipeline_interface
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.common.gcloud_stub import is_decoupled
 from tests.utils.test_helpers import get_test_base_output_directory, get_test_config_path, get_test_dataset_path
+
+
+class TestTfdsTfrecordPathFallback:
+  """Tests TFrecord path construction without reading a dataset."""
+
+  def test_construct_tfds_tfrecord_path(self):
+    with patch.object(grain_data_processing.max_logging, "log") as log:
+      assert (
+          grain_data_processing.construct_tfds_tfrecord_path("  gs://maxtext-dataset/  ", "c4/en:3.0.1", "train")
+          == "gs://maxtext-dataset/c4/en/3.0.1/*-train.tfrecord-*"
+      )
+      log.assert_called_once_with(
+          "Automatically constructed Grain TFRecord path from TFDS configuration: "
+          "gs://maxtext-dataset/c4/en/3.0.1/*-train.tfrecord-*"
+      )
+
+  def test_missing_derived_path_reports_pattern(self, tmp_path):
+    pattern = str(tmp_path / "c4/en/3.0.1/*-train.tfrecord-*")
+
+    with pytest.raises(FileNotFoundError, match=r"No files found matching pattern: .*\*-train\.tfrecord-\*"):
+      grain_data_processing.find_data_files(pattern)
 
 
 class GrainBaseProcessingTest:
@@ -570,6 +592,16 @@ class GrainTFRecordProcessingTest(_GrainTFRecordSetup, GrainDeterminismMixin, Gr
   @classmethod
   def setUpClass(cls):
     super().setUpClass()
+
+  def test_config_accepts_tfds_tfrecord_fallback(self):
+    config = self._make_config(
+        grain_train_files="",
+        dataset_path="gs://maxtext-dataset",
+        dataset_name="c4/en:3.0.1",
+        train_split="train",
+        eval_interval=0,
+    )
+    self.assertEqual(config.grain_train_files, "")
 
 
 class GrainTFRecordPreTokenizedProcessingTest(_GrainTFRecordSetup, GrainBaseProcessingTest, unittest.TestCase):


### PR DESCRIPTION
# Description

This change makes it easier for existing TFDS users to migrate to the Grain TFRecord pipeline. Previously, flags `dataset_name` and `dataset_path` are only used by the tfds pipeline, while grain uses `grain_train_files`
`grain_eval_files`. For migration, user needs to construct `grain_train_files` for the tfds dataset. After this PR, the file path is auto-constructed.

For example, a user is using:
```
dataset_type: tfds
dataset_path: gs://maxtext-dataset
dataset_name: c4/en:3.0.1
train_split: train
```
To migrate to grain, only these config changes:
```
dataset_type: grain
grain_file_type: tfrecord
# keep dataset_path, dataset_name and train_split the same
```
In addition, this PR adds clear migration instructions to tfds users.


# Tests
* Added unit test
* end to end test works on TPU v5p-8:
```
python3 -m maxtext.trainers.pre_train.train \
  run_name=${RUN_NAME} \
  base_output_directory=${GCS_BUCKET} \
  dataset_path=gs://maxtext-dataset \
  dataset_type=grain \
  grain_file_type=tfrecord \
  grain_worker_count=1 \
  per_device_batch_size=1 \
  num_epoch=1 \
  steps=11 \
``` 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
