### PR TITLE
Add GPT-OSS-20b support at GPU.

### DIFF
--- a/src/maxtext/configs/gpu/models/gpt-oss-20b.yml
+++ b/src/maxtext/configs/gpu/models/gpt-oss-20b.yml
@@ -1,0 +1,67 @@
+# model config for gpt-oss-20b
+# https://huggingface.co/openai/gpt-oss-20b/blob/main/config.json
+
+# tokenizer_type: "huggingface"
+
+base_config: "base.yml"
+
+hardware: "gpu"
+enable_checkpointing: False
+
+dataset_type: "synthetic"
+tokenizer_path: openai/gpt-oss-20b
+
+per_device_batch_size: 16
+
+remat_policy: "custom"
+mlpwo: "device"
+moe_mlpwo: "device"
+
+# not supported at GPU
+megablox: false
+# less memory usage, faster training
+sparse_matmul: false
+
+attention: "cudnn_flash_te"
+#max_segments_per_seq must be set when using TransformerEngine attention
+max_segments_per_seq: 32
+# Attention
+base_emb_dim: 2880
+base_num_query_heads: 64
+base_num_kv_heads: 8
+head_dim: 64
+sliding_window_size: 128
+attention_bias: true
+attention_sink: true
+
+# RoPE
+rope_type: "yarn"
+rope_max_timescale: 150_000
+max_position_embeddings: 131072
+original_max_position_embeddings: 4096
+rope_factor: 32
+beta_fast: 32
+beta_slow: 1
+rope_interleave: false
+rope_truncate: false
+rope_attention_scaling: true
+
+# MLP
+base_mlp_dim: 2880
+base_moe_mlp_dim: 2880
+mlp_activations: ["sigmoid","linear"]
+mlp_activations_limit: 7.0
+routed_bias: true
+mlp_bias: true
+num_experts: 32
+num_experts_per_tok: 4
+
+# General
+weight_dtype: bfloat16
+base_num_decoder_layers: 24
+vocab_size: 201088
+normalization_layer_epsilon: 1.0e-5
+enable_dropout: false
+logits_via_embedding: false
+decoder_block: "gpt_oss"
+inhomogeneous_layer_cycle_interval: 2

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -134,12 +134,56 @@ def apply_mask_to_logits(logits: Array, mask: Array):
   return jnp.where((mask >= DEFAULT_MASK_VALUE * 0.5), logits, DEFAULT_MASK_VALUE)
 
 
-def validate_gpu_flash_attention(sinks: Array | None, record_max_logits: bool) -> None:
+def validate_gpu_flash_attention(
+    sinks: Array | None,
+    record_max_logits: bool,
+    attention_kernel: str | None = None,
+) -> None:
   """Helper function to check for unsupported features with flash attention on GPU."""
-  if sinks is not None:
-    raise ValueError("The flash attention with sinks is not supported on GPU yet.")
+  if sinks is not None and attention_kernel not in ("cudnn_flash_te",):
+    raise ValueError(
+        "Attention sinks on GPU are only supported with attention=cudnn_flash_te. "
+        f"Got attention_kernel={attention_kernel!r}."
+    )
   if record_max_logits:
     raise NotImplementedError("record_max_logits (QK-Clip) is not supported for GPU flash attention kernels yet.")
