### PR TITLE
Add explicit sharding support for the Qwen3 model family

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4024,11 +4024,24 @@ class MaxTextConfig(
     if self.use_sft and self.use_dpo:
       raise ValueError("Only one of `use_sft` or `use_dpo` can be True.")
     if self.shard_mode == ShardMode.EXPLICIT:
-      supported_decoders = {"simple", "simple_mlp", "llama2", "deepseek"}
+      supported_decoders = {
+          "simple",
+          "simple_mlp",
+          "llama2",
+          "deepseek",
+          "qwen3",
+          "qwen3_moe",
+          "qwen3_custom_moe",
+      }
       if self.decoder_block.value not in supported_decoders:
         raise ValueError(
             f"Decoder '{self.decoder_block.value}' is not supported with 'explicit' sharding. "
-            f"Supported options are: {list(supported_decoders)}."
+            f"Supported options are: {sorted(supported_decoders)}."
+        )
+      if self.use_multimodal:
+        raise ValueError(
+            "'explicit' sharding is not supported with `use_multimodal`; the vision and audio encoders "
+            "have not been onboarded to explicit sharding yet."
         )
     if self.context_sharding not in ("context", "expert"):
       raise ValueError(f"Assigned context_sharding f{self.context_sharding} is not supported.")

--- a/src/maxtext/layers/normalizations.py
+++ b/src/maxtext/layers/normalizations.py
@@ -31,6 +31,26 @@ from maxtext.utils import max_utils
 from maxtext.utils.sharding import truncate_out_sharding
 
 
+def _align_scale_with_normalized_axis(scale: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
+  """Reshards a 1-D norm scale to match the sharding of the axis it normalizes.
+
+  The scale is stored with the `kernel_axes` layout, which is picked for the
+  usual case of normalizing over the embedding axis (`norm` -> `tensor`). A
+  per-head QK norm instead normalizes over `head_dim`, which is unsharded while
+  the neighbouring `heads` axis is the one on `tensor`. Multiplying those
+  directly under `ShardMode.EXPLICIT` would place `tensor` on two axes of the
+  result, which JAX rejects, so align the scale with the activation instead.
+
+  This is a no-op whenever the two already agree, which includes every
+  auto-sharding-equivalent layout for the ordinary layer norms.
+  """
+  activation_spec = jax.typeof(y).sharding.spec
+  scale_spec = jax.typeof(scale).sharding.spec
+  if scale_spec[-1] == activation_spec[-1]:
+    return scale
+  return jax.sharding.reshard(scale, jax.sharding.PartitionSpec(activation_spec[-1]))
+
+
 class RMSNorm(nnx.Module):
   """RMS normalization."""
 
@@ -93,6 +113,8 @@ class RMSNorm(nnx.Module):
 
     scale = jnp.asarray(scale, self.dtype)
     effective_scale = scale + self.scale_offset
+    if self.shard_mode == ShardMode.EXPLICIT:
+      effective_scale = _align_scale_with_normalized_axis(effective_scale, y)
     return jnp.einsum("...k,k->...k", y, effective_scale, out_sharding=out_sharding)
 
 

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -34,8 +34,10 @@ from flax import nnx
 from maxtext.common.common_types import AttentionType, Config, DType, Array, BATCH, EMBED, MODEL_MODE_TRAIN, LENGTH, MODEL_MODE_AUTOREGRESSIVE
 from maxtext.common.common_types import KV_BATCH, KV_HEAD
 from maxtext.utils.sharding import (
+    create_sharding,
     get_logical_axis_rules,
     logical_to_mesh_axes,
+    maybe_shard_with_logical,
     remove_incompatible_mesh_axes_from_partition_spec,
 )
 from maxtext.layers import attentions
@@ -1436,12 +1438,26 @@ class AttentionWithNorm(nnx.Module):
     batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
     self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    self.mlp_activation_axis_names = ("activation_batch", "activation_norm_length", "activation_mlp")
+
+    # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore these and let GSPMD infer the layout.
+    self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
+    self.mlp_intermediate_sharding = create_sharding(mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules())
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
 
     # Corresponds to Qwen3's `input_layernorm`
     self.pre_self_attention_layer_norm = RMSNorm(
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=rngs,
@@ -1482,6 +1498,7 @@ class AttentionWithNorm(nnx.Module):
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=rngs,
@@ -1498,11 +1515,11 @@ class AttentionWithNorm(nnx.Module):
       attention_metadata: None | dict[str, Any] = None,
   ):
     """Applies self-attention with pre and post-layer normalization."""
-    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     # Pre attention norm
-    lnx = self.pre_self_attention_layer_norm(inputs)
-    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+    lnx = self.pre_self_attention_layer_norm(inputs, out_sharding=self.out_sharding)
+    lnx = self._maybe_shard_with_logical(lnx, self.activation_axis_names)
     # Self attention
     attention_lnx, kv_cache = self.self_attention(
         lnx,
@@ -1511,15 +1528,16 @@ class AttentionWithNorm(nnx.Module):
         decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
         model_mode=model_mode,
+        out_sharding=self.out_sharding,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
     )
-    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
+    attention_lnx = self._maybe_shard_with_logical(attention_lnx, self.activation_axis_names)
     # Residual connection after attention
     intermediate_inputs = inputs + attention_lnx
     # Post attention norm
-    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
     return hidden_states, intermediate_inputs, kv_cache
 
 
@@ -1577,11 +1595,16 @@ class Qwen3DecoderLayer(AttentionWithNorm):
         attention_metadata=attention_metadata,
     )
 
-    mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+    mlp_lnx = self.mlp(
+        hidden_states,
+        deterministic=deterministic,
+        intermediate_sharding=self.mlp_intermediate_sharding,
+        out_sharding=self.out_sharding,
+    )
+    mlp_lnx = self._maybe_shard_with_logical(mlp_lnx, self.activation_axis_names)
 
     layer_output = intermediate_inputs + mlp_lnx
-    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+    layer_output = self._maybe_shard_with_logical(layer_output, self.activation_axis_names)
 
     return layer_output, kv_cache
 
@@ -1648,13 +1671,13 @@ class Qwen3MoeDecoderLayer(AttentionWithNorm):
         attention_metadata=attention_metadata,
     )
 
