### PR TITLE
Test: XLA:TPU host offload fails inside nested lax.scan

### DIFF
--- a/xla_repro/README.md
+++ b/xla_repro/README.md
@@ -1,0 +1,115 @@
+# XLA:TPU — host-offload remat policies fail inside nested `lax.scan`
+
+A `jax.checkpoint` policy that offloads residuals to pinned host works when the
+checkpointed body sits inside a single `jax.lax.scan`. Put that scan inside a
+second `lax.scan` and the compile fails with an internal post-optimization
+error.
+
+`nested_scan_host_offload.py` is self-contained (~100 lines, JAX only, no model
+code) and runs on any TPU.
+
+## Reproduce
+
+```
+python nested_scan_host_offload.py
+```
+
+Observed on jax/jaxlib `0.10.2`, libtpu `0.0.42.1`, v5p.
+
+```
+FLAT: compiled
+NESTED: FAILED -- INTERNAL: during context [post-optimization]: The async-start
+  expects the shape of operand 0 to match the async shape at index {0}
+  (bf16[4,3,8,512,1024]{4,3,2,1,0:T(8,128)(2,1)}
+   vs bf16[4,3,8,512,1024]{4,3,2,1,0:T(8,128)(2,1)S(5)}).
+TRIP_COUNT_ONE: FAILED -- INTERNAL: during context [post-optimization]:
+  %bitcast.31 = bf16[1,1,8,512,1024]{4,3,2,1,0:T(8,128)(2,1)S(5)} bitcast(%closed_call.6),
+  metadata={op_name="jit(trip_count_one)/jvp()/while/body/jit(dynamic_update_index_in_dim)/broadcast_in_dim"}:
+  Bitcast cannot have different memory spaces of output (5) and operand (0)
+  (bf16[1,1,8,512,1024]{4,3,2,1,0:T(8,128)(2,1)S(5)})
+  (bf16[1,8,512,1024]{3,2,1,0:T(8,128)(2,1)}).
+```
+
+## The three cases
+
+All three run the same layer body, `tanh(x @ w)`, checkpointed with
+
+```python
+jax.checkpoint_policies.save_and_offload_only_these_names(
+    names_which_can_be_saved=(),
+    names_which_can_be_offloaded=("layer_input",),
+    offload_src="device",
+    offload_dst="pinned_host",
+)
+```
+
+| case | loop structure | result |
+| --- | --- | --- |
+| `FLAT` | one `scan` over 12 layers | compiles |
+| `NESTED` | `scan` over 4 blocks, each an inner `scan` over 3 layers | fails |
+| `TRIP_COUNT_ONE` | `scan` over 12 layers, each an inner `scan` of `length=1` | fails |
+
+`TRIP_COUNT_ONE` computes exactly the same thing as `FLAT`. The only difference
+is a loop that executes once and produces nothing extra. That it fails is why we
+read this as a limitation in how the offload pass walks loop structure, rather
+than anything to do with the volume of data being moved.
+
+It needs the `skip-simplify-while-loops_trip-count-one` frontend attribute to
+reproduce, otherwise the simplifier deletes the loop and the nesting with it.
+That attribute is not contrived: models set it deliberately to keep a
+trip-count-one scan as a scheduling barrier around a single layer.
+
+## What we think is happening
+
+A residual that leaves a `lax.scan` body is not a value — it is a slice write
+into a preallocated stacked accumulator, `dynamic-update-slice(acc, value, i, …)`,
+where `acc` is a while-loop carry. For one scan level the host-offloader handles
+this: the accumulator is placed in `S(5)` and each iteration DMAs into a slice.
+
+With two levels the residual is stacked twice — into the inner accumulator, then
+into the outer one — and the pass has to carry an `S(5)` buffer out of the inner
+`while` as a tuple element, `dynamic-update-slice` it into an outer `S(5)`
+accumulator of a different shape, and pair one `copy-start` in the inner body
+with a `copy-done` in the outer backward. It appears to annotate only one side of
+that boundary:
+
+- `TRIP_COUNT_ONE` shows it directly. The bitcast's result was rewritten to
+  `S(5)` and its operand was not. A bitcast is a pure shape reinterpretation, so
+  a memory-space mismatch across one is unrepresentable — the pass constructed
+  invalid HLO itself.
+- `NESTED` shows the same thing at the async-copy pairing step.
+
+## Why this matters
+
+This is the layout any model with a heterogeneous layer cycle produces. Scanning
+over *blocks*, where each block loops over its own layers, is how you scan a
+repeating pattern of mixed layer types (linear-attention layers plus a periodic
+full-attention layer, sliding-window plus global, and so on) without unrolling
+the whole stack. Those are exactly the models where offloading activations is
+most attractive, and today the combination cannot be compiled.
+
+The only workaround available from the framework side is to flatten the inner
+level into a Python loop so that just one scan level remains. That works, but it
+unrolls the block body, which duplicates the rematerialized forward and costs
+real HBM — on one 80B configuration, 7.2 GB, against 2.0 GB actually moved to
+host. So the workaround is what makes offload unusable on these models, not the
+offload itself.
+
+## Ask
+
+Support offloaded residuals stacked across nested loops. Failing that, a clean
+error at lowering that names the nesting would at least be actionable — all
+three symptoms we have seen surface as internal post-optimization crashes.
+
+A third symptom appears in larger programs with more offloaded names, which we
+have not reduced to a small repro:
+
+```
+INVALID_ARGUMENT: E1200: CompileTimeHostOffloadOutputLocationMismatch:
+Tensor which is moved to host (starting from ...) is returned from the entry
+computation but the layout for this output is not set to host memory.
+```
+
+That one looks like the same propagation overshooting instead of undershooting:
+`S(5)` reaches an entry-computation result because the matching `MoveToDevice`
+was never found across the nest.

