### PR TITLE
fix(qwen3-next): make activation offload work under the nested block scan

### DIFF
--- a/src/maxtext/layers/nnx_scan.py
+++ b/src/maxtext/layers/nnx_scan.py
@@ -101,6 +101,7 @@ def apply_scanned_layers(
     remat_policy: Callable[..., Any] | None = None,
     prevent_cse: bool = True,
     unroll: int = 1,
+    static_unroll: bool = False,
 ) -> Any:
   """Applies stacked NNX layers using ``jax.lax.scan``.
 
@@ -111,6 +112,12 @@ def apply_scanned_layers(
 
   Externally managed per-layer state, such as KV caches, is not supported by
   this scan path.
+
+  ``static_unroll`` swaps ``jax.lax.scan`` for a Python loop over the stacked
+  layers. The traced program is identical apart from the loop structure, but the
+  per-layer rematerialization residuals stay separate values instead of being
+  stacked on a leading axis, which is what an enclosing scan needs when the
+  policy offloads them to pinned host.
 
   Note:
     This is a minimal, model-agnostic scan primitive. The other NNX decoder
@@ -187,10 +194,31 @@ def apply_scanned_layers(
     )
     return next_carry, (new_params, updated_rest)
 
-  scan_fn = jax.checkpoint(scan_body, policy=remat_policy, prevent_cse=prevent_cse) if remat else scan_body
-  final_carry, (scanned_new_params, scanned_rest) = jax.lax.scan(
-      scan_fn, carry, (params, rest), length=length, unroll=unroll
-  )
+  if static_unroll:
+    # ``prevent_cse=False`` relies on the scan boundary to keep XLA from folding a
+    # rematerialized forward back into the original one. Straight-line code has no
+    # such boundary, so leaving CSE enabled would undo the rematerialization: on
+    # qwen3-next-80b at 8k tokens it costs 3.4GB of HBM.
+    prevent_cse = True
+
+  body_fn = jax.checkpoint(scan_body, policy=remat_policy, prevent_cse=prevent_cse) if remat else scan_body
+
+  if static_unroll:
+    # A Python loop instead of ``jax.lax.scan``: the per-iteration outputs stay
+    # separate values rather than being stacked into a leading-axis array. That
+    # matters when this helper runs inside another scan and ``remat_policy``
+    # offloads a residual to pinned host -- see ``offload_needs_static_unroll``.
+    final_carry = carry
+    per_iteration = []
+    for i in range(length):
+      slice_i = jax.tree.map(lambda x, i=i: x[i], (params, rest))
+      final_carry, outputs = body_fn(final_carry, slice_i)
+      per_iteration.append(outputs)
+    scanned_new_params, scanned_rest = jax.tree.map(lambda *xs: jnp.stack(xs), *per_iteration)
+  else:
+    final_carry, (scanned_new_params, scanned_rest) = jax.lax.scan(
+        body_fn, carry, (params, rest), length=length, unroll=unroll
+    )
 
   if param_scan_axis != 0:
     scanned_new_params = jax.tree.map(lambda x: jnp.moveaxis(x, 0, param_scan_axis), scanned_new_params)

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -1319,6 +1319,7 @@ class Qwen3NextScannableBlock(nnx.Module):
         remat=remat,
         remat_policy=self.remat_policy_fn if remat else None,
         prevent_cse=maxtext_utils.should_prevent_cse_in_remat(self.config) if remat else True,
+        static_unroll=remat and maxtext_utils.offload_needs_static_unroll(self.config),
     )
 
   def _scan_global_layer(self, y, layer_kwargs):
@@ -1420,6 +1421,9 @@ class Qwen3NextScannableBlock(nnx.Module):
     cfg = self.config
     inputs = carry
     inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    # Name the block input so remat policies can save or offload it, as in Gemma4's
+    # scannable block. The per-layer inputs inside the block carry the same name.
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
 
     layer_kwargs = {
         "decoder_segment_ids": decoder_segment_ids,
@@ -1542,6 +1546,10 @@ class Qwen3NextDecoderLayer(nnx.Module):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):
       inputs = inputs[0]
+    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    # The residual entering the layer is the natural remat checkpoint: it is cheap to
+    # keep (or offload) and everything else in the layer can be recomputed from it.
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
     residual = inputs
 
     # First LayerNorm, applied before the attention block.

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -246,6 +246,40 @@ def get_save_and_offload_names(config) -> tuple[list[str], list[str]]:
   return [], []
 
 
+def offload_needs_static_unroll(config) -> bool:
+  """Whether a rematerialized inner layer loop must be a Python loop rather than a scan.
+
+  Hybrid models (Gemma4, Qwen3-Next) scan over *blocks*, and each block scans over
+  its own layers and rematerializes them itself. When the remat policy offloads a
+  tensor, the block's inner scan emits that residual as a pinned-host stacked
+  output and the outer block scan stacks it once more. XLA's host-offload pass
+  cannot pair the copy-start/copy-done across those two levels, and the compile
+  fails post-optimization (``Bitcast cannot have different memory spaces``, or an
+  ``async-start ... operand`` shape mismatch between the ``S(5)`` and default
+  memory spaces).
+
+  Unrolling the inner loop in Python keeps every offloaded residual exactly one
+  scan level deep -- the same shape a homogeneous model such as Llama2 produces --
+  while leaving the outer block loop rolled, so XLA still pipelines one block's
+  host copies at a time. ``jax.lax.scan(..., unroll=n)`` is not a substitute: it
+  removes the loop but still stacks the per-iteration outputs, so the extra
+  dimension survives.
+
+  Only applied when the policy actually offloads something. It grows the block
+  body by the number of layers per block, which costs compile time that runs
+  keeping every checkpointed tensor in HBM should not pay.
+
+  Losing the inner loop also costs some HBM, because the rematerialized forward
+  is no longer confined to one loop iteration, so the unroll only pays for itself
+  when the policy offloads enough. On qwen3-next-80b at 8k tokens the unroll
+  costs 2.5GB and ``minimal_offloaded`` moves 16.9GB off device, a 13.2GB win;
+  offloading only ``decoder_layer_input`` moves 1.2GB against a 4.3GB unroll and
+  comes out 1.3GB behind.
+  """
+  _, offload_names = get_save_and_offload_names(config)
+  return bool(offload_names)
+
+
 def load_compiled(config, partial_train, state, execution_devices):
   """# Loading a serialized compiled train step function."""
 

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -1850,5 +1850,28 @@ class TestGetSaveAndOffloadNames(unittest.TestCase):
       self.assertEqual(maxtext_utils.get_save_and_offload_names(self._cfg(policy)), ([], []))
 
 
