### PR TITLE
MoE fp8 backward: in-kernel drhs operand quantization + configurable gradient dtype

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -228,6 +228,7 @@ load_balance_loss_weight: 0.0 # weight for the load balance loss
 use_random_routing: false # whether to use random routing for debug/test purpose
 use_custom_sort_vjp: true # whether to use a custom VJP sort for efficient backward pass processing in sparse matmul
 use_ring_of_experts: false # whether to use ring of experts for sparse matmul expert parallelism
+moe_quantize_token_all_gather: false # whether to quantize token activations to FP8 before All-Gather across EP shards in Ring of Experts
 num_moe_emb_chunks: 0 # number of chunks for overlapping token all-gather and GMM computation along embedding dimension
 # If true, peel the 'expert' mesh axis off the MoE dispatch/MLP batch dim so the expert GEMM
 # stays expert-parallel (AllToAll); false keeps 'expert' on the batch dim (activation_batch_moe).

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -897,7 +897,7 @@ class MoEGeneral(BaseModel):
           "dropless (worst-case) ragged buffer sizes."
       ),
   )
-  bwd_quantization_dtype: str = Field(
+  bwd_quantization_dtype: Literal["e5m2", "e4m3"] = Field(
       "e5m2",
       description=(
           "fp8 dtype for the BACKWARD (gradient) quantization in the fp8_full qwix recipe: 'e5m2' "

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -884,6 +884,10 @@ class MoEGeneral(BaseModel):
       False,
       description="Whether to use Ring of Experts for sparse matmul expert parallelism.",
   )
+  moe_quantize_token_all_gather: bool = Field(
+      False,
+      description="Whether to quantize token activations to FP8 before All-Gather across EP shards in Ring of Experts.",
+  )
   moe_dispatch_no_expert_sharding: bool = Field(
       False,
       description=(

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -884,6 +884,26 @@ class MoEGeneral(BaseModel):
       False,
       description="Whether to use Ring of Experts for sparse matmul expert parallelism.",
   )
+  moe_bwd_inkernel_quant: bool = Field(
+      False,
+      description=(
+          "Quantize the MoE backward-gmm operands INSIDE the ragged kernels instead of with dense "
+          "XLA-level quantize ops. The dense quantize/amax ops process every row of the ragged "
+          "buffer at its STATIC size (worst-case at ragged_buffer_factor<=0); the in-kernel path "
+          "touches only the valid group_sizes rows/tiles, and no reduction ever reads "
+          "uninitialized buffer tail rows. drhs: tgmm quantizes BOTH operands in-kernel "
+          "(per-gm-tile-per-channel e4m3). Requires use_tokamax_gmm + use_gmm_v2 + an fp8 qwix "
+          "bwd_qtype; falls back to the XLA quantize otherwise. For performance improvement at "
+          "dropless (worst-case) ragged buffer sizes."
+      ),
+  )
+  bwd_quantization_dtype: str = Field(
+      "e5m2",
+      description=(
+          "fp8 dtype for the BACKWARD (gradient) quantization in the fp8_full qwix recipe: 'e5m2' "
+          "(default) or 'e4m3'."
+      ),
+  )
   moe_ring_cotangent_ag: bool = Field(
       False,
       description=(

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -884,6 +884,15 @@ class MoEGeneral(BaseModel):
       False,
       description="Whether to use Ring of Experts for sparse matmul expert parallelism.",
   )
+  moe_ring_cotangent_ag: bool = Field(
+      False,
+      description=(
+          "Run the BACKWARD cotangent all-gather of the ring-of-experts combine reduce-scatter on "
+          "a TensorCore Pallas ring kernel instead of the XLA collective (which can serialize on "
+          "the SparseCore collective-offload queue). Forward is unchanged. For performance "
+          "improvement; numerically equal to lax.all_gather."
+      ),
+  )
   moe_quantize_token_all_gather: bool = Field(
       False,
       description="Whether to quantize token activations to FP8 before All-Gather across EP shards in Ring of Experts.",
@@ -1320,6 +1329,15 @@ class RematAndOffload(BaseModel):
   moe_mlpwi_0: RematLocation = Field(
       RematLocation.REMAT,
       description="Remat policy for the first part of a gated MoE's output.",
+  )
+  moe_x_sorted: RematLocation = Field(
+      RematLocation.REMAT,
+      description=(
+          "Remat policy for the routed (post-dispatch, expert-sorted) MoE input plus its small "
+          "routing/metadata bundle. 'device' saves them across the remat boundary so the backward "
+          "does not re-run the dispatch token all-gather and sort; the expert GMMs re-run from the "
+          "saved tensor. Default 'remat' recomputes (existing behavior)."
+      ),
   )
   moe_mlpwi_1: RematLocation = Field(
       RematLocation.REMAT,
@@ -3423,6 +3441,7 @@ class MaxTextConfig(
           "context",
           "mlpwi",
           "moe_mlpwi_0",
+          "moe_x_sorted",
           "moe_mlpwi_1",
           "moe_mlpwo",
           "mlpwi_0",
@@ -4564,6 +4583,7 @@ class RLConfig(
           "context",
           "mlpwi",
           "moe_mlpwi_0",
+          "moe_x_sorted",
           "moe_mlpwi_1",
           "moe_mlpwo",
           "mlpwi_0",

--- a/src/maxtext/kernels/megablox/ops.py
+++ b/src/maxtext/kernels/megablox/ops.py
@@ -76,6 +76,7 @@ def gmm(
     use_manual_quantization: bool = False,  # used in batchsplit
     use_gmm_v2: bool = False,
     partial_sum: jnp.ndarray | None = None,
+    bwd_inkernel_quant: bool = False,
 ):
   """Grouped matrix multiplication operation."""
   if interpret is None:
@@ -106,7 +107,7 @@ def gmm(
   gmm_fwd_bwd = lambda *args: _gmm_fwd(*args)[0]  # pylint: disable=C3001
   gmm_fwd_bwd = jax.custom_vjp(
       gmm_fwd_bwd,
-      nondiff_argnums=(3, 4, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+      nondiff_argnums=(3, 4, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17),
   )
   gmm_fwd_bwd.defvjp(_gmm_fwd, functools.partial(_gmm_bwd, lhs.dtype, rhs.dtype))
   return gmm_fwd_bwd(
@@ -127,6 +128,7 @@ def gmm(
       rhs_vma_axes,
       use_gmm_v2,
       partial_sum,
+      bwd_inkernel_quant,
   )
 
 
@@ -163,6 +165,7 @@ def _gmm_fwd(
     rhs_vma_axes: tuple = tuple(),
     use_gmm_v2: bool = False,
     partial_sum: jnp.ndarray | None = None,
+    bwd_inkernel_quant: bool = False,
 ) -> tuple[
     jnp.ndarray,
     tuple[
@@ -462,6 +465,7 @@ def _gmm_bwd(
     lhs_vma_axes: tuple,
     rhs_vma_axes: tuple,
     use_gmm_v2: bool,
+    bwd_inkernel_quant: bool,
     residual: tuple[
         jnp.ndarray | qpl.QArray,
         jnp.ndarray | qpl.QArray,
@@ -493,14 +497,36 @@ def _gmm_bwd(
   #  - dlhs_dout: the incoming gradient used to calculate dlhs.
   #  - drhs_dout: the incoming gradient used to calculate drhs.
 
+  # moe_bwd_inkernel_quant: run the drhs tgmm with BOTH operands quantized in-kernel
+  # (per-gm-tile-per-channel), touching only rows covered by group_sizes. This subsumes three
+  # dense buffer-sized XLA ops -- the per-row lhs re-quantize, the drhs_dout *= lhs.scale
+  # multiply, and the per-N cotangent quantize -- and, because no reduction ever reads past the
+  # valid rows, removes the NaN hazard of amax over uninitialized ragged-buffer tail rows.
+  inkernel_drhs = (
+      bwd_inkernel_quant
+      and use_tokamax_backend
+      and use_gmm_v2
+      and quantization_rule is not None
+      and bool(quantization_rule.bwd_qtype)
+  )
+
   # 1. Scale Application & QArray Unwrapping
   dlhs_dout, drhs_dout, lhs, rhs = _bwd_prepare_inputs(
-      grad, residual_lhs, residual_rhs, group_sizes, use_gmm_v2, transpose_rhs, quantization_rule
+      grad, residual_lhs, residual_rhs, group_sizes, use_gmm_v2, transpose_rhs, quantization_rule,
+      skip_lhs_quant=inkernel_drhs,
   )
 
   # 2. Backward Pass Quantization
   if quantization_rule:
-    dlhs_dout, drhs_dout = _bwd_quantize_gradient(dlhs_dout, drhs_dout, quantization_rule)
+    if inkernel_drhs:
+      # the in-kernel tgmm quantizes drhs_dout ITSELF; keep the raw cotangent for the drhs side.
+      dlhs_dout, _ = _bwd_quantize_gradient(dlhs_dout, drhs_dout, quantization_rule)
+      if not isinstance(drhs_dout, qpl.QArray) and drhs_dout.dtype != lhs.dtype:
+        # tgmm requires equal operand widths; the in-kernel path reads the RAW cotangent, so
+        # carry it at the activation width (halves the kernel's cotangent read bytes vs f32).
+        drhs_dout = drhs_dout.astype(lhs.dtype)
+    else:
+      dlhs_dout, drhs_dout = _bwd_quantize_gradient(dlhs_dout, drhs_dout, quantization_rule)
 
   # 3. DLHS Gradient Execution
   dlhs = _compute_dlhs(
@@ -534,6 +560,7 @@ def _gmm_bwd(
       interpret,
       rhs_vma_axes,
       quantization_rule,
+      inkernel_quant=inkernel_drhs,
   )
 
   # 5. Output Formatting
@@ -572,8 +599,14 @@ def _bwd_prepare_inputs(
     use_gmm_v2: bool,
     transpose_rhs: bool,
     quantization_rule: qwix.QtRule | None,
+    skip_lhs_quant: bool = False,
 ) -> tuple[jnp.ndarray | qpl.QArray, jnp.ndarray | qpl.QArray, jnp.ndarray, jnp.ndarray]:
-  """Prepares backward operands."""
+  """Prepares backward operands.
+
+  `skip_lhs_quant=True` (bwd_inkernel_quant) keeps the lhs as the raw wide array: the drhs
+  tgmm quantizes BOTH operands in-kernel over valid gm tiles only, so the dense per-row XLA
+  quantize here (and the drhs_dout *= lhs.scale multiply below) would be buffer-sized overhead.
+  """
 
   # dlhs_dout and drhs_dout can be different when quantization is enabled.
   dlhs_dout = grad
@@ -597,7 +630,7 @@ def _bwd_prepare_inputs(
 
   # GMM2 FWD performs lhs quantization inside kernel, lhs is stored as unquantized dtype
   # in the residual tuple. In BWD, we explicitly quantize lhs.
-  if quantization_rule and quantization_rule.act_qtype and not isinstance(lhs, qpl.QArray):
+  if quantization_rule and quantization_rule.act_qtype and not isinstance(lhs, qpl.QArray) and not skip_lhs_quant:
     lhs = qpl.quantize(  # pyrefly: ignore[bad-assignment]
         lhs,
         quantization_rule.act_qtype,
@@ -816,12 +849,16 @@ def _compute_drhs(
     interpret: bool,
     rhs_vma_axes: tuple,
     quantization_rule: qwix.QtRule | None,
+    inkernel_quant: bool = False,
 ) -> jnp.ndarray:
   """Routes execution of DRHS based on backend choices."""
   if use_tokamax_backend and not use_gmm_v2:
     drhs = _drhs_run_tokamax_v1(drhs_dout, lhs, group_sizes, rhs_dtype, use_manual_quantization)
   elif use_tokamax_backend and use_gmm_v2:
-    drhs = _drhs_run_tokamax_v2(drhs_dout, lhs, group_sizes, group_offset, num_actual_groups, rhs_dtype, tiling)
+    drhs = _drhs_run_tokamax_v2(
+        drhs_dout, lhs, group_sizes, group_offset, num_actual_groups, rhs_dtype, tiling,
+        quantize_operands=inkernel_quant,
+    )
   else:
     drhs = _drhs_run_megablox(
         drhs_dout, lhs, group_sizes, group_offset, num_actual_groups, rhs_dtype, tiling, interpret, rhs_vma_axes
@@ -888,6 +925,7 @@ def _drhs_run_tokamax_v2(
     num_actual_groups: int,
     rhs_dtype: jax.typing.DTypeLike,
     tiling: tuple,
+    quantize_operands: bool = False,
 ) -> jnp.ndarray:
   """Executes Tokamax TGMM V2 backend for DRHS = LHS^T @ DRHS_dout."""
   drhs_rhs = drhs_dout.qvalue if isinstance(drhs_dout, qpl.QArray) else drhs_dout
@@ -909,6 +947,7 @@ def _drhs_run_tokamax_v2(
       preferred_element_type=rhs_dtype,  # pyrefly: ignore[bad-argument-type]
       group_offset=group_offset,
       tile_info=custom_drhs_tiling,
+      quantize_operands=quantize_operands and rhs_scale is None,
   )
 
 

--- a/src/maxtext/kernels/megablox/ops.py
+++ b/src/maxtext/kernels/megablox/ops.py
@@ -519,8 +519,16 @@ def _gmm_bwd(
   # 2. Backward Pass Quantization
   if quantization_rule:
     if inkernel_drhs:
-      # the in-kernel tgmm quantizes drhs_dout ITSELF; keep the raw cotangent for the drhs side.
-      dlhs_dout, _ = _bwd_quantize_gradient(dlhs_dout, drhs_dout, quantization_rule)
+      # the in-kernel tgmm quantizes drhs_dout ITSELF; quantize ONLY the dlhs cotangent here
+      # (calling the two-sided helper would emit the dense drhs quantize just to discard it).
+      if quantization_rule.bwd_qtype:
+        dlhs_dout = qpl.quantize(
+            # pyrefly: ignore[bad-argument-type]
+            dlhs_dout,
+            quantization_rule.bwd_qtype,
+            channelwise_axes=[] if quantization_rule.disable_channelwise_axes else [0],
+            calibration_method=quantization_rule.bwd_calibration_method,
+        )
       if not isinstance(drhs_dout, qpl.QArray) and drhs_dout.dtype != lhs.dtype:
         # tgmm requires equal operand widths; the in-kernel path reads the RAW cotangent, so
         # carry it at the activation width (halves the kernel's cotangent read bytes vs f32).

--- a/src/maxtext/kernels/megablox/ops.py
+++ b/src/maxtext/kernels/megablox/ops.py
@@ -25,6 +25,7 @@ from maxtext.kernels.megablox import backend
 from maxtext.kernels.megablox import pallas_mosaic_tpu_v2_gmm_kernel as gmm_v2
 from maxtext.kernels.megablox import pallas_mosaic_tpu_v2_tgmm_kernel as tgmm_v2
 from maxtext.layers import quantizations
+from maxtext.utils import max_logging
 import qwix
 import qwix.pallas as qpl
 import tokamax
@@ -178,13 +179,16 @@ def _gmm_fwd(
   - rhs: [g, k, n] if transpose_rhs=False. [g, n, k] if transpose_rhs=True
   """
 
+  lhs_is_qarray = isinstance(lhs, qpl.QArray)
+  rhs_is_qarray = isinstance(rhs, qpl.QArray)
+
   # Quantize activation and weight
   if quantization_rule:
     # pyrefly: ignore[bad-assignment]
     lhs, rhs = _fwd_quantize_activation_and_weight(
         lhs, rhs, quantization_rule, use_gmm_v2, use_manual_quantization, transpose_rhs
     )
-
+  max_logging.info(f"before QAG: {rhs.shape=}, {lhs.shape=}, {group_sizes.shape=}")
   # Quantization All-Gather (QAG) for weight: only supported for following conditions
   if (
       use_tokamax_backend
@@ -196,6 +200,7 @@ def _gmm_fwd(
   ):
     # pyrefly: ignore[bad-assignment]
     rhs = _fwd_gather_weight(rhs, weight_gather_axes)
+  max_logging.info(f"after QAG: {rhs.shape=}, {lhs.shape=}, {group_sizes.shape=}")
 
   # Backend Execution Routing
   if use_tokamax_backend and not use_gmm_v2:
@@ -226,7 +231,7 @@ def _gmm_fwd(
         lhs_vma_axes,
     )
 
-  return out, (lhs, rhs, group_sizes, group_offset, partial_sum)  # pyrefly: ignore[bad-return]
+  return out, (lhs, rhs, group_sizes, group_offset, partial_sum, lhs_is_qarray, rhs_is_qarray)  # pyrefly: ignore[bad-return]
 
 
 def _fwd_quantize_activation_and_weight(
@@ -382,14 +387,16 @@ def _fwd_run_tokamax_v2(
     rhs_operand = rhs_operand.qvalue
     rhs_scale = _fwd_prepare_rhs_scale(rhs, transpose_rhs=transpose_rhs)
 
+  lhs_operand = lhs.qvalue if isinstance(lhs, qpl.QArray) else lhs
+
   custom_fwd_tiling = gmm_v2.TileSizes(
       tile_m=tiling[0],
       tile_k=tiling[1],
       tile_n=tiling[2],
   )
 
-  return gmm_v2.gmm_v2(
-      lhs=lhs,  # pyrefly: ignore[bad-argument-type]
+  out = gmm_v2.gmm_v2(
+      lhs=lhs_operand,  # pyrefly: ignore[bad-argument-type]
       rhs=rhs_operand,  # pyrefly: ignore[bad-argument-type]
       group_sizes=group_sizes,
       rhs_scale=rhs_scale,
@@ -397,8 +404,14 @@ def _fwd_run_tokamax_v2(
       preferred_element_type=preferred_element_type,
       partial_sum=partial_sum,
       group_offset=group_offset,
-      lhs_scale=_fwd_prepare_lhs_scale(quantization_rule),
+      lhs_scale=_fwd_prepare_lhs_scale(quantization_rule) if not isinstance(lhs, qpl.QArray) else None,
+      maybe_quantize_lhs=not isinstance(lhs, qpl.QArray),
   )
+
+  if isinstance(lhs, qpl.QArray):
+    out = out * (lhs.scale.squeeze() if lhs.scale.size == 1 else lhs.scale).astype(out.dtype)
+
+  return out
 
 
 def _fwd_run_megablox(
@@ -455,13 +468,21 @@ def _gmm_bwd(
         jnp.ndarray,
         jnp.ndarray | None,
         jnp.ndarray | None,
+        bool,
+        bool,
     ],
     grad: jnp.ndarray,
-) -> tuple[jnp.ndarray, jnp.ndarray, None, None, jnp.ndarray | None, jnp.ndarray | None]:
+) -> tuple[
+    jnp.ndarray | qpl.QArray,
+    jnp.ndarray | qpl.QArray,
+    None,
+    None,
+    jnp.ndarray | None,
+    jnp.ndarray | None,
+]:
   """Backward function for throughput GMM VJP."""
-  del preferred_element_type
-  lhs, rhs, group_sizes, group_offset, partial_sum_fwd = residual
-  num_actual_groups = rhs.shape[0]
+  residual_lhs, residual_rhs, group_sizes, group_offset, partial_sum_fwd, lhs_is_qarray, rhs_is_qarray = residual
+  num_actual_groups = residual_rhs.shape[0]
 
   # Jargon used here:
   #  - lhs: input activation in forward pass, possibly quantized.
@@ -474,7 +495,7 @@ def _gmm_bwd(
 
   # 1. Scale Application & QArray Unwrapping
   dlhs_dout, drhs_dout, lhs, rhs = _bwd_prepare_inputs(
-      grad, lhs, rhs, group_sizes, use_gmm_v2, transpose_rhs, quantization_rule
+      grad, residual_lhs, residual_rhs, group_sizes, use_gmm_v2, transpose_rhs, quantization_rule
   )
 
   # 2. Backward Pass Quantization
@@ -523,6 +544,22 @@ def _gmm_bwd(
   drhs = drhs.swapaxes(1, 2) if transpose_rhs else drhs
   dpartial_sum = grad if partial_sum_fwd is not None else None
   d_existing_out = None if use_tokamax_backend else grad
+
+  if lhs_is_qarray and isinstance(residual_lhs, qpl.QArray):
+    lhs_scale = (residual_lhs.scale.squeeze() if residual_lhs.scale.size == 1 else residual_lhs.scale).astype(dlhs.dtype)
+    dlhs = qpl.QArray(
+        qvalue=dlhs * lhs_scale,
+        scale=jnp.zeros_like(residual_lhs.scale),
+        zero_point=jnp.zeros_like(residual_lhs.zero_point) if residual_lhs.zero_point is not None else None,
+        qtype=residual_lhs.qtype,
+    )
+  if rhs_is_qarray and isinstance(residual_rhs, qpl.QArray):
+    drhs = qpl.QArray(
+        qvalue=drhs.astype(residual_rhs.qvalue.dtype) if drhs.dtype != residual_rhs.qvalue.dtype else drhs,
+        scale=jnp.zeros_like(residual_rhs.scale),
+        zero_point=jnp.zeros_like(residual_rhs.zero_point) if residual_rhs.zero_point is not None else None,
+        qtype=residual_rhs.qtype,
+    )
 
   return dlhs, drhs, None, None, d_existing_out, dpartial_sum
 
@@ -574,7 +611,7 @@ def _bwd_prepare_inputs(
   # Apply lhs.scale to drhs_dout, as axis m will disappear in drhs.
   if isinstance(lhs, qpl.QArray):
     # lhs - qvalue: [m, k] scale: [m, 1]
-    drhs_dout *= lhs.scale.astype(grad.dtype)
+    drhs_dout = drhs_dout * (lhs.scale.squeeze() if lhs.scale.size == 1 else lhs.scale).astype(grad.dtype)
     lhs = lhs.qvalue
 
   return dlhs_dout, drhs_dout, lhs, rhs
@@ -725,10 +762,11 @@ def _dlhs_run_tokamax_v2(
       tile_info=custom_dlhs_tiling,
       preferred_element_type=lhs_dtype,  # pyrefly: ignore[bad-argument-type]
       group_offset=group_offset,
+      maybe_quantize_lhs=not isinstance(dlhs_dout, qpl.QArray),
   )
 
   if isinstance(dlhs_dout, qpl.QArray):
-    dlhs *= dlhs_dout.scale.astype(dlhs.dtype)
+    dlhs = dlhs * (dlhs_dout.scale.squeeze() if dlhs_dout.scale.size == 1 else dlhs_dout.scale).astype(dlhs.dtype)
 
   return dlhs
 

--- a/src/maxtext/kernels/megablox/pallas_mosaic_tpu_v2_tgmm_kernel.py
+++ b/src/maxtext/kernels/megablox/pallas_mosaic_tpu_v2_tgmm_kernel.py
@@ -191,6 +191,7 @@ def make_tgmm_configs(
     out_dtype: jnp.dtype,
     acc_dtype: jnp.dtype | None,
     target_zero_ref_bytes: int,
+    quantize_operands: bool = False,
 ):
   """Fills the GMM config for the TGMM kernel."""
   assert out_dtype, "out_dtype cannot be None"
@@ -233,15 +234,24 @@ def make_tgmm_configs(
       size_lhs_sublane=size_lhs_sublane,
   )
 
+  # moe_bwd_inkernel_quant: quantize_operands puts a per-(gm-tile x channel) dynamic e4m3
+  # quantize of BOTH operands inside the inner kernel (signalled to tgmm_inner_kernel via
+  # lhs_cfgs.quant_dtype). Mutually exclusive with a pre-computed per-N rhs_scale.
+  if quantize_operands:
+    assert rhs_scale is None, "quantize_operands is mutually exclusive with rhs_scale"
+    inkernel_q_dtype = jnp.float8_e4m3fn.dtype
+  else:
+    inkernel_q_dtype = None
+
   rhs_quant_block_size_m = size_m
   rhs_cfgs = gmm_v2.InputConfigs(
-      quant_dtype=None,
+      quant_dtype=inkernel_q_dtype,
       quant_block_size=rhs_quant_block_size_m,
       dtype=rhs.dtype,
       has_scale=(rhs_scale is not None),
   )
   lhs_cfgs = gmm_v2.InputConfigs(
-      quant_dtype=None,
+      quant_dtype=inkernel_q_dtype,
       quant_block_size=-1,
       dtype=lhs.dtype,
   )
@@ -334,12 +344,43 @@ def tgmm_inner_kernel(
     rhs_mask = jnp.logical_and(m_start_local <= rhs_iota, rhs_iota < m_end_local)
     rhs_masked = jnp.where(rhs_mask, tiled_rhs_ref[...], 0)
 
-    acc = jax.lax.dot_general(
-        lhs_masked,
-        rhs_masked,
-        (((0,), (0,)), ((), ())),
-        preferred_element_type=jnp.float32,
-    )
+    if cfgs.lhs_cfgs.quant_dtype is not None:
+      # moe_bwd_inkernel_quant: quantize BOTH operands in-kernel with per-(gm-tile x channel)
+      # dynamic scales and rescale the partial product by the scale outer-product before
+      # accumulation (the tgmm_block per-segment pattern, fused into the tile loop -- no dense
+      # XLA-level quantize/amax over the ragged buffer, only valid gm tiles pay). The masked
+      # rows are zero, so they neither perturb the amax nor the product.
+      q_dtype = cfgs.lhs_cfgs.quant_dtype
+      dtype_max = float(jnp.finfo(q_dtype).max)
+      lhs_f = lhs_masked.astype(jnp.float32)
+      rhs_f = rhs_masked.astype(jnp.float32)
+      lhs_scale = jnp.max(jnp.abs(lhs_f), axis=0) / dtype_max  # [tile_k] f32
+      rhs_scale = jnp.max(jnp.abs(rhs_f), axis=0) / dtype_max  # [tile_n] f32
+      # A near-zero scale would give 0 * inf = NaN. An `== 0` guard is NOT enough: for any column
+      # whose amax is nonzero but below ~1.3e-36, `1/scale` OVERFLOWS f32 to inf, the guard does not
+      # fire, and every exactly-zero element in that column becomes 0*inf = NaN. Masked rows are set
+      # to exactly 0 above, so MORE masked rows = more NaN sites -- imbalanced (real) routing makes
+      # small groups and mostly-masked tiles, so it is strictly more exposed than a balanced
+      # synthetic router. Guard on the smallest scale with a finite reciprocal instead.
+      _recip_min = jnp.float32(1.0) / jnp.finfo(jnp.float32).max
+      lhs_inv = jnp.where(lhs_scale > _recip_min, 1.0 / lhs_scale, 0.0)
+      rhs_inv = jnp.where(rhs_scale > _recip_min, 1.0 / rhs_scale, 0.0)
+      lhs_q = (lhs_f * lhs_inv.reshape(1, -1)).astype(q_dtype)
+      rhs_q = (rhs_f * rhs_inv.reshape(1, -1)).astype(q_dtype)
+      acc = jax.lax.dot_general(
+          lhs_q,
+          rhs_q,
+          (((0,), (0,)), ((), ())),
+          preferred_element_type=jnp.float32,
+      )
+      acc = acc * lhs_scale.reshape(-1, 1) * rhs_scale.reshape(1, -1)
+    else:
+      acc = jax.lax.dot_general(
+          lhs_masked,
+          rhs_masked,
+          (((0,), (0,)), ((), ())),
+          preferred_element_type=jnp.float32,
+      )
 
     if not is_new_group:
       acc += acc_ref[...]
@@ -642,6 +683,7 @@ def validate_tgmm_inputs(
         "precision",
         "preferred_element_type",
         "acc_dtype",
+        "quantize_operands",
     ],
 )
 def tgmm_v2(
@@ -658,6 +700,7 @@ def tgmm_v2(
     precision: jax.lax.Precision = jax.lax.Precision.DEFAULT,
     preferred_element_type: jnp.dtype | None = None,
     acc_dtype: jnp.dtype | None = None,
+    quantize_operands: bool = False,
 ):
   """Computes a transposed grouped matrix multiplication.
 
@@ -710,6 +753,7 @@ def tgmm_v2(
       out_dtype=preferred_element_type,  # pyrefly: ignore[bad-argument-type]
       acc_dtype=acc_dtype,
       target_zero_ref_bytes=target_zero_ref_bytes,
+      quantize_operands=quantize_operands,
   )
   dims = cfgs.dims
   tiles = cfgs.tiles

--- a/src/maxtext/kernels/ring_ag.py
+++ b/src/maxtext/kernels/ring_ag.py
@@ -131,14 +131,12 @@ def _kernel(w_ref, o_ref, send_sem, recv_sem, local_sem, *,
   # 1. place our own shard at its tiled slot: chunk index = sum coord_j * strides[j].
   my_chunk = sum(lax.axis_index(axes[j]) * strides[j] for j in range(len(axes)))
   my_start = my_chunk * chunk
-  pltpu.make_async_copy(
+  local_copy = pltpu.make_async_copy(
       w_ref.at[_full_index(w_ref, gather_dim, 0, chunk)],
       o_ref.at[_full_index(o_ref, gather_dim, my_start, chunk)],
-      local_sem).start()
-  pltpu.make_async_copy(
-      w_ref.at[_full_index(w_ref, gather_dim, 0, chunk)],
-      o_ref.at[_full_index(o_ref, gather_dim, my_start, chunk)],
-      local_sem).wait()
+      local_sem)
+  local_copy.start()
+  local_copy.wait()
   # 2. nested rings, innermost axis first (largest k -> smallest stride).
   for k in range(len(axes) - 1, -1, -1):
     _ring_stage(o_ref, all_axes, axes, sizes, strides, k, chunk, gather_dim,

--- a/src/maxtext/kernels/ring_ag.py
+++ b/src/maxtext/kernels/ring_ag.py
@@ -1,0 +1,193 @@
+"""Bidirectional store-and-forward ring all-gather (TensorCore Pallas, ICI DMA).
+
+Validated on v7x: tiled semantics bit-exact vs ``jax.lax.all_gather(..., tiled=True)``. Written for
+IN-shard_map use: `ring_all_gather` runs the pallas_call directly on the local shard
+inside an enclosing shard_map, with a caller-supplied `collective_id` (a fixed id would collide
+with other in-flight Pallas collectives' barrier semaphores) and an explicit `CostEstimate` so the latency-hiding scheduler can see the ~2x-bytes
+DMA cost instead of treating the custom-call as free (kernels without a cost estimate are
+invisible to the scheduler's overlap decisions).
+
+Why a RING (not the direct-to-owner broadcast `_direct_all_gather` in moe.py): the direct pattern
+sends every shard's block over multi-hop paths to all peers (bisection congestion, measured
+regressing at EP=8); the ring moves each block over neighbor links only, at the validated
+159-179 GB/s.
+"""
+
+import jax
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+import jax.numpy as jnp
+
+MESH = pl.DeviceIdType.MESH
+
+
+def _strides(sizes):
+  """Tiled chunk strides for axes ordered outermost..innermost. strides[k]=prod(sizes[k+1:])."""
+  st = [1] * len(sizes)
+  for i in range(len(sizes) - 2, -1, -1):
+    st[i] = st[i + 1] * sizes[i + 1]
+  return st
+
+
+def _full_index(ref, gather_dim, start, length, split_dim=None, s_start=0, s_len=None):
+  """Index tuple: whole array, a [start:start+length] window on gather_dim, and (for bidi) a
+  [s_start:s_start+s_len] window on split_dim. The split is on a NON-gather dim so the gather_dim
+  offsets stay tile-aligned (splitting the gather/concat dim breaks Mosaic tile alignment)."""
+  idx = [pl.ds(0, ref.shape[d]) for d in range(ref.ndim)]
+  idx[gather_dim] = pl.ds(start, length)
+  if split_dim is not None:
+    idx[split_dim] = pl.ds(s_start, s_len)
+  return tuple(idx)
+
+
+def _pick_split_dim(shape, gather_dim):
+  """First non-gather dim with an even extent (to halve for bidirectional). None -> force uni."""
+  for d in range(len(shape)):
+    if d != gather_dim and shape[d] % 2 == 0:
+      return d
+  return None
+
+
+def _neighbor(all_axes, axis, delta):
+  """device_id MESH dict: step `delta` along `axis` (wrap), hold every other mesh axis fixed."""
+  size = lax.axis_size(axis)
+  nxt = lax.rem(lax.axis_index(axis) + delta + size, size)
+  return {a: (nxt if a == axis else lax.axis_index(a)) for a in all_axes}
+
+
+def _ring_stage(o_ref, all_axes, axes, sizes, strides, k, chunk, gather_dim,
+                send_sem, recv_sem, bidi, split_dim, pipe):
+  """One store-and-forward ring over axes[k]; fills sizes[k] blocks of cur_len rows.
+
+  Bidirectional splits each block along split_dim (a NON-gather dim): +dir carries the upper half,
+  -dir the lower half, each over the FULL gather block -> gather_dim offsets stay tile-aligned.
+
+  Pipelining: each direction's half is further sliced into `pipe` independent sub-chunks along
+  split_dim, each with its OWN sem. Store-and-forward forces depth-1 PER sub-chunk (can't forward
+  what hasn't arrived), but the 2*pipe sub-chunks progress independently and are issued
+  round-robin, so at steady state 2*pipe DMAs are in flight. pipe=1 is the baseline."""
+  s = sizes[k]
+  if s == 1:
+    return
+  cur_rows = strides[k] * chunk           # gather-dim block length in rows
+  # Base row of this axis-k group = (sum_{j<k} coord_j * strides[j]) * chunk (shared across the ring).
+  base_rows = (sum(lax.axis_index(axes[j]) * strides[j] for j in range(k)) if k > 0 else 0) * chunk
+  my = lax.axis_index(axes[k])
+  use_bidi = bidi and split_dim is not None
+
+  right_n = _neighbor(all_axes, axes[k], +1)
+  left_n = _neighbor(all_axes, axes[k], -1)
+  bsem = pltpu.get_barrier_semaphore()
+  pl.semaphore_signal(bsem, inc=1, device_id=right_n, device_id_type=MESH)
+  if use_bidi:
+    pl.semaphore_signal(bsem, inc=1, device_id=left_n, device_id_type=MESH)
+  pl.semaphore_wait(bsem, 2 if use_bidi else 1)
+
+  # Pipeline "lanes": (sem_idx, neighbor, hop_sign, split_start, split_len). hop_sign=-1 forwards
+  # source-coord (my-i) to the +1 neighbor; +1 forwards (my+i) to the -1 neighbor.
+  lanes = []
+  if split_dim is not None:
+    E = o_ref.shape[split_dim]
+    if use_bidi:
+      half = E // 2
+      assert half % pipe == 0, (E, pipe)
+      w = half // pipe
+      for j in range(pipe):
+        lanes.append((j,        right_n, -1, half + j * w, w))   # +dir, upper half
+        lanes.append((pipe + j, left_n,  +1, j * w,        w))   # -dir, lower half
+    else:
+      assert E % pipe == 0, (E, pipe)
+      w = E // pipe
+      for j in range(pipe):
+        lanes.append((j, right_n, -1, j * w, w))                 # uni, full split sliced into pipe
+  else:
+    lanes.append((0, right_n, -1, None, None))                   # uni, no split_dim: single block
+
+  def idx(start, ss, sl):
+    if ss is None:
+      return _full_index(o_ref, gather_dim, start, cur_rows)
+    return _full_index(o_ref, gather_dim, start, cur_rows, split_dim=split_dim, s_start=ss, s_len=sl)
+
+  def block_start(u):
+    return base_rows + lax.rem(u + s, s) * cur_rows
+
+  prev = [None] * len(lanes)
+  for i in range(s - 1):
+    for li, (si, nb, sign, ss, sl) in enumerate(lanes):
+      start = block_start(my - i if sign < 0 else my + i)
+      if prev[li] is not None:
+        prev[li].wait()
+      prev[li] = pltpu.async_remote_copy(
+          o_ref.at[idx(start, ss, sl)], o_ref.at[idx(start, ss, sl)],
+          send_sem.at[si], recv_sem.at[si], device_id=nb, device_id_type=MESH)
+  for d in prev:
+    if d is not None:
+      d.wait()
+
+
+def _kernel(w_ref, o_ref, send_sem, recv_sem, local_sem, *,
+            all_axes, axes, sizes, strides, chunk, gather_dim, bidi, split_dim, pipe):
+  # 1. place our own shard at its tiled slot: chunk index = sum coord_j * strides[j].
+  my_chunk = sum(lax.axis_index(axes[j]) * strides[j] for j in range(len(axes)))
+  my_start = my_chunk * chunk
+  pltpu.make_async_copy(
+      w_ref.at[_full_index(w_ref, gather_dim, 0, chunk)],
+      o_ref.at[_full_index(o_ref, gather_dim, my_start, chunk)],
+      local_sem).start()
+  pltpu.make_async_copy(
+      w_ref.at[_full_index(w_ref, gather_dim, 0, chunk)],
+      o_ref.at[_full_index(o_ref, gather_dim, my_start, chunk)],
+      local_sem).wait()
+  # 2. nested rings, innermost axis first (largest k -> smallest stride).
+  for k in range(len(axes) - 1, -1, -1):
+    _ring_stage(o_ref, all_axes, axes, sizes, strides, k, chunk, gather_dim,
+                send_sem, recv_sem, bidi, split_dim, pipe)
+
+
+def ring_all_gather(x, mesh, gather_axes, gather_dim, collective_id, *, bidi=True, pipe=1):
+  """In-shard_map ring all-gather of the LOCAL shard `x` over `gather_axes` (mesh axis names,
+  outermost..innermost), tiled on `gather_dim`. Semantics ==
+  ``jax.lax.all_gather(x, gather_axes, axis=gather_dim, tiled=True)`` (bit-exact, pure data move).
+
+  MUST be called INSIDE a shard_map spanning `mesh` (uses lax.axis_index on the mesh axes for MESH
+  device_id addressing). `collective_id` selects the barrier semaphore and must be DISTINCT from
+  every other concurrently in-flight Pallas collective's id."""
+  if isinstance(gather_axes, str):
+    gather_axes = (gather_axes,)
+  sizes = tuple(mesh.shape[ax] for ax in gather_axes)
+  strides = _strides(sizes)
+  n_total = 1
+  for s_ in sizes:
+    n_total *= s_
+  chunk = x.shape[gather_dim]  # local rows on the gather dim
+  out_shape = list(x.shape)
+  out_shape[gather_dim] = chunk * n_total
+  out_shape = tuple(out_shape)
+  all_axes = tuple(mesh.axis_names)
+  split_dim = _pick_split_dim(out_shape, gather_dim) if bidi else None
+  HBM = pltpu.MemorySpace.HBM
+
+  def kern(w_ref, o_ref, send_sem, recv_sem, local_sem):
+    _kernel(w_ref, o_ref, send_sem, recv_sem, local_sem,
+            all_axes=all_axes, axes=tuple(gather_axes), sizes=sizes, strides=strides,
+            chunk=chunk, gather_dim=gather_dim, bidi=bidi, split_dim=split_dim, pipe=pipe)
+
+  nsem = 2 * pipe   # 2 directions x pipe sub-chunks (uni uses the first `pipe`)
+  # Cost estimate: each device receives + forwards ~2x the full gathered bytes over the ring.
+  # Without it the custom-call is invisible to the latency-hiding scheduler's overlap decisions.
+  full_bytes = 1
+  for d_ in out_shape:
+    full_bytes *= d_
+  full_bytes *= x.dtype.itemsize
+  return pl.pallas_call(
+      kern,
+      out_shape=jax.ShapeDtypeStruct(out_shape, x.dtype),
+      in_specs=[pl.BlockSpec(memory_space=HBM)],
+      out_specs=pl.BlockSpec(memory_space=HBM),
+      scratch_shapes=[pltpu.SemaphoreType.DMA((nsem,)),   # send, per (dir,sub) lane
+                      pltpu.SemaphoreType.DMA((nsem,)),   # recv, per (dir,sub) lane
+                      pltpu.SemaphoreType.DMA],            # local copy
+      compiler_params=pltpu.CompilerParams(collective_id=collective_id),
+      cost_estimate=pl.CostEstimate(flops=0, bytes_accessed=2 * full_bytes, transcendentals=0),
+  )(x)

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -42,8 +42,8 @@ from maxtext.kernels.ragged.ragged_sort import ring_ragged_unsort
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
-from maxtext.utils.sharding import create_sharding, maybe_shard_with_logical, maybe_shard_with_pspec, logical_to_mesh_axes
-from maxtext.utils.sharding import get_logical_axis_rules, remove_expert_from_partition_spec, remove_mesh_axes_from_partition_spec
+from maxtext.utils.sharding import create_sharding, maybe_shard_with_logical, maybe_shard_with_pspec
+from maxtext.utils.sharding import logical_to_mesh_axes, remove_expert_from_partition_spec, get_logical_axis_rules
 import numpy as np
 import qwix
 from qwix.contrib.sparsity import sparsity_module
@@ -747,12 +747,6 @@ class RoutedMoE(nnx.Module):
       if self.config.norm_topk_prob:
         top_k_weights /= top_k_weights.sum(axis=-1, keepdims=True)
 
-      if self.per_expert_scale is not None and not (
-          self.config.model_call_mode == "inference" and self.config.fuse_expert_scales
-      ):
-        per_expert_scale_topk = jnp.take_along_axis(self.per_expert_scale.value[None, None, :], top_k_indices, axis=-1)
-        top_k_weights = top_k_weights * per_expert_scale_topk.astype(top_k_weights.dtype)
-
     return top_k_weights, top_k_indices
 
   def deepseek_scale_weights(self, weights):
@@ -871,10 +865,12 @@ class RoutedMoE(nnx.Module):
       input_ids=None,
   ):
     """Permute tokens to group by expert to fit gmm call."""
+    is_qarray = isinstance(inputs, qpl.QArray)
+    raw_inputs = inputs.qvalue if is_qarray else inputs
     # reshape inputs (batch, sequence, emb) to (batch * sequence, emb)
-    inputs_shape = inputs.shape
+    inputs_shape = raw_inputs.shape
     bsz_times_seq_len = inputs_shape[0] * inputs_shape[1]
-    inputs_2d = jnp.reshape(inputs, (bsz_times_seq_len, inputs_shape[2]))
+    inputs_2d = jnp.reshape(raw_inputs, (bsz_times_seq_len, inputs_shape[2]))
     weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs, input_ids)
     lb_loss = None
     if self.config.load_balance_loss_weight > 0.0 and not self.is_hash_routing:
@@ -945,9 +941,9 @@ class RoutedMoE(nnx.Module):
       sorted_selected_experts = jnp.argsort(flatten_selected_experts)
       # sort inputs for number of selected experts
       replicated_inputs_2d = jnp.repeat(inputs_2d, self.num_experts_per_tok, axis=0)
-      sorted_inputs = _sort_activations(replicated_inputs_2d, sorted_selected_experts, use_custom_sort_vjp).astype(
-          self.dtype
-      )
+      sorted_inputs = _sort_activations(replicated_inputs_2d, sorted_selected_experts, use_custom_sort_vjp)
+      if not is_qarray:
+        sorted_inputs = sorted_inputs.astype(self.dtype)
       group_size = jnp.bincount(flatten_selected_experts, length=self.num_experts)
 
     num_tokens = bsz_times_seq_len * self.num_experts_per_tok
@@ -980,6 +976,9 @@ class RoutedMoE(nnx.Module):
           repeats=group_size,
           total_repeat_length=math.prod(selected_experts.shape),
       )
+
+    if is_qarray:
+      sorted_inputs = qpl.QArray(qvalue=sorted_inputs, scale=inputs.scale)
 
     return (
         sorted_inputs,
@@ -1323,7 +1322,11 @@ class RoutedMoE(nnx.Module):
             is_batch_sharded,
         )
     else:
-      matrix = all_shards_group_sizes if is_dispatch else jnp.transpose(all_shards_group_sizes)
+      matrix = (
+          all_shards_group_sizes
+          if is_dispatch
+          else jnp.transpose(all_shards_group_sizes)
+      )
       input_offsets = transform_array(
           matrix,
           shard_id,
@@ -1356,18 +1359,26 @@ class RoutedMoE(nnx.Module):
     return tuple(bias[experts_index] for bias in biases)
 
   @staticmethod
-  def get_ragged_buffer_size(local_batch, ep_degree, global_experts, top_k, ragged_buffer_factor):
+  def get_ragged_buffer_size(
+      local_batch, ep_degree, global_experts, top_k, ragged_buffer_factor
+  ):
     """Calculates the token batch size of the ragged buffer.
-    When explicitly setting ragged_buffer_factor>0, this is balanced_size * ragged_buffer_factor, which can drop tokens.
-    Otherwise this will be worst case size to ensure no dropping.
+
+    When explicitly setting ragged_buffer_factor>0, this is balanced_size *
+    ragged_buffer_factor, which can drop tokens. Otherwise this will be worst
+    case size to ensure no dropping.
 
     Inputs:
-      local_batch: local token batch (batch*seq blown up by top_k) shard on this device (e.g. inside shard_map)
-      ep_degree: degree of expert parallelism, generally equal to ici_expert_parallelism
+      local_batch: local token batch (batch*seq blown up by top_k) shard on this
+      device (e.g. inside shard_map)
+      ep_degree: degree of expert parallelism, generally equal to
+      ici_expert_parallelism
       global_experts: unsharded expert count, e.g. 256 for deepseek
       top_k: aka num_experts_per_tok, 8 for deepseek.
-      ragged_buffer_factor: When set > 0, the buffer is balanced_size * ragged_buffer_factor.
-        The value 1.0 will be dropless only in the perfectly balanced case, else tokens will be dropped.
+      ragged_buffer_factor: When set > 0, the buffer is balanced_size *
+      ragged_buffer_factor.
+        The value 1.0 will be dropless only in the perfectly balanced case, else
+        tokens will be dropped.
     Outputs:
       The ragged buffer's token batch size.
     """
@@ -1406,7 +1417,9 @@ class RoutedMoE(nnx.Module):
   ):
     """Perform sparse matrix multiplication of inputs and Experts."""
 
-    def jax_ragged_dot_gmm(inputs, kernel, tiling, group_sizes, expert_assignments, padding_amount):
+    def jax_ragged_dot_gmm(
+        inputs, kernel, tiling, group_sizes, expert_assignments, padding_amount
+    ):
       """Execute jax.lax.ragged_dot, with potential quantization"""
       m, k, n = inputs.shape[0], inputs.shape[1], kernel.shape[2]
       # Clamps the tile size using the minimum
@@ -1418,7 +1431,9 @@ class RoutedMoE(nnx.Module):
       rhs_inputs = kernel
       if isinstance(kernel, aqt.QTensor):
         if kernel.bias or kernel.sparsity_mask or len(kernel.scale) > 1:
-          raise ValueError("Unsupported usecase for ragged_dot with quantized kernel.")
+          raise ValueError(
+              "Unsupported usecase for ragged_dot with quantized kernel."
+          )
         rhs_inputs = kernel.qvalue
       if self.config.quantization and self.config.use_qwix_quantization:
         # Use full contraction for QWIX quantization to allow quantization
@@ -1440,7 +1455,9 @@ class RoutedMoE(nnx.Module):
         )
       if isinstance(kernel, aqt.QTensor):
         # Multiply outputs by the kernely scale
-        scales = jnp.take(kernel.scale[0].squeeze(), indices=expert_assignments, axis=0)
+        scales = jnp.take(
+            kernel.scale[0].squeeze(), indices=expert_assignments, axis=0
+        )
         if padding_amount > 0:
           scales = jax.lax.pad(
               scales,
@@ -1480,6 +1497,8 @@ class RoutedMoE(nnx.Module):
         partial_sum=None,
     ):
       def extract_vma(tensor):
+        if isinstance(tensor, qpl.QArray):
+          tensor = tensor.qvalue
         # Parses the varying mesh axes from JAX's type string for a tensor inside shard_map.
         # jax.typeof(t) renders as e.g. 'f32[128,256]{V:(expert, fsdp)}'; this extracts
         # ('expert', 'fsdp'). Returns () if the tensor has no varying axes.
@@ -1491,17 +1510,42 @@ class RoutedMoE(nnx.Module):
           return tuple(sorted(a.strip() for a in vma_content.split(",")))
         return tuple()
 
-      lhs_vma_axes = extract_vma(inputs)
-      rhs_vma_axes = extract_vma(kernel)
+      # VMA (varying mesh axes) extraction is only required for the legacy Megablox backend
+      # fallback (_fwd_run_megablox) to restore lost sharding properties via jax.lax.pcast.
+      # Tokamax and GMM v2 track shard mapping natively and do not consume VMA axes.
+      if (
+          self.config.megablox
+          and not self.config.use_tokamax_gmm
+          and not self.config.moe_quantize_token_all_gather
+      ):
+        lhs_vma_axes = extract_vma(inputs)
+        rhs_vma_axes = extract_vma(kernel)
+      else:
+        lhs_vma_axes = tuple()
+        rhs_vma_axes = tuple()
       if inputs.shape[0] != expert_assignments.shape[0]:
-        raise ValueError("The number of input tokens must match the number of expert assignments!")
+        raise ValueError(
+            "The number of input tokens must match the number of expert"
+            " assignments!"
+        )
 
       tokamax_group_sizes = get_tokamax_group_sizes(group_sizes, inputs, kernel)
-      orig_inputs_shape = inputs.shape  # save shape of inputs before potentially padding.
-      inputs, padding_amount = max_utils.maybe_pad(inputs, self.config.wi_tile_fwd_batch_seq)
+      orig_inputs_shape = (
+          inputs.shape
+      )  # save shape of inputs before potentially padding.
+      if isinstance(inputs, qpl.QArray):
+        padded_qval, padding_amount = max_utils.maybe_pad(
+            inputs.qvalue, self.config.wi_tile_fwd_batch_seq
+        )
+        inputs = qpl.QArray(qvalue=padded_qval, scale=inputs.scale)
+      else:
+        inputs, padding_amount = max_utils.maybe_pad(
+            inputs, self.config.wi_tile_fwd_batch_seq
+        )
       if padding_amount > 0 and partial_sum is not None:
         partial_sum = jnp.pad(partial_sum, ((0, padding_amount), (0, 0)))
-      inputs = inputs.astype(self.dtype)
+      if not isinstance(inputs, qpl.QArray):
+        inputs = inputs.astype(self.dtype)
       kernel = kernel.astype(self.dtype)
       lhs_quantize_dtype, rhs_quantize_dtype = get_quantization_dtypes()
 
@@ -1514,7 +1558,10 @@ class RoutedMoE(nnx.Module):
       # We support various implementations for gmm - tokamax gmm (v1, v2), older forked megablox, or jax.lax.ragged_dot
       # Determine whether we can use: tokamax gmm v1 (quantized)
       is_tokamax_v1_unquantized = (
-          self.config.use_tokamax_gmm and not self.config.quantization and not self.config.use_gmm_v2
+          self.config.use_tokamax_gmm
+          and not self.config.quantization
+          and not self.config.use_gmm_v2
+          and not isinstance(inputs, qpl.QArray)
       )
       # Use custom vjp: tokamax gmm v1 (quantized), tokamax gmm v2 (quantized, unquantized), older forked megablox
       use_custom_vjp_gmm = self.config.use_tokamax_gmm or self.config.megablox
@@ -1542,9 +1589,8 @@ class RoutedMoE(nnx.Module):
             group_offset=group_offset,
             lhs_quantize_dtype=lhs_quantize_dtype,
             rhs_quantize_dtype=rhs_quantize_dtype,
-            # Only "fp8_full" quantizes GMM; other schemes (e.g. "fp8", "int8")
-            # do not define a GMM quantization rule.
-            use_qwix_quantization=bool(self.config.quantization == "fp8_full") and self.config.use_qwix_quantization,
+            use_qwix_quantization=bool(self.config.quantization)
+            and self.config.use_qwix_quantization,
             use_tokamax_backend=self.config.use_tokamax_gmm,
             weight_gather_axes=weight_gather_axes,
             lhs_vma_axes=lhs_vma_axes,
@@ -1574,19 +1620,29 @@ class RoutedMoE(nnx.Module):
       return input_activation.shape[0] > 1
 
     def explicitly_weight_ag(shard_exp_on_fsdp):
-      if shard_exp_on_fsdp:
-        quantization_rule = qpl.get_current_rule("gmm")
-        if quantization_rule and quantization_rule.weight_calibration_method.startswith("fixed"):
-          return True
+      quantization_rule = qpl.get_current_rule("gmm")
+      if (
+          quantization_rule
+          and quantization_rule.weight_calibration_method.startswith("fixed")
+      ):
+        return True
       return False
 
-    def maybe_aqt_partition(w0_kernel, w0_pspec, w1_kernel, w1_pspec, wo_kernel, wo_pspec):
+    def maybe_aqt_partition(
+        w0_kernel, w0_pspec, w1_kernel, w1_pspec, wo_kernel, wo_pspec
+    ):
       if isinstance(w0_kernel, aqt.QTensor):
-        w0_pspec = aqt.partition_spec(w0_pspec, (1,), w0_kernel.dtype, use_bias=False)
+        w0_pspec = aqt.partition_spec(
+            w0_pspec, (1,), w0_kernel.dtype, use_bias=False
+        )
       if isinstance(w1_kernel, aqt.QTensor):
-        w1_pspec = aqt.partition_spec(w1_pspec, (1,), w1_kernel.dtype, use_bias=False)
+        w1_pspec = aqt.partition_spec(
+            w1_pspec, (1,), w1_kernel.dtype, use_bias=False
+        )
       if isinstance(wo_kernel, aqt.QTensor):
-        wo_pspec = aqt.partition_spec(wo_pspec, (1,), wo_kernel.dtype, use_bias=False)
+        wo_pspec = aqt.partition_spec(
+            wo_pspec, (1,), wo_kernel.dtype, use_bias=False
+        )
       return w0_pspec, w1_pspec, wo_pspec
 
     def get_routed_moe_shardings(is_batch_sharded_by_expert, has_input_ids):
@@ -1595,21 +1651,29 @@ class RoutedMoE(nnx.Module):
       else:
         batch_logical_axis = "decode_batch_moe"
 
-      input_partition_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
+      input_partition_pspec = self._logical_to_mesh_axes(
+          (batch_logical_axis, "activation_norm_length", None)
+      )
       w0_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_mlp"))
       w1_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_mlp"))
       wo_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_embed"))
 
-      gate_logits_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
+      gate_logits_pspec = self._logical_to_mesh_axes(
+          (batch_logical_axis, "activation_norm_length", None)
+      )
       # NOTE: deepseek2 has a different pattern
       if self.config.model_name.startswith(("deepseek3", "deepseek4")):
-        pre_bias_logits_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
+        pre_bias_logits_pspec = self._logical_to_mesh_axes(
+            (batch_logical_axis, "activation_norm_length", None)
+        )
       else:
         # pre_bias_logits is None for non-deepseek3/4 models, including deepseek2
         pre_bias_logits_pspec = None
 
       if has_input_ids:
-        decoder_tokens_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length"))
+        decoder_tokens_pspec = self._logical_to_mesh_axes(
+            (batch_logical_axis, "activation_norm_length")
+        )
       else:
         decoder_tokens_pspec = None
 
@@ -1617,7 +1681,10 @@ class RoutedMoE(nnx.Module):
       # mlp_no_fsdp axis
       if self.config.shard_exp_on_fsdp:
         quantization_rule = qpl.get_current_rule("gmm")
-        if quantization_rule and quantization_rule.weight_calibration_method.startswith("fixed"):
+        if (
+            quantization_rule
+            and quantization_rule.weight_calibration_method.startswith("fixed")
+        ):
           # special sharding when using static scaling for weights in quantization with shard_exp_on_fsdp
           w0_pspec = self._logical_to_mesh_axes(self.wi_kernel_axes)
           w1_pspec = self._logical_to_mesh_axes(self.wi_kernel_axes)
@@ -1632,14 +1699,16 @@ class RoutedMoE(nnx.Module):
         w1_pspec = self._logical_to_mesh_axes((None, "mlp_no_fsdp", None))
         wo_pspec = self._logical_to_mesh_axes((None, "mlp_no_fsdp", None))
       else:
-        # These are the main shardings used by default - they use funky rules to AG over FSDP.
-        w0_pspec = self._logical_to_mesh_axes(("exp", None, "mlp_no_fsdp"))
-        w1_pspec = self._logical_to_mesh_axes(("exp", None, "mlp_no_fsdp"))
-        wo_pspec = self._logical_to_mesh_axes(("exp", "mlp_no_fsdp", None))
-        # Update kernel pspec for FSDP AG
-        w0_pspec = remove_mesh_axes_from_partition_spec(w0_pspec, ("fsdp",))
-        w1_pspec = remove_mesh_axes_from_partition_spec(w1_pspec, ("fsdp",))
-        wo_pspec = remove_mesh_axes_from_partition_spec(wo_pspec, ("fsdp",))
+        # Keep embed_moe sharded so we can manually QAG it over FSDP
+        w0_pspec = self._logical_to_mesh_axes(
+            ("exp", "embed_moe", "mlp_no_fsdp")
+        )
+        w1_pspec = self._logical_to_mesh_axes(
+            ("exp", "embed_moe", "mlp_no_fsdp")
+        )
+        wo_pspec = self._logical_to_mesh_axes(
+            ("exp", "mlp_no_fsdp", "embed_moe")
+        )
       return (
           batch_logical_axis,
           input_partition_pspec,
@@ -1668,17 +1737,66 @@ class RoutedMoE(nnx.Module):
         w1_bias_pspec,
         wo_bias_pspec,
         decoder_tokens_pspec,
-    ) = get_routed_moe_shardings(is_batch_sharded_by_expert, input_ids is not None)
-    w0_pspec, w1_pspec, wo_pspec = maybe_aqt_partition(w0_kernel, w0_pspec, w1_kernel, w1_pspec, wo_kernel, wo_pspec)
+    ) = get_routed_moe_shardings(
+        is_batch_sharded_by_expert, input_ids is not None
+    )
+    w0_pspec, w1_pspec, wo_pspec = maybe_aqt_partition(
+        w0_kernel, w0_pspec, w1_kernel, w1_pspec, wo_kernel, wo_pspec
+    )
 
-    def roe_ag_and_route(x, logits, pre_bias_logits, num_ep, expert_shard_id, rngs, input_ids=None):
+    def roe_ag_and_route(
+        x,
+        logits,
+        pre_bias_logits,
+        num_ep,
+        expert_shard_id,
+        rngs,
+        input_ids=None,
+    ):
       # The ring-of-experts strategy first duplicates the inputs to all
       # expert shards, and then routes within each shard.
 
       # Duplicate inputs to all expert shards.
-      x, logits, pre_bias_logits = tuple(
-          jax.lax.all_gather(z, axis_name=self._expert_parallelism_name, tiled=True) for z in (x, logits, pre_bias_logits)
-      )
+      if self.config.moe_quantize_token_all_gather:
+        calibration_method = self.config.act_quantization_calibration_method
+        if num_ep > 1 and (
+            calibration_method is None
+            or calibration_method.lower().startswith("absmax")
+        ):
+          global_max = jax.lax.pmax(
+              jnp.max(jnp.abs(x)), axis_name=self._expert_parallelism_name
+          )
+          dtype_max = jnp.finfo(jnp.float8_e4m3fn).max
+          scale = (global_max / dtype_max).astype(x.dtype)
+          qval = jnp.clip(x / scale, -dtype_max, dtype_max).astype(
+              jnp.float8_e4m3fn
+          )
+          x_input = qpl.QArray(qvalue=qval, scale=jnp.reshape(scale, (1,)))
+        else:
+          x_input = qpl.quantize(
+              x,
+              qtype=jnp.float8_e4m3fn,
+              channelwise_axes=(),
+              calibration_method=calibration_method,
+          )
+        x_gathered_qval, logits, pre_bias_logits = tuple(
+            jax.lax.all_gather(
+                z, axis_name=self._expert_parallelism_name, tiled=True
+            )
+            if z is not None
+            else None
+            for z in (x_input.qvalue, logits, pre_bias_logits)
+        )
+        x = qpl.QArray(qvalue=x_gathered_qval, scale=x_input.scale)
+      else:
+        x, logits, pre_bias_logits = tuple(
+            jax.lax.all_gather(
+                z, axis_name=self._expert_parallelism_name, tiled=True
+            )
+            if z is not None
+            else None
+            for z in (x, logits, pre_bias_logits)
+        )
 
       # "Route" tokens within each shard.
       num_experts_per_shard = self.config.num_experts // num_ep
@@ -1719,7 +1837,15 @@ class RoutedMoE(nnx.Module):
           ),
       )
 
-    def ra2a_and_route(x, logits, pre_bias_logits, num_ep, expert_shard_id, rngs, input_ids=None):
+    def ra2a_and_route(
+        x,
+        logits,
+        pre_bias_logits,
+        num_ep,
+        expert_shard_id,
+        rngs,
+        input_ids=None,
+    ):
       local_sorted_indices = None
       all_shards_group_sizes = None
       reshaped_group_sizes = None
@@ -1742,14 +1868,22 @@ class RoutedMoE(nnx.Module):
       )
 
       if num_ep > 1:
-        batch_axis = self._expert_parallelism_name if is_batch_sharded_by_expert else "data"
+        batch_axis = (
+            self._expert_parallelism_name
+            if is_batch_sharded_by_expert
+            else "data"
+        )
         # get group sizes for all shards
         local_expert_size = self.config.num_experts // num_ep
-        reshaped_group_sizes = jnp.sum(group_sizes.reshape(-1, local_expert_size), axis=1)
+        reshaped_group_sizes = jnp.sum(
+            group_sizes.reshape(-1, local_expert_size), axis=1
+        )
         global_group_sizes = group_sizes
 
         if is_batch_sharded_by_expert:
-          all_shards_group_sizes = jax.lax.all_gather(reshaped_group_sizes, axis_name=batch_axis)
+          all_shards_group_sizes = jax.lax.all_gather(
+              reshaped_group_sizes, axis_name=batch_axis
+          )
           buffer_size = self.get_ragged_buffer_size(
               jnp.shape(x)[0],
               num_ep,
@@ -1757,15 +1891,19 @@ class RoutedMoE(nnx.Module):
               self.config.num_experts_per_tok,
               self.config.ragged_buffer_factor,
           )
-          input_offsets, send_sizes, output_offsets, recv_sizes = RoutedMoE.get_all_to_all_params(
-              all_shards_group_sizes,
-              expert_shard_id,
-              num_ep,
-              ragged_buffer_factor=self.config.ragged_buffer_factor,
-              buffer_size=buffer_size,
+          input_offsets, send_sizes, output_offsets, recv_sizes = (
+              RoutedMoE.get_all_to_all_params(
+                  all_shards_group_sizes,
+                  expert_shard_id,
+                  num_ep,
+                  ragged_buffer_factor=self.config.ragged_buffer_factor,
+                  buffer_size=buffer_size,
+              )
           )
 
-          output_shape = jax.lax.empty((buffer_size, self.moe_expert_input_dim), dtype=x.dtype)
+          output_shape = jax.lax.empty(
+              (buffer_size, self.moe_expert_input_dim), dtype=x.dtype
+          )
 
           x = jax.lax.ragged_all_to_all(
               x,
@@ -1776,29 +1914,35 @@ class RoutedMoE(nnx.Module):
               recv_sizes,
               axis_name=self._expert_parallelism_name,
           )
-          global_group_sizes = jax.lax.all_gather(group_sizes, axis_name=self._expert_parallelism_name)
-          x, local_sorted_indices, group_sizes, selected_experts = RoutedMoE.local_permute(
-              x,
-              global_group_sizes,
-              local_expert_size,
-              shard_index=expert_shard_id,
-              use_custom_sort_vjp=self.config.use_custom_sort_vjp,
-              use_ragged_sort=self.config.use_ragged_sort,
-              ragged_buffer_factor=self.config.ragged_buffer_factor,
-              use_single_sparsecore=self.config.ragged_sort_use_single_sparsecore,
+          global_group_sizes = jax.lax.all_gather(
+              group_sizes, axis_name=self._expert_parallelism_name
+          )
+          x, local_sorted_indices, group_sizes, selected_experts = (
+              RoutedMoE.local_permute(
+                  x,
+                  global_group_sizes,
+                  local_expert_size,
+                  shard_index=expert_shard_id,
+                  use_custom_sort_vjp=self.config.use_custom_sort_vjp,
+                  use_ragged_sort=self.config.use_ragged_sort,
+                  ragged_buffer_factor=self.config.ragged_buffer_factor,
+                  use_single_sparsecore=self.config.ragged_sort_use_single_sparsecore,
+              )
           )
         else:
-          x, local_sorted_indices, group_sizes, selected_experts = RoutedMoE.local_permute(
-              x,
-              global_group_sizes[None, :],
-              local_expert_size,
-              shard_index=expert_shard_id,
-              is_offset=True,
-              global_sorted_experts=selected_experts,
-              use_custom_sort_vjp=self.config.use_custom_sort_vjp,
-              use_ragged_sort=self.config.use_ragged_sort,
-              ragged_buffer_factor=self.config.ragged_buffer_factor,
-              use_single_sparsecore=self.config.ragged_sort_use_single_sparsecore,
+          x, local_sorted_indices, group_sizes, selected_experts = (
+              RoutedMoE.local_permute(
+                  x,
+                  global_group_sizes[None, :],
+                  local_expert_size,
+                  shard_index=expert_shard_id,
+                  is_offset=True,
+                  global_sorted_experts=selected_experts,
+                  use_custom_sort_vjp=self.config.use_custom_sort_vjp,
+                  use_ragged_sort=self.config.use_ragged_sort,
+                  ragged_buffer_factor=self.config.ragged_buffer_factor,
+                  use_single_sparsecore=self.config.ragged_sort_use_single_sparsecore,
+              )
           )
 
       return (
@@ -1823,7 +1967,9 @@ class RoutedMoE(nnx.Module):
     def route(x, logits, pre_bias_logits, rngs, input_ids=None):
       """Performs both across device and within device token routing/sorting"""
       num_ep = self.get_expert_parallelism_size()
-      expert_shard_id = jax.lax.axis_index(self._expert_parallelism_name) if num_ep > 1 else 0
+      expert_shard_id = (
+          jax.lax.axis_index(self._expert_parallelism_name) if num_ep > 1 else 0
+      )
 
       if self.config.use_ring_of_experts:
         return roe_ag_and_route(
@@ -1849,7 +1995,11 @@ class RoutedMoE(nnx.Module):
     def get_active_sharding_axes(pspec_dim_axes, tensor_dim_index):
       if pspec_dim_axes is None:
         return []
-      axes = (pspec_dim_axes,) if isinstance(pspec_dim_axes, str) else pspec_dim_axes
+      axes = (
+          (pspec_dim_axes,)
+          if isinstance(pspec_dim_axes, str)
+          else pspec_dim_axes
+      )
       active = []
       for ax in axes:
         if ax and self.mesh.shape.get(ax, 1) > 1:
@@ -1859,8 +2009,13 @@ class RoutedMoE(nnx.Module):
     def get_wi_gmm_params():
       wi_gather_axes = []
       if weight_gather:
-        # wi [Experts, In, Hidden] -> Gather Exp(0) and Hidden(2)
-        wi_gather_axes.extend(get_active_sharding_axes(w0_pspec[0], 0))
+        if self.config.shard_exp_on_fsdp:
+          # wi [Experts, In, Hidden] -> Gather Exp(0)
+          wi_gather_axes.extend(get_active_sharding_axes(w0_pspec[0], 0))
+        else:
+          # Gather In(1)
+          wi_gather_axes.extend(get_active_sharding_axes(w0_pspec[1], 1))
+        # Gather Hidden(2)
         wi_gather_axes.extend(get_active_sharding_axes(w0_pspec[2], 2))
       wi_tile_size = (
           self.config.wi_tile_fwd_batch_seq,  # m (LHS batch)
@@ -1878,8 +2033,13 @@ class RoutedMoE(nnx.Module):
     def get_wo_gmm_params():
       wo_gather_axes = []
       if weight_gather:
-        # wo [Experts, Hidden, Out] -> Gather Exp(0) and Hidden(1)
-        wo_gather_axes.extend(get_active_sharding_axes(wo_pspec[0], 0))
+        if self.config.shard_exp_on_fsdp:
+          # wo [Experts, Hidden, Out] -> Gather Exp(0)
+          wo_gather_axes.extend(get_active_sharding_axes(wo_pspec[0], 0))
+        else:
+          # Gather Out(2)
+          wo_gather_axes.extend(get_active_sharding_axes(wo_pspec[2], 2))
+        # Gather Hidden(1)
         wo_gather_axes.extend(get_active_sharding_axes(wo_pspec[1], 1))
       wo_tile_size = (
           self.config.wo_tile_fwd_batch_seq,  # m (LHS batch)
@@ -1910,13 +2070,17 @@ class RoutedMoE(nnx.Module):
       if self.config.prefuse_moe_weights:
         # Weights are stored as (G,K,2N); w0/w1 are adjacent slices so XLA elides this concat.
         w_fused = jnp.concatenate([w0, w1], axis=-1)
-        out = gmm_fn(x, w_fused, tiling=wi_tile_size, weight_gather_axes=wi_gather_axes)
+        out = gmm_fn(
+            x, w_fused, tiling=wi_tile_size, weight_gather_axes=wi_gather_axes
+        )
         n = out.shape[-1] // 2
         layer_w0, layer_w1 = out[:, :n], out[:, n:]
         if self.config.mlp_bias and w0_bias is not None and w1_bias is not None:
           layer_w0 = layer_w0 + w0_bias
           layer_w1 = layer_w1 + w1_bias
-        layer_w0 = adc.checkpoint_name(adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0")
+        layer_w0 = adc.checkpoint_name(
+            adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0"
+        )
         layer_w1 = adc.checkpoint_name(layer_w1, "moe_mlpwi_1")
       else:
         layer_w0 = gmm_fn(
@@ -1928,7 +2092,9 @@ class RoutedMoE(nnx.Module):
         )
         if self.config.mlp_bias and w0_bias is not None:
           layer_w0 = layer_w0 + w0_bias
-        layer_w0 = adc.checkpoint_name(adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0")
+        layer_w0 = adc.checkpoint_name(
+            adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0"
+        )
 
         layer_w1 = gmm_fn(
             x,
@@ -1946,7 +2112,10 @@ class RoutedMoE(nnx.Module):
       """Return a partial GMM function with preconfigured routing params."""
       num_ep = self.get_expert_parallelism_size()
       num_experts_per_shard = self.config.num_experts // num_ep
-      if self.config.use_ring_of_experts and x.shape[0] < routing.sorted_selected_experts.shape[0]:
+      if (
+          self.config.use_ring_of_experts
+          and x.shape[0] < routing.sorted_selected_experts.shape[0]
+      ):
         local_group_sizes = routing.local_group_sizes
         return functools.partial(
             gmm,
@@ -1994,13 +2163,15 @@ class RoutedMoE(nnx.Module):
           )
 
         buffer_size = intermediate_output.shape[0]
-        input_offsets, send_sizes, output_offsets, recv_sizes = RoutedMoE.get_all_to_all_params(
-            route_metadata.all_shards_group_sizes,
-            route_metadata.expert_shard_id,
-            self.get_expert_parallelism_size(),
-            ragged_buffer_factor=self.config.ragged_buffer_factor,
-            buffer_size=buffer_size,
-            is_dispatch=False,
+        input_offsets, send_sizes, output_offsets, recv_sizes = (
+            RoutedMoE.get_all_to_all_params(
+                route_metadata.all_shards_group_sizes,
+                route_metadata.expert_shard_id,
+                self.get_expert_parallelism_size(),
+                ragged_buffer_factor=self.config.ragged_buffer_factor,
+                buffer_size=buffer_size,
+                is_dispatch=False,
+            )
         )
         return jax.lax.ragged_all_to_all(
             local_output,
@@ -2015,12 +2186,14 @@ class RoutedMoE(nnx.Module):
       # If batch is replicated across EP shards then each shard should send
       # 0..local_shard_size data to the other shards and receive the
       # local_shard data from all of the other shards using ragged_all_to_all.
-      input_offsets, send_sizes, output_offsets, recv_sizes = RoutedMoE.get_all_to_all_params(
-          route_metadata.reshaped_group_sizes,
-          route_metadata.expert_shard_id,
-          self.get_expert_parallelism_size(),
-          is_batch_sharded=False,
-          is_dispatch=False,
+      input_offsets, send_sizes, output_offsets, recv_sizes = (
+          RoutedMoE.get_all_to_all_params(
+              route_metadata.reshaped_group_sizes,
+              route_metadata.expert_shard_id,
+              self.get_expert_parallelism_size(),
+              is_batch_sharded=False,
+              is_dispatch=False,
+          )
       )
       return jax.lax.ragged_all_to_all(
           intermediate_output,
@@ -2047,11 +2220,17 @@ class RoutedMoE(nnx.Module):
     ):
       """Overlap token all-gather and GMM computation along embedding dimension."""
       num_ep = self.get_expert_parallelism_size()
-      expert_shard_id = jax.lax.axis_index(self._expert_parallelism_name) if num_ep > 1 else 0
+      expert_shard_id = (
+          jax.lax.axis_index(self._expert_parallelism_name) if num_ep > 1 else 0
+      )
 
       chunk_dim = embed_dim // self.config.num_moe_emb_chunks
       chunk_rngs_key = (
-          rngs.params() if rngs is not None and hasattr(rngs, "params") and callable(getattr(rngs, "params")) else None
+          rngs.params()
+          if rngs is not None
+          and hasattr(rngs, "params")
+          and callable(getattr(rngs, "params"))
+          else None
       )
 
       first_x_unrouted = jax.lax.dynamic_slice_in_dim(x, 0, chunk_dim, axis=2)
@@ -2066,16 +2245,26 @@ class RoutedMoE(nnx.Module):
       )
 
       if self.config.mlp_bias:
-        w0_bias, w1_bias, wo_bias = self.transform_bias(routing.selected_experts, w0_bias, w1_bias, wo_bias)
+        w0_bias, w1_bias, wo_bias = self.transform_bias(
+            routing.selected_experts, w0_bias, w1_bias, wo_bias
+        )
 
-      partial_sum0 = jnp.zeros((cur_x_chunk.shape[0], w0.shape[-1]), dtype=cur_x_chunk.dtype)
-      partial_sum1 = jnp.zeros((cur_x_chunk.shape[0], w1.shape[-1]), dtype=cur_x_chunk.dtype)
+      partial_sum0 = jnp.zeros(
+          (cur_x_chunk.shape[0], w0.shape[-1]), dtype=cur_x_chunk.dtype
+      )
+      partial_sum1 = jnp.zeros(
+          (cur_x_chunk.shape[0], w1.shape[-1]), dtype=cur_x_chunk.dtype
+      )
 
       def scan_fn(carry, _):
         cur_x, ps0, ps1, chunk_idx = carry
 
-        cur_w0 = jax.lax.dynamic_slice_in_dim(w0, chunk_idx * chunk_dim, chunk_dim, axis=1)
-        cur_w1 = jax.lax.dynamic_slice_in_dim(w1, chunk_idx * chunk_dim, chunk_dim, axis=1)
+        cur_w0 = jax.lax.dynamic_slice_in_dim(
+            w0, chunk_idx * chunk_dim, chunk_dim, axis=1
+        )
+        cur_w1 = jax.lax.dynamic_slice_in_dim(
+            w1, chunk_idx * chunk_dim, chunk_dim, axis=1
+        )
         gmm_fn = get_gmm_for_local_experts(cur_x, routing, route_metadata)
         next_ps0, next_ps1 = gmm_up(
             cur_x,
@@ -2088,7 +2277,9 @@ class RoutedMoE(nnx.Module):
             partial_accum0=ps0,
             partial_accum1=ps1,
         )
-        next_x_unrouted = jax.lax.dynamic_slice_in_dim(x, (chunk_idx + 1) * chunk_dim, chunk_dim, axis=2)
+        next_x_unrouted = jax.lax.dynamic_slice_in_dim(
+            x, (chunk_idx + 1) * chunk_dim, chunk_dim, axis=2
+        )
         next_x, _, _ = roe_ag_and_route(
             next_x_unrouted,
             logits,
@@ -2107,8 +2298,18 @@ class RoutedMoE(nnx.Module):
           length=self.config.num_moe_emb_chunks - 1,
       )
       # gmm the last chunk
-      last_w0 = jax.lax.dynamic_slice_in_dim(w0, (self.config.num_moe_emb_chunks - 1) * chunk_dim, chunk_dim, axis=1)
-      last_w1 = jax.lax.dynamic_slice_in_dim(w1, (self.config.num_moe_emb_chunks - 1) * chunk_dim, chunk_dim, axis=1)
+      last_w0 = jax.lax.dynamic_slice_in_dim(
+          w0,
+          (self.config.num_moe_emb_chunks - 1) * chunk_dim,
+          chunk_dim,
+          axis=1,
+      )
+      last_w1 = jax.lax.dynamic_slice_in_dim(
+          w1,
+          (self.config.num_moe_emb_chunks - 1) * chunk_dim,
+          chunk_dim,
+          axis=1,
+      )
       gmm_fn = get_gmm_for_local_experts(last_x_chunk, routing, route_metadata)
       output0, output1 = gmm_up(
           last_x_chunk,
@@ -2138,27 +2339,35 @@ class RoutedMoE(nnx.Module):
     ):
       batch_size, sequence_length, embed_dim = x.shape
       if self.config.num_moe_emb_chunks > 0:
-        output0, output1, gmm_fn, routing, route_metadata, wo_bias = moe_emb_chunking(
-            x,
-            logits,
-            pre_bias_logits,
-            w0,
-            w1,
-            w0_bias,
-            w1_bias,
-            wo_bias,
-            sharded_input_ids,
-            rngs,
-            embed_dim,
+        output0, output1, gmm_fn, routing, route_metadata, wo_bias = (
+            moe_emb_chunking(
+                x,
+                logits,
+                pre_bias_logits,
+                w0,
+                w1,
+                w0_bias,
+                w1_bias,
+                wo_bias,
+                sharded_input_ids,
+                rngs,
+                embed_dim,
+            )
         )
       else:
-        x, routing, route_metadata = route(x, logits, pre_bias_logits, rngs, input_ids=sharded_input_ids)
+        x, routing, route_metadata = route(
+            x, logits, pre_bias_logits, rngs, input_ids=sharded_input_ids
+        )
 
         if self.config.mlp_bias:
-          w0_bias, w1_bias, wo_bias = self.transform_bias(routing.selected_experts, w0_bias, w1_bias, wo_bias)
+          w0_bias, w1_bias, wo_bias = self.transform_bias(
+              routing.selected_experts, w0_bias, w1_bias, wo_bias
+          )
 
         gmm_fn = get_gmm_for_local_experts(x, routing, route_metadata)
-        output0, output1 = gmm_up(x, w0, w1, w0_bias, w1_bias, gmm_fn, weight_gather)
+        output0, output1 = gmm_up(
+            x, w0, w1, w0_bias, w1_bias, gmm_fn, weight_gather
+        )
 
       intermediate_layer = self.apply_ffn_activation(output0, output1)
       wo_gather_axes, wo_tile_size = get_wo_gmm_params()
@@ -2177,7 +2386,9 @@ class RoutedMoE(nnx.Module):
         )
       if self.config.mlp_bias:
         intermediate_output = intermediate_output + wo_bias
-      intermediate_output = adc.checkpoint_name(adc.checkpoint_name(intermediate_output, "mlpwo"), "moe_mlpwo")
+      intermediate_output = adc.checkpoint_name(
+          adc.checkpoint_name(intermediate_output, "mlpwo"), "moe_mlpwo"
+      )
 
       if self.config.use_ring_of_experts:
         # Unsort and deduplicate the outputs locally.
@@ -2209,9 +2420,17 @@ class RoutedMoE(nnx.Module):
         return output, routing.lb_loss, routing.bias_updates
 
       if self.get_expert_parallelism_size() > 1:
-        original_inputs_first_dim = batch_size * sequence_length * self.config.num_experts_per_tok
-        if routing.sorted_selected_experts.shape[0] != original_inputs_first_dim:
-          raise ValueError("original_inputs_first_dim does not match the original tensor" " shape!")
+        original_inputs_first_dim = (
+            batch_size * sequence_length * self.config.num_experts_per_tok
+        )
+        if (
+            routing.sorted_selected_experts.shape[0]
+            != original_inputs_first_dim
+        ):
+          raise ValueError(
+              "original_inputs_first_dim does not match the original tensor"
+              " shape!"
+          )
         output_shape = jax.lax.empty(
             (
                 original_inputs_first_dim,
@@ -2257,13 +2476,11 @@ class RoutedMoE(nnx.Module):
             P(),  # Replicate the input key
         ),
         out_specs=(
-            self._logical_to_mesh_axes(
-                (
-                    batch_logical_axis,
-                    "activation_norm_length",
-                    "activation_embed",
-                )
-            ),
+            self._logical_to_mesh_axes((
+                batch_logical_axis,
+                "activation_norm_length",
+                "activation_embed",
+            )),
             P(),  # Handle None or replicate the output
             P(),  # Handle None or replicate the output
         ),
@@ -2342,16 +2559,26 @@ class RoutedMoE(nnx.Module):
         bias_updates_list.append(bu_c)
       output = jnp.concatenate(outs, axis=1)
       lb_loss = None if lb_losses[0] is None else sum(lb_losses) / n_chunks
-      bias_updates = None if bias_updates_list[0] is None else sum(bias_updates_list) / n_chunks
+      bias_updates = (
+          None
+          if bias_updates_list[0] is None
+          else sum(bias_updates_list) / n_chunks
+      )
       return output, lb_loss, bias_updates
 
     if self.config.moe_fsdp_use_two_stage_all_gather:
       # Unshard on fsdp axis
-      w0_kernel = self._maybe_shard_with_logical(w0_kernel, ("exp_with_fsdp", None, "mlp"))
-      w1_kernel = self._maybe_shard_with_logical(w1_kernel, ("exp_with_fsdp", None, "mlp"))
+      w0_kernel = self._maybe_shard_with_logical(
+          w0_kernel, ("exp_with_fsdp", None, "mlp")
+      )
+      w1_kernel = self._maybe_shard_with_logical(
+          w1_kernel, ("exp_with_fsdp", None, "mlp")
+      )
 
       # Unshard on fsdp_transpose axis
-      wo_kernel = self._maybe_shard_with_logical(wo_kernel, ("exp_with_fsdp", "mlp", None))
+      wo_kernel = self._maybe_shard_with_logical(
+          wo_kernel, ("exp_with_fsdp", "mlp", None)
+      )
 
       # Make sure XLA does not optimize by combining above All-Gather to unshard
       # on FSDP axis and the subsequent unshard on fsdp_transpose axis
@@ -2360,22 +2587,34 @@ class RoutedMoE(nnx.Module):
       wo_kernel = jax.lax.optimization_barrier(wo_kernel)
 
       # Unshard on both fsdp and fsdp_transpose transpose
-      w0_kernel = self._maybe_shard_with_logical(w0_kernel, ("exp_with_fsdp", None, "mlp_no_fsdp"))
-      w1_kernel = self._maybe_shard_with_logical(w1_kernel, ("exp_with_fsdp", None, "mlp_no_fsdp"))
-      wo_kernel = self._maybe_shard_with_logical(wo_kernel, ("exp_with_fsdp", "mlp_no_fsdp", None))
+      w0_kernel = self._maybe_shard_with_logical(
+          w0_kernel, ("exp_with_fsdp", None, "mlp_no_fsdp")
+      )
+      w1_kernel = self._maybe_shard_with_logical(
+          w1_kernel, ("exp_with_fsdp", None, "mlp_no_fsdp")
+      )
+      wo_kernel = self._maybe_shard_with_logical(
+          wo_kernel, ("exp_with_fsdp", "mlp_no_fsdp", None)
+      )
 
     input_axes = (batch_logical_axis, "activation_norm_length", None)
 
     gate_logits_axes = (batch_logical_axis, "activation_norm_length", None)
     # NOTE: deepseek2 has a different pattern
     if self.config.model_name.startswith(("deepseek3", "deepseek4")):
-      pre_bias_logits_axes = (batch_logical_axis, "activation_norm_length", None)
+      pre_bias_logits_axes = (
+          batch_logical_axis,
+          "activation_norm_length",
+          None,
+      )
     else:
       pre_bias_logits_axes = None
 
     inputs = self._maybe_shard_with_logical(inputs, input_axes)
     gate_logits = self._maybe_shard_with_logical(gate_logits, gate_logits_axes)
-    pre_bias_logits = self._maybe_shard_with_logical(pre_bias_logits, pre_bias_logits_axes)
+    pre_bias_logits = self._maybe_shard_with_logical(
+        pre_bias_logits, pre_bias_logits_axes
+    )
 
     w0_kernel = self._maybe_shard_with_pspec(w0_kernel, w0_pspec)
     w1_kernel = self._maybe_shard_with_pspec(w1_kernel, w1_pspec)
@@ -2405,21 +2644,29 @@ class RoutedMoE(nnx.Module):
     """reshape and update weights."""
     # input of weights and indices: (batch_size, seq_len, num_experts_per_tok)
     # output of updated weights: (batch_size, seq_len, num_experts)
-    update_weights = jnp.zeros((weights.shape[0], weights.shape[1], self.num_experts), dtype=self.dtype)
+    update_weights = jnp.zeros(
+        (weights.shape[0], weights.shape[1], self.num_experts), dtype=self.dtype
+    )
     index_update = (
         self._maybe_shard_with_logical(
             jnp.arange(weights.shape[0])[:, None, None],
             ("activation_batch", None, None),
         ),
-        self._maybe_shard_with_logical(jnp.arange(weights.shape[1])[:, None], ("activation_length", None)),
+        self._maybe_shard_with_logical(
+            jnp.arange(weights.shape[1])[:, None], ("activation_length", None)
+        ),
         indices,
     )
     weight_sharding = (
-        create_sharding(self.mesh, ("activation_batch", "activation_length", None))
+        create_sharding(
+            self.mesh, ("activation_batch", "activation_length", None)
+        )
         if self.config.shard_mode == ShardMode.EXPLICIT
         else None
     )
-    update_weights = update_weights.at[index_update].set(weights, out_sharding=weight_sharding)
+    update_weights = update_weights.at[index_update].set(
+        weights, out_sharding=weight_sharding
+    )
     return update_weights
 
   def get_context_partition_and_sub_seq(self, seq_len):
@@ -2438,17 +2685,23 @@ class RoutedMoE(nnx.Module):
 
     # Break sequence into subsequences (groups) of tokens, and route only within
     # each group.
-    top_k_indices = jnp.reshape(top_k_indices, (batch_size, cp, sub_seq, top_k_indices.shape[2]))
+    top_k_indices = jnp.reshape(
+        top_k_indices, (batch_size, cp, sub_seq, top_k_indices.shape[2])
+    )
 
     tokens_per_batch = sub_seq * self.num_experts_per_tok
     # this is to avoid expert_capacity_per_batch = 0
     expert_capacity_per_batch = int(
         max(
-            math.ceil(tokens_per_batch / self.num_experts) * self.config.capacity_factor,
+            math.ceil(tokens_per_batch / self.num_experts)
+            * self.config.capacity_factor,
             self.config.capacity_factor,
         )
     )
-    max_logging.log("Applying potential token dropping with a batch expert_capacity of" f" {expert_capacity_per_batch}")
+    max_logging.log(
+        "Applying potential token dropping with a batch expert_capacity of"
+        f" {expert_capacity_per_batch}"
+    )
 
     # calculate expert mask and drop tokens if needed
     # shape of output expert mask: (batch, sequence, num_experts_per_tok)
@@ -2465,12 +2718,16 @@ class RoutedMoE(nnx.Module):
     # [[[[1, 0, 0, 0],[0, 1, 0, 0]], [[0, 0, 0, 0],[0, 0, 0, 1]]]],
     # so the 2nd token for expert #1 ([0, 1] & [1, 3]) is dropped, output of
     # updated_expert_mask is [[[1, 1],[0, 1]]].
-    expert_mask = jax.nn.one_hot(top_k_indices, num_classes=self.num_experts, dtype=jnp.int32)
+    expert_mask = jax.nn.one_hot(
+        top_k_indices, num_classes=self.num_experts, dtype=jnp.int32
+    )
     expert_mask_fused = jnp.reshape(
         expert_mask,
         (batch_size, cp, sub_seq * self.num_experts_per_tok, self.num_experts),
     )
-    expert_mask_fused = self._maybe_shard_with_logical(expert_mask_fused, ("activation_batch", None, None, None))
+    expert_mask_fused = self._maybe_shard_with_logical(
+        expert_mask_fused, ("activation_batch", None, None, None)
+    )
     expert_token_count_fused = jnp.cumsum(expert_mask_fused, axis=2)
     expert_token_count = jnp.reshape(
         expert_token_count_fused,
@@ -2480,7 +2737,9 @@ class RoutedMoE(nnx.Module):
         expert_token_count,
         ("activation_batch", "activation_norm_length", None, None, None),
     )
-    trunc_expert_mask = expert_mask * jnp.less_equal(expert_token_count, expert_capacity_per_batch)
+    trunc_expert_mask = expert_mask * jnp.less_equal(
+        expert_token_count, expert_capacity_per_batch
+    )
     combined_expert_mask = jnp.sum(trunc_expert_mask, axis=3)
 
     # reshape & update weights
@@ -2496,7 +2755,9 @@ class RoutedMoE(nnx.Module):
         expert_token_position_fused,
         (batch_size, cp, sub_seq, self.num_experts_per_tok, self.num_experts),
     )
-    combined_expert_token_position = jnp.sum(expert_token_position, axis=3) * combined_expert_mask
+    combined_expert_token_position = (
+        jnp.sum(expert_token_position, axis=3) * combined_expert_mask
+    )
     expert_token_position_in_capacity = jax.nn.one_hot(
         combined_expert_token_position,
         num_classes=expert_capacity_per_batch + 1,
@@ -2532,11 +2793,15 @@ class RoutedMoE(nnx.Module):
     # this is to avoid expert_capacity_per_batch = 0
     expert_capacity_per_batch = int(
         max(
-            math.ceil(tokens_per_batch / self.num_experts) * self.config.capacity_factor,
+            math.ceil(tokens_per_batch / self.num_experts)
+            * self.config.capacity_factor,
             self.config.capacity_factor,
         )
     )
-    max_logging.log("Applying potential token dropping with a batch expert_capacity of" f" {expert_capacity_per_batch}")
+    max_logging.log(
+        "Applying potential token dropping with a batch expert_capacity of"
+        f" {expert_capacity_per_batch}"
+    )
 
     # calculate expert mask and drop tokens if needed
     # shape of output expert mask: (batch, sequence, num_experts_per_tok)
@@ -2553,12 +2818,16 @@ class RoutedMoE(nnx.Module):
     # [[[[1, 0, 0, 0],[0, 1, 0, 0]], [[0, 0, 0, 0],[0, 0, 0, 1]]]],
     # so the 2nd token for expert #1 ([0, 1] & [1, 3]) is dropped, output of
     # updated_expert_mask is [[[1, 1],[0, 1]]].
-    expert_mask = jax.nn.one_hot(top_k_indices, num_classes=self.num_experts, dtype=jnp.int32)
+    expert_mask = jax.nn.one_hot(
+        top_k_indices, num_classes=self.num_experts, dtype=jnp.int32
+    )
     expert_mask_fused = jnp.reshape(
         expert_mask,
         (batch_size, seq_len * self.num_experts_per_tok, self.num_experts),
     )
-    expert_mask_fused = self._maybe_shard_with_logical(expert_mask_fused, ("activation_batch_moe", None, None))
+    expert_mask_fused = self._maybe_shard_with_logical(
+        expert_mask_fused, ("activation_batch_moe", None, None)
+    )
     expert_token_count_fused = jnp.cumsum(expert_mask_fused, axis=1)
     expert_token_count = jnp.reshape(
         expert_token_count_fused,
@@ -2568,7 +2837,9 @@ class RoutedMoE(nnx.Module):
         expert_token_count,
         ("activation_batch", "activation_norm_length", None, None),
     )
-    trunc_expert_mask = expert_mask * jnp.less_equal(expert_token_count, expert_capacity_per_batch)
+    trunc_expert_mask = expert_mask * jnp.less_equal(
+        expert_token_count, expert_capacity_per_batch
+    )
     combined_expert_mask = jnp.sum(trunc_expert_mask, axis=2)
 
     softmax_probs *= combined_expert_mask
@@ -2579,7 +2850,9 @@ class RoutedMoE(nnx.Module):
         expert_token_position_fused,
         (batch_size, seq_len, self.num_experts_per_tok, self.num_experts),
     )
-    combined_expert_token_position = jnp.sum(expert_token_position, axis=2) * combined_expert_mask
+    combined_expert_token_position = (
+        jnp.sum(expert_token_position, axis=2) * combined_expert_mask
+    )
     expert_token_position_in_capacity = jax.nn.one_hot(
         combined_expert_token_position,
         num_classes=expert_capacity_per_batch + 1,
@@ -2599,10 +2872,12 @@ class RoutedMoE(nnx.Module):
   def load_balance_loss(self, top_k_indices, logits) -> jax.Array:
     """Compute the sequence-wise load balance loss.
 
-    For DeepSeek V4 like models, standard load balancing across an entire batch can
+    For DeepSeek V4 like models, standard load balancing across an entire batch
+    can
     be inadequate due to heterogeneous prompt lengths and varying sequence
     characteristics. This method implements sequence-wise load balancing by
-    computing the token density and routing probabilities on a per-sequence basis.
+    computing the token density and routing probabilities on a per-sequence
+    basis.
 
     The resulting loss is scaled by `self.config.load_balance_loss_weight`.
     When this configuration value is set > 0, the computed loss is aggregated
@@ -2610,7 +2885,9 @@ class RoutedMoE(nnx.Module):
     the optimizer updates the routing parameters to actively enforce an even
     distribution of tokens to experts within each individual sequence.
     """
-    expert_mask = jax.nn.one_hot(top_k_indices, num_classes=self.num_experts, dtype=jnp.int32)
+    expert_mask = jax.nn.one_hot(
+        top_k_indices, num_classes=self.num_experts, dtype=jnp.int32
+    )
     summed_expert_mask = jnp.sum(expert_mask, axis=2)
     # Get fraction of tokens dispatched to each expert
     # jnp.mean over axis=1 (sequence length) isolates the token density per sequence.
@@ -2620,7 +2897,11 @@ class RoutedMoE(nnx.Module):
     density_prob = jnp.mean(logits, axis=1)
     # The sequence-wise densities and probabilities are multiplied and then averaged
     # over the batch dimension, scaled by the required constant.
-    loss = jnp.mean(density * density_prob) * (self.num_experts**2) * self.config.load_balance_loss_weight
+    loss = (
+        jnp.mean(density * density_prob)
+        * (self.num_experts**2)
+        * self.config.load_balance_loss_weight
+    )
     return loss
 
   def get_einsum(
@@ -2681,17 +2962,26 @@ class RoutedMoE(nnx.Module):
   ) -> tuple[jax.Array, Optional[jax.Array], Optional[jax.Array]]:
     """Dense matrix multiplication."""
     # gate_logits: batch, length, expert
-    gate_logits = self._maybe_shard_with_logical(gate_logits, ("activation_batch_moe", "activation_length_moe", None))
+    gate_logits = self._maybe_shard_with_logical(
+        gate_logits, ("activation_batch_moe", "activation_length_moe", None)
+    )
     # NOTE: deepseek2 has a different pattern
     if self.config.model_name.startswith(("deepseek3", "deepseek4")):
       # pre_bias_logits is None for non-deepseek3/4 models, including deepseek2
       pre_bias_logits = self._maybe_shard_with_logical(
-          pre_bias_logits, ("activation_batch_moe", "activation_length_moe", None)
+          pre_bias_logits,
+          ("activation_batch_moe", "activation_length_moe", None),
       )
-    top_k_weights, top_k_indices = self.get_topk(gate_logits, pre_bias_logits, self.rngs, input_ids=input_ids)
-    is_llama4_decoder_layer = self.config.decoder_block == ctypes.DecoderBlockType.LLAMA4
+    top_k_weights, top_k_indices = self.get_topk(
+        gate_logits, pre_bias_logits, self.rngs, input_ids=input_ids
+    )
+    is_llama4_decoder_layer = (
+        self.config.decoder_block == ctypes.DecoderBlockType.LLAMA4
+    )
     if is_llama4_decoder_layer:
-      router_scores = jax.nn.sigmoid(top_k_weights.astype(jnp.float32)).astype(self.dtype)
+      router_scores = jax.nn.sigmoid(top_k_weights.astype(jnp.float32)).astype(
+          self.dtype
+      )
       inputs = inputs * router_scores
     else:
       weights = self.reshape_and_update_weights(top_k_weights, top_k_indices)
@@ -2701,9 +2991,13 @@ class RoutedMoE(nnx.Module):
     # DeepSeek V4 uses Hash Routing for the first `first_num_hash_layers` layers.
     # These layers route deterministically based on token IDs and do not generate auxiliary loss.
     if self.config.model_call_mode != "inference" and not self.is_hash_routing:
-      softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
+      softmax_probs = jax.nn.softmax(
+          gate_logits.astype(jnp.float32), axis=-1
+      ).astype(self.dtype)
       lb_loss = (
-          self.load_balance_loss(top_k_indices, softmax_probs) if self.config.load_balance_loss_weight > 0.0 else None
+          self.load_balance_loss(top_k_indices, softmax_probs)
+          if self.config.load_balance_loss_weight > 0.0
+          else None
       )
       # TODO(dipakg-lang, b/521990776): Add sequence-wise balance loss * 0.0001
     else:
@@ -2763,8 +3057,12 @@ class RoutedMoE(nnx.Module):
       else:
         # TODO(b/425930507): Try replacing `softmax_probs` with padded weights
         # and verify with decode acc tests.
-        softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
-        dispatch_mask, combine_mask = self.generate_masks_subgroup(top_k_indices, softmax_probs)
+        softmax_probs = jax.nn.softmax(
+            gate_logits.astype(jnp.float32), axis=-1
+        ).astype(self.dtype)
+        dispatch_mask, combine_mask = self.generate_masks_subgroup(
+            top_k_indices, softmax_probs
+        )
         if self.get_context_autoregressive_parallelism_size() > 0 and cp == 1:
           mask_axes = (
               "activation_norm_length_moe",
@@ -2834,9 +3132,9 @@ class RoutedMoE(nnx.Module):
 
       with jax.named_scope("dispatch"):
         # only cp during prefill
-        dispatch = self.get_einsum(rhs_mesh_axes=mask_axes, einsum_name=DISPATCH)(
-            dispatch_eimsum, inputs, dispatch_mask, precision=matmul_precision
-        )
+        dispatch = self.get_einsum(
+            rhs_mesh_axes=mask_axes, einsum_name=DISPATCH
+        )(dispatch_eimsum, inputs, dispatch_mask, precision=matmul_precision)
         if cp > 1:
           dispatch = self._maybe_shard_with_logical(
               dispatch,
@@ -2848,10 +3146,14 @@ class RoutedMoE(nnx.Module):
                   "activation_embed_moe",
               ),
           )
-        dispatch = self._maybe_shard_moe_dispatch(dispatch, dispatch_axis, moe_peel_expert)
+        dispatch = self._maybe_shard_moe_dispatch(
+            dispatch, dispatch_axis, moe_peel_expert
+        )
       with jax.named_scope("wi_0"):
         w0_kernel_axes = ("exp", None, "mlp")
-        w0_kernel = self.maybe_all_gather_kernel_weight_in_expert_parallelism(w0_kernel, w0_kernel_axes)
+        w0_kernel = self.maybe_all_gather_kernel_weight_in_expert_parallelism(
+            w0_kernel, w0_kernel_axes
+        )
         layer_w0 = self.get_einsum(rhs_mesh_axes=w0_kernel_axes)(
             mlp_up_einsum, dispatch, w0_kernel, precision=matmul_precision
         )
@@ -2861,11 +3163,17 @@ class RoutedMoE(nnx.Module):
 
         if self.config.activations_in_float32:
           layer_w0 = layer_w0.astype(jnp.float32)
-        layer_w0 = self._maybe_shard_moe_dispatch(layer_w0, mlp_axis, moe_peel_expert)
-        layer_w0 = adc.checkpoint_name(adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0")
+        layer_w0 = self._maybe_shard_moe_dispatch(
+            layer_w0, mlp_axis, moe_peel_expert
+        )
+        layer_w0 = adc.checkpoint_name(
+            adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0"
+        )
       with jax.named_scope("wi_1"):
         w1_kernel_axes = ("exp", None, "mlp")
-        w1_kernel = self.maybe_all_gather_kernel_weight_in_expert_parallelism(w1_kernel, w1_kernel_axes)
+        w1_kernel = self.maybe_all_gather_kernel_weight_in_expert_parallelism(
+            w1_kernel, w1_kernel_axes
+        )
         layer_w1 = self.get_einsum(rhs_mesh_axes=w1_kernel_axes)(
             mlp_up_einsum, dispatch, w1_kernel, precision=matmul_precision
         )
@@ -2874,12 +3182,18 @@ class RoutedMoE(nnx.Module):
           layer_w1 = layer_w1 + w1_bias
         if self.config.activations_in_float32:
           layer_w1 = layer_w1.astype(jnp.float32)
-        layer_w1 = self._maybe_shard_moe_dispatch(layer_w1, mlp_axis, moe_peel_expert)
-        layer_w1 = adc.checkpoint_name(adc.checkpoint_name(layer_w1, "mlpwi_1"), "moe_mlpwi_1")
+        layer_w1 = self._maybe_shard_moe_dispatch(
+            layer_w1, mlp_axis, moe_peel_expert
+        )
+        layer_w1 = adc.checkpoint_name(
+            adc.checkpoint_name(layer_w1, "mlpwi_1"), "moe_mlpwi_1"
+        )
       layer_multiply = self.apply_ffn_activation(layer_w0, layer_w1)
       with jax.named_scope("wo"):
         wo_kernel_axes = ("exp", "mlp", None)
-        wo_kernel = self.maybe_all_gather_kernel_weight_in_expert_parallelism(wo_kernel, wo_kernel_axes)
+        wo_kernel = self.maybe_all_gather_kernel_weight_in_expert_parallelism(
+            wo_kernel, wo_kernel_axes
+        )
         intermediate_layer = self.get_einsum(rhs_mesh_axes=wo_kernel_axes)(
             mlp_down_einsum,
             layer_multiply,
@@ -2901,7 +3215,9 @@ class RoutedMoE(nnx.Module):
                   "activation_embed_moe",
               ),
           )
-        intermediate_layer = adc.checkpoint_name(adc.checkpoint_name(intermediate_layer, "mlpwo"), "moe_mlpwo")
+        intermediate_layer = adc.checkpoint_name(
+            adc.checkpoint_name(intermediate_layer, "mlpwo"), "moe_mlpwo"
+        )
       with jax.named_scope("combine"):
         # Matmul & element wise operation
         output = self.get_einsum(rhs_mesh_axes=mask_axes, einsum_name=COMBINE)(
@@ -2937,7 +3253,9 @@ class RoutedMoE(nnx.Module):
           layer_w0 = layer_w0 + w0_bias[None, None, :, :]
         if self.config.activations_in_float32:
           layer_w0 = layer_w0.astype(jnp.float32)
-        layer_w0 = adc.checkpoint_name(adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0")
+        layer_w0 = adc.checkpoint_name(
+            adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0"
+        )
       with jax.named_scope("wi_1"):
         layer_w1 = self.get_einsum(rhs_mesh_axes=self.wi_kernel_axes)(
             "BSM,EMH -> BSEH", inputs, w1_kernel, precision=matmul_precision
@@ -2946,7 +3264,9 @@ class RoutedMoE(nnx.Module):
           layer_w1 = layer_w1 + w1_bias[None, None, :, :]
         if self.config.activations_in_float32:
           layer_w1 = layer_w1.astype(jnp.float32)
-        layer_w1 = adc.checkpoint_name(adc.checkpoint_name(layer_w1, "mlpwi_1"), "moe_mlpwi_1")
+        layer_w1 = adc.checkpoint_name(
+            adc.checkpoint_name(layer_w1, "mlpwi_1"), "moe_mlpwi_1"
+        )
       layer_multiply = self.apply_ffn_activation(layer_w0, layer_w1)
 
       with jax.named_scope("wo"):
@@ -2960,10 +3280,14 @@ class RoutedMoE(nnx.Module):
           intermediate_layer = intermediate_layer + wo_bias[None, None, :, :]
         if self.config.activations_in_float32:
           intermediate_layer = intermediate_layer.astype(jnp.float32)
-        intermediate_layer = adc.checkpoint_name(adc.checkpoint_name(intermediate_layer, "mlpwo"), "moe_mlpwo")
+        intermediate_layer = adc.checkpoint_name(
+            adc.checkpoint_name(intermediate_layer, "mlpwo"), "moe_mlpwo"
+        )
       with jax.named_scope("weight_sum"):
         if is_llama4_decoder_layer:
-          weights = self.reshape_and_update_weights(jnp.ones_like(top_k_weights), top_k_indices)
+          weights = self.reshape_and_update_weights(
+              jnp.ones_like(top_k_weights), top_k_indices
+          )
         if self.config.float32_weight_sum:
           intermediate_layer = intermediate_layer.astype(jnp.float32)
           weights = weights.astype(jnp.float32)
@@ -2995,12 +3319,16 @@ class RoutedMoE(nnx.Module):
       # pytype: disable=import-error
       from tpu_inference.layers.common.fused_moe_gmm import fused_moe_func
     except ImportError as e:
-      raise ImportError("fused_moe_matmul requires the tpu-inference package.") from e
+      raise ImportError(
+          "fused_moe_matmul requires the tpu-inference package."
+      ) from e
 
     # Reshape 3D [B, S, D] -> 2D [T, D] (fused_moe_func expects 2D input)
     batch_size, seq_len, emb_dim = inputs.shape
     hidden_states = jnp.reshape(inputs, (batch_size * seq_len, emb_dim))
-    gating_output = jnp.reshape(gate_logits, (batch_size * seq_len, self.num_experts))
+    gating_output = jnp.reshape(
+        gate_logits, (batch_size * seq_len, self.num_experts)
+    )
 
     # Concatenate gate and up projections: [E, D, H] + [E, D, H] -> [E, D, 2H]
     # fused_moe_func splits this internally: gate=w1[..., :H], up=w1[..., H:]
@@ -3012,11 +3340,16 @@ class RoutedMoE(nnx.Module):
 
     # Map MaxText config fields to fused_moe_func args
     activation = self.config.mlp_activations[0]  # e.g. "silu"
-    scoring_fn = self.config.routed_score_func if self.config.routed_score_func else "softmax"
+    scoring_fn = (
+        self.config.routed_score_func
+        if self.config.routed_score_func
+        else "softmax"
+    )
 
     # Check if the model architecture intrinsically renormalizes weights
     renormalize = self.config.norm_topk_prob or (
-        self.config.decoder_block not in (ctypes.DecoderBlockType.LLAMA4, ctypes.DecoderBlockType.GEMMA4)
+        self.config.decoder_block
+        not in (ctypes.DecoderBlockType.LLAMA4, ctypes.DecoderBlockType.GEMMA4)
     )
 
     output_2d = fused_moe_func(
@@ -3068,9 +3401,15 @@ class RoutedMoE(nnx.Module):
         wo_bias,
     )
 
-    w0_kernel = self.variables["aqt"]["AqtEinsum_0"]["AqtDotGeneral_0"]["qrhs"]["frozen"]
-    w1_kernel = self.variables["aqt"]["AqtEinsum_1"]["AqtDotGeneral_0"]["qrhs"]["frozen"]
-    wo_kernel = self.variables["aqt"]["AqtEinsum_2"]["AqtDotGeneral_0"]["qrhs"]["frozen"]
+    w0_kernel = self.variables["aqt"]["AqtEinsum_0"]["AqtDotGeneral_0"]["qrhs"][
+        "frozen"
+    ]
+    w1_kernel = self.variables["aqt"]["AqtEinsum_1"]["AqtDotGeneral_0"]["qrhs"][
+        "frozen"
+    ]
+    wo_kernel = self.variables["aqt"]["AqtEinsum_2"]["AqtDotGeneral_0"]["qrhs"][
+        "frozen"
+    ]
 
     w0_kernel = max_utils.unbox_logicallypartioned(w0_kernel)
     w1_kernel = max_utils.unbox_logicallypartioned(w1_kernel)
@@ -3088,8 +3427,9 @@ class RoutedMoE(nnx.Module):
 
     Args:
       inputs: The input activations.
-      input_ids: Optional token IDs corresponding to the inputs, used strictly for Hash Routing
-        in DeepSeek V4's early MoE layers. If None, routing relies purely on `gate_inputs` or `inputs`.
+      input_ids: Optional token IDs corresponding to the inputs, used strictly
+        for Hash Routing in DeepSeek V4's early MoE layers. If None, routing
+        relies purely on `gate_inputs` or `inputs`.
       gate_inputs: Optional alternate inputs to feed into the routing gate.
       out_sharding: Optional sharding specification for the output.
 
@@ -3100,7 +3440,9 @@ class RoutedMoE(nnx.Module):
     cfg = self.config
     inputs = inputs.astype(cfg.dtype)
     gate_dtype = jnp.float32 if cfg.float32_gate_logits else cfg.dtype
-    routing_inputs = inputs if gate_inputs is None else gate_inputs.astype(gate_dtype)
+    routing_inputs = (
+        inputs if gate_inputs is None else gate_inputs.astype(gate_dtype)
+    )
     gate_logits, pre_bias_logits = self.gate(routing_inputs)
 
     wo_kernel = jnp.asarray(self.wo[...], self.dtype)
@@ -3108,7 +3450,11 @@ class RoutedMoE(nnx.Module):
     fused_kernel = None
     w0_kernel = None
     w1_kernel = None
-    if cfg.prefuse_moe_weights and cfg.attention in ("vllm_rpa", "vllm_batched_rpa") and not self.is_hash_routing:
+    if (
+        cfg.prefuse_moe_weights
+        and cfg.attention in ("vllm_rpa", "vllm_batched_rpa")
+        and not self.is_hash_routing
+    ):
       fused_kernel = jnp.asarray(self.wi[...], self.dtype)
     elif cfg.prefuse_moe_weights:
       wi = jnp.asarray(self.wi[...], self.dtype)
@@ -3119,19 +3465,27 @@ class RoutedMoE(nnx.Module):
       w0_kernel = jnp.asarray(self.wi_0[...], self.dtype)
       w1_kernel = jnp.asarray(self.wi_1[...], self.dtype)
 
-    # For fused MoE path (inference only), if we have not fused expert
-    # scales at init, we must apply them to wo_kernel here because
-    # fused_moe_func doesn't support them. Other paths (dense/sparse
-    # matmul) apply them to top_k_weights in get_topk.
-    is_fused_moe_path = cfg.attention in ("vllm_rpa", "vllm_batched_rpa") and not self.is_hash_routing
-    if is_fused_moe_path:
-      if self.per_expert_scale is not None and not (cfg.model_call_mode == "inference" and cfg.fuse_expert_scales):
-        wo_kernel = wo_kernel * jnp.asarray(self.per_expert_scale[...], self.dtype)[:, None, None]
+    # Only apply per expert scales if we have not fused with the out-projections at init time.
+    if (
+        self.per_expert_scale is not None
+        and cfg.model_call_mode != "inference"
+        and not cfg.fuse_expert_scales
+    ):
+      wo_kernel = (
+          wo_kernel
+          * jnp.asarray(self.per_expert_scale[...], self.dtype)[:, None, None]
+      )
 
     if self.wi_0_sparsity_module is not None:
-      _, w0_kernel = self.wi_0_sparsity_module(jnp.zeros_like(w0_kernel), w0_kernel)
-      _, w1_kernel = self.wi_1_sparsity_module(jnp.zeros_like(w1_kernel), w1_kernel)
-      _, wo_kernel = self.wo_sparsity_module(jnp.zeros_like(wo_kernel), wo_kernel)
+      _, w0_kernel = self.wi_0_sparsity_module(
+          jnp.zeros_like(w0_kernel), w0_kernel
+      )
+      _, w1_kernel = self.wi_1_sparsity_module(
+          jnp.zeros_like(w1_kernel), w1_kernel
+      )
+      _, wo_kernel = self.wo_sparsity_module(
+          jnp.zeros_like(wo_kernel), wo_kernel
+      )
     if cfg.mlp_bias:
       w0_bias = jnp.asarray(self.wi_0_bias[...], self.dtype)
       w1_bias = jnp.asarray(self.wi_1_bias[...], self.dtype)
@@ -3143,7 +3497,10 @@ class RoutedMoE(nnx.Module):
     # The fused MoE kernel currently only supports standard Top-K routing with associated
     # weights. Hash routed layers bypass this kernel and fall back
     # to the sparse matmul implementation.
-    if cfg.attention in ("vllm_rpa", "vllm_batched_rpa") and not self.is_hash_routing:
+    if (
+        cfg.attention in ("vllm_rpa", "vllm_batched_rpa")
+        and not self.is_hash_routing
+    ):
       output, lb_loss, bias_updates = self.fused_moe_matmul(
           inputs,
           gate_logits,
@@ -3218,8 +3575,10 @@ class RoutedAndSharedMoE(nnx.Module):
       rngs: An `nnx.Rngs` object used for initializing parameters.
       weight_dtype: The data type of the kernel weights.
       dtype: The data type for the computation.
-      quant: The quantization configuration. If None, no quantization is applied.
-      is_hash_routing: Passed down to the internal `RoutedMoE` to determine routing behavior (e.g. hash vs top-K).
+      quant: The quantization configuration. If None, no quantization is
+        applied.
+      is_hash_routing: Passed down to the internal `RoutedMoE` to determine
+        routing behavior (e.g. hash vs top-K).
     """
     self.config = config
     self.mesh = mesh
@@ -3231,7 +3590,9 @@ class RoutedAndSharedMoE(nnx.Module):
     self.rngs = rngs
     self.is_hash_routing = is_hash_routing
     self.moe_expert_input_dim = (
-        self.config.emb_dim if self.config.moe_expert_input_dim <= 0 else self.config.moe_expert_input_dim
+        self.config.emb_dim
+        if self.config.moe_expert_input_dim <= 0
+        else self.config.moe_expert_input_dim
     )
 
     # NOTE: the name MoeBlock_0 is to ensure reverse compatibility with
@@ -3283,12 +3644,14 @@ class RoutedAndSharedMoE(nnx.Module):
 
     Args:
       inputs: The input activations.
-      original_inputs: The original pre-normalization inputs (unused by default).
+      original_inputs: The original pre-normalization inputs (unused by
+        default).
       gate_inputs: Optional alternate inputs to feed into the routing gate.
-      intermediate_sharding: Optional sharding spec for the shared experts intermediate output.
+      intermediate_sharding: Optional sharding spec for the shared experts
+        intermediate output.
       out_sharding: Optional sharding spec for the final combined output.
-      input_ids: Optional token IDs corresponding to the inputs, used strictly for Hash Routing
-        in DeepSeek V4's early MoE layers.
+      input_ids: Optional token IDs corresponding to the inputs, used strictly
+        for Hash Routing in DeepSeek V4's early MoE layers.
 
     Returns:
       A tuple containing the combined MoE output (routed + shared),
@@ -3315,7 +3678,9 @@ def get_gate_logit(
     axis: Union[Iterable[int], int] = -1,
     weight_dtype: ctypes.DType = jnp.float32,
     dtype: ctypes.DType = jnp.float32,
-    kernel_init: NdInitializer = nd_dense_init(1.0, "fan_in", "truncated_normal"),
+    kernel_init: NdInitializer = nd_dense_init(
+        1.0, "fan_in", "truncated_normal"
+    ),
     kernel_axes: Tuple[Optional[str], ...] = (),
     use_bias: bool = False,
     score_func: str = "",
@@ -3326,7 +3691,9 @@ def get_gate_logit(
   """Creates a GateLogit Linen module."""
 
   axis = linears.canonicalize_tuple(axis)
-  in_features_shape = tuple(inputs_shape[ax] for ax in linears.normalize_axes(axis, len(inputs_shape)))
+  in_features_shape = tuple(
+      inputs_shape[ax] for ax in linears.normalize_axes(axis, len(inputs_shape))
+  )
 
   module = nnx_wrappers.to_linen(
       GateLogit,

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -1634,6 +1634,7 @@ class RoutedMoE(nnx.Module):
             use_gmm_v2=self.config.use_gmm_v2,
             partial_sum=partial_sum,
             interpret=megablox_interpret,
+            bwd_inkernel_quant=getattr(self.config, "moe_bwd_inkernel_quant", False),
         )
       else:
         # jax.lax.ragged_dot

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -31,6 +31,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from maxtext.common import common_types as ctypes
+from maxtext.kernels.ring_ag import ring_all_gather
 from maxtext.common.common_types import ShardMode
 from maxtext.kernels import megablox as mblx
 from maxtext.layers import attentions, linears, nnx_wrappers, quantizations
@@ -55,6 +56,41 @@ set_xla_metadata = xla_metadata.set_xla_metadata
 
 DISPATCH = "dispatch"
 COMBINE = "combine"
+
+
+# Distinct barrier-semaphore ids for the in-MoE Pallas ring collectives; must not collide with
+# any other collective_id in flight in the same program.
+_RING_CT_AG_COLLECTIVE_ID = 55  # moe_ring_cotangent_ag: backward combine-cotangent ring all-gather
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(1, 2, 3))
+def _ring_ct_reduce_scatter(output, mesh, ep_name, collective_id):
+  """Combine reduce-scatter whose BACKWARD cotangent all-gather runs on the TC ring kernel.
+
+  FORWARD: byte-identical to the stock path -- the plain
+  ``jax.lax.psum_scatter(output, ep_name, scatter_dimension=0, tiled=True)`` (also what a remat
+  recompute re-traces: the primal is the plain collective, so no Pallas DMA ever runs inside a
+  rematted region). BACKWARD: the autodiff transpose of the tiled psum_scatter is a tiled EP
+  all-gather of the combine cotangent; as an XLA collective it can ride the SparseCore
+  collective-offload queue and serialize behind other SC work. Here it runs on the bidirectional
+  store-and-forward TensorCore ring kernel instead (ICI DMAs issued from the TC, where the
+  backward has slack), numerically == ``lax.all_gather`` (pure tiled data move, bit-exact).
+  """
+  return jax.lax.psum_scatter(output, ep_name, scatter_dimension=0, tiled=True)
+
+
+def _ring_ct_rs_fwd(output, mesh, ep_name, collective_id):
+  return _ring_ct_reduce_scatter(output, mesh, ep_name, collective_id), None
+
+
+def _ring_ct_rs_bwd(mesh, ep_name, collective_id, _res, ct):
+  return (ring_all_gather(ct, mesh, (ep_name,), 0, collective_id),)
+
+
+_ring_ct_reduce_scatter.defvjp(_ring_ct_rs_fwd, _ring_ct_rs_bwd)
+
+
+
 
 
 @struct.dataclass
@@ -2358,6 +2394,18 @@ class RoutedMoE(nnx.Module):
         x, routing, route_metadata = route(
             x, logits, pre_bias_logits, rngs, input_ids=sharded_input_ids
         )
+        # moe_x_sorted: tag the routed expert input and its small routing/metadata bundle for
+        # the remat policy. With moe_x_sorted=device the backward LOADS these instead of
+        # re-running route() -- removing the rematted dispatch token all-gather and sort from the
+        # backward (the up-projection weight gradient needs the sorted input anyway). The
+        # routing/metadata leaves (indices, group sizes, weights -- tiny) must be saved too, else
+        # the sort re-runs just to reproduce them. Tags are inert under the default
+        # moe_x_sorted=remat.
+        _cn = lambda t: adc.checkpoint_name(t, "moe_x_sorted") if isinstance(t, jax.Array) else t
+        # tree.map so a QArray x (moe_quantize_token_all_gather) gets its qvalue/scale leaves tagged
+        x = jax.tree.map(_cn, x)
+        routing = jax.tree.map(_cn, routing)
+        route_metadata = jax.tree.map(_cn, route_metadata)
 
         if self.config.mlp_bias:
           w0_bias, w1_bias, wo_bias = self.transform_bias(
@@ -2411,12 +2459,20 @@ class RoutedMoE(nnx.Module):
                 self.moe_expert_input_dim // self.get_tensor_parallelism_size(),
             ),
         )
-        output = jax.lax.psum_scatter(
-            output,
-            self._expert_parallelism_name,
-            scatter_dimension=0,
-            tiled=True,
-        )
+        if (
+            getattr(self.config, "moe_ring_cotangent_ag", False)
+            and isinstance(self._expert_parallelism_name, str)
+        ):
+          output = _ring_ct_reduce_scatter(
+              output, self.mesh, self._expert_parallelism_name, _RING_CT_AG_COLLECTIVE_ID
+          )
+        else:
+          output = jax.lax.psum_scatter(
+              output,
+              self._expert_parallelism_name,
+              scatter_dimension=0,
+              tiled=True,
+          )
         return output, routing.lb_loss, routing.bias_updates
 
       if self.get_expert_parallelism_size() > 1:

--- a/src/maxtext/layers/quantizations.py
+++ b/src/maxtext/layers/quantizations.py
@@ -809,7 +809,9 @@ def get_fp8_full_qwix_rule_w_sparsity(config: Config):
           module_path="decoder/.*layers.*",
           weight_qtype=jnp.float8_e4m3fn,
           act_qtype=jnp.float8_e4m3fn,
-          bwd_qtype=jnp.float8_e5m2,
+          # bwd_quantization_dtype: e5m2 (default, wider exponent range) or e4m3 (finer
+          # mantissa; some fp8 recipes use e4m3 gradients).
+          bwd_qtype=jnp.float8_e4m3fn if config.bwd_quantization_dtype == "e4m3" else jnp.float8_e5m2,
           weight_calibration_method=config.weight_quantization_calibration_method,
           act_calibration_method=config.act_quantization_calibration_method,
           bwd_calibration_method=config.bwd_quantization_calibration_method,

--- a/tests/integration/tokamax_test.py
+++ b/tests/integration/tokamax_test.py
@@ -38,15 +38,16 @@ class Train(parameterized.TestCase):
           "quantization": quantization,
           "use_gmm_v2": use_gmm_v2,
           "ici_expert_parallelism": ici_expert_parallelism,
+          "moe_quantize_token_all_gather": moe_quantize_token_all_gather,
       }
-      for base_name, quantization, use_gmm_v2, ici_expert_parallelism in [
-          ("tokamax_v1_bf16", "", False, 1),
-          ("tokamax_v1_fp8", "fp8", False, 1),  # not quantize gmm
-          ("tokamax_v1_fp8_full", "fp8_full", False, 1),  # quantize gmm
-          ("tokamax_v2_bf16", "", True, 1),
-          ("tokamax_v2_fp8_full", "fp8_full", True, 1),
-          ("tokamax_v2_bf16", "", True, 2),
-          ("tokamax_v2_fp8_full", "fp8_full", True, 2),
+      for base_name, quantization, use_gmm_v2, ici_expert_parallelism, moe_quantize_token_all_gather in [
+          ("tokamax_v1_bf16", "", False, 1, False),
+          ("tokamax_v1_fp8", "fp8_full", False, 1, False),
+          ("tokamax_v2_bf16", "", True, 1, False),
+          ("tokamax_v2_fp8", "fp8_full", True, 1, False),
+          ("tokamax_v2_bf16", "", True, 2, False),
+          ("tokamax_v2_fp8", "fp8_full", True, 2, False),
+          ("tokamax_v2_fp8_tag", "fp8_full", True, 2, True),
       ]
   )
   @pytest.mark.tpu_only
@@ -55,13 +56,14 @@ class Train(parameterized.TestCase):
       quantization: str,
       use_gmm_v2: bool,
       ici_expert_parallelism: int,
+      moe_quantize_token_all_gather: bool = False,
   ):
     """Smoke train with small config."""
     sharding_tolerance = 0.22 if ici_expert_parallelism > 1 else 2e-2
     test_tmpdir = os.environ.get("TEST_TMPDIR", gettempdir())
     outputs_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", test_tmpdir)
     args = [
-        None,
+        "",
         get_test_config_path(),
         f"base_output_directory={test_tmpdir}",
         "run_name=test_smoke_train",
@@ -109,6 +111,7 @@ class Train(parameterized.TestCase):
         "use_tokamax_splash=False",
         # quantization
         f"quantization={quantization}",
+        f"moe_quantize_token_all_gather={moe_quantize_token_all_gather}",
         "use_qwix_quantization=True",
         "weight_quantization_calibration_method=fixed,-224,224",
         "act_quantization_calibration_method=fixed,-224,224",

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -14,6 +14,7 @@
 """Mixture of Experts (MoE) tests."""
 
 import unittest
+from absl.testing import absltest
 from absl.testing import parameterized
 import pytest
 
@@ -58,13 +59,14 @@ def compare_tree(a, b, relative_norm_diff_threshold=1e-02):
     val_b = val_b.astype(jnp.float32)
 
     max_abs_diff = jnp.max(jnp.abs(val_a - val_b))
-    relative_norm_diff = jnp.linalg.norm(val_a - val_b) / jnp.linalg.norm(val_a)
+    relative_norm_diff = jnp.linalg.norm(val_a - val_b) / (jnp.linalg.norm(val_a) + 1e-12)
 
     log_line = f"{path}" f" | max_abs_diff: {max_abs_diff}" f" | relative_norm_diff: | {relative_norm_diff}"
     log_lines.append(log_line)
-    assert (
-        relative_norm_diff < relative_norm_diff_threshold
-    ), f"relative_norm_diff exceeds {relative_norm_diff_threshold=}"
+    assert relative_norm_diff < relative_norm_diff_threshold, (
+        f"{path}: relative_norm_diff={relative_norm_diff} exceeds"
+        f" {relative_norm_diff_threshold=}, max_abs_diff={max_abs_diff}"
+    )
   diff_summary = "\n".join(log_lines)
   return diff_summary
 
@@ -244,7 +246,7 @@ class MlpBlockTest(unittest.TestCase):
         dtype=jnp.bfloat16,
         weight_dtype=jnp.bfloat16,
         name="mlp",
-        quant=quant,
+        quant=quant,  # pyrefly: ignore[bad-argument-type]
         use_bias=True,
     )
 
@@ -674,15 +676,141 @@ class RoutedMoeTest(parameterized.TestCase):
         rngs=nnx.Rngs(params=rng_model),
     )
 
-    moe_non_chunked.gate.kernel.value = moe_chunked.gate.kernel.value
-    moe_non_chunked.wi_0.value = moe_chunked.wi_0.value
-    moe_non_chunked.wi_1.value = moe_chunked.wi_1.value
-    moe_non_chunked.wo.value = moe_chunked.wo.value
+    moe_non_chunked.gate.kernel = moe_chunked.gate.kernel
+    moe_non_chunked.wi_0 = moe_chunked.wi_0
+    moe_non_chunked.wi_1 = moe_chunked.wi_1
+    moe_non_chunked.wo = moe_chunked.wo
 
     chunked_out, _, _ = moe_chunked(hidden_states)
     non_chunked_out, _, _ = moe_non_chunked(hidden_states)
 
     self.assertTrue(jax.numpy.allclose(chunked_out, non_chunked_out, rtol=1e-01, atol=1e-01, equal_nan=False))
+
+  def test_moe_quantize_token_all_gather(self):
+    ep = 4
+    weight_quantization_calibration_method = "fixed,-224,224"
+    act_quantization_calibration_method = "fixed,-224,224"
+
+    def _build_cfg(moe_quantize_token_all_gather: bool):
+      return pyconfig.initialize(
+          [None, get_test_config_path()],
+          run_name="moe_quantize_token_all_gather_test",
+          enable_checkpointing=False,
+          model_name="mixtral-8x7b",
+          weight_dtype="float32",
+          dtype="bfloat16",
+          per_device_batch_size=1,
+          max_target_length=128,
+          float32_gate_logits=True,
+          ici_expert_parallelism=ep,
+          sparse_matmul=True,
+          megablox=False,
+          use_tokamax_gmm=True,
+          use_gmm_v2=True,
+          use_ring_of_experts=True,
+          mlp_bias=True,
+          moe_quantize_token_all_gather=moe_quantize_token_all_gather,
+          quantization="fp8_full",
+          use_qwix_quantization=True,
+          weight_quantization_calibration_method=weight_quantization_calibration_method,
+          act_quantization_calibration_method=act_quantization_calibration_method,
+          bwd_quantization_calibration_method="absmax",
+          wi_tile_fwd_batch_seq=128,
+          wi_tile_dlhs_batch_seq=128,
+          wi_tile_dlhs_embed_dim=256,
+          wi_tile_drhs_batch_seq=128,
+          wo_tile_fwd_batch_seq=128,
+          wo_tile_fwd_embed_dim=256,
+          wo_tile_dlhs_batch_seq=128,
+          wo_tile_dlhs_mlp_dim=256,
+          wo_tile_drhs_batch_seq=128,
+      )
+
+    def _build_model(cfg, mesh):
+      model = moe.get_routed_moe(
+          name="MoeBlock",
+          config=cfg,
+          num_experts=cfg.num_experts,
+          num_experts_per_tok=cfg.num_experts_per_tok,
+          mesh=mesh,
+          kernel_init=nd_dense_init(1.0, "fan_in", "truncated_normal"),
+          kernel_axes=("embed", "mlp"),
+          intermediate_dim=cfg.mlp_dim,
+          dtype=cfg.dtype,
+      )
+
+      def get_fp8_full_qwix_rule_for_test(config: Config):
+        return [
+            qwix.QtRule(
+                module_path=".*",
+                weight_qtype=jnp.float8_e4m3fn,
+                act_qtype=jnp.float8_e4m3fn,
+                bwd_qtype=jnp.float8_e5m2,
+                weight_calibration_method=config.weight_quantization_calibration_method,
+                act_calibration_method=config.act_quantization_calibration_method,
+                bwd_calibration_method=config.bwd_quantization_calibration_method,
+                op_names=("gmm", "ragged_dot"),
+            ),
+        ]
+
+      quantization_rule = get_fp8_full_qwix_rule_for_test(cfg)
+      quantization_provider = qwix.QtProvider(quantization_rule)
+      model = qwix.quantize_model(model, quantization_provider)
+      return model
+
+    def _loss_and_grad(model, variables, hidden_states):
+      def loss_fn(params, x):
+        out, lb_loss, _ = model.apply({"params": params}, x)
+        loss = jnp.mean(out.astype(jnp.float32) ** 2)
+        if lb_loss is not None:
+          loss = loss + lb_loss.astype(jnp.float32)
+        return loss, out
+
+      return jax.jit(jax.value_and_grad(loss_fn, argnums=(0, 1), has_aux=True))(variables["params"], hidden_states)
+
+    rng = jax.random.PRNGKey(2345)
+    rng_model, rng_hidden_states = jax.random.split(rng)
+    device_count = jax.device_count()
+
+    cfg_ref = _build_cfg(moe_quantize_token_all_gather=False)
+    hidden_states = jax.random.normal(
+        rng_hidden_states,
+        (
+            int(cfg_ref.per_device_batch_size) * device_count,
+            cfg_ref.max_target_length,
+            cfg_ref.base_emb_dim,
+        ),
+        dtype=cfg_ref.dtype,
+    )
+
+    devices_array = maxtext_utils.create_device_mesh(cfg_ref)
+    mesh = Mesh(devices_array, cfg_ref.mesh_axes)
+
+    model_ref = _build_model(cfg_ref, mesh)
+    with jax.set_mesh(mesh), nn_partitioning.axis_rules(cfg_ref.logical_axis_rules):
+      variables = model_ref.init({"params": rng_model, "dropout": rng_model}, hidden_states)
+      (_, output_ref), (grads_ref, x_grad_ref) = _loss_and_grad(model_ref, variables, hidden_states)
+
+    cfg_tgt = _build_cfg(moe_quantize_token_all_gather=True)
+    model_tgt = _build_model(cfg_tgt, mesh)
+    with jax.set_mesh(mesh), nn_partitioning.axis_rules(cfg_tgt.logical_axis_rules):
+      variables_tgt = model_tgt.init({"params": rng_model, "dropout": rng_model}, hidden_states)
+      (_, output_tgt), (grads_tgt, x_grad_tgt) = _loss_and_grad(model_tgt, variables_tgt, hidden_states)
+
+    tree_ref = {
+        "output": output_ref,
+        "state_grad": x_grad_ref,
+        "var_grad": grads_ref,
+    }
+    tree_tgt = {
+        "output": output_tgt,
+        "state_grad": x_grad_tgt,
+        "var_grad": grads_tgt,
+    }
+
+    relative_norm_diff_threshold = 0.22
+    diff_summary = compare_tree(tree_ref, tree_tgt, relative_norm_diff_threshold)
+    max_logging.log("\n" + diff_summary)
 
   @pytest.mark.tpu_only
   @pytest.mark.skip(reason="Correctness fails after adding EP. (b/540041424)")
@@ -1179,7 +1307,7 @@ class RoutedMoeTest(parameterized.TestCase):
       expected_sorted_indices = jnp.arange(shard_total_tokens)
       # Local expert IDs: repeat local expert index (0, 1, ...) by its count
       expected_sorted_experts_ids = jnp.repeat(
-          jnp.arange(experts_per_shard), expected_local_group_size, total_repeat_length=shard_total_tokens
+          jnp.arange(experts_per_shard), expected_local_group_size, total_repeat_length=shard_total_tokens  # pyrefly: ignore[bad-argument-type]
       )
 
       self.assertTrue(
@@ -1943,7 +2071,7 @@ def test_moe_dispatch_keeps_expert_on_expert_dim(model_name, flag):
   if cfg.moe_dispatch_no_expert_sharding:
     b_spec = remove_expert_from_partition_spec(b_spec, dims_to_peel=(0,))
 
-  e_axes, b_axes = _as_set(e_spec[0]), _as_set(b_spec[0])
+  e_axes, b_axes = _as_set(e_spec[0] if e_spec is not None else None), _as_set(b_spec[0] if b_spec is not None else None)
   assert "expert" in e_axes, "expert dim must be sharded by the 'expert' mesh axis"
   if cfg.moe_dispatch_no_expert_sharding:
     assert "expert" not in b_axes, "flag on: the batch dim must not take 'expert'"
@@ -2056,4 +2184,4 @@ class FusedMlpMoETest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-  unittest.main()
+  absltest.main()


### PR DESCRIPTION
Stacked on #4895 (token quantized all-gather) and #4969 (ring collectives + x_sorted save); the base branch is #4895's head, so the diff shows this change plus #4969's commit — review the top commit.

## What

Two default-off knobs for performance improvement of fp8 MoE training at dropless (worst-case) ragged buffer sizes:

- **`moe_bwd_inkernel_quant`** — quantize the drhs tgmm's operands *inside* the kernel (per-gm-tile-per-channel e4m3, implemented in `tgmm_v2`'s `quantize_operands` path) instead of with dense XLA-level quantize ops. The dense quantize/amax ops process every row of the ragged buffer at its **static** size — at `ragged_buffer_factor<=0` (dropless worst case) that is `tokens * top_k` rows regardless of how many are valid — while the in-kernel path touches only the tiles covered by `group_sizes`. It subsumes three buffer-sized ops: the per-row lhs re-quantize, the `drhs_dout *= lhs.scale` multiply, and the per-N cotangent quantize. A second effect: because no reduction ever reads past the valid rows, the amax can never ingest uninitialized buffer tail rows (with the dense path, a stale-row `amax=Inf` propagates `Inf*0=NaN` into the weight gradient; we root-caused a training NaN to exactly this).
- **`bwd_quantization_dtype`** — the gradient fp8 dtype for the `fp8_full` qwix recipe: `e5m2` (default, existing behavior) or `e4m3`.

Requires `use_tokamax_gmm=true use_gmm_v2=true` and an fp8 qwix `bwd_qtype`; falls back to the XLA-level quantize otherwise. Flags off reproduce the existing behavior.

## Repro

DeepSeek-V3 671B on v7x, the #4895 recipe at the dropless configuration this lever targets:

```
python3 -m maxtext.trainers.pre_train.train maxtext/configs/base.yml \
  model_name=deepseek3-671b per_device_batch_size=1.0 max_target_length=4096 \
  ici_fsdp_parallelism=64 ici_expert_parallelism=8 \
  attention=flash sparse_matmul=true megablox=true use_tokamax_gmm=true use_gmm_v2=true \
  use_tokamax_splash=true use_ring_of_experts=true use_ragged_sort=true \
  use_custom_sort_vjp=true ragged_buffer_factor=-1 num_moe_token_chunks=2 \
  remat_policy=custom decoder_layer_input=offload context=device out_proj=device \
  quantization=fp8_full use_qwix_quantization=true \
  weight_quantization_calibration_method=fixed,-224,224 \
  act_quantization_calibration_method=fixed,-224,224 \
  bwd_quantization_calibration_method=absmax \
  moe_quantize_token_all_gather=true \
  moe_bwd_inkernel_quant=true bwd_quantization_dtype=e4m3 \
  dataset_type=synthetic use_random_routing=true steps=20
```

- The win scales with the gap between the buffer's static size and the balanced size; at small `ragged_buffer_factor` (e.g. 2.0) the dense ops are cheap and the flag is roughly neutral. Use it for dropless (`ragged_buffer_factor=-1`) configurations.
- The in-kernel scales are finer-grained than the XLA path's, so losses match the flag-off run closely but not bit-exactly.

## Validation

- AOT compile (virtual `tpu7x` topology) green: flag-on at the dropless `per_device_batch_size=1.0 / ragged_buffer_factor=-1` config above, and flag-off on the unmodified #4895 recipe.
- 512-chip DeepSeek-V3 runs with this path train cleanly at `ragged_buffer_factor=-1` with no buffer sanitization and no non-finite losses; a 500-step real-data curve on this backward matches the dense-quantize reference at every eval point.