-    mlp_lnx, load_balance_loss, _ = self.moe_block(hidden_states)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+    mlp_lnx, load_balance_loss, _ = self.moe_block(hidden_states, out_sharding=self.out_sharding)
+    mlp_lnx = self._maybe_shard_with_logical(mlp_lnx, self.activation_axis_names)
     if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
       self.moe_lb_loss = nnx.Intermediate(load_balance_loss)
 
     layer_output = intermediate_inputs + mlp_lnx
-    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+    layer_output = self._maybe_shard_with_logical(layer_output, self.activation_axis_names)
 
     if is_scan_carry:
 

--- a/src/maxtext/models/qwen3_custom.py
+++ b/src/maxtext/models/qwen3_custom.py
@@ -16,7 +16,6 @@ from typing import Any
 from jax.sharding import Mesh
 import jax.numpy as jnp
 
-from flax import linen as nn
 from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
 
@@ -29,7 +28,6 @@ from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.layers.attentions import Attention
 from maxtext.layers.linears import DenseGeneral
 from maxtext.utils import max_utils
-from maxtext.utils.sharding import create_sharding
 from maxtext.models.qwen3 import AttentionWithNorm
 from maxtext.layers.normalizations import RMSNorm
 
@@ -128,6 +126,7 @@ class Qwen3CustomMoeDecoderLayer(AttentionWithNorm):
         num_features=config.attention_output_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=rngs,
@@ -166,8 +165,6 @@ class Qwen3CustomMoeDecoderLayer(AttentionWithNorm):
     else:
       self.layer_up_projection = None
 
-    self.out_sharding = create_sharding(self.mesh, self.activation_axis_names)
-
   def apply_attention_with_norm(
       self,
       inputs: jnp.ndarray,
@@ -180,10 +177,10 @@ class Qwen3CustomMoeDecoderLayer(AttentionWithNorm):
   ):
     """Applies attention layer with pre/post normalization."""
 