+class TestOffloadNeedsStaticUnroll(unittest.TestCase):
+  """Tests for maxtext_utils.offload_needs_static_unroll (pure config logic, no device needed)."""
+
+  _cfg = staticmethod(TestGetSaveAndOffloadNames._cfg)  # pylint: disable=protected-access
+
+  def test_offloading_policy_needs_a_static_unroll(self):
+    """An offloaded residual cannot cross two nested scans, so the inner loop must be a Python loop."""
+    cfg = self._cfg("custom", tensors_to_offload=["decoder_layer_input"])
+    self.assertTrue(maxtext_utils.offload_needs_static_unroll(cfg))
+
+  def test_preset_offload_policies_also_need_it(self):
+    """The named offload presets go through the same save/offload split, so they unroll too."""
+    for policy in ("qkv_proj_offloaded", "minimal_offloaded"):
+      self.assertTrue(maxtext_utils.offload_needs_static_unroll(self._cfg(policy)))
+
+  def test_device_only_policies_keep_the_inner_scan(self):
+    """Unrolling costs compile time, so policies that offload nothing must not pay it."""
+    self.assertFalse(maxtext_utils.offload_needs_static_unroll(self._cfg("full")))
+    self.assertFalse(
+        maxtext_utils.offload_needs_static_unroll(self._cfg("custom", tensors_on_device=["decoder_layer_input"]))
+    )
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/tests/unit/nnx_decoders_test.py
+++ b/tests/unit/nnx_decoders_test.py
@@ -1088,6 +1088,74 @@ class TestQwen3NextDecoderParity(unittest.TestCase):
     self.assertEqual(self._param_tree(6, True), self._param_tree(6, False))
 
 
