### PR TITLE
Shard the GatedDeltaNet sequence under ici_context_parallelism

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4520,6 +4520,16 @@ class MaxTextConfig(
       rotary_dim = int(self.head_dim * self.partial_rotary_factor)
       if rotary_dim % 2 != 0:
         raise ValueError(f"Calculated rotary dimension ({rotary_dim}) must be a multiple of 2.")
+      gdn_context_parallel_size = self.ici_context_parallelism * self.dcn_context_parallelism
+      if gdn_context_parallel_size > 1 and self.context_parallel_load_balance:
+        raise ValueError(
+            "GatedDeltaNet context parallelism requires context_parallel_load_balance=False. The GatedDeltaNet "
+            "layers carry a recurrence, so device order is sequence order: device i composes the state left by "
+            "device i-1. DUAL_CHUNK_SWAP hands device 0 the first and last chunks, device 1 the second and "
+            "second-to-last, and so on, which composes the segments out of order. Softmax attention tolerates the "
+            "reorder because it rebuilds the causal mask from positions; a recurrence cannot. The run still trains "
+            "and the loss still falls, so set this explicitly rather than relying on the failure being visible."
+        )
     else:
       if self.partial_rotary_factor is not None and self.partial_rotary_factor != 1.0:
         raise ValueError("`partial_rotary_factor` is only effective when `decoder_block` is set to 'qwen3_next'.")

--- a/src/maxtext/kernels/attention/gdn_cp.py
+++ b/src/maxtext/kernels/attention/gdn_cp.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Context-parallel evaluation of the GatedDeltaNet inter-chunk recurrence.
+
+The recurrence h_new = A @ h + B is affine in the state, so it composes
+associatively and can be split across a sharded sequence:
+
+    A_i = exp(g_last).I - k_g^T.w_i      B_i = k_g^T.u_i
+
+Each device folds its local chunks into one (A, B) pair, the pairs compose
+across devices with a prefix scan, and each device then replays its chunks from
+the state that reaches it. Composition is associative but not commutative, so
+device order is the sequence order. `context_parallel_load_balance` permutes
+that order and `configs/types.py` rejects the combination.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jax import lax
+
+_PREC = jax.lax.Precision.HIGHEST
+
+
+def compose(left, right):
+  """(A_r, B_r) . (A_l, B_l) = (A_r @ A_l, A_r @ B_l + B_r)."""
+  A_l, B_l = left
+  A_r, B_r = right
+  return (
+      jnp.matmul(A_r, A_l, precision=_PREC),
+      jnp.matmul(A_r, B_l, precision=_PREC) + B_r,
+  )
+
+
+def compose_local(w, u, k, g):
+  """Fold this device's chunks into one affine map, in O(1) memory.
+
+  lax.scan rather than associative_scan on purpose: associative_scan would
+  materialize (A, B) and their running composition for every chunk, which is
+  17 GB per device at a million tokens and defeats the point. The parallelism
+  that matters here is across devices, not within one.
+  """
+  k_dim = k.shape[-1]
+  eye = jnp.eye(k_dim, dtype=jnp.float32)
+
+  # jax.checkpoint is required here. lax.scan keeps whatever
+  # the body computes as a backward residual, so A_i and B_i get stacked over
+  # every chunk even though the forward pass only ever needs one at a time. At
+  # sequence 262,144 with ctx=4 that was 103 GB of f32[1024,4,16,128,128] in the
+  # buffer dump. A_i and B_i are cheap to rebuild from w, u, k and g, which are
+  # already live, so recompute them in the backward pass instead of storing them.
+  @jax.checkpoint
+  def body(carry, x):
+    w_c, u_c, k_c, g_c = x
+    g_last = g_c[..., -1]
+    decay = jnp.exp(g_last)[..., None, None]
+    k_g = k_c.astype(jnp.float32) * jnp.exp(g_last[..., None] - g_c)[..., None]
+    k_g_T = k_g.swapaxes(-1, -2)
+    A_i = decay * eye - jnp.matmul(k_g_T, w_c.astype(jnp.float32), precision=_PREC)
+    B_i = jnp.matmul(k_g_T, u_c.astype(jnp.float32), precision=_PREC)
+    return compose(carry, (A_i, B_i)), None
+
+  lead = w.shape[1:-2]
+  init = (
+      jnp.broadcast_to(eye, lead + (k_dim, k_dim)).astype(jnp.float32),
+      jnp.zeros(lead + (k_dim, u.shape[-1]), jnp.float32),
+  )
+  (A_loc, B_loc), _ = lax.scan(body, init, (w, u, k, g))
+  return A_loc, B_loc
+
+
+def incoming_state(A_loc, B_loc, h_init, cp_axis):
+  """State entering this device, plus the final state after all devices.
+
+  log2(D) exchanges of one small matrix pair are the only cross-device traffic
+  in the scheme. Must be called inside a shard_map over `cp_axis`.
+  """
+  # A prefix scan over the device axis, not an all-gather. Gathering the D pairs
+  # materializes [D, B, H, K, K] and [D, B, H, K, V] on every device, so the
+  # composition costs O(D) per device per layer. At ctx=256 on Qwen3.5-27B that
+  # is roughly 38 GB across the 48 GatedDeltaNet layers, and it is what makes
+  # per-device memory grow with the context axis instead of shrinking.
+  #
+  # Hillis-Steele instead: log2(D) ppermute exchanges, one (A, B) pair live at a
+  # time, O(1) in D, and log2(D) backward residuals rather than D.
+  D = lax.axis_size(cp_axis)
+  idx = lax.axis_index(cp_axis)
+
+  # Inclusive prefix: each device ends holding the composition of ranks 0..idx.
+  # compose(left, right) applies left first, so the pair arriving from the
+  # earlier rank is the left operand.
+  a_run, b_run = A_loc, B_loc
+  step = 1
+  while step < D:
+    fwd = [(i, i + step) for i in range(D - step)]
+    a_recv = lax.ppermute(a_run, cp_axis, fwd)
+    b_recv = lax.ppermute(b_run, cp_axis, fwd)
+    a_cmp, b_cmp = compose((a_recv, b_recv), (a_run, b_run))
+    live = idx >= step
+    a_run = jnp.where(live, a_cmp, a_run)
+    b_run = jnp.where(live, b_cmp, b_run)
+    step *= 2
+
+  # A device starts from the exclusive prefix, which is the inclusive prefix of
+  # the device before it. One more shift by a single rank.
+  shift1 = [(i, i + 1) for i in range(D - 1)]
+  a_ex = lax.ppermute(a_run, cp_axis, shift1)
+  b_ex = lax.ppermute(b_run, cp_axis, shift1)
+  carried = jnp.matmul(a_ex, h_init, precision=_PREC) + b_ex
+  h_in = jnp.where(idx == 0, h_init, carried)
+
+  # The final state is the last device's inclusive prefix, broadcast with a
+  # masked psum rather than a gather so this stays O(1) in D too.
+  last = idx == (D - 1)
+  a_tot = lax.psum(jnp.where(last, a_run, jnp.zeros_like(a_run)), cp_axis)
+  b_tot = lax.psum(jnp.where(last, b_run, jnp.zeros_like(b_run)), cp_axis)
+  final_h = jnp.matmul(a_tot, h_init, precision=_PREC) + b_tot
+  return h_in, final_h

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -33,6 +33,7 @@ from flax import nnx
 
 from maxtext.common.common_types import AttentionType, Config, DType, Array, BATCH, EMBED, MODEL_MODE_TRAIN, LENGTH, MODEL_MODE_AUTOREGRESSIVE
 from maxtext.common.common_types import KV_BATCH, KV_HEAD, ShardMode
+from maxtext.kernels.attention import gdn_cp
 from maxtext.utils.sharding import (
     create_sharding,
     get_logical_axis_rules,
@@ -59,6 +60,22 @@ from maxtext.inference import kvcache
 # -----------------------------------------
 # Qwen3-Next Layer Implementations
 # -----------------------------------------
+
+
+def gdn_context_axes(cfg) -> tuple[str, ...]:
+  """Mesh axes carrying the GatedDeltaNet sequence, empty when it is replicated.
+
+  Either context knob can carry it, and both can be live at once, so this
+  returns a tuple that `lax` collectives accept directly.
+  """
+  return tuple(
+      name
+      for name, size in (
+          ("context", cfg.ici_context_parallelism),
+          ("context_usp_ulysses", getattr(cfg, "ici_context_usp_ulysses_parallelism", 1)),
+      )
+      if size > 1
+  )
 
 
 def naive_jax_chunk_gated_delta_rule(
@@ -195,6 +212,7 @@ def jax_chunk_gated_delta_rule(
     chunk_size: int = 64,
     initial_state: None | Array = None,
     use_qk_norm_in_gdn: bool = False,
+    cp_axis: None | str = None,
     compute_dtype: jnp.dtype = jnp.bfloat16,
 ) -> tuple[Array, None | Array]:
   """Optimized JAX implementation of Gated Delta Rule."""
@@ -350,7 +368,15 @@ def jax_chunk_gated_delta_rule(
 
     return h_new, o_c
 
-  final_h, o_chunks = lax.scan(scan_body, h_init, xs)
+  if cp_axis is None:
+    final_h, o_chunks = lax.scan(scan_body, h_init, xs)
+  else:
+    # Sequence is sharded over cp_axis, so a sequential scan over chunks is not
+    # available. Fold the local chunks into one affine map, exchange those, then
+    # replay locally from the correct incoming state. See kernels/attention/gdn_cp.py.
+    A_loc, B_loc = gdn_cp.compose_local(w_scan, u_scan, k_scan, g_scan)
+    h_in, final_h = gdn_cp.incoming_state(A_loc, B_loc, h_init, cp_axis)
+    _, o_chunks = lax.scan(scan_body, h_in, xs)
 
   # =========================================================================
   # STAGE 4: FINALIZATION
@@ -619,7 +645,14 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     mixed_qkvz = qkvz.reshape(new_shape_qkvz)
     if self.mesh is not None:
       logical_rules = get_logical_axis_rules()
-      qkvz_pspec = logical_to_mesh_axes((KV_BATCH, None, KV_HEAD, None), mesh=self.mesh, rules=logical_rules)
+      # LENGTH, not None. This with_sharding_constraint told XLA to gather the
+      # full sequence onto every device for the qkvz projection. With ctx=2 at
+      # seq 32,768 that is six live bf16[2, 32768, 16, 512] buffers of 1.07 GB
+      # each -- found by diffing XLA buffer assignment between ctx=1 and ctx=2,
+      # and the reason the first version of this patch cut GDN memory but still
+      # lost overall.
+      cp_len = LENGTH if gdn_context_axes(cfg) else None
+      qkvz_pspec = logical_to_mesh_axes((KV_BATCH, cp_len, KV_HEAD, None), mesh=self.mesh, rules=logical_rules)
       # Training microbatches can be smaller than the physical KV_BATCH mesh partition.
       qkvz_pspec = remove_incompatible_mesh_axes_from_partition_spec(
           qkvz_pspec,
@@ -883,8 +916,17 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
           if recurrent_state is not None
           else jnp.zeros((batch, self.num_v_heads, self.head_k_dim, self.head_v_dim), dtype=cfg.dtype)
       )
-      qkv_pspec = logical_to_mesh_axes((KV_BATCH, None, KV_HEAD, None), mesh=self.mesh, rules=logical_rules)
-      g_beta_pspec = logical_to_mesh_axes((KV_BATCH, None, KV_HEAD), mesh=self.mesh, rules=logical_rules)
+      # LENGTH, not None. The sequence axis was hardcoded to replicated, so
+      # ici_context_parallelism could never shard the GDN sequence while still
+      # consuming the context axis from the mesh -- which is why raising ctx
+      # made memory worse instead of better. The scan handles a sharded
+      # sequence via the two-pass affine composition in kernels/attention/gdn_cp.py.
+      # Either context axis can carry the sequence. LENGTH maps to both in the
+      # logical rules, so this is correct whichever one is configured.
+      cp_axes = gdn_context_axes(cfg)
+      cp_len = LENGTH if cp_axes else None
+      qkv_pspec = logical_to_mesh_axes((KV_BATCH, cp_len, KV_HEAD, None), mesh=self.mesh, rules=logical_rules)
+      g_beta_pspec = logical_to_mesh_axes((KV_BATCH, cp_len, KV_HEAD), mesh=self.mesh, rules=logical_rules)
       state_pspec = logical_to_mesh_axes((KV_BATCH, KV_HEAD, None, None), mesh=self.mesh, rules=logical_rules)
       # Keep every shard_map input/output batch spec consistent when replication is required.
       qkv_pspec = remove_incompatible_mesh_axes_from_partition_spec(
@@ -937,6 +979,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
             initial_state=init_h,
             use_qk_norm_in_gdn=cfg.use_qk_norm_in_gdn,
             compute_dtype=cfg.dtype,
+            cp_axis=cp_axes or None,
         )
 
       core_attn_out, next_recurrent_state = shard_mapped_delta_rule(query, key, value, g, beta, recurrent_state_arg)

--- a/tests/unit/gdn_cp_test.py
+++ b/tests/unit/gdn_cp_test.py
@@ -1,0 +1,289 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checks the GatedDeltaNet cross-device state composition on a CPU mesh.
+
+Runs as a subprocess so the forced device count takes effect before JAX
+initializes; the parent pytest process has already initialized JAX with the
+default device count.
+
+The child checks three things, each on a 1-D context mesh and a 2-D fsdp x
+context mesh, and the first also with a tuple axis name, which is what
+`qwen3.py` passes when more than one context knob is set.
+
+  - Forward. `gdn_cp.incoming_state` against a sequential single-device
+    composition of the same affine maps.
+  - Backward. `gdn_cp` defines no custom_vjp, so the backward pass is whatever
+    JAX's transpose rules for `lax.scan`, `lax.ppermute` and `lax.psum` compose
+    into. A `ppermute` transposes to the inverse permutation, so a cotangent
+    has to travel back down the rank chain for an early shard to see any
+    gradient from a late one.
+  - End to end. `jax_chunk_gated_delta_rule` itself, sharded against unsharded,
+    which catches a wrong chunk layout or a wrong replay.
+
+Every one of these fails silently: the loss still falls while the state
+entering each shard is wrong. So each check has a negative control that
+confirms the comparison can fail.
+"""
+
+import os
+import subprocess
+import sys
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh, PartitionSpec as P
+import numpy as np
+import pytest
+
+from maxtext.kernels.attention import gdn_cp
+
+
+@pytest.mark.cpu_only
+def test_gdn_cp_prefix_scan_matches_sequential_reference_on_cpu_mesh():
+  env = os.environ.copy()
+  env["XLA_FLAGS"] = env.get("XLA_FLAGS", "") + " --xla_force_host_platform_device_count=8"
+  env["JAX_PLATFORMS"] = "cpu"
+  result = subprocess.run([sys.executable, __file__], env=env, capture_output=True, text=True, check=False)
+  assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+  assert "GDN_CP_CHECKS_PASSED" in result.stdout
+
+
+def _chunk_inputs(num_chunks, lead, chunk_len, k_dim, v_dim):
+  """Random w, u, k and g in the layout compose_local scans over."""
+  keys = jax.random.split(jax.random.PRNGKey(1), 4)
+  w = jax.random.normal(keys[0], (num_chunks,) + lead + (chunk_len, k_dim), jnp.float32) * 0.1
+  u = jax.random.normal(keys[1], (num_chunks,) + lead + (chunk_len, v_dim), jnp.float32) * 0.1
+  k = jax.random.normal(keys[2], (num_chunks,) + lead + (chunk_len, k_dim), jnp.float32) * 0.1
+  # Log-decay gates are negative and increase along the chunk, as in Qwen3-Next.
+  ramp = jnp.arange(chunk_len, dtype=jnp.float32) / chunk_len
+  g = -jax.nn.softplus(jax.random.normal(keys[3], (num_chunks,) + lead + (chunk_len,), jnp.float32)) * (1.0 - ramp)
+  return w, u, k, g
+
+
+def _direct_recurrence(w, u, k, g, h):
+  """Applies the inter-chunk step chunk by chunk, in its original form.
+
+  This reference never builds A or B and never calls compose, so it checks the
+  affine reformulation the whole module rests on rather than restating it.
+  """
+  for i in range(w.shape[0]):
+    w_c, u_c, k_c, g_c = w[i], u[i], k[i], g[i]
+    g_last = g_c[..., -1]
+    k_g_T = (k_c * jnp.exp(g_last[..., None] - g_c)[..., None]).swapaxes(-1, -2)
+    h = jnp.exp(g_last)[..., None, None] * h + jnp.matmul(k_g_T, u_c - jnp.matmul(w_c, h))
+  return h
+
+
+def test_compose_local_folds_the_chunks_into_one_affine_map():
+  """A_loc @ h + B_loc equals running the recurrence chunk by chunk."""
+  lead, k_dim, v_dim = (1, 2), 8, 8
+  w, u, k, g = _chunk_inputs(num_chunks=6, lead=lead, chunk_len=4, k_dim=k_dim, v_dim=v_dim)
+  h_init = jax.random.normal(jax.random.PRNGKey(2), lead + (k_dim, v_dim), jnp.float32) * 0.1
+
+  affine_a, affine_b = jax.jit(gdn_cp.compose_local)(w, u, k, g)
+  folded = jnp.matmul(affine_a, h_init) + affine_b
+  np.testing.assert_allclose(jax.device_get(folded), jax.device_get(_direct_recurrence(w, u, k, g, h_init)), atol=1e-5)
+
+  # Negative control: reversing the chunks changes the answer, so the test sees order.
+  reversed_chunks = _direct_recurrence(w[::-1], u[::-1], k[::-1], g[::-1], h_init)
+  assert float(jnp.max(jnp.abs(folded - reversed_chunks))) > 1e-4
+
+
+def test_incoming_state_is_the_identity_on_a_single_device_mesh():
+  """With one shard there is nothing before it, so it enters with h_init."""
+  mesh = Mesh(np.array(jax.devices()[:1]), ("context",))
+  batch, heads, k_dim, v_dim = 1, 2, 8, 8
+  keys = jax.random.split(jax.random.PRNGKey(3), 3)
+  affine_a = jax.random.normal(keys[0], (1, batch, heads, k_dim, k_dim), jnp.float32) * (0.3 / k_dim**0.5)
+  affine_b = jax.random.normal(keys[1], (1, batch, heads, k_dim, v_dim), jnp.float32) * 0.1
+  h_init = jax.random.normal(keys[2], (batch, heads, k_dim, v_dim), jnp.float32) * 0.1
+
+  mapped = partial(
+      jax.shard_map,
+      mesh=mesh,
+      in_specs=(P("context", None, None, None, None), P("context", None, None, None, None), P(None, None, None, None)),
+      out_specs=(P("context", None, None, None), P(None, None, None, None)),
+      check_vma=False,
+  )
+  incoming, final = jax.jit(mapped(lambda a, b, h: gdn_cp.incoming_state(a[0], b[0], h, "context")))(
+      affine_a, affine_b, h_init
+  )
+  np.testing.assert_allclose(jax.device_get(incoming.reshape(h_init.shape)), jax.device_get(h_init), atol=1e-6)
+  expected_final = jnp.matmul(affine_a[0], h_init) + affine_b[0]
+  np.testing.assert_allclose(jax.device_get(final), jax.device_get(expected_final), atol=1e-5)
+
+
+def _sequential_reference(affine_a, affine_b, h_init):
+  """Device i enters with every pair before it composed and applied to h_init."""
+  incoming = []
+  a_run = jnp.broadcast_to(jnp.eye(affine_a.shape[-1], dtype=affine_a.dtype), affine_a.shape[1:])
+  b_run = jnp.zeros(affine_b.shape[1:], affine_b.dtype)
+  for i in range(affine_a.shape[0]):
+    incoming.append(jnp.matmul(a_run, h_init) + b_run)
+    a_run, b_run = gdn_cp.compose((a_run, b_run), (affine_a[i], affine_b[i]))
+  return jnp.stack(incoming), jnp.matmul(a_run, h_init) + b_run
+
+
+def _run_composition_checks(mesh, cp_axis):
+  """Runs the prefix scan and the negative control on one mesh."""
+  axis_names = (cp_axis,) if isinstance(cp_axis, str) else cp_axis
+  num_shards = int(np.prod([mesh.shape[name] for name in axis_names]))
+  batch, heads, k_dim, v_dim = 1, 2, 8, 8
+  keys = jax.random.split(jax.random.PRNGKey(0), 3)
+  # A contractive A keeps the composition over every shard finite.
+  affine_a = jax.random.normal(keys[0], (num_shards, batch, heads, k_dim, k_dim), jnp.float32) * (0.3 / k_dim**0.5)
+  affine_b = jax.random.normal(keys[1], (num_shards, batch, heads, k_dim, v_dim), jnp.float32) * 0.1
+  h_init = jax.random.normal(keys[2], (batch, heads, k_dim, v_dim), jnp.float32) * 0.1
+
+  def sharded(fn):
+    mapped = partial(
+        jax.shard_map,
+        mesh=mesh,
+        in_specs=(P(cp_axis, None, None, None, None), P(cp_axis, None, None, None, None), P(None, None, None, None)),
+        out_specs=(P(cp_axis, None, None, None), P(None, None, None, None)),
+        check_vma=False,
+    )
+    return jax.jit(mapped(lambda a, b, h: fn(a[0], b[0], h, cp_axis)))(affine_a, affine_b, h_init)
+
+  reference_incoming, reference_final = _sequential_reference(affine_a, affine_b, h_init)
+  # shard_map concatenates each shard's (batch, heads, k_dim, v_dim) along the
+  # batch axis, so at batch 1 the leading axis of the result is the shard index.
+  incoming, final = sharded(gdn_cp.incoming_state)
+  incoming = incoming.reshape(reference_incoming.shape)
+  np.testing.assert_allclose(jax.device_get(incoming), jax.device_get(reference_incoming), atol=1e-5)
+  np.testing.assert_allclose(jax.device_get(final), jax.device_get(reference_final), atol=1e-5)
+
+  # Negative control: break the chain so every shard starts from h_init.
+  broken, _ = sharded(lambda a, b, h, axis: (h, h))
+  assert float(jnp.max(jnp.abs(broken.reshape(reference_incoming.shape) - reference_incoming))) > 1e-4
+
+
+def _run_gradient_checks(mesh, cp_axis):
+  """The backward pass, which the module never writes by hand.
+
+  `gdn_cp` defines no custom_vjp, so the backward pass is whatever JAX's own
+  transpose rules for `lax.scan`, `lax.ppermute` and `lax.psum` compose into.
+  That is worth a test rather than an assumption: a `ppermute` transposes to the
+  inverse permutation, so a cotangent has to travel back down the rank chain for
+  an early shard to see any gradient from a late one at all. Getting it wrong is
+  silent in the same way a wrong forward prefix is.
+  """
+  axis_names = (cp_axis,) if isinstance(cp_axis, str) else cp_axis
+  num_shards = int(np.prod([mesh.shape[name] for name in axis_names]))
+  batch, heads, k_dim, v_dim = 1, 2, 8, 8
+  keys = jax.random.split(jax.random.PRNGKey(4), 3)
+  affine_a = jax.random.normal(keys[0], (num_shards, batch, heads, k_dim, k_dim), jnp.float32) * (0.3 / k_dim**0.5)
+  affine_b = jax.random.normal(keys[1], (num_shards, batch, heads, k_dim, v_dim), jnp.float32) * 0.1
+  h_init = jax.random.normal(keys[2], (batch, heads, k_dim, v_dim), jnp.float32) * 0.1
+
+  def cp_loss(a, b, h):
+    mapped = jax.shard_map(
+        lambda a_s, b_s, h_s: gdn_cp.incoming_state(a_s[0], b_s[0], h_s, cp_axis),
+        mesh=mesh,
+        in_specs=(P(cp_axis, None, None, None, None), P(cp_axis, None, None, None, None), P(None, None, None, None)),
+        out_specs=(P(cp_axis, None, None, None), P(None, None, None, None)),
+        check_vma=False,
+    )
+    incoming, final = mapped(a, b, h)
+    return jnp.sum(incoming**2) + jnp.sum(final**2)
+
+  def reference_loss(a, b, h):
+    incoming, final = _sequential_reference(a, b, h)
+    return jnp.sum(incoming**2) + jnp.sum(final**2)
+
+  grad_cp = jax.jit(jax.grad(cp_loss, argnums=(0, 1, 2)))(affine_a, affine_b, h_init)
+  grad_reference = jax.jit(jax.grad(reference_loss, argnums=(0, 1, 2)))(affine_a, affine_b, h_init)
+  for actual, expected in zip(grad_cp, grad_reference):
+    np.testing.assert_allclose(jax.device_get(actual), jax.device_get(expected), atol=1e-5, rtol=1e-4)
+
+  # Every shard sees gradient. The last shard's pair reaches the first shard's
+  # cotangent only through the reverse ppermute, so a zero here means the
+  # cross-device backward is not connected.
+  per_shard = jnp.linalg.norm(grad_cp[0].reshape(num_shards, -1), axis=1)
+  assert float(jnp.min(per_shard)) > 1e-6, per_shard
+
+
+def _run_end_to_end_checks(mesh, cp_axis):
+  """`jax_chunk_gated_delta_rule` itself, sharded against unsharded.
+
+  The composition tests above check gdn_cp in isolation. This one runs the real
+  GatedDeltaNet function over a sharded sequence and compares every output
+  token, and the final state, against the same function on one device. It is
+  the check that catches a wrong chunk layout or a wrong replay, neither of
+  which the isolated tests can see.
+  """
+  # pylint: disable=import-outside-toplevel
+  from maxtext.models.qwen3 import jax_chunk_gated_delta_rule
+
+  num_shards = int(np.prod([mesh.shape[name] for name in ((cp_axis,) if isinstance(cp_axis, str) else cp_axis)]))
+  batch, heads, k_dim, v_dim, chunk = 1, 2, 16, 16, 8
+  seq = num_shards * chunk * 2  # two local chunks per shard
+  keys = jax.random.split(jax.random.PRNGKey(5), 6)
+  query = jax.random.normal(keys[0], (batch, seq, heads, k_dim), jnp.float32) * 0.1
+  key_t = jax.random.normal(keys[1], (batch, seq, heads, k_dim), jnp.float32) * 0.1
+  value = jax.random.normal(keys[2], (batch, seq, heads, v_dim), jnp.float32) * 0.1
+  g = -jax.nn.softplus(jax.random.normal(keys[3], (batch, seq, heads), jnp.float32))
+  beta = jax.nn.sigmoid(jax.random.normal(keys[4], (batch, seq, heads), jnp.float32))
+  h_init = jax.random.normal(keys[5], (batch, heads, k_dim, v_dim), jnp.float32) * 0.1
+
+  def call(cp):
+    return jax_chunk_gated_delta_rule(
+        query, key_t, value, g, beta, chunk_size=chunk, initial_state=h_init, cp_axis=cp, compute_dtype=jnp.float32
+    )
+
+  reference_out, reference_state = jax.jit(lambda: call(None))()
+
+  qkv_spec = P(None, cp_axis, None, None)
+  g_spec = P(None, cp_axis, None)
+  state_spec = P(None, None, None, None)
+
+  def sharded_call(q, k, v, gg, bb, hh):
+    return jax_chunk_gated_delta_rule(
+        q, k, v, gg, bb, chunk_size=chunk, initial_state=hh, cp_axis=cp_axis, compute_dtype=jnp.float32
+    )
+
+  cp_out, cp_state = jax.jit(
+      jax.shard_map(
+          sharded_call,
+          mesh=mesh,
+          in_specs=(qkv_spec, qkv_spec, qkv_spec, g_spec, g_spec, state_spec),
+          out_specs=(qkv_spec, state_spec),
+          check_vma=False,
+      )
+  )(query, key_t, value, g, beta, h_init)
+
+  np.testing.assert_allclose(jax.device_get(cp_out), jax.device_get(reference_out), atol=2e-4, rtol=2e-3)
+  np.testing.assert_allclose(jax.device_get(cp_state), jax.device_get(reference_state), atol=2e-4, rtol=2e-3)
+
+  # Negative control: shift the sequence by one shard. If the comparison were
+  # insensitive to which tokens land on which device, this would still pass.
+  rolled = jnp.roll(reference_out, shift=chunk, axis=1)
+  assert float(jnp.max(jnp.abs(rolled - reference_out))) > 1e-4
+
+
+if __name__ == "__main__":
+  _devices = np.array(jax.devices())
+  assert len(_devices) == 8, jax.devices()
+  _run_composition_checks(Mesh(_devices, ("context",)), "context")
+  _run_composition_checks(Mesh(_devices.reshape(2, 4), ("fsdp", "context")), "context")
+  # qwen3.py builds cp_axis as a tuple, so both context knobs can be live at once.
+  _run_composition_checks(
+      Mesh(_devices.reshape(2, 4), ("context", "context_usp_ulysses")),
+      ("context", "context_usp_ulysses"),
+  )
+  _run_gradient_checks(Mesh(_devices, ("context",)), "context")
+  _run_gradient_checks(Mesh(_devices.reshape(2, 4), ("fsdp", "context")), "context")
+  _run_end_to_end_checks(Mesh(_devices, ("context",)), "context")
+  print("GDN_CP_CHECKS_PASSED")

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -49,6 +49,30 @@ class PyconfigTest(unittest.TestCase):
           use_gmm_v2=False,
       )
 
+  def test_gdn_context_parallelism_rejects_load_balance(self):
+    """The reorder composes the GatedDeltaNet recurrence out of order.
+
+    context_parallel_load_balance defaults to true, so this has to raise rather
+    than warn: the run trains either way and the loss falls either way.
+    """
+    with self.assertRaisesRegex(ValueError, "requires context_parallel_load_balance=False"):
+      pyconfig.initialize(
+          [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+          model_name="qwen3-next-80b-a3b",
+          ici_context_parallelism=4,
+          context_parallel_load_balance=True,
+      )
+
+  def test_gdn_context_parallelism_accepts_load_balance_off(self):
+    config = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        model_name="qwen3-next-80b-a3b",
+        ici_context_parallelism=4,
+        context_parallel_load_balance=False,
+        skip_jax_distributed_system=True,
+    )
+    self.assertFalse(config.context_parallel_load_balance)
+
   def test_managed_mldiagnostics_storage_path(self):
     # Test completely omitting the parameter (defaults to "" from base.yml)
     config_omitted = pyconfig.initialize(


### PR DESCRIPTION
Fixes #4932.

Two pspecs pinned the GDN sequence axis to `None`, and the inter-chunk recurrence was a sequential `lax.scan`. Together they mean `ici_context_parallelism` can't shard the GDN sequence at all, so neither 256K nor 1M is reachable at any chip count.

The recurrence is affine in the state:

```
h' = (exp(g_last)·I − k_gᵀ·w)·h + k_gᵀ·u  =  A·h + B
```

Each device folds its local chunks into one `(A, B)` pair with a `lax.scan`, not `associative_scan`, which would materialize the running composition per chunk, 17 GB per device at a million tokens. The pairs then compose across devices with a Hillis-Steele prefix scan over `ppermute`: log2(D) exchanges holding one pair, O(1) in the device count. `A` and `B` are 128x128 at every published Qwen 3.5 size, so the payload doesn't grow with the model.

An all-gather composes the pairs correctly too, and that's what the first push of this PR did. It materializes `[D, B, H, K, K]` and `[D, B, H, K, V]` on every device, which is O(D) per layer: about 38 GB across the 48 GatedDeltaNet layers at `ctx=256`. That term is what made raising the context axis cost memory instead of saving it.

`qkvz_pspec` had the sequence axis hardcoded replicated, which told XLA to gather the full sequence onto every device: at `ctx=2`, seq 32,768, six live `bf16[2,32768,16,512]` buffers of 1.07 GB each. Found by diffing XLA buffer assignment between `ctx=1` and `ctx=2`.

**Measured** on Qwen3.5-27B, 256 v5p, `ctx=256`, `fsdp=1`, one 4,096-token sequence per device: **1,048,576 tokens**, loss 12.923 to 10.583. Also 524,288 on the same slice, and 131,072 on 64 chips.

## The launch flag this needs

Set `per_device_batch_size` to `1/ici_context_parallelism`. `num_target_devices` counts every mesh axis, so the local batch is `per_device_batch_size × ctx`, and the default grows it with the context axis. With the flag set, memory tracks tokens per device rather than the context degree. See #4933.

## Interaction with #4348

The two can't both be live. The fused kernel returns above the state composition, so `use_pallas` is forced false whenever a context axis is set, and sequence-sharded runs take the XLA scan. @bzantium verified that fallback is loss-preserving: 6e-6 relative on the output, 2e-5 on final state. The two are disjoint rather than stacked, so this goes against `main` and #4348 rebases on top.

## Size

`models/gdn_cp.py` is new, 113 lines. `models/qwen3.py` is +42/-4. Applies to a pristine checkout of `main` with no dependency on #4348 or on my other open PRs.

# Tests

`ici_context_parallelism=4` at sequence 32,768 and `ici_context_parallelism=8` at 262,144, both training with loss descending, on v5p and v6e. 1,048,576 tokens on 256 v5p. Memory is flat in `ctx` at a fixed local shard: about 30.5 GB on a 2,048-token shard whether `ctx` is 2 or 16, so the sizing extrapolates.

`tests/unit/gdn_cp_test.py` covers three things:

- `compose_local`, against the recurrence applied chunk by chunk in its original form. That reference never builds `A` or `B` and never calls `compose`, so it checks the affine reformulation rather than restating it. Reversing the chunk order is the negative control.
- `incoming_state` on a single-device mesh, where a shard has nothing before it.
- `incoming_state` against a sequential composition on a forced 8-device CPU mesh, over a 1-D context mesh, a 2-D fsdp x context mesh, and a tuple axis name. Breaking the chain is the negative control.

The multi-device case runs as a subprocess, so the forced device count takes effect before JAX initializes, following `tests/unit/usp_collective_test.py`. pyink clean at `--line-length=122`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

---

_2026-09-15: the 485.5 tok/s/chip this originally published is withdrawn — a two-step artifact of the step timer. Unprofiled over six steps it is 90.2 at `ctx=256` and 104.9 at `ctx=64`. The runs stand._