-    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
-    lnx = self.pre_self_attention_layer_norm(inputs)
-    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+    lnx = self.pre_self_attention_layer_norm(inputs, out_sharding=self.out_sharding)
+    lnx = self._maybe_shard_with_logical(lnx, self.activation_axis_names)
     attention_lnx, kv_cache = self.self_attention(
         lnx,
         lnx,
@@ -191,10 +188,11 @@ class Qwen3CustomMoeDecoderLayer(AttentionWithNorm):
         decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
         model_mode=model_mode,
+        out_sharding=self.out_sharding,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
     )
-    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
+    attention_lnx = self._maybe_shard_with_logical(attention_lnx, self.activation_axis_names)
     return inputs, attention_lnx, kv_cache
 
   def __call__(
@@ -240,17 +238,17 @@ class Qwen3CustomMoeDecoderLayer(AttentionWithNorm):
         attention_metadata=attention_metadata,
     )
 
-    attention_lnx = self.latent_norm(attention_lnx)
+    attention_lnx = self.latent_norm(attention_lnx, out_sharding=self.out_sharding)
     mlp_lnx, load_balance_loss, _ = self.moe_block(attention_lnx, out_sharding=self.out_sharding)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+    mlp_lnx = self._maybe_shard_with_logical(mlp_lnx, self.activation_axis_names)
 
     if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
       self.sow(nnx.Intermediate, "moe_lb_loss", load_balance_loss)
 
     layer_output = mlp_lnx
     if self.layer_up_projection is not None:
-      layer_output = self.layer_up_projection(layer_output)
-      layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+      layer_output = self.layer_up_projection(layer_output, out_sharding=self.out_sharding)
+      layer_output = self._maybe_shard_with_logical(layer_output, self.activation_axis_names)
 
     layer_output = inputs + layer_output
 

--- a/tests/integration/smoke/train_smoke_test.py
+++ b/tests/integration/smoke/train_smoke_test.py
@@ -160,6 +160,42 @@ class Train(unittest.TestCase):
         ]
     )
 