+class TestQwen3NextDecoderLayerInputOffload(unittest.TestCase):
+  """`decoder_layer_input` must be nameable and offloadable on the Qwen3-Next stack.
+
+  Two things have to hold for `remat_policy=custom decoder_layer_input=offload` to
+  do anything. The layers have to attach the name (otherwise the policy matches
+  nothing and the setting is silently ignored), and the offloaded residual has to
+  survive lowering -- XLA cannot carry a pinned-host tensor out of two nested
+  scans, which is why the block loop unrolls when the policy offloads.
+  """
+
+  def _grad_jaxpr(self, num_decoder_layers=8, **overrides):
+    """Returns the printed jaxpr of a gradient through the scanned Qwen3-Next decoder."""
+    cfg = _make_config(
+        **{
+            **_QWEN3_NEXT_CONFIG,
+            "base_num_decoder_layers": num_decoder_layers,
+            "scan_layers": True,
+            **overrides,
+        }
+    )
+    mesh = _make_mesh(cfg)
+    decoder = NNXDecoder(config=cfg, mesh=mesh, model_mode=MODEL_MODE_TRAIN, rngs=nnx.Rngs(params=0, dropout=1))
+    embedding = Embed(
+        num_embeddings=cfg.vocab_size,
+        num_features=cfg.emb_dim,
+        dtype=cfg.dtype,
+        config=cfg,
+        mesh=mesh,
+        rngs=nnx.Rngs(params=0),
+    )
+    batch, seq = cfg.global_batch_size_to_train_on, cfg.max_target_length
+    ids = jnp.zeros((batch, seq), dtype=jnp.int32)
+    segment_ids = jnp.full((batch, seq), DECODING_ACTIVE_SEQUENCE_INDICATOR)
+    positions = jnp.broadcast_to(jnp.arange(seq)[None], (batch, seq))
+
+    decoder_graphdef, decoder_params, decoder_rest = nnx.split(decoder, nnx.Param, ...)
+    embed_graphdef, embed_params, embed_rest = nnx.split(embedding, nnx.Param, ...)
+
+    def loss(dec_params, emb_params, dec_rest, emb_rest):
+      dec = nnx.merge(decoder_graphdef, dec_params, dec_rest)
+      emb = nnx.merge(embed_graphdef, emb_params, emb_rest)
+      logits, _, _ = dec(
+          emb,
+          ids,
+          decoder_positions=positions,
+          decoder_segment_ids=segment_ids,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.sum(logits**2)
+
+    jaxpr = jax.make_jaxpr(jax.grad(loss, argnums=(0, 1)))(decoder_params, embed_params, decoder_rest, embed_rest)
+    return jaxpr.pretty_print(use_color=False)
+
+  def test_layers_name_their_input_for_the_remat_policy(self):
+    """Without the name, `decoder_layer_input=device|offload` would be a no-op."""
+    self.assertIn("name=decoder_layer_input", self._grad_jaxpr(remat_policy="full"))
+
+  def test_offloading_policy_moves_the_residual_to_host(self):
+    """`MemorySpace.Host` is how a device_put to pinned host renders in a jaxpr."""
+    offloaded = self._grad_jaxpr(remat_policy="custom", decoder_layer_input="offload")
+    self.assertIn("MemorySpace.Host", offloaded)
+
+  def test_no_host_transfer_without_an_offloading_policy(self):
+    """Nothing should reach host memory when every checkpointed tensor stays on device."""
+    self.assertNotIn("MemorySpace.Host", self._grad_jaxpr(remat_policy="full"))
+
+
 class TestNNXDecoderDeepseekAndGemma4(unittest.TestCase):
   """Tests for Deepseek and Gemma4 specific decoder logic."""
 

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -802,6 +802,33 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
+  def test_qwen3_next_offloaded_decoder_layer_input(self):
+    """AOT test for offloading a Qwen3-Next remat checkpoint to pinned host.
+
+    Qwen3-Next scans over blocks that scan (and rematerialize) their own layers.
+    An offloaded residual therefore leaves two nested scans, which XLA could not
+    lower until the block loop was unrolled -- the compile used to fail
+    post-optimization with a memory-space mismatch. Kept small: the unroll makes
+    compile time grow with the block count.
+    """
+    compiled_trainstep_file = "/tmp/test_qwen3_next_offloaded"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-64",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3-next-80b-a3b",
+            "override_model_config=true",
+            "base_num_decoder_layers=8",
+            "per_device_batch_size=1",
+            "max_target_length=1024",
+            "remat_policy=custom",
+            "decoder_layer_input=offload",
+        )
+    )
+
   def test_deepseek32(self):
     # test deepseek3.2 with sparse attention
     compiled_trainstep_file = "/tmp/test_deepseek32.pickle"