--- a/xla_repro/nested_scan_host_offload.py
+++ b/xla_repro/nested_scan_host_offload.py
@@ -1,0 +1,127 @@
+"""Minimal repro: `jax.checkpoint` host-offload policies crash XLA:TPU when the
+offloaded residual is produced inside a *nested* `jax.lax.scan`.
+
+A remat policy built with `save_and_offload_only_these_names(...,
+offload_dst="pinned_host")` emits MoveToHost/MoveToDevice around the named
+residual. When the checkpointed body sits inside a single `lax.scan`, XLA
+handles this: the stacked residual accumulator lives in memory space S(5) and
+each iteration DMAs into a slice of it. This is the ordinary "scan over
+transformer layers + offload activations" pattern and it compiles fine.
+
+Wrap that scan in a second `lax.scan` -- as any model with a heterogeneous layer
+cycle does, scanning over *blocks* where each block loops over its own layers --
+and the same policy fails to compile with an internal post-optimization error.
+The residual is now stacked twice: `dynamic-update-slice` into the inner
+accumulator, then again into the outer one. XLA's host-offloader appears to
+propagate the S(5) annotation across only one of those levels.
+
+Run:
+    python nested_scan_host_offload.py
+
+Expected output: FLAT passes, NESTED and TRIP_COUNT_ONE fail.
+
+The TRIP_COUNT_ONE case is the same program as FLAT plus an inner `lax.scan` of
+`length=1` -- a loop that runs exactly once and computes nothing extra. It is
+enough to trigger the failure, which is why we believe this is a structural
+limitation of the offload pass rather than anything to do with the amount of
+data being moved.
+
+Observed on jax/jaxlib 0.10.2, libtpu 0.0.42.1.
+"""
+
+import sys
+
+import jax
+import jax.numpy as jnp
+from jax.ad_checkpoint import checkpoint_name
+from jax.experimental import xla_metadata
+
+# Shapes are only large enough to make the offload worth doing; the failure does
+# not depend on them.
+BATCH, SEQ, DIM = 8, 512, 1024
+NUM_BLOCKS, LAYERS_PER_BLOCK = 4, 3
+
+OFFLOAD_POLICY = jax.checkpoint_policies.save_and_offload_only_these_names(
+    names_which_can_be_saved=(),
+    names_which_can_be_offloaded=("layer_input",),
+    offload_src="device",
+    offload_dst="pinned_host",
+)
+
+
+def layer(carry, weight):
+  """One 'transformer layer'. Its input is the tensor we ask to be offloaded."""
+  carry = checkpoint_name(carry, "layer_input")
+  return jnp.tanh(carry @ weight), None
+
+
+def flat(x, weights):
+  """Single scan over all layers -- the homogeneous-model layout. Compiles."""
+  body = jax.checkpoint(layer, policy=OFFLOAD_POLICY)
+  out, _ = jax.lax.scan(body, x, weights)
+  return jnp.sum(out)
+
+
+def nested(x, weights):
+  """Scan over blocks, each block scans over its own layers. Fails."""
+  body = jax.checkpoint(layer, policy=OFFLOAD_POLICY)
+
+  def block(carry, block_weights):
+    out, _ = jax.lax.scan(body, carry, block_weights)
+    return out, None
+
+  # weights: [NUM_BLOCKS * LAYERS_PER_BLOCK, DIM, DIM] -> [NUM_BLOCKS, LAYERS_PER_BLOCK, ...]
+  grouped = weights.reshape(NUM_BLOCKS, LAYERS_PER_BLOCK, *weights.shape[1:])
+  out, _ = jax.lax.scan(block, x, grouped)
+  return jnp.sum(out)
+
+
+def trip_count_one(x, weights):
+  """Identical to `flat`, plus an inner scan of `length=1` around each layer.
+
+  The inner loop executes exactly once and computes nothing extra, so this is
+  the same computation as `flat` -- only the loop structure differs. It still
+  fails, which is why we read this as a structural limitation of the offload
+  pass rather than anything to do with how much data is being moved.
+
+  `skip-simplify-while-loops_trip-count-one` keeps XLA from deleting the loop.
+  Real models use a trip-count-one scan deliberately, as a scheduling barrier
+  around a single layer, and set this attribute for exactly that reason; without
+  it the simplifier removes the loop and the nesting -- and the bug -- with it.
+  """
+  body = jax.checkpoint(layer, policy=OFFLOAD_POLICY)
+
+  def outer_body(carry, weight):
+    with xla_metadata.set_xla_metadata(**{"skip-simplify-while-loops_trip-count-one": "true"}):
+      out, _ = jax.lax.scan(body, carry, weight[None], length=1)
+    return out, None
+
+  out, _ = jax.lax.scan(outer_body, x, weights)
+  return jnp.sum(out)
+
+
+CASES = {"FLAT": flat, "NESTED": nested, "TRIP_COUNT_ONE": trip_count_one}
+
+
+def main():
+  x = jnp.zeros((BATCH, SEQ, DIM), jnp.bfloat16)
+  weights = jnp.zeros((NUM_BLOCKS * LAYERS_PER_BLOCK, DIM, DIM), jnp.bfloat16)
+
+  failures = 0
+  for name, fn in CASES.items():
+    # Offloading only has an effect through the backward pass, which is what
+    # consumes the rematerialization residuals.
+    grad_fn = jax.jit(jax.grad(fn, argnums=1))
+    try:
+      grad_fn.lower(x, weights).compile()
+      print(f"{name}: compiled")
+    except Exception as e:  # pylint: disable=broad-except
+      failures += 1
+      first_line = str(e).strip().splitlines()[0]
+      print(f"{name}: FAILED -- {first_line}")
+
+  return 1 if failures else 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
Not for merge. Self-contained reproducer for an XLA:TPU bug, to attach to a report for the compiler team.

A jax.checkpoint policy built with save_and_offload_only_these_names(..., offload_dst="pinned_host") compiles when the checkpointed body sits inside a single lax.scan -- the ordinary scan-over-layers layout of a homogeneous model. Wrapping that scan in a second lax.scan, which is how a heterogeneous layer cycle is scanned (over blocks, each block looping over its own layers), makes the same policy fail with an internal post-optimization error.

The script covers three cases and needs only JAX and a TPU:

  FLAT            one scan over 12 layers                        compiles
  NESTED          scan over 4 blocks x inner scan over 3 layers  fails
  TRIP_COUNT_ONE  scan over 12 layers x inner scan of length 1   fails

TRIP_COUNT_ONE computes exactly what FLAT computes; the only difference is a loop that runs once and produces nothing extra. Both failures are the same symptom the Qwen3-Next block scan hits, down to the shape of the bad bitcast.

This blocks remat offload policies on every hybrid-attention model. The one workaround available to us -- flattening the inner loop into a Python loop so a single scan level remains -- unrolls the block body and costs more HBM than the offload recovers.

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

You can also provide a comma-separated list. If you don't want to close a bug but
simply to reference it, use BUGS, e.g.: 
BUGS: b/123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