+  def test_qwen3_custom_moe_explicit_shardmode(self):
+    test_tmpdir = os.environ.get("TEST_TMPDIR")  # pylint: disable=unused-variable
+    train_main(  # pyrefly: ignore[bad-argument-type]
+        [  # pyrefly: ignore[bad-argument-type]
+            None,
+            get_test_config_path(),
+            "model_name=qwen3-custom-30b-a3b",
+            "override_model_config=True",
+            f"base_output_directory={self.base_output_directory}",
+            "run_name=runner_test",
+            f"dataset_path={self.dataset_path}",
+            "base_emb_dim=256",
+            "attention_output_dim=256",
+            "moe_expert_input_dim=256",
+            "base_mlp_dim=256",
+            "base_moe_mlp_dim=256",
+            "head_dim=128",
+            "base_num_query_heads=4",
+            "base_num_kv_heads=4",
+            "num_experts=4",  # Reduced from 128
+            "num_experts_per_tok=2",  # Reduced from 8
+            "base_num_decoder_layers=2",
+            "per_device_batch_size=2",
+            "max_target_length=128",
+            "dataset_type=synthetic",
+            "steps=2",
+            "shard_mode=explicit",
+            "enable_checkpointing=False",
+            rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+            "enable_goodput_recording=False",
+            "enable_checkpoint_cloud_logger=False",
+            "monitor_goodput=False",
+            "scan_layers=False",
+        ]
+    )
+
   def test_tiny_config_explicit_shardmode(self):
     test_tmpdir = os.environ.get("TEST_TMPDIR")  # pylint: disable=unused-variable
     train_main(  # pyrefly: ignore[bad-argument-type]

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 """Tests for train.py with various configs"""
+import json
 import os
+import tempfile
 import unittest
+import numpy as np
 import pytest
 import jax
 
@@ -33,6 +36,23 @@ from tests.utils.test_helpers import (
 def _small_model_base_emb_dim(device_count):
   """Return a tiny embedding dim divisible by local devices."""
   return ((28 + device_count - 1) // device_count) * device_count
+
+
+_MOE_OVERRIDES = ["base_moe_mlp_dim=512", "num_experts=8", "num_experts_per_tok=2"]
+
+# One tiny model per Qwen3 decoder block that supports explicit sharding.
+_QWEN3_MODELS = {
+    "qwen3": ["model_name=qwen3-0.6b"],
+    "qwen3_moe": ["model_name=qwen3-30b-a3b"] + _MOE_OVERRIDES,
+    "qwen3_custom_moe": [
+        "model_name=qwen3-custom-30b-a3b",
+        "attention_output_dim=256",
+        "moe_expert_input_dim=256",
+        # Qwen3CustomMoeDecoderLayer is only registered for the unscanned path.
+        "scan_layers=False",
+    ]
+    + _MOE_OVERRIDES,
+}
 
 
 class TrainTests(unittest.TestCase):
@@ -65,6 +85,22 @@ class TrainTests(unittest.TestCase):
       "base_moe_mlp_dim=32",
       "sparse_matmul=False",
       "megablox=False",
+  ]
+
+  _qwen3_overrides = [
+      "override_model_config=True",
+      "base_num_decoder_layers=2",
+      "base_emb_dim=256",
+      "base_mlp_dim=512",
+      "base_num_query_heads=4",
+      "base_num_kv_heads=4",
+      "head_dim=128",
+      "vocab_size=2048",
+      "max_target_length=256",
+      # The Qwen3 model configs default to a HuggingFace tokenizer that is not
+      # vendored in the repo; use the checked-in tiktoken asset instead.
+      "tokenizer_type=tiktoken",
+      rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
   ]
 
   CONFIGS = {
@@ -588,6 +624,91 @@ class TrainTests(unittest.TestCase):
         rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
     ]
     train_main(zero1_ga)
+
+  def _qwen3_losses(self, run_name, extra_args):
+    """Trains a tiny Qwen3 model for a few steps and returns its per-step losses."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      metrics_file = os.path.join(tmp_dir, "metrics.txt")
+      train_main(
+          [
+              None,
+              get_test_config_path(),
+              f"base_output_directory={self._base_output_directory}",
+              f"dataset_path={self.dataset_path}",
+              f"run_name={run_name}",
+              f"metrics_file={metrics_file}",
+              "dataset_type=synthetic",
+              "steps=3",
+              "enable_checkpointing=False",
+              "enable_goodput_recording=False",
+          ]
+          + self._qwen3_overrides
+          + list(extra_args)
+      )
+      with open(metrics_file, "rt", encoding="utf8") as f:
+        return [json.loads(line)["learning/loss"] for line in f if line.strip()]
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  def test_tpu_qwen3_explicit_sharding_matches_auto(self):
+    """Explicit sharding only changes how layouts are expressed, so the losses must not move.
+
+    Each decoder block is paired with the parallelism that stresses it most:
+    tensor parallelism puts the `heads` axis on the same mesh axis as the
+    QK-norm scale, and expert parallelism shards the MoE dispatch.
+    """
+    parallelism = {
+        "qwen3": ["ici_fsdp_parallelism=1", "ici_tensor_parallelism=-1"],
+        "qwen3_moe": ["ici_fsdp_parallelism=1", "ici_expert_parallelism=-1"],
+        "qwen3_custom_moe": [],
+    }
+    for decoder_block, model_args in _QWEN3_MODELS.items():
+      with self.subTest(decoder_block=decoder_block):
+        args = model_args + parallelism[decoder_block]
+        auto_losses = self._qwen3_losses(f"{decoder_block}_auto", args + ["shard_mode=auto"])
+        explicit_losses = self._qwen3_losses(f"{decoder_block}_explicit", args + ["shard_mode=explicit"])
+        print(f"[{decoder_block}] auto losses: {auto_losses}", flush=True)
+        print(f"[{decoder_block}] explicit losses: {explicit_losses}", flush=True)
+        self.assertTrue(auto_losses, "auto run produced no metrics")
+        # The two runs execute the same math, so they match bit-for-bit.
+        np.testing.assert_allclose(explicit_losses, auto_losses, rtol=1e-6, atol=0.0)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  # TODO(b/517509898): Skip ZeRo-1 compiler Segfault on TPU7x SparseCore platforms
+  @pytest.mark.skip_on_tpu7x
+  def test_tpu_qwen3_zero1_gradient_accumulation(self):
+    """ZeRO-1 only shards the optimizer state, so it must not change the loss trajectory.
+
+    Under explicit sharding this routes the accumulated gradients through the
+    `reduced`/`unreduced` PartitionSpec labels applied in
+    `maxtext.utils.gradient_accumulation`.
+    """
+    zero1_ga = [
+        "remat_policy=minimal",
+        "per_device_batch_size=2",
+        "ici_data_parallelism=-1",
+        "dcn_data_parallelism=1",
+        "ici_fsdp_parallelism=1",
+        "dcn_fsdp_parallelism=1",
+        "gradient_accumulation_steps=8",
+    ]
+    for decoder_block in ("qwen3", "qwen3_moe"):
+      with self.subTest(decoder_block=decoder_block):
+        args = _QWEN3_MODELS[decoder_block] + zero1_ga
+        baseline = self._qwen3_losses(
+            f"{decoder_block}_ga",
+            args + ["shard_mode=auto", "shard_optimizer_over_data=False"],
+        )
+        sharded = self._qwen3_losses(
+            f"{decoder_block}_ga_zero1",
+            args + ["shard_mode=explicit", "shard_optimizer_over_data=True"],
+        )
+        print(f"[{decoder_block}] auto + GA losses: {baseline}", flush=True)
+        print(f"[{decoder_block}] explicit + ZeRO-1 + GA losses: {sharded}", flush=True)
+        self.assertTrue(baseline, "baseline run produced no metrics")
+        # ZeRO-1 reassociates the gradient all-reduce, so allow a little float slack.
+        np.testing.assert_allclose(sharded, baseline, rtol=1e-4, atol=0.0)
 
   @pytest.mark.integration_test
   @pytest.mark.gpu_only

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -164,6 +164,41 @@ class PyconfigTest(unittest.TestCase):
     )
     self.assertEqual(config.tokenizer_path, "Qwen/Qwen3-30B-A3B-Base")
 
+  def test_explicit_sharding_qwen3_decoder_support(self):
+    """The Qwen3 decoders that have been onboarded to explicit sharding are accepted."""
+    for decoder_block in ("qwen3", "qwen3_moe", "qwen3_custom_moe"):
+      with self.subTest(decoder_block=decoder_block):
+        config = pyconfig.initialize(
+            [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+            skip_jax_distributed_system=True,
+            shard_mode="explicit",
+            decoder_block=decoder_block,
+        )
+        self.assertEqual(config.decoder_block.value, decoder_block)
+
+    # Qwen3-Next and Qwen3.5 use gated-delta-net linear attention, and the
+    # Qwen3-VL/Omni encoders are multimodal; neither is onboarded yet.
+    for decoder_block in ("qwen3_next", "qwen3_5"):
+      with self.subTest(decoder_block=decoder_block):
+        with self.assertRaisesRegex(Exception, "not supported with 'explicit' sharding"):
+          pyconfig.initialize(
+              [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+              skip_jax_distributed_system=True,
+              shard_mode="explicit",
+              decoder_block=decoder_block,
+          )
+
+    with self.assertRaisesRegex(Exception, "not supported with `use_multimodal`"):
+      pyconfig.initialize(
+          [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+          skip_jax_distributed_system=True,
+          shard_mode="explicit",
+          model_name="qwen3-vl-4b",
+          override_model_config=True,
+          use_multimodal=True,
+          scan_layers=False,  # Required by the Qwen3-VL deepstack path; unrelated to sharding.
+      )
+
   def test_resolve_config_path(self):
     self.assertEqual(resolve_config_path("foo"), os.path.join("src", "foo"))
     self.assertEqual(resolve_config_path(__file__), __file__)

--- a/tests/utils/sharding_info/qwen3-0.6b/tpu7x-16/slice_1/rule_default/input_shardings.json
+++ b/tests/utils/sharding_info/qwen3-0.6b/tpu7x-16/slice_1/rule_default/input_shardings.json
@@ -1,6 +1,18 @@
 {
   "Activation Sharding Dump": [
     {
+      "qwen3/inputs: bfloat16[192,2048,1024]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
+        "PartitionSpec": "P('fsdp', None, None)"
+      }
+    },
+    {
+      "Unknown: bfloat16[192,2048,1024]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
+        "PartitionSpec": "P('fsdp', None, None)"
+      }
+    },
+    {
       "attentions/inputs_q: bfloat16[192,2048,1024]": {
         "logic_axes": "('activation_batch_attn', 'activation_input_length_attn', 'activation_embed_attn')",
         "PartitionSpec": "P('fsdp', None, None)"


### PR DESCRIPTION
## Description

Onboards the Qwen3 family to explicit sharding (shard-in-types), following the pattern established for llama2 (#2470) and deepseek (#2783). The `qwen3`, `qwen3_moe` and `qwen3_custom_moe` decoder blocks — 21 of the 23 checked-in qwen3 model configs — now run with `shard_mode=explicit`, including ZeRO-1 optimizer sharding combined with gradient accumulation.

### Model changes

`AttentionWithNorm` is shared by the dense, MoE and custom-MoE Qwen3 layers, so most of the work lands there:

- It builds `out_sharding` / `mlp_intermediate_sharding` from the logical axis rules and threads them through the norms, the attention call and the MLP/MoE block. Without an explicit output sharding the attention out-projection has no legal layout to infer under explicit axes.
- `shard_mode` is passed into the pre/post attention RMSNorms.
- `nn.with_logical_constraint` is replaced with `maybe_shard_with_logical`, which reshards under explicit axes and constrains under auto, so the same call site serves both modes.

`qwen3_custom.py` gets the same treatment for its `latent_norm` and `layer_up_projection` paths.

### RMSNorm fix

The RMSNorm scale is stored with the `norm` logical axis (→ `tensor`). That is correct for a norm over the embedding axis, but wrong for Qwen3's per-head QK norm: it normalizes `head_dim`, which is unsharded, while the neighbouring `heads` axis is the one on `tensor`. The multiply therefore placed `tensor` on two axes of the result and JAX rejected it:

```
ShardingTypeError: dot_general operation with inputs: bf16[128@tensor], bf16[4,256,4@tensor,128]
produces an illegally sharded result: bf16[128@tensor,4,256,4@tensor]
```

The scale is now realigned to the activation's last-dim sharding before the multiply. This runs only under `ShardMode.EXPLICIT` and is a no-op when the two already agree, so no other model's layout changes. The alternative — relabelling the QK-norm `kernel_axes` — would have churned every model's golden sharding descriptors.

### Config guards

- `use_multimodal` is rejected under explicit sharding: the Qwen3-VL/Omni vision and audio encoders are not onboarded (a reshape in the patch embed fails).
- `qwen3_next` and `qwen3_5` remain unsupported — they use gated-delta-net linear attention and are a separate piece of work.

## Tests

Explicit sharding is only a change in how layouts are expressed, so it must be numerically neutral. The new tests run the same tiny model under both shard modes and compare per-step losses:

- `train_tests.py::test_tpu_qwen3_explicit_sharding_matches_auto` — all three decoder blocks, each paired with the parallelism that stresses it most (tensor parallelism for the dense QK norm, expert parallelism for the MoE dispatch, FSDP for the unscanned custom MoE).
- `train_tests.py::test_tpu_qwen3_zero1_gradient_accumulation` — `shard_optimizer_over_data` + `gradient_accumulation_steps=8` under explicit sharding versus a plain auto + GA baseline, for the dense and MoE decoders. This is what exercises the `reduced`/`unreduced` gradient PartitionSpec labels.
- `pyconfig_test.py::test_explicit_sharding_qwen3_decoder_support` — the accept/reject config guards.
- One smoke test for the custom-MoE block under explicit sharding.

## Verification

Run on a v6e-4:

- Every auto-vs-explicit pair matches **bit-for-bit** (e.g. dense TP-4 `189.796 / 189.196 / 188.858` in both modes; MoE EP-4 `8.082 / 8.065 / 8.055`). Beyond the configurations kept in the test file, parity was also confirmed manually for DP2×FSDP2, unscanned layers, and the custom-MoE latent up-projection path.
- ZeRO-1 + GA matches the auto + GA baseline exactly for both MoE decoders and to ~1e-5 for dense (ZeRO-1 reassociates the gradient all-reduce, so the assertion allows `rtol=1e-4`).
- No regressions: the llama2 `test_tpu_zero1_gradient_accumulation` still passes, and 185 sharding/config unit tests pass. The qwen3-0.6b golden input-sharding dump was regenerated; the diff is purely additive (two activation entries the decoder now reports through `maybe_shard_with_logical`).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