+
+
+def _sinks_to_te_softmax_offset(sinks: Array, num_query_heads: int) -> Array:
+  """Convert MaxText per-head sinks (H,) to TE softmax_offset (1, H, 1, 1) float32."""
+  sinks = jnp.asarray(sinks, dtype=jnp.float32)
+  if sinks.ndim == 1:
+    if sinks.shape[0] != num_query_heads:
+      raise ValueError(f"Expected sinks shape ({num_query_heads},), got {sinks.shape}.")
+    return sinks.reshape(1, num_query_heads, 1, 1)
+  if sinks.shape == (1, num_query_heads, 1, 1):
+    return sinks
+  raise ValueError(
+      f"Unsupported sinks shape {sinks.shape}; expected ({num_query_heads},) or (1, {num_query_heads}, 1, 1)."
+  )
+
+
+def _inject_te_softmax_offset(dpa_layer, softmax_offset: Array) -> None:
+  """Overwrites the learnable softmax offset of a ToNNX-wrapped TE DotProductAttention.
+
+  Transformer Engine owns `softmax_offset` as a parameter of its own module (matching the
+  PyTorch API), so MaxText grafts its `sinks` parameter into that slot right before the call.
+  The grafted array is an ordinary input of the computation, so gradients flow back to `sinks`
+  and TE's internal zero-initialized parameter never reaches the optimizer or the checkpoint.
+
+  The parameter lives under a TE-internal submodule whose name depends on whether the fused or
+  the unfused backend was selected, hence the lookup by leaf name.
+  """
+  flat_state = nnx.to_flat_state(nnx.state(dpa_layer))
+  offset_path = next((path for path, _ in flat_state if path[-1] == "softmax_offset"), None)
+  if offset_path is None:
+    raise RuntimeError(
+        "Attention sinks require a `softmax_offset` parameter in Transformer Engine's "
+        "DotProductAttention, but no such parameter was found after initialization. The "
+        "installed Transformer Engine likely renamed it. Available parameters: "
+        f"{sorted('/'.join(map(str, path)) for path, _ in flat_state)}."
+    )
+  nnx.update(dpa_layer, nnx.from_flat_state([(offset_path, nnx.Param(softmax_offset))]))
 
 
 # TODO(agagik): change splash_attention_mask._ComputableMask to be non protected
@@ -867,6 +911,7 @@ class AttentionOp(nnx.Module):
       segment_positions: Array | None = None,
       pad_kv_total: int = 0,
       decoder_segment_ids_kv: Optional[Array] = None,
+      attention_type: AttentionType | None = None,
   ) -> Array | None:
     """Generates a combined attention mask for Transformer models.
 
@@ -883,7 +928,7 @@ class AttentionOp(nnx.Module):
       standard for autoregressive decoding. For chunked prefill, as
       described in the SARATHI paper [2], causality is adjusted based
       on `previous_chunk` information.
-    3.  **Specialized Attention Patterns:** Depending on `self.attention_type`,
+    3.  **Specialized Attention Patterns:** Depending on `attention_type`,
       it can apply:
       * Local Sliding Window Attention: Restricts attention to a
           fixed-size window around each query position.
@@ -934,6 +979,10 @@ class AttentionOp(nnx.Module):
         block-size alignment required by Splash kernels.
       decoder_segment_ids_kv: Optional `Array` of shape `[batch_size,
         kv_sequence_length]`. Identifies distinct sequences for keys/values.
+      attention_type: Optional `AttentionType` overriding the layer's own for
+        this call. Lets a caller ask for a subset of the usual mask, e.g. a
+        kernel that applies causality and the sliding window itself and only
+        needs sequence separation. Defaults to `self.attention_type`.
 
     Returns:
       An `Array` representing the attention mask, with shape
@@ -952,6 +1001,7 @@ class AttentionOp(nnx.Module):
       [2] SARATHI: Efficient LLM Inference by Piggybacking Decodes with
           Chunked Prefills - ArXiv:2308.16369 (https://arxiv.org/abs/2308.16369)
     """
+    attention_type = self.attention_type if attention_type is None else attention_type
     mask = None
     if model_mode == MODEL_MODE_AUTOREGRESSIVE and decoder_segment_ids is not None:
       mask = decoder_segment_ids[:, None, None, None, :] == DECODING_ACTIVE_SEQUENCE_INDICATOR
@@ -982,7 +1032,7 @@ class AttentionOp(nnx.Module):
       position_col_ids = segment_positions[:, None, :]
 
     causal_mask = None
