### PR TITLE
Add default rule constants to types.py and add base.yml parity test

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=too-many-lines
 
+import copy
 import datetime
 import enum
 from enum import Enum
@@ -828,15 +829,15 @@ class SplashAttention(BaseModel):
   local_use_splash_scheduler: bool | None = Field(None, description="Use experimental local splash attention scheduler.")
   local_sa_fuse_reciprocal: bool | None = Field(None, description="Maps to local fuse_reciprocal in SplashConfig.")
   local_sa_use_base2_exp: bool | None = Field(None, description="Maps to local use_base2_exp in SplashConfig.")
-  experimental_sa_quant_q_fp8: bool | None = Field(
-      None,
+  experimental_sa_quant_q_fp8: bool = Field(
+      False,
       description=(
           "Experimental flag: If enabled, the Q tensor in splash attention is"
           " quantized to jnp.float8_e4m3fn, without scaling factors."
       ),
   )
-  experimental_sa_quant_k_fp8: bool | None = Field(
-      None,
+  experimental_sa_quant_k_fp8: bool = Field(
+      False,
       description=(
           "Experimental flag: If enabled, the K tensor in splash attention is"
           " quantized to jnp.float8_e4m3fn, without scaling factors."
@@ -1142,26 +1143,160 @@ class Qwen3Next(BaseModel):
   partial_rotary_factor: float = Field(1.0, description="The ratio of dimension to apply ROPE on")
 
 
+# ----------------------------------------------------------------------------
+# Default Mesh Axes, Data Sharding, and Logical Axis Rules
+# ----------------------------------------------------------------------------
+
+DEFAULT_MESH_AXES: list[str] = [
+    "diloco",
+    "data",
+    "stage",
+    "fsdp",
+    "fsdp_transpose",
+    "context",
+    "context_usp_ulysses",
+    "context_autoregressive",
+    "tensor",
+    "tensor_sequence",
+    "expert",
+    "autoregressive",
+]
+
+DEFAULT_DATA_SHARDING: list[list[str]] = [
+    [
+        "data",
+        "stage",
+        "fsdp",
+        "fsdp_transpose",
+        "context",
+        "context_usp_ulysses",
+        "context_autoregressive",
+        "tensor",
+        "tensor_sequence",
+        "expert",
+        "autoregressive",
+    ]
+]
+
+DEFAULT_LOGICAL_AXIS_RULES: list[list] = [
+    ["circular_repeats", []],
+    # ==========================================
+    # Vocabulary Embedding
+    # ==========================================
+    # Vocab Activations
+    ["activation_embed_and_logits_batch", ["data", "stage", "fsdp", "fsdp_transpose", "expert"]],
+    [
+        "activation_embed_and_logits_batch_sequence",
+        ["data", "stage", "fsdp", "fsdp_transpose", "context", "context_usp_ulysses", "expert"],
+    ],
+    ["activation_vocab", ["tensor", "tensor_sequence"]],
+    ["activation_vocab", ["tensor"]],
+    ["activation_vocab", "tensor_sequence"],
+    # Vocab Weights
+    ["vocab", ["tensor", "tensor_sequence", "autoregressive"]],
+    ["embed_vocab", ["fsdp", "fsdp_transpose", "context", "context_usp_ulysses", "expert"]],
+    # ==========================================
+    # Attention
+    # ==========================================
+    # Attention Activations
+    ["activation_batch_attn", ["data", "fsdp", "fsdp_transpose", "expert"]],
+    ["activation_input_length_attn", ["tensor_sequence", "context"]],
+    ["activation_heads", ["tensor", "tensor_sequence", "autoregressive"]],
+    ["activation_kv_heads", ["tensor", "tensor_sequence"]],
+    ["activation_length_attn", ["context", "context_usp_ulysses"]],
+    ["activation_q_length", ["context", "context_usp_ulysses"]],
+    ["activation_kv_length", []],
+    ["activation_embed_attn", ["tensor"]],
+    ["activation_kv", ["tensor", "tensor_sequence"]],
+    ["activation_kv_batch", ["data", "fsdp", "fsdp_transpose", "expert"]],
+    ["activation_kv_head_dim", ["tensor", "tensor_sequence"]],
+    # Attention Weights
+    ["heads", ["tensor", "tensor_sequence", "autoregressive"]],
+    ["q_heads", ["tensor", "tensor_sequence", "autoregressive"]],
+    ["kv_heads", ["tensor", "tensor_sequence", "autoregressive"]],
+    ["qkv", []],
+    ["kv", []],
+    ["kv_head_dim", []],
+    ["q_lora", ["fsdp", "fsdp_transpose", "context", "context_usp_ulysses", "expert"]],
+    ["q_lora", ["fsdp", "context", "context_usp_ulysses", "expert"]],
+    ["q_lora_up_proj", []],
+    ["kv_lora", ["fsdp", "fsdp_transpose", "context", "context_usp_ulysses", "expert"]],
+    ["kv_lora", ["fsdp", "context", "context_usp_ulysses", "expert"]],
+    ["kv_lora_up_proj", []],
+    ["embed_attn", ["fsdp", "fsdp_transpose", "context", "context_usp_ulysses", "expert"]],
+    # ==========================================
+    # Mixture of Experts (MoE)
+    # ==========================================
+    # MoE Activations
+    ["activation_batch_moe", ["data", "fsdp", "fsdp_transpose", "expert"]],
+    ["activation_length_moe", ["context", "context_usp_ulysses"]],
+    ["activation_norm_length_moe", ["tensor_sequence", "context", "context_usp_ulysses"]],
+    ["activation_embed_moe", ["tensor"]],
+    ["activation_mlp_moe", ["tensor", "tensor_sequence"]],
+    ["activation_exp", ["expert"]],
+    # MoE Weights
+    ["exp", "expert"],
+    ["mlp_moe", ["fsdp_transpose", "tensor", "tensor_sequence", "autoregressive"]],
+    ["embed_moe", ["fsdp", "fsdp_transpose", "context", "context_usp_ulysses"]],
+    ["embed_moe", ["fsdp", "context", "context_usp_ulysses"]],
+    # ==========================================
+    # Standard MLP / Dense Layers / Model Structure
+    # ==========================================
+    # Dense Activations
+    ["segment_ids_batch", ["data", "fsdp", "fsdp_transpose", "expert"]],
+    ["activation_mlp", ["tensor", "tensor_sequence"]],
+    # Note activation batch and length also get used in vocab
+    ["activation_batch", ["data", "fsdp", "fsdp_transpose", "expert"]],
+    ["activation_length", ["context", "context_usp_ulysses"]],
+    ["activation_norm_length", ["tensor_sequence", "context", "context_usp_ulysses"]],
+    ["activation_embed", ["tensor"]],
+    ["activation_stage", "stage"],
+    # General Weights
+    ["mlp", ["fsdp_transpose", "tensor", "tensor_sequence", "autoregressive"]],
+    ["gdn_head", ["fsdp_transpose", "tensor", "tensor_sequence", "autoregressive"]],
+    ["embed", ["fsdp", "fsdp_transpose", "context", "context_usp_ulysses", "expert"]],
+    ["embed", ["fsdp", "context", "context_usp_ulysses", "expert"]],
+    ["norm", ["tensor"]],
+    ["layers", "stage"],
+    ["diloco", "diloco"],
+    ["engram_dim", ["tensor"]],
+    ["dense_layers", []],
+    ["moe_layers", []],
+    ["local_layers", []],
+    ["mhc", []],
+    # ==========================================
+    # Inference (Prefill, Decode, Cache)
+    # ==========================================
+    ["prefill_activation_length", ["context", "context_usp_ulysses"]],
+    ["prefill_activation_norm_length", ["tensor_sequence", "context", "context_usp_ulysses"]],
+    ["activation_prefill_kv_batch", ["data", "fsdp", "fsdp_transpose", "expert"]],
+    ["decode_batch", ["data", "fsdp", "fsdp_transpose", "expert"]],
+    ["decode_length", []],
+    ["cache_heads", ["autoregressive", "tensor", "tensor_sequence"]],
+    ["paged_kv_heads", ["tensor"]],
+    ["cache_batch_prefill", []],
+    ["cache_batch", []],
+    ["cache_heads_none", []],
+    ["cache_kv", []],
+    ["cache_sequence", []],
+    ["num_pages", []],
+    ["tokens_per_page", []],
+    ["paged_kv_head_dim_size", []],
+    # ==========================================
+    # Deprecated / Scheduled for Removal
+    # ==========================================
+    ["mlp_no_fsdp", ["tensor", "tensor_sequence", "autoregressive"]],
+    ["exp_with_fsdp", "fsdp"],
+]
+
+
 class HardwareAndMesh(BaseModel):
   """Configuration for hardware and parallelism mesh."""
 
   hardware: Literal["tpu", "gpu", "gpu_multiprocess", "cpu"] = Field("tpu", description="The type of hardware to run on.")
   num_slices: int = Field(-1, description="Number of TPU slices. Automatically determined.")
   mesh_axes: list[str] = Field(
-      [
-          "data",
-          "stage",
-          "fsdp",
-          "fsdp_transpose",
-          "sequence",
-          "context",
-          "context_usp_ulysses",
-          "context_autoregressive",
-          "tensor",
-          "tensor_sequence",
-          "expert",
-          "autoregressive",
-      ],
+      default_factory=lambda: copy.deepcopy(DEFAULT_MESH_AXES),
       description="The names of the axes in the logical device mesh.",
   )
   shard_mode: ShardMode = Field("auto", description="can be either auto or explicit")
@@ -1225,11 +1360,18 @@ class HardwareAndMesh(BaseModel):
 class LayoutAndSharding(BaseModel):
   """Configuration for data and model sharding rules."""
 
-  logical_axis_rules: Any = Field([], description="Rules for mapping logical axes to physical mesh axes.")
-  logical_axis_rules_for_eval: Any = Field(
-      [], description="Rules for mapping logical axes to physical mesh axes during evaluation."
+  logical_axis_rules: Any = Field(
+      default_factory=lambda: copy.deepcopy(DEFAULT_LOGICAL_AXIS_RULES),
+      description="Rules for mapping logical axes to physical mesh axes.",
   )
-  data_sharding: Any = Field([], description="Sharding for input data.")
+  logical_axis_rules_for_eval: Any = Field(
+      default_factory=list,
+      description="Rules for mapping logical axes to physical mesh axes during evaluation.",
+  )
+  data_sharding: Any = Field(
+      default_factory=lambda: copy.deepcopy(DEFAULT_DATA_SHARDING),
+      description="Sharding for input data.",
+  )
   context_sharding: str = Field("context", description="Physical axis name for context parallelism.")
   ulysses_context_sharding: str = Field(
       "context_usp_ulysses",
@@ -1330,7 +1472,7 @@ class PipelineParallelism(BaseModel):
   )
   pipeline_fsdp_ag_once: bool = Field(False, description="If True, all-gather FSDP weights once per pipeline repeat.")
   scan_pipeline_iterations: bool = Field(True, description="Use jax.lax.scan over pipeline iterations.")
-  scan_pipeline_repeats: bool = Field(True, description="Use jax.lax.scan over pipeline repeats.")
+  scan_pipeline_repeats: bool = Field(False, description="Use jax.lax.scan over pipeline repeats.")
   scan_layers_per_stage: bool = Field(False, description="Use jax.lax.scan over layers within a stage.")
   set_remat_policy_on_pipeline_iterations: bool = Field(True, description="Set remat policy on the pipeline scan.")
   set_remat_policy_on_layers_per_stage: bool = Field(False, description="Set remat policy on the inner layer scan.")
@@ -2167,7 +2309,7 @@ class DevelopmentAndDebugging(BaseModel):
 
   constant_bound_config: list = Field([], description="Legacy configuration for constant bounds.")
   jax_cache_dir: PathStr | None = Field(
-      os.path.join(os.path.expanduser("~"), "jax_cache"),
+      "~/jax_cache",
       description="Directory for JAX compilation cache.",
   )
   jax_distributed_initialization_timeout: int = Field(300, description="Timeout for jax.distributed.initialize.")

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import yaml
 
 from maxtext.configs import pyconfig
 from maxtext.configs.pyconfig import resolve_config_path, _CONFIG_FILE_MAPPING, _module_from_path
@@ -54,6 +55,7 @@ class PyconfigTest(unittest.TestCase):
         [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
         run_name="test_run_1",
         base_output_directory="gs://base_dir1",
+        skip_jax_distributed_system=True,
     )
     self.assertEqual(
         config_omitted.managed_mldiagnostics_dir,
@@ -65,6 +67,7 @@ class PyconfigTest(unittest.TestCase):
         run_name="test_run_2",
         base_output_directory="gs://base_dir2",
         managed_mldiagnostics_storage_path="",
+        skip_jax_distributed_system=True,
     )
     self.assertEqual(
         config_none.managed_mldiagnostics_dir,
@@ -76,6 +79,7 @@ class PyconfigTest(unittest.TestCase):
         run_name="test_run_3",
         base_output_directory="gs://base_dir3",
         managed_mldiagnostics_storage_path="gs://custom_base",
+        skip_jax_distributed_system=True,
     )
     self.assertEqual(
         config_custom.managed_mldiagnostics_dir,
@@ -611,6 +615,66 @@ assert train._TF_AVAILABLE is False
         quantization="int8",
         weight_quantization_calibration_method="fixed,-1,1",
     )
+
+  def test_base_yml_types_parity(self):
+    """Verifies that types.MaxTextConfig() defaults match MaxTextConfig(**base_yaml)."""
+    base_yml_path = os.path.join(MAXTEXT_CONFIGS_DIR, "base.yml")
+    with open(base_yml_path, "r", encoding="utf-8") as f:
+      base_yaml = yaml.safe_load(f)
+
+    # 1. Ensure all base.yml keys exist in types.py
+    pydantic_fields = pyconfig.types.MaxTextConfig.model_fields
+    for key in base_yaml.keys():
+      if key == "base_config":
+        continue
+      self.assertIn(
+          key,
+          pydantic_fields,
+          f"Key '{key}' from base.yml is missing in types.MaxTextConfig",
+      )
+
+    # Clean YAML dictionary (normalize string 'none' to None)
+    clean_yaml = {}
+    for k, v in base_yaml.items():
+      if k in ("base_config", "run_name"):
+        continue
+      if isinstance(v, str) and v.lower() == "none":
+        clean_yaml[k] = None
+      elif k == "tokenizer_path" and v == "":
+        clean_yaml[k] = None
+      else:
+        clean_yaml[k] = v
+
+    # 2. Instantiate MaxTextConfig with pure defaults vs cleaned base.yml.
+    # Note: MaxTextConfig.__init__ sets os.environ["XLA_FLAGS"] as a side-effect during validation,
+    # so we clean it up between instantiations to ensure identical test conditions.
+    orig_xla_flags = os.environ.pop("XLA_FLAGS", None)
+    try:
+      cfg_defaults = pyconfig.types.MaxTextConfig(run_name="parity_test_run")
+      os.environ.pop("XLA_FLAGS", None)
+      cfg_from_yaml = pyconfig.types.MaxTextConfig(run_name="parity_test_run", **clean_yaml)
+    finally:
+      if orig_xla_flags is not None:
+        os.environ["XLA_FLAGS"] = orig_xla_flags
+      else:
+        os.environ.pop("XLA_FLAGS", None)
+
+    for field_name in pydantic_fields.keys():
+      if field_name in pyconfig.types.DerivedValues.model_fields:
+        continue
+
+      val_default = getattr(cfg_defaults, field_name)
+      val_yaml = getattr(cfg_from_yaml, field_name)
+
+      # Treat None and "" as semantically equivalent for unset optional string/path fields
+      if (val_default is None and val_yaml == "") or (val_default == "" and val_yaml is None):
+        continue
+
+      self.assertEqual(
+          val_default,
+          val_yaml,
+          f"Default value mismatch for field '{field_name}': types.py default={val_default} vs base.yml={val_yaml}",
+      )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Currently, MaxText uses a dual-configuration system where base.yml supplies baseline dictionary keys and types.py defines the Pydantic schema. This causes duplicate maintenance whenever a config flag is added or modified.

This PR is Phase 1 of consolidating configuration management to use types.py as the single source of truth. This is making `base.yml` and `types.py` fully consistent with each other.

Key Changes
* Default Rule Constants in Python: Moved DEFAULT_MESH_AXES, DEFAULT_DATA_SHARDING, and the complete list of 60+ DEFAULT_LOGICAL_AXIS_RULES from base.yml into src/maxtext/configs/types.py.
* Pydantic Default Factories: Updated HardwareAndMesh and LayoutAndSharding to populate their fields using default_factory=lambda: copy.deepcopy(...).
* Exhaustive Parity Test: Added test_base_yml_types_parity in tests/unit/pyconfig_test.py to assert that:
    * 100% of keys in base.yml exist in types.MaxTextConfig.
    * Direct instantiation of types.MaxTextConfig() matches all default values from base.yml.

# Tests

* `python3 -m unittest tests/unit/pyconfig_test.py -k test_base_yml_types_parity`
* `pytest tests/unit/configs_test.py`
* `pytest tests/unit/configs_value_test.py`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