### PR DESCRIPTION
Stacked on #4964 — please review/merge that first; this PR targets its branch, so the diff here is just the two files of new logic plus tests.

## Summary

Offloading a rematerialization checkpoint to pinned host does not work on Qwen3-Next today. `decoder_layer_input=offload` is silently ignored, and the named offload presets (`minimal_offloaded`, `qkv_proj_offloaded`) fail to compile. This PR fixes both, which is what makes `remat_policy=minimal_offloaded` usable on the model: 69.74 GB → 56.54 GB of HBM at 8k tokens, a 19% reduction.

## The two bugs

**1. The checkpoint name was never attached.** `Qwen3NextDecoderLayer` never called `checkpoint_name(inputs, "decoder_layer_input")`, so the remat policy had nothing to match and both `decoder_layer_input=device` and `decoder_layer_input=offload` were no-ops. An AOT compile of qwen3-next-80b-a3b produces byte-identical memory stats for the two settings (`temp_size_in_bytes=46,779,974,304` for both). Only the unrelated dense `Qwen3DecoderLayer` had the name, via `AttentionWithNorm`.

The fix attaches it in the layer and in `Qwen3NextScannableBlock`, mirroring what `Gemma4DecoderLayer` and `Gemma4ScannableBlock` already do.

**2. Once named, offload does not compile.** The block's inner local-layer scan emits the offloaded residual as a pinned-host stacked output, and the outer block scan stacks it a second time. XLA's host-offload pass cannot pair the copy-start with the copy-done across two scan levels, and the compile fails post-optimization with either `Bitcast cannot have different memory spaces` or an `async-start expects the shape of operand 0 to match the async shape` mismatch between the `S(5)` and default memory spaces. Confirmed on the real model: the offending buffer is `bf16[12,3,1,1024,2048]{...S(5)}` = [12 blocks, 3 local layers, batch, seq, emb]. A 4-layer config (outer scan length 1) compiles; 8 and 12 layers fail.

## The fix

`apply_scanned_layers` grows a `static_unroll` mode that replaces `jax.lax.scan` with a Python loop over the stacked layers. Each layer's residual then stays a separate value instead of being stacked on a leading axis, so the outer block scan stacks it exactly once — the same single-level shape a homogeneous model such as Llama2 produces, which XLA handles. The outer block loop stays rolled, so host copies still pipeline one block at a time.

Two things that look like they should work but don't:

- `jax.lax.scan(..., unroll=n)` is not a substitute. It removes the loop but still stacks the per-iteration outputs, so the extra dimension survives and the compile still fails.
- Breaking the nesting at the *outer* block loop instead does compile, but it costs about 7 GB of HBM and 4x the compile time, which defeats the purpose of offloading. The inner loop is the right place to break it.

