### PR TITLE
Remove `--parallel_threads` flag from `to_huggingface.py`

### DIFF
--- a/src/maxtext/checkpoint_conversion/to_huggingface.py
+++ b/src/maxtext/checkpoint_conversion/to_huggingface.py
@@ -118,17 +118,6 @@ flags.DEFINE_string(
     "the instruction-tuned one).",
 )
 
-flags.DEFINE_integer(
-    "parallel_threads",
-    4,
-    "Number of threads used for parallel saving of weights. Lower this value to reduce peak host RAM usage.",
-)
-flags.register_validator(
-    "parallel_threads",
-    lambda value: value > 0,
-    message="--parallel_threads must be a positive integer.",
-)
-
 FLAGS = flags.FLAGS
 
 
@@ -453,14 +442,7 @@ def _transform_and_save_weights(
       raise ValueError("Error: No weights were transformed. Check mappings and parameter paths.")
 
     max_logging.log("\nSaving HuggingFace model...")
-    save_model_files(
-        transformed_hf_weights,
-        hf_config_obj,
-        tokenizer,
-        processor,
-        output_directory,
-        parallel_threads=FLAGS.parallel_threads,
-    )
+    save_model_files(transformed_hf_weights, hf_config_obj, tokenizer, processor, output_directory)
     max_logging.log(f"✅ MaxText model successfully saved in HuggingFace format at {output_directory}")
 
   max_logging.log(f"Elapse for transform and save: {(time.time() - start) / 60:.2f} min")


### PR DESCRIPTION
# Description

This PR removes the exposed `--parallel_threads` command-line flag from `src/maxtext/checkpoint_conversion/to_huggingface.py` and cleans up its arguments.

The `--parallel_threads` flag was originally introduced to explicitly limit concurrency in the E2E testing script (`test_llama3.1_70b_to_hf.sh`) to prevent OOM errors on smaller memory profiles like v5p-8. 
  
Since that script was subsequently refactored to use alternative memory optimization techniques and no longer passes `--parallel_threads=2`, keeping this isolated flag implementation in `to_huggingface.py` is obsolete.

# Tests

```bash
xpk workload create \
  --cluster=mlperf-v5p \
  --workload=llama-hf-3 \
  --device-type=v5p-8 \
  --num-slices=1 \
  --docker-image=[gcr.io/tpu-prod-env-multipod/maxtext_post_training_stable:32316847848](http://gcr.io/tpu-prod-env-multipod/maxtext_post_training_stable:32316847848) \
  --project=cloud-tpu-multipod-dev \
  --zone=europe-west4-b \
  --priority=very-high \
  --skip-validation \
  --env GCS_OUTPUT=gs://ml-auto-solutions/output/unowned/to-hf-v5p-8-2026-08-19-01-47-34/ \
  --command="set -xue; export HF_HOME=/dev/shm/hf_cache; export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"; python3 -m maxtext.checkpoint_conversion.to_huggingface model_name=llama3.1-70b tokenizer_type=huggingface load_parameters_path=gs://runner-maxtext-logs/llama3.1-70b/sft/e2e-32200790571/checkpoints/2/model_params base_output_directory=gs://runner-maxtext-logs/llama3.1-70b/to_huggingface/scanned/e2e-32200790571 use_multimodal=false scan_layers=true weight_dtype=bfloat16 checkpoint_storage_concurrent_gb=48 checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False skip_jax_distributed_system=true"
```

Log: https://cloudlogging.app.goo.gl/Wh68u2VnKSo3hw9u7

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
