### PR TITLE
Accept **kwargs in the Gemma4/Qwen3.5 vLLM converter convert() overrides

### DIFF
--- a/src/maxtext/integration/vllm/torchax_converter/gemma4_moe.py
+++ b/src/maxtext/integration/vllm/torchax_converter/gemma4_moe.py
@@ -63,7 +63,7 @@ class Gemma4MaxTextToVLLMConverter(BaseMaxTextToVLLMConverter):
 
   # --- 1. Top-Level Entry Point ---
 
-  def convert(self, model_state: dict):
+  def convert(self, model_state: dict, **kwargs):
     """Convert a MaxText Gemma4 model state into vLLM weight tensors."""
     logging.info(
         "\n%sStarting Gemma4 Conversion (is_moe=%s, num_layers=%d, num_reps=%d)...%s",

--- a/src/maxtext/integration/vllm/torchax_converter/qwen35_moe.py
+++ b/src/maxtext/integration/vllm/torchax_converter/qwen35_moe.py
@@ -25,7 +25,7 @@ from maxtext.integration.vllm.torchax_converter.base import BaseMaxTextToVLLMCon
 class Qwen35MaxTextToVLLMConverter(BaseMaxTextToVLLMConverter):
   """Converts MaxText Qwen3.5 (Scanned Block) layout to vLLM execution layout."""
 
-  def convert(self, model_state: dict):
+  def convert(self, model_state: dict, **kwargs):
     """Converts model_state parameters to vLLM format."""
     logging.info("\n%sStarting Qwen 3.5 Conversion (Hybrid MoE)...%s", GREEN, RESET)
     self.vllm_state = {}


### PR DESCRIPTION
# Description

`BaseMaxTextToVLLMConverter.convert()` gained a `**kwargs` parameter, and `validate_converter.py` relies on it:

https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/integration/vllm/validate_converter.py#L776

```python
maxtext_vllm_state = converter.convert(model_state, target_state=golden_llm_state)
```

The two subclasses that override `convert` were not updated and still declare `convert(self, model_state)`, so that call raises `TypeError: convert() got an unexpected keyword argument 'target_state'` for the Gemma4 and Qwen3.5 MoE converters specifically. The base class accepts it; those two do not.

This is also currently failing the `pylint` pre-commit hook on `main` as `W0221` (arguments-differ) see the Code Quality Check on b18ceac97.

The fix adds `**kwargs` to both overrides, matching the base signature.

# Tests

No test covers this path: both modules import `tpu_inference` at module scope, so they cannot be imported (let alone constructed) off a TPU host, which is why only the static check catches it.

`pylint` with the hook's own arguments, before and after, on the two files:

```
pylint --disable=R0401,R0917,W0201,W0613 \
  src/maxtext/integration/vllm/torchax_converter/gemma4_moe.py \
  src/maxtext/integration/vllm/torchax_converter/qwen35_moe.py
```

Before:

```
gemma4_moe.py:66:2: W0221: Variadics removed in overriding 'Gemma4MaxTextToVLLMConverter.convert' method (arguments-differ)
qwen35_moe.py:28:2: W0221: Variadics removed in overriding 'Qwen35MaxTextToVLLMConverter.convert' method (arguments-differ)
Your code has been rated at 9.94/10
```

After:

```
Your code has been rated at 10.00/10
```

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.