### PR TITLE
fix(ci): use actions/checkout in run_pathways_tests.yml to support AI-Hypercomputer repo

### DIFF
--- a/.github/workflows/run_pathways_tests.yml
+++ b/.github/workflows/run_pathways_tests.yml
@@ -82,13 +82,11 @@ jobs:
       options: ${{ inputs.container_resource_option }}
     steps:
       - name: Checkout MaxText
-        env:
-          MAXTEXT_SHA: ${{ inputs.maxtext_sha }}
-        run: |
-          git config --global --add safe.directory /__w/maxtext/maxtext
-          git clone https://github.com/google/maxtext.git .
-          git fetch origin "$MAXTEXT_SHA"
-          git checkout FETCH_HEAD
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          ref: ${{ inputs.maxtext_sha }}
+          fetch-depth: 0
+          persist-credentials: false
       - name: Download the maxtext wheel
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:


### PR DESCRIPTION
# Description

In `.github/workflows/run_pathways_tests.yml`, the `Checkout MaxText` step previously hardcoded `git clone https://github.com/google/maxtext.git .` and fetched `$MAXTEXT_SHA` from `origin`. Because the active repository has migrated to `AI-Hypercomputer/maxtext`, `git fetch origin "$MAXTEXT_SHA"` fails on PR branches with `fatal: couldn't find remote ref`, causing `tpu-pathways-unit` (1 & 2) and `tpu-pathways-integration` to fail deterministically across PRs.

This PR updates `.github/workflows/run_pathways_tests.yml` to use `actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0` with `ref: ${{ inputs.maxtext_sha }}`, `fetch-depth: 0`, and `persist-credentials: false`, matching `.github/workflows/run_tests_against_package.yml`.

FIXES: b/552094348

cc @SurbhiJainUSC

# Tests

CI workflow validation on PR.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
