### PR TITLE
Fix RL Training pipeline: Restrict scanned weight unrolling to MaxText vLLM syncs

### DIFF
--- a/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
@@ -449,7 +449,8 @@ class MaxTextVllmSampler(VllmSampler):
       scan_axis: int = 1,
       layer_pattern_length: Optional[int] = None,
   ):
-    super().__init__(tokenizer=tokenizer, config=config, converter=converter)
+    super().__init__(tokenizer=tokenizer, config=config)
+    self._converter = converter
     self._direct_maxtext_sync = direct_maxtext_sync
     self._scan_axis = scan_axis
     self._layer_pattern_length = layer_pattern_length
@@ -460,14 +461,14 @@ class MaxTextVllmSampler(VllmSampler):
       filter_types: Optional[Tuple[Any, ...]] = None,
   ):
     """Update the vLLM runner weights from a MaxText state tree."""
-    if self.converter is None:
+    if self._converter is None:
       if self._direct_maxtext_sync:
         updated_weights = unroll_qwen_scanned_weights(
             updated_weights,
             scan_axis=self._scan_axis,
             pattern_length=self._layer_pattern_length,
         )
-      updated_weights = unroll_gemma_scanned_weights(updated_weights)
+        updated_weights = unroll_gemma_scanned_weights(updated_weights)
     try:
       return super().update_params(updated_weights, filter_types)
     except BaseException:
@@ -652,7 +653,7 @@ class MaxTextVllmRollout(vllm_rollout.VllmRollout):
 
   def _sync_path_name(self) -> str:
     """Which of the three sync implementations this rollout actually uses."""
-    converter = getattr(self._sampler, "converter", None)
+    converter = getattr(self._sampler, "converter", getattr(self._sampler, "_converter", None))
     if converter is not None:
       return type(converter).__name__
     if getattr(self._sampler, "to_hf_key_mappings", None):


### PR DESCRIPTION
## Description

This PR resolves a silent but fatal TrainState corruption that crashes the RL post-training pipeline.             
When the vLLM rollout sampler attempts to synchronize the JAX TrainState into the vLLM engine for sequence generation, Tunix crashes during the parameter transfer because the PyTree structure has been incorrectly stripped away.
  
## Root Cause

1. **Unconditional Unrolling Error:** In PR #4524 , the `unroll_gemma_scanned_weights` operation was made unconditional. Applying this MaxText-specific logic to models corrupts the internal state format and causes immediate crashes during vLLM rollout synchronization.
2. **Converter Typos:** There were tracking typos in the initialization where `self.converter` was used instead of the correct `self._converter` attribute.

## Solution

Restored `unroll_gemma_scanned_weights()` strictly inside the `if self._direct_maxtext_sync:` condition block in `maxtext_vllm_rollout.py`, ensuring it is bypassed for workflows. Additionally, fixed residual `self.converter` spelling typos.

# Tests

RL end-to-end:

- Gemma3-4b: https://cloudlogging.app.goo.gl/yU6FTLxizXc5VaJz5
- Gemma4-26b: https://cloudlogging.app.goo.gl/dWUkvcbaL3vPywBv9
- Qwen3-30b: https://cloudlogging.app.goo.gl/UXariXvbB1Q9FEBf9
- Llama3.1-70b: https://cloudlogging.app.goo.gl/J52kWeY8buaM9yCF6
- GPT-OSS-20b: https://cloudlogging.app.goo.gl/iAoiNf4UygDgsRWQ9

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
