### PR TITLE
Fix zero loss bug in DSV3.2 by adding indexer flags

### DIFF
--- a/tests/end_to_end/tpu/deepseek/v3.2-671b/2_test_deepseek.sh
+++ b/tests/end_to_end/tpu/deepseek/v3.2-671b/2_test_deepseek.sh
@@ -53,7 +53,7 @@ python3 -m tests.utils.forward_pass_logit_checker ${MAXTEXT_CONFIGS_DIR:-${MAXTE
 
 # Run pre-training - tokamax_gmm implementation
 # Note: use sgd due to memory constraint
-python3 -m maxtext.trainers.pre_train.train ${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}/base.yml base_output_directory=${BASE_OUTPUT_PATH} run_name=tokamax_gmm_pre_training model_name=${MODEL_NAME} tokenizer_type=huggingface tokenizer_path=${TOKENIZER_PATH} dataset_type=synthetic enable_checkpointing=false attention=flash use_tokamax_splash=True sparse_matmul=True use_tokamax_gmm=True dtype=bfloat16 weight_dtype=bfloat16 per_device_batch_size=1 steps=5 max_target_length=4096 ici_fsdp_parallelism=-1 opt_type=sgd
+python3 -m maxtext.trainers.pre_train.train ${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}/base.yml base_output_directory=${BASE_OUTPUT_PATH} run_name=tokamax_gmm_pre_training model_name=${MODEL_NAME} tokenizer_type=huggingface tokenizer_path=${TOKENIZER_PATH} dataset_type=synthetic enable_checkpointing=false attention=flash use_tokamax_splash=True sparse_matmul=True use_tokamax_gmm=True dtype=bfloat16 weight_dtype=bfloat16 per_device_batch_size=1 steps=5 max_target_length=4096 ici_fsdp_parallelism=-1 opt_type=sgd use_indexer=True indexer_loss_scaling_factor=0.01 indexer_sparse_training=True
 
 # Run decoding - megablox implementation
 # Note: decode requires the access token for huggingface tokenizer even if the model is not gated


### PR DESCRIPTION
# Description

Update the deepseek v3.2 script used by XLML to fix training loss set to 0

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/519029446

# Tests

Verified on mini-config on synthetic data. Details in https://b.corp.google.com/issues/519029446#comment4.

PR Unit tests should pass.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
