### PR TITLE
Stop post-training tripping on config a model never set

### DIFF
--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -438,7 +438,7 @@ class NNXDecoder(nnx.Module):
     self.is_gemma4 = self.config.decoder_block == DecoderBlockType.GEMMA4
     self.is_gemma4_small = self.config.decoder_block == DecoderBlockType.GEMMA4_SMALL
 
-    if config.mhc_expansion_rate > 1 and config.decoder_block == DecoderBlockType.DEEPSEEK4:
+    if getattr(config, "mhc_expansion_rate", 1) > 1 and config.decoder_block == DecoderBlockType.DEEPSEEK4:
       self.hc_head = mhc.DeepSeek4HyperHead(
           config=config,
           mesh=self.mesh,

--- a/tests/utils/forward_pass_logit_checker.py
+++ b/tests/utils/forward_pass_logit_checker.py
@@ -379,6 +379,12 @@ def main(config, test_args):  # pylint: disable=W0621
     try:
       max_logging.log(f"Loading tokenizer from {path}.")
       tokenizer = AutoTokenizer.from_pretrained(path, token=hf_token, trust_remote_code=test_args.trust_remote_code)
+      # Mistral and Llama tokenizers ship no pad token, and the calls below pass padding=True, which
+      # transformers refuses without one ("Asking to pad but the tokenizer does not have a padding
+      # token"). Prompts are tokenized one at a time here, so nothing is ever actually padded and
+      # borrowing eos changes no result -- it only satisfies the check that rejects the call.
+      if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
       break
     except Exception as e:  # pylint: disable=broad-except,broad-exception-caught
       last_exception = e


### PR DESCRIPTION
# Description

Two places read a config field that only some configs carry, and both fail on a model that has nothing to do with the field. Neither is specific to post-training, but post-training is where they surface, because it builds its models through a config that pre-training does not use.

`nnx_decoders.py` reads `mhc_expansion_rate` directly. Every config the pre-training path builds carries it; the one post-training builds does not, so a run that never touches deepseek4 still raised `AttributeError` on the way past the check. Reading it with the default the attribute would have held leaves the deepseek4 behaviour alone.

`forward_pass_logit_checker.py` passes `padding=True` to the tokenizer. Mistral's and Llama's ship without a pad token, and transformers refuses outright: "Asking to pad but the tokenizer does not have a padding token". Prompts are tokenized one at a time there, so nothing is ever actually padded and borrowing eos changes no result — it only satisfies the check that rejects the call.


# Tests

`tests/unit/nnx_decoders_test.py` — 47 passed,.

The logit checker change has no test of its own: it is only reachable through a conversion correctness run, which needs the weights. It was exercised by hand while measuring mistral-7b against the Llama mapping (see the model registry PR), which is where the missing pad token first blocked the check.

[e2e log](https://paste.googleplex.com/6061069188595712)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