The unrolled path also forces `prevent_cse=True`. `should_prevent_cse_in_remat` returns `False` whenever `scan_layers=True`, because the scan boundary is what stops XLA folding a rematerialized forward back into the original one. Straight-line code has no such boundary, so leaving CSE enabled silently undoes the rematerialization — worth 3.4 GB of HBM on its own.

The whole mechanism is gated on the policy actually offloading something (`maxtext_utils.offload_needs_static_unroll`), so runs that keep every checkpointed tensor in HBM pay nothing: same scan, same compile time as before.

## Measurements

AOT compiles of qwen3-next-80b-a3b on v5p-64, `max_target_length=8192`, `per_device_batch_size=1`. HBM is `temp_size_in_bytes` from `compiled.memory_analysis()`.

| `remat_policy` | HBM | host | compile |
| --- | --- | --- | --- |
| `minimal` | 69.74 GB | 0 | 54 s |
| `minimal_offloaded` | **56.54 GB** | 16.91 GB | 109 s |

Isolating the two effects under `minimal`: the static unroll costs 2.48 GB (69.74 → 72.22 GB with offload disabled), and the offload returns 15.68 GB, close to 1:1 on the 16.91 GB moved off device.

The practical value is that offload buys `minimal`-level recompute at close to full-remat memory: 56.54 GB with `minimal`'s FLOPs, against 69.74 GB for `minimal` on device or 46.78 GB for a policy that recomputes everything.

## What this does not buy

Offloading `decoder_layer_input` on its own is a weak lever on this model, and the PR does not pretend otherwise:

| `remat_policy=custom`, pdbs | rolled + `device` | unrolled + `device` | unrolled + `offload` | net |
| --- | --- | --- | --- | --- |
| 1 | 46.78 GB | 51.12 GB | 48.07 GB (1.21 GB host) | +1.29 GB |
| 4 | 92.05 GB | 99.77 GB | 92.66 GB (4.83 GB host) | +0.61 GB |

The offload itself works and is roughly 1:1, but the unroll costs slightly more than it returns. Two reasons: `jax.checkpoint` always keeps its own inputs as residuals regardless of policy, so naming `decoder_layer_input` and setting it to `device` changes HBM by 163 KB — the only thing the name buys is the ability to offload it; and under `custom` almost everything else is recomputed, which makes the rematerialized region that the unroll has to inline large. Under `minimal` that region is small, which is why the unroll tax there is 2.48 GB rather than 4.34 GB.

The gap narrows with batch size but does not cross zero, and `per_device_batch_size=8` does not fit on v5p-64 at all (108 GB required vs 95.74 GB available), so there is no headroom above 4 to find a crossover. This is documented on `offload_needs_static_unroll` so it does not have to be re-measured.

## Testing

- `tests/unit/nnx_decoders_test.py::TestQwen3NextDecoderLayerInputOffload` — three jaxpr-level tests on the scanned Qwen3-Next decoder: the layers name their input, an offloading policy puts `MemorySpace.Host` in the gradient jaxpr, and a device-only policy does not.
- `tests/unit/train_compile_test.py::test_qwen3_next_offloaded_decoder_layer_input` — AOT regression test on v5p-64. Verified that it fails without the fix and passes with it.
- `tests/unit/maxtext_utils_test.py::TestOffloadNeedsStaticUnroll` — the gating logic, including that device-only policies keep the inner scan.
- Full `tests/unit/nnx_decoders_test.py` (60 passed, 2 skipped) and the qwen3-next and gemma4 AOT tests pass. pre-commit clean.

## Follow-up

Gemma4 has the same nested-scan offload problem and currently pays the expensive workaround unconditionally: `_apply_gemma4_scanned_blocks` sets `block_unroll = max(1, scan_length)` for every run, offload or not. The same `static_unroll=True` argument would let it keep its block loop rolled. Left out of this PR because it needs its own AOT validation.