-    if model_mode != MODEL_MODE_AUTOREGRESSIVE and self.attention_type not in (
+    if model_mode != MODEL_MODE_AUTOREGRESSIVE and attention_type not in (
         AttentionType.FULL,
         AttentionType.COMPRESSED,
         AttentionType.BLOCK_DIFFUSION,
@@ -1007,7 +1057,7 @@ class AttentionOp(nnx.Module):
     elif causal_mask is not None:
       output_mask = causal_mask
 
-    if self.attention_type == AttentionType.LOCAL_SLIDING and output_mask is not None:
+    if attention_type == AttentionType.LOCAL_SLIDING and output_mask is not None:
       if self.sliding_window_size is None:
         raise ValueError("Sliding_window_size must be set if Local Sliding attention type")
 
@@ -1023,7 +1073,7 @@ class AttentionOp(nnx.Module):
       if use_segment_positions:
         sliding_mask = sliding_mask[:, None, None, :, :]
       output_mask = sliding_mask * output_mask
-    elif self.attention_type == AttentionType.COMPRESSED:
+    elif attention_type == AttentionType.COMPRESSED:
       c_len = compressed_mask.shape[-1] if compressed_mask is not None else 0
       s_len = kv_seq_len - c_len
 
@@ -1110,7 +1160,7 @@ class AttentionOp(nnx.Module):
       )
       return jnp.concatenate([expanded_uncompressed_mask, compressed_mask], axis=-1)
 
-    elif self.attention_type == AttentionType.CHUNK and output_mask is not None:
+    elif attention_type == AttentionType.CHUNK and output_mask is not None:
       if use_segment_positions:
         same_chunk = (position_row_ids // self.chunk_attn_window_size) == (
             position_col_ids // self.chunk_attn_window_size
@@ -1127,7 +1177,7 @@ class AttentionOp(nnx.Module):
     # For standard token-by-token autoregressive decoding, keep the existing
     # causal mask path unchanged. BD3LM generation instead uses block-level
     # parallel sampling.
-    elif self.attention_type == AttentionType.BLOCK_DIFFUSION and model_mode != MODEL_MODE_AUTOREGRESSIVE:
+    elif attention_type == AttentionType.BLOCK_DIFFUSION and model_mode != MODEL_MODE_AUTOREGRESSIVE:
       if use_segment_positions:
         block_mask = ((position_row_ids // self.causal_block_size) >= (position_col_ids // self.causal_block_size))[
             :, None, None, :, :
@@ -1488,7 +1538,7 @@ class AttentionOp(nnx.Module):
               wv_product_einsum=wv_product_einsum,
           )
         else:
-          validate_gpu_flash_attention(sinks, record_max_logits)
+          validate_gpu_flash_attention(sinks, record_max_logits, attention_kernel=self.attention_kernel)
           mask = tokamax_attention_base.Mask(is_causal=True)
           if decoder_segment_ids is not None:
             seg_mask = decoder_segment_ids[:, :, None] == decoder_segment_ids[:, None, :]
@@ -1497,7 +1547,7 @@ class AttentionOp(nnx.Module):
           out = gpu_flash_attn(query, key, value, logits_scale=1.0, mask=mask)
           return out, None, None
     elif self.attention_kernel == "cudnn_flash_te":
-      validate_gpu_flash_attention(sinks, record_max_logits)
+      validate_gpu_flash_attention(sinks, record_max_logits, attention_kernel=self.attention_kernel)
       if isinstance(key, KVTensor):
         key = key.dequant()
       if isinstance(value, KVTensor):
@@ -1508,7 +1558,15 @@ class AttentionOp(nnx.Module):
                            Use `dot_product` instead."""
         )
       return (
-          self.cudnn_flash_attention(query, key, value, decoder_segment_ids, segment_positions, model_mode),
+          self.cudnn_flash_attention(
+              query,
+              key,
+              value,
+              decoder_segment_ids,
+              segment_positions,
+              model_mode,
+              sinks=sinks,
+          ),
           None,
           None,
       )
@@ -2235,6 +2293,7 @@ class AttentionOp(nnx.Module):
       decoder_segment_ids: Array | None,
       segment_positions: Array | None,
       model_mode: str = MODEL_MODE_TRAIN,
+      sinks: Array | None = None,
   ) -> Array:
     """CUDNN Flash Attention with Transformer Engine.
     1. Stable API, supports MHA, GQA, SWA, Packing and Context Parallelism
@@ -2265,10 +2324,24 @@ class AttentionOp(nnx.Module):
     qkv_layout = "BSHD_BSHD_BSHD"  # Non-packed format: 'BS3HD', 'BSHD_BS2HD' or 'BSHD_BSHD_BSHD'
     max_segments_per_seq = 1  # max number of segments per sequence; for non-packed its 1
 
-    # Handle local sliding window attention if configured
+    # Handle local sliding window attention if configured.
+    # TE attends to keys in [i - left, i + right] inclusive (`make_swa_mask`). MaxText
+    # LOCAL_SLIDING is (col > row - w) & (col <= row) == [i - (w - 1), i], matching Splash's
+    # LocalMask window of (w - 1, w). Passing [w, 0] is an off-by-one against dot_product.
     if self.attention_type == AttentionType.LOCAL_SLIDING:
-      sliding_window_size = [self.sliding_window_size, 0]
+      sliding_window_size = [self.sliding_window_size - 1, 0]
 
+    if sinks is not None:
+      # TE rejects a non-vanilla softmax inside its context parallel partitioner, which surfaces
+      # as an opaque custom_partitioner error, so reject the combination here instead.
+      if using_context_parallelism:
+        raise ValueError(
+            "Attention sinks are not supported with context parallelism by Transformer Engine "
+            "fused attention, which requires a vanilla softmax when context parallelism is "
+            f"active (mesh axis {self.config.context_sharding!r} has size "
+            f"{self.mesh.shape[self.config.context_sharding]}). Disable context parallelism or "
+            "use attention=dot_product."
+        )
     # Handle packing configurations
     if self.config.packing and self.config.dataset_type != "synthetic":
       if using_context_parallelism and not using_load_balanced_ring_cp:
@@ -2310,12 +2383,30 @@ class AttentionOp(nnx.Module):
       dummy_attn_mask = None
       mask_type = "causal"
     else:
-      # Default case: no packing, no context parallelism
+      # Dense BSHD layout: no context parallelism, and either packing is off or
+      # dataset_type is "synthetic", which keeps the non-THD layout.
+      # TE `padding_causal` does not apply a dense ndarray as an attention pattern: it
+      # `logical_not`s it and sums to seqlens. A causal/SWA bitmap therefore collapses
+      # seqlens to the window (local) instead of the sequence length. Build the mask as
+      # FULL so it carries padding/segment occupancy only; causal and the sliding window
+      # come from mask_type and window_size.
+      if decoder_segment_ids is None:
+        # Without segment ids every token is valid, and FULL would yield no mask at all.
+        decoder_segment_ids = jnp.ones(shape=query.shape[:2], dtype=jnp.int32)
       dummy_attn_mask = jnp.zeros(
           (1, 1, 1, self.max_target_length, self.max_target_length),
           dtype=jnp.uint8,
       )
-      attn_mask = self.generate_attention_mask(query, key, decoder_segment_ids, model_mode)
+      mask_attention_type = self.attention_type
+      if mask_attention_type == AttentionType.LOCAL_SLIDING:
+        mask_attention_type = AttentionType.FULL
+      attn_mask = self.generate_attention_mask(
+          query,
+          key,
+          decoder_segment_ids,
+          model_mode,
+          attention_type=mask_attention_type,
+      )
       attn_mask = jnp.where((attn_mask >= DEFAULT_MASK_VALUE * 0.5), 0, 1).astype(jnp.uint8)
 
     dpa_layer = DotProductAttention(
@@ -2336,6 +2427,7 @@ class AttentionOp(nnx.Module):
         context_parallel_axis=self.config.context_sharding,
         context_parallel_strategy=self.config.context_parallel_strategy,
         max_segments_per_seq=max_segments_per_seq,
+        softmax_type="learnable" if sinks is not None else "vanilla",
     )
 
     dpa_layer = nnx_wrappers.ToNNX(dpa_layer, rngs=self.rngs)
@@ -2358,6 +2450,8 @@ class AttentionOp(nnx.Module):
         dummy_value_prefill,
         sequence_descriptor=dummy_attn_mask,
     )
+    if sinks is not None:
+      _inject_te_softmax_offset(dpa_layer, _sinks_to_te_softmax_offset(sinks, self.num_query_heads))
     return dpa_layer(query, key, value, sequence_descriptor=attn_mask)
 
   def cudnn_jax_flash_attention(

--- a/tests/unit/gpt_vs_reference_test.py
+++ b/tests/unit/gpt_vs_reference_test.py
@@ -25,11 +25,14 @@ import math
 import unittest
 
 import numpy as np
+import pytest
 
 import torch
 from torch import nn
 import torch.nn.functional as F
 
+from flax import nnx
+from flax.linen import partitioning as nn_partitioning
 from jax.sharding import Mesh
 import jax
 import jax.numpy as jnp
@@ -511,6 +514,250 @@ class GptOssAttentionTest(unittest.TestCase):
     mse_flash = jnp.mean((to_jax(expected_attn_output) - actual_attn_output_flash) ** 2)
     self.assertLess(mse_flash, 1e-3, f"flash attention mismatch, MSE: {mse_flash}")
     np.testing.assert_allclose(to_jax(expected_attn_output), actual_attn_output_flash, rtol=1e-3, atol=1e-2)
+
+  def _run_cudnn_flash_te_attention_with_sinks(
+      self,
+      attention_type,
+      packing,
+      check_sinks_grad=False,
+  ):
+    """Compare MaxText `cudnn_flash_attention` to the PyTorch reference for one (type, packing) pair.
+
+    Sinks reach Transformer Engine through its internal `softmax_offset` parameter, which MaxText
+    overwrites right after `lazy_init`. The original FULL / packing=False case also checks that
+    the grafted array stays part of the computation, i.e. that gradients still flow back into
+    `sinks`.
+    """
+    te_attention = pytest.importorskip("transformer_engine.jax.attention")
+
+    is_local = attention_type == attentions.AttentionType.LOCAL_SLIDING
+    # Window must be clearly smaller than seq_len or local and global degenerate into the same
+    # computation. Asserted against the causal reference rather than assumed.
+    sliding_window_size = 32
+    # A realistic head_dim for the TE fused kernels, set locally because the shared Config's
+    # head_dim of 8 is what the other tests in this file expect. The head counts are left alone so
+    # that the sinks prepared in setUp can be reused as-is.
+    head_dim = 64
+    tensors = self._pytorch_sinks_attention_reference(
+        is_local=is_local, sliding_window_size=sliding_window_size, head_dim=head_dim
+    )
+    expected_attn_output = tensors["expected_attn_output"]
+    query_bf16 = tensors["query_bf16"]
+    key_bf16 = tensors["key_bf16"]
+    value_bf16 = tensors["value_bf16"]
+
+    cfg_kwargs = {
+        "run_name": f"gpt_oss_attention_test_cudnn_flash_te_{attention_type.name}_packing_{packing}",
+        "enable_checkpointing": False,
+        "model_name": "default",
+        # The fused kernels need bf16/fp16; on fp32 TE falls back to its unfused path.
+        "dtype": "bfloat16",
+        "per_device_batch_size": 1,
+        "max_target_length": self.seq_len,
+        "max_prefill_predict_length": self.seq_len,
+        "base_num_query_heads": self.config.num_attention_heads,
+        "base_num_kv_heads": self.config.num_key_value_heads,
+        "head_dim": head_dim,
+        "attention": "cudnn_flash_te",
+        "attention_bias": False,
+        "attention_sink": True,
+        "packing": packing,
+    }
+    if packing:
+      # Required by configs/types.py when hardware=gpu, packing, and cudnn_flash_te. dataset_type
+      # is left at base.yml's tfds so this combination actually takes the THD packed branch.
+      cfg_kwargs["max_segments_per_seq"] = 32
+    if is_local:
+      cfg_kwargs["attention_type"] = "local_sliding"
+      cfg_kwargs["sliding_window_size"] = sliding_window_size
+
+    cfg_te = pyconfig.initialize([None, get_test_config_path()], **cfg_kwargs)
+    devices_array = maxtext_utils.create_device_mesh(cfg_te)
+    mesh = Mesh(devices_array, cfg_te.mesh_axes)
+
+    def run_cudnn_flash_te_attention(q, k, v, sinks_logits):
+      # Building the layer forks the rng streams, so AttentionOp has to be created inside the
+      # traced function to keep flax from complaining about a mutation across trace levels.
+      attention_op_kwargs = {
+          "config": cfg_te,
+          "mesh": mesh,
+          "attention_kernel": "cudnn_flash_te",
+          "max_target_length": self.seq_len,
+          "num_query_heads": self.config.num_attention_heads,
+          "num_kv_heads": self.config.num_key_value_heads,
+          "dtype": jnp.bfloat16,
+          "attention_type": attention_type,
+          "rngs": nnx.Rngs(0),
+      }
+      if is_local:
+        attention_op_kwargs["sliding_window_size"] = sliding_window_size
+      attention_op_te = attentions.AttentionOp(**attention_op_kwargs)
+      # Non-zero segment ids: TE treats 0 as padding, and zeros would validate attending to nothing.
+      decoder_segment_ids = jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32)
+      # TE 2.17+ requires segment_pos for the THD SequenceDescriptor; a single packed segment is
+      # positions 0..S-1. Passing None hits ValueError before the kernel runs.
+      segment_positions = None
+      if packing:
+        segment_positions = jnp.broadcast_to(
+            jnp.arange(self.seq_len, dtype=jnp.int32)[None, :],
+            (self.batch_size, self.seq_len),
+        )
+      return attention_op_te.cudnn_flash_attention(
+          q,
+          k,
+          v,
+          decoder_segment_ids,
+          segment_positions,
+          "train",
+          sinks=sinks_logits,
+      )
+
+    scaled_query_te_t = jnp.transpose(to_jax(query_bf16.to(torch.float32)), (0, 2, 1, 3)).astype(jnp.bfloat16)
+    key_te_t = jnp.transpose(to_jax(key_bf16.to(torch.float32)), (0, 2, 1, 3)).astype(jnp.bfloat16)
+    value_te_t = jnp.transpose(to_jax(value_bf16.to(torch.float32)), (0, 2, 1, 3)).astype(jnp.bfloat16)
+
+    qkv_layout = te_attention.QKVLayout.THD_THD_THD if packing else te_attention.QKVLayout.BSHD_BSHD_BSHD
+    # Must match AttentionOp.cudnn_flash_attention: TE inclusive [i-left, i] vs MaxText [i-(w-1), i].
+    window_size = (sliding_window_size - 1, 0) if is_local else None
+    fused_kernel_available = te_attention.is_fused_attn_kernel_available(
+        True,  # is_training
+        jnp.bfloat16,
+        jnp.bfloat16,
+        qkv_layout,
+        te_attention.AttnBiasType.NO_BIAS,
+        te_attention.AttnMaskType.PADDING_CAUSAL_MASK,
+        te_attention.AttnSoftmaxType.LEARNABLE_SOFTMAX,
+        0.0,  # dropout_probability
+        self.config.num_attention_heads,
+        self.config.num_key_value_heads,
+        self.seq_len,
+        self.seq_len,
+        head_dim,
+        head_dim,
+        window_size,
+    )
+    if not fused_kernel_available:
+      self.skipTest(
+          "no TE fused attention kernel for "
+          f"{attention_type.name} packing={packing} qkv_layout={qkv_layout.name} "
+          f"window_size={window_size}; would silently validate the unfused fallback"
+      )
+
+    with mesh, nn_partitioning.axis_rules(cfg_te.logical_axis_rules):
+      actual_attn_output_te = jax.jit(run_cudnn_flash_te_attention)(
+          scaled_query_te_t, key_te_t, value_te_t, self.jax_sinks
+      )
+      if check_sinks_grad:
+
+        def sinks_output_sum_of_squares(sinks_logits):
+          output = run_cudnn_flash_te_attention(scaled_query_te_t, key_te_t, value_te_t, sinks_logits)
+          return jnp.sum(output.astype(jnp.float32) ** 2)
+
+        sinks_grad = jax.jit(jax.grad(sinks_output_sum_of_squares))(self.jax_sinks)
+
+    actual_attn_output_te = actual_attn_output_te.astype(jnp.float32)
+    mse_te = float(jnp.mean((to_jax(expected_attn_output) - actual_attn_output_te) ** 2))
+    combo = f"{attention_type.name} packing={packing}"
+    print(f"cudnn_flash_te vs pytorch MSE ({combo}): {mse_te:.6e}")
+    self.assertLess(mse_te, 1e-3, f"cudnn_flash_te attention mismatch ({combo}), MSE: {mse_te}")
+    np.testing.assert_allclose(to_jax(expected_attn_output), actual_attn_output_te, rtol=1e-3, atol=1e-2)
+
+    if check_sinks_grad:
+      # The whole point of grafting sinks into `softmax_offset` is that they stay differentiable.
+      self.assertEqual(sinks_grad.shape, (self.config.num_attention_heads,))
+      self.assertTrue(bool(jnp.all(jnp.isfinite(sinks_grad))), f"non-finite gradient w.r.t. sinks: {sinks_grad}")
+      self.assertGreater(
+          float(jnp.max(jnp.abs(sinks_grad))),
+          0.0,
+          "gradient w.r.t. sinks is identically zero, softmax_offset injection is not taking effect",
+      )
+
+  @pytest.mark.gpu_only
+  def test_cudnn_flash_te_attention_with_sinks(self):
+    """FULL, packing=False: the original TE fused-attn baseline, including sink gradients."""
+    self._run_cudnn_flash_te_attention_with_sinks(attentions.AttentionType.FULL, packing=False, check_sinks_grad=True)
+
+  @pytest.mark.gpu_only
+  def test_cudnn_flash_te_attention_with_sinks_packed(self):
+    """FULL, packing=True: THD SequenceDescriptor branch."""
+    self._run_cudnn_flash_te_attention_with_sinks(attentions.AttentionType.FULL, packing=True)
+
+  @pytest.mark.gpu_only
+  def test_cudnn_flash_te_attention_with_sinks_local_sliding(self):
+    """LOCAL_SLIDING, packing=False: padding seqlens plus window_size=[w-1, 0]."""
+    self._run_cudnn_flash_te_attention_with_sinks(attentions.AttentionType.LOCAL_SLIDING, packing=False)
+
+  @pytest.mark.gpu_only
+  def test_cudnn_flash_te_attention_with_sinks_local_sliding_packed(self):
+    """LOCAL_SLIDING, packing=True: THD SequenceDescriptor plus window_size=[w-1, 0]."""
+    self._run_cudnn_flash_te_attention_with_sinks(attentions.AttentionType.LOCAL_SLIDING, packing=True)
+
+  def _pytorch_sinks_attention_reference(self, *, is_local: bool, sliding_window_size: int, head_dim: int):
+    """QKV, causal/window mask, and PyTorch output used by the TE fused-attn checks."""
+    scaling = 1.0 / (head_dim**0.5)
+    query = torch.randn(self.batch_size, self.config.num_attention_heads, self.seq_len, head_dim)
+    key = torch.randn(self.batch_size, self.config.num_key_value_heads, self.seq_len, head_dim)
+    value = torch.randn(self.batch_size, self.config.num_key_value_heads, self.seq_len, head_dim)
+
+    neg_inf = torch.finfo(torch.float32).min
+    causal_2d = torch.triu(torch.full((self.seq_len, self.seq_len), neg_inf), diagonal=1)
+    attention_mask_2d = causal_2d
+    if is_local:
+      row_ids = torch.arange(self.seq_len).view(self.seq_len, 1)
+      col_ids = torch.arange(self.seq_len).view(1, self.seq_len)
+      sliding_ok = (col_ids > (row_ids - sliding_window_size)) & (col_ids <= row_ids)
+      sliding_2d = torch.where(
+          sliding_ok,
+          torch.zeros(self.seq_len, self.seq_len),
+          torch.full((self.seq_len, self.seq_len), neg_inf),
+      )
+      attention_mask_2d = torch.minimum(causal_2d, sliding_2d)
+
+    causal_mask = causal_2d.reshape(1, 1, self.seq_len, self.seq_len).expand(self.batch_size, 1, -1, -1)
+    attention_mask = attention_mask_2d.reshape(1, 1, self.seq_len, self.seq_len).expand(self.batch_size, 1, -1, -1)
+
+    query_bf16 = (query * scaling).to(torch.bfloat16)
+    key_bf16 = key.to(torch.bfloat16)
+    value_bf16 = value.to(torch.bfloat16)
+    query_ref = query_bf16.to(torch.float32)
+    key_ref = key_bf16.to(torch.float32)
+    value_ref = value_bf16.to(torch.float32)
+
+    expected_attn_output, _ = eager_attention_forward(
+        module=self.mock_module_with_sinks,
+        query=query_ref,
+        key=key_ref,
+        value=value_ref,
+        attention_mask=attention_mask,
+        scaling=1.0,
+        dropout=0.0,
+    )
+
+    if is_local:
+      expected_causal, _ = eager_attention_forward(
+          module=self.mock_module_with_sinks,
+          query=query_ref,
+          key=key_ref,
+          value=value_ref,
+          attention_mask=causal_mask,
+          scaling=1.0,
+          dropout=0.0,
+      )
+      window_vs_causal_mse = float(torch.mean((expected_causal - expected_attn_output) ** 2))
+      self.assertGreater(
+          window_vs_causal_mse,
+          1e-4,
+          "windowed PyTorch reference is indistinguishable from the causal reference at "
+          f"seq_len={self.seq_len} sliding_window_size={sliding_window_size} "
+          f"(MSE={window_vs_causal_mse}); the local case would not actually cover the window",
+      )
+
+    return {
+        "expected_attn_output": expected_attn_output,
+        "query_bf16": query_bf16,
+        "key_bf16": key_bf16,
+        "value_bf16": value_bf16,
+    }
 
 
 class GptOssRotaryEmbedding(nn.Module):


### PR DESCRIPTION
# Description

This PR adds GPU support for the GPT-OSS model by enabling TransformerEngine as the attention-with-sink kernel implementation. Fused attention - less memory, better performance. 
And .yml config for GPU, and test for gpt-oss attention via TransformerEngine .

# Tests

JAX_PLATFORMS=gpu pytest ./tests/unit/gpt_vs_reference_test.py 
tests/unit/gpt_vs_reference_test.py::GptOssAttentionTest::test_cudnn_flash_te_attention_with_sinks

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
