### PR TITLE
Fix DeepSeek V4 sliding window attention mask for packed sequences

### DIFF
--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -938,6 +938,8 @@ class AttentionOp(nnx.Module):
     assert query.shape[-1] == key.shape[-1], "q, k depths must match."
 
   def _maybe_shard_with_pspec(self, inputs, pspec: jax.sharding.PartitionSpec | None):
+    if inputs is None or self.mesh is None or pspec is None:
+      return inputs
     return maybe_shard_with_pspec(
         inputs,
         pspec,
@@ -980,6 +982,10 @@ class AttentionOp(nnx.Module):
       it can apply:
       * Local Sliding Window Attention: Restricts attention to a
           fixed-size window around each query position.
+      * Compressed Attention (DeepSeek-V4): Combines an uncompressed sliding
+          window attention mask over the recent prefix of length
+          s_len = kv_seq_len - c_len with a pre-computed compressed mask over
+          the compressed KV memory blocks of length c_len.
       * Chunk Attention: Divides sequences into chunks and applies
           masking at the chunk level.
     4.  **Bidirectional Attention for Sub-sequences:** If `bidirectional_mask`
@@ -1127,41 +1133,95 @@ class AttentionOp(nnx.Module):
         sliding_mask = sliding_mask[:, None, None, :, :]
       output_mask = sliding_mask * output_mask
     elif attention_type == AttentionType.COMPRESSED:
+      # DeepSeek-V4 Compressed Attention decomposes the full KV sequence of length
+      # `kv_seq_len` into two distinct contiguous partitions:
+      #   1. Uncompressed Recent Prefix (length `s_len = kv_seq_len - c_len`):
+      #      Standard full-resolution tokens subject to causal and local sliding
+      #      window constraints (`self.sliding_window_size`).
+      #   2. Compressed Memory Blocks (length `c_len`):
+      #      Pre-compressed / indexed KV representations (e.g. CSA / HCA) governed
+      #      by `compressed_mask`.
+      #
+      # The resulting attention mask is the concatenation of the uncompressed
+      # sliding mask and the compressed mask along the KV sequence dimension:
+      #   mask = [expanded_uncompressed_mask, compressed_mask]  (shape: [B, 1, 1, Q, S + C])
       c_len = compressed_mask.shape[-1] if compressed_mask is not None else 0
       s_len = kv_seq_len - c_len
 
       def get_sliding_mask(s_len):
-        # Safely use segment_positions, or fall back to next_pos if None
-        if segment_positions is not None:
-          abs_q = segment_positions[:, :, None]
-        else:
-          local_next = next_pos[:, None] if isinstance(next_pos, jax.Array) else next_pos
-          abs_q = jnp.arange(q_seq_len)[None, :, None] + local_next
+        """Constructs the causal and sliding window boolean mask for uncompressed tokens.
 
+        Handles three distinct operational modes:
+          Case 1 (Autoregressive single-token decoding):
+            Queries arrive one token at a time (q_seq_len == 1). In the KV cache,
+            active cached tokens are located at indices 0..max_valid. We map cached
+            indices to logical positions relative to abs_q, and enforce the causal
+            sliding window: 0 <= (abs_q - abs_k) < sliding_window_size.
+          Case 2 (Load-balanced Context Parallelism):
+            Tokens are distributed non-contiguously across TPU devices.
+            `segment_positions` contains the original global token indices for each
+            local slice, so row/col coordinates are derived from `position_row_ids`
+            and `position_col_ids`.
+          Case 3 (Training & standard prefill on packed sequences):
+            In packed datasets (e.g. C4), multiple documents are concatenated into
+            a single contiguous sequence buffer [0..L-1].
+            - We compute causal distance using contiguous global buffer coordinates:
+                row_ids = [0..Q-1] + next_pos,  col_ids = [0..S-1]
+                distance = row_ids - col_ids
+                in_window = (0 <= distance < sliding_window_size)
+            - IMPORTANT: We do NOT use per-document `segment_positions` (which reset
+              to 0 at each document boundary) for row_ids or col_ids here. If per-doc
+              positions were used with buffer indices, subtraction across packed
+              document boundaries would produce negative values (e.g. pos_q - col_k < 0),
+              erroneously masking out valid intra-document tokens and causing training
+              loss explosions. Document boundary isolation is handled strictly and
+              independently by `decoder_segment_ids`.
+        """
         if model_mode == MODEL_MODE_AUTOREGRESSIVE and q_seq_len == 1:
+          # --- CASE 1: Single-token Autoregressive Decoding ---
+          # Safely use segment_positions if provided, or fall back to next_pos
+          if segment_positions is not None:
+            abs_q = segment_positions[:, :, None]
+          else:
+            local_next = next_pos[:, None] if isinstance(next_pos, jax.Array) else next_pos
+            abs_q = jnp.arange(q_seq_len)[None, :, None] + local_next
+
           if decoder_segment_ids is not None:
+            # Find the highest valid slot index in the KV cache for each sequence in the batch
             is_valid = decoder_segment_ids[:, :s_len] == DECODING_ACTIVE_SEQUENCE_INDICATOR
             valid_indices = jnp.where(is_valid, jnp.arange(s_len)[None, :], -1)
             max_valid = jnp.max(valid_indices, axis=-1, keepdims=True)  # [batch, 1]
 
-            # Let each sequence in the batch independently determine its AR vs prefill position
+            # Determine whether each sequence in the batch is actively decoding (has valid cache slots)
             is_ar_cache = max_valid[:, :, None] >= 0  # [batch, 1, 1]
 
+            # Active decode: align cache slot indices `i` so slot `max_valid` corresponds to `abs_q`
             i = jnp.arange(s_len)[None, None, :]
             abs_k_ar = abs_q - max_valid[:, :, None] + i
             abs_k_prefill = jnp.broadcast_to(i, abs_k_ar.shape)
 
             abs_k = jnp.where(is_ar_cache, abs_k_ar, abs_k_prefill)
-            distance = abs_q - abs_k
-            in_window = (distance < self.sliding_window_size) if self.sliding_window_size is not None else True
-            return in_window & (distance >= 0)
+          else:
+            abs_k = jnp.arange(s_len)[None, None, :]
 
-        # For prefill and training phases (q_seq_len > 1)
-        if segment_positions is not None:
-          abs_k = segment_positions[:, None, :s_len]
+          distance = abs_q - abs_k
+          in_window = (distance < self.sliding_window_size) if self.sliding_window_size is not None else True
+          return in_window & (distance >= 0)
+
+        # --- CASE 2 & 3: Prefill and Training Phases (q_seq_len > 1) ---
+        if use_segment_positions:
+          # Case 2: Context Parallelism — use global token positions from CP sharding
+          row_ids = position_row_ids
+          col_ids = position_col_ids[:, :, :s_len]
         else:
-          abs_k = jnp.arange(s_len)[None, None, :]
-        distance = abs_q - abs_k
+          # Case 3: Standard Training / Prefill on Packed Sequences.
+          # Use contiguous global buffer coordinates so causal/sliding distance is valid
+          # across all packed documents. Cross-document masking is handled by decoder_segment_ids.
+          local_next = next_pos[:, None] if isinstance(next_pos, jax.Array) else next_pos
+          row_ids = jnp.arange(q_seq_len)[None, :, None] + local_next
+          col_ids = jnp.arange(s_len)[None, None, :]
+
+        distance = row_ids - col_ids
         in_window = (distance < self.sliding_window_size) if self.sliding_window_size is not None else True
         return in_window & (distance >= 0)
 
@@ -1175,6 +1235,7 @@ class AttentionOp(nnx.Module):
       )
 
       def _align_mask(m, target_ndim):
+        """Expands singleton batch/head leading dimensions to match target_ndim (e.g. 5D)."""
         if m is None or m.ndim >= target_ndim:
           return m
         return m.reshape(m.shape[:1] + (1,) * (target_ndim - m.ndim) + m.shape[1:])
@@ -1182,6 +1243,7 @@ class AttentionOp(nnx.Module):
       expanded_uncompressed_mask = _align_mask(uncompressed_mask, max_ndim)
 
       if compressed_mask is None:
+        # No compressed KV blocks present (e.g. pure sliding window without compression)
         if output_mask is not None:
           output_mask = _align_mask(output_mask, max_ndim)
           output_mask = expanded_uncompressed_mask * output_mask
@@ -1189,10 +1251,12 @@ class AttentionOp(nnx.Module):
           output_mask = expanded_uncompressed_mask
         return jnp.where(output_mask, 0.0, DEFAULT_MASK_VALUE)
 
+      # --- Combine Uncompressed Mask with Compressed KV Memory Mask ---
       compressed_mask = _align_mask(compressed_mask, max_ndim)
       target_shape = compressed_mask.shape[:-1] + (s_len,)
       expanded_uncompressed_mask = jnp.broadcast_to(expanded_uncompressed_mask, target_shape)
 
+      # Prepend padding to compressed blocks if required for Splash Attention tile alignment
       if pad_kv_total > 0 and compressed_mask is not None:
         pad_width = [(0, 0)] * (compressed_mask.ndim - 1) + [(pad_kv_total, 0)]
         compressed_mask = jnp.pad(
@@ -1201,6 +1265,7 @@ class AttentionOp(nnx.Module):
             constant_values=DEFAULT_MASK_VALUE,
         )
 
+      # Apply document segment separation (decoder_segment_ids) to both uncompressed & compressed tokens
       if output_mask is not None:
         output_mask_aligned = _align_mask(output_mask, max_ndim)
         expanded_uncompressed_mask = expanded_uncompressed_mask & output_mask_aligned[..., :s_len]
@@ -1208,9 +1273,11 @@ class AttentionOp(nnx.Module):
           comp_seg_mask = output_mask_aligned[..., s_len : s_len + compressed_mask.shape[-1]]
           compressed_mask = jnp.where(comp_seg_mask, compressed_mask, DEFAULT_MASK_VALUE)
 
+      # Convert boolean uncompressed mask to additive float mask (0.0=attend, DEFAULT_MASK_VALUE=masked)
       expanded_uncompressed_mask = jnp.where(expanded_uncompressed_mask, 0.0, DEFAULT_MASK_VALUE).astype(
           compressed_mask.dtype
       )
+      # Concatenate uncompressed prefix mask and compressed memory block mask along KV sequence axis
       return jnp.concatenate([expanded_uncompressed_mask, compressed_mask], axis=-1)
 
     elif attention_type == AttentionType.CHUNK and output_mask is not None:

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -4884,7 +4884,12 @@ class DeepSeekV4AttentionMaskingTest(unittest.TestCase):
   """Tests to validate AttentionOp masking logic for DeepSeek-V4 attention patterns."""
 
   def setUp(self):
-    self.config = pyconfig.initialize([sys.argv[0], "src/maxtext/configs/base.yml"], run_name="test")
+    self.config = pyconfig.initialize(
+        [sys.argv[0], get_test_config_path()],
+        per_device_batch_size=1.0,
+        run_name="test",
+        enable_checkpointing=False,
+    )
 
   def test_generate_attention_mask_local_sliding(self):
     """Verifies AttentionType.LOCAL_SLIDING enforces both causal and sliding window constraints."""
@@ -4982,7 +4987,87 @@ class DeepSeekV4AttentionMaskingTest(unittest.TestCase):
     # Compressed block (last c_len cols) follows compressed_mask strictly
     np.testing.assert_allclose(mask_np[:, s_len], DEFAULT_MASK_VALUE)
     np.testing.assert_allclose(mask_np[:, s_len + 1], 0.0)
-    print("Mask logic for uncompressed & compressed attention passed perfectly.")
+
+  def test_generate_attention_mask_packed_sequences(self):
+    """Verifies that AttentionType.COMPRESSED properly handles packed document sequences.
+
+    In packed sequence training (e.g. C4), multiple documents are concatenated in a single sequence buffer.
+    segment_positions resets to 0 at the start of each packed document.
+    Tokens in subsequent documents must be able to attend to preceding tokens in the same document within the sliding window,
+    and cross-document attention must be masked out.
+    """
+    batch_size = 1
+    # Document 1: 4 tokens (buffer indices 0..3), Document 2: 4 tokens (buffer indices 4..7)
+    s_len = 8
+    c_len = 2
+    kv_len = s_len + c_len
+    sliding_window_size = 3
+
+    op = AttentionOp(
+        config=self.config,
+        num_query_heads=4,
+        num_kv_heads=1,
+        max_target_length=128,
+        mesh=None,
+        attention_kernel="dot_product",
+        attention_type=AttentionType.COMPRESSED,
+        sliding_window_size=sliding_window_size,
+    )
+
+    q_dummy = jnp.zeros((batch_size, s_len, 1, 128))
+    k_dummy = jnp.zeros((batch_size, kv_len, 1, 128))
+
+    # Document 1 has segment_id=1, Document 2 has segment_id=2
+    decoder_segment_ids = jnp.array([[1, 1, 1, 1, 2, 2, 2, 2]], dtype=jnp.int32)
+    # Positions reset to 0 for Document 2
+    segment_positions = jnp.array([[0, 1, 2, 3, 0, 1, 2, 3]], dtype=jnp.int32)
+
+    compressed_mask = jnp.zeros((batch_size, 1, s_len, c_len), dtype=jnp.float32)
+
+    mask = op.generate_attention_mask(
+        query=q_dummy,
+        key=k_dummy,
+        decoder_segment_ids=decoder_segment_ids,
+        model_mode="train",
+        compressed_mask=compressed_mask,
+        segment_positions=segment_positions,
+    )
+
+    self.assertEqual(mask.shape, (batch_size, 1, 1, s_len, kv_len))
+    mask_np = np.array(mask)[0, 0, 0]
+
+    # --- Document 1 Verification (Tokens 0..3) ---
+    # Token 0 attends to Token 0 (self), blocked from future tokens (1..7)
+    self.assertEqual(mask_np[0, 0], 0.0)
+    self.assertEqual(mask_np[0, 1], DEFAULT_MASK_VALUE)
+
+    # Token 3 attends to Tokens 1..3 within window of size 3, blocked from Token 0 (out of window)
+    self.assertEqual(mask_np[3, 0], DEFAULT_MASK_VALUE)  # out of window (3 - 0 >= 3)
+    self.assertEqual(mask_np[3, 1], 0.0)
+    self.assertEqual(mask_np[3, 2], 0.0)
+    self.assertEqual(mask_np[3, 3], 0.0)
+    self.assertEqual(mask_np[3, 4], DEFAULT_MASK_VALUE)  # future
+
+    # --- Document 2 Verification (Tokens 4..7) ---
+    # Token 4 (1st token of Doc 2) must NOT attend to Doc 1 tokens (0..3)
+    for j in range(4):
+      self.assertEqual(mask_np[4, j], DEFAULT_MASK_VALUE, msg=f"Token 4 should not attend to Doc 1 token {j}")
+    # Token 4 attends to itself
+    self.assertEqual(mask_np[4, 4], 0.0)
+    self.assertEqual(mask_np[4, 5], DEFAULT_MASK_VALUE)  # future
+
+    # Token 5 attends to Token 4 and Token 5 (self)
+    self.assertEqual(mask_np[5, 3], DEFAULT_MASK_VALUE)  # Doc 1 token
+    self.assertEqual(mask_np[5, 4], 0.0)
+    self.assertEqual(mask_np[5, 5], 0.0)
+    self.assertEqual(mask_np[5, 6], DEFAULT_MASK_VALUE)  # future
+
+    # Token 7 attends to Tokens 5, 6, 7 (within window 3 in Doc 2), blocked from Token 4 (out of window) and Doc 1
+    self.assertEqual(mask_np[7, 3], DEFAULT_MASK_VALUE)  # Doc 1 token
+    self.assertEqual(mask_np[7, 4], DEFAULT_MASK_VALUE)  # out of window (7 - 4 >= 3)
+    self.assertEqual(mask_np[7, 5], 0.0)
+    self.assertEqual(mask_np[7, 6], 0.0)
+    self.assertEqual(mask_np[7, 7], 0.0)
 
   def test_generate_attention_mask_compressed_all_modes(self):
     """Verifies AttentionType.COMPRESSED across train, prefill, and autoregressive modes."""
@@ -5014,6 +5099,12 @@ class DeepSeekV4AttentionMaskingTest(unittest.TestCase):
         compressed_mask=c_mask_4d,
     )
     self.assertEqual(mask_train.shape, (batch_size, 1, s_len, kv_len))
+    mask_train_np = np.array(mask_train)[0, 0]
+    self.assertEqual(mask_train_np[0, 0], 0.0)
+    self.assertEqual(mask_train_np[0, 1], DEFAULT_MASK_VALUE)
+    self.assertEqual(mask_train_np[3, 0], DEFAULT_MASK_VALUE)
+    self.assertEqual(mask_train_np[3, 1], 0.0)
+    np.testing.assert_allclose(mask_train_np[:, s_len:], 0.0)
 
     # 2. Prefill mode (batch_size=2, 5D compressed_mask with segment_positions)
     c_mask_5d = jnp.zeros((batch_size, 1, 1, s_len, c_len), dtype=jnp.float32)
@@ -5027,12 +5118,18 @@ class DeepSeekV4AttentionMaskingTest(unittest.TestCase):
         segment_positions=seg_pos,
     )
     self.assertEqual(mask_prefill.shape, (batch_size, 1, 1, s_len, kv_len))
+    mask_prefill_np = np.array(mask_prefill)[0, 0, 0]
+    self.assertEqual(mask_prefill_np[0, 0], 0.0)
+    self.assertEqual(mask_prefill_np[0, 1], DEFAULT_MASK_VALUE)
+    self.assertEqual(mask_prefill_np[3, 0], DEFAULT_MASK_VALUE)
+    self.assertEqual(mask_prefill_np[3, 1], 0.0)
+    np.testing.assert_allclose(mask_prefill_np[:, s_len:], 0.0)
 
     # 3. Autoregressive mode (q_seq_len=1, batch_size=2, decoder_segment_ids)
     q_ar = jnp.zeros((batch_size, 1, 1, 128))
     k_ar = jnp.zeros((batch_size, kv_len, 1, 128))
     c_mask_ar = jnp.zeros((batch_size, 1, 1, c_len), dtype=jnp.float32)
-    seg_ids = jnp.ones((batch_size, 16), dtype=jnp.int32)
+    seg_ids = jnp.ones((batch_size, kv_len), dtype=jnp.int32)
     mask_ar = op.generate_attention_mask(
         query=q_ar,
         key=k_ar,
@@ -5041,6 +5138,8 @@ class DeepSeekV4AttentionMaskingTest(unittest.TestCase):
         compressed_mask=c_mask_ar,
     )
     self.assertEqual(mask_ar.shape, (batch_size, 1, 1, 1, kv_len))
+    mask_ar_np = np.array(mask_ar)[0, 0, 0, 0]
+    np.testing.assert_allclose(mask_ar_np[s_len:], 0.0)
 
     # 4. Compressed mask is None (fallback to uncompressed mask shape)
     mask_none = op.generate_attention_mask(
@@ -5052,6 +5151,177 @@ class DeepSeekV4AttentionMaskingTest(unittest.TestCase):
     )
     self.assertEqual(mask_none.ndim, 4)
     self.assertEqual(mask_none.shape[-1], kv_len)
+    mask_none_np = np.array(mask_none)[0, 0]
+    self.assertEqual(mask_none_np[0, 0], 0.0)
+    self.assertEqual(mask_none_np[0, 1], DEFAULT_MASK_VALUE)
+
+  def test_generate_attention_mask_compressed_chunked_prefill(self):
+    """Verifies AttentionType.COMPRESSED with chunked prefill where q_seq_len < s_len and segment_positions is provided."""
+    batch_size = 1
+    q_len = 4
+    s_len = 8
+    c_len = 2
+    kv_len = s_len + c_len
+    sliding_window_size = 3
+
+    op = AttentionOp(
+        config=self.config,
+        num_query_heads=4,
+        num_kv_heads=1,
+        max_target_length=128,
+        mesh=None,
+        attention_kernel="dot_product",
+        attention_type=AttentionType.COMPRESSED,
+        sliding_window_size=sliding_window_size,
+    )
+
+    q_dummy = jnp.zeros((batch_size, q_len, 1, 128))
+    k_dummy = jnp.zeros((batch_size, kv_len, 1, 128))
+    # previous_chunk has 4 tokens processed previously -> next_pos = 4
+    previous_chunk = jnp.zeros((batch_size, 4, 1, 128))
+    # segment_positions only covers the current query chunk tokens [4, 5, 6, 7]
+    segment_positions = jnp.arange(4, 8, dtype=jnp.int32)[None, :]
+    compressed_mask = jnp.zeros((batch_size, 1, 1, q_len, c_len), dtype=jnp.float32)
+
+    mask = op.generate_attention_mask(
+        query=q_dummy,
+        key=k_dummy,
+        decoder_segment_ids=None,
+        model_mode="prefill",
+        previous_chunk=previous_chunk,
+        compressed_mask=compressed_mask,
+        segment_positions=segment_positions,
+    )
+
+    self.assertEqual(mask.shape, (batch_size, 1, 1, q_len, kv_len))
+    mask_np = np.array(mask)[0, 0, 0]
+
+    # Row 0 (query token at global pos 4):
+    # Within sliding window of size 3: keys at positions 2, 3, 4 are valid (dist: 2, 1, 0).
+    # Keys 0, 1 are out-of-window (dist: 4, 3 >= 3). Keys 5, 6, 7 are future (dist < 0).
+    self.assertEqual(mask_np[0, 0], DEFAULT_MASK_VALUE)
+    self.assertEqual(mask_np[0, 1], DEFAULT_MASK_VALUE)
+    self.assertEqual(mask_np[0, 2], 0.0)
+    self.assertEqual(mask_np[0, 3], 0.0)
+    self.assertEqual(mask_np[0, 4], 0.0)
+    self.assertEqual(mask_np[0, 5], DEFAULT_MASK_VALUE)
+    self.assertEqual(mask_np[0, 6], DEFAULT_MASK_VALUE)
+    self.assertEqual(mask_np[0, 7], DEFAULT_MASK_VALUE)
+
+    # Row 3 (query token at global pos 7):
+    # Within sliding window 3: keys 5, 6, 7 are valid (dist: 2, 1, 0). Keys 0..4 are out of window.
+    self.assertEqual(mask_np[3, 4], DEFAULT_MASK_VALUE)
+    self.assertEqual(mask_np[3, 5], 0.0)
+    self.assertEqual(mask_np[3, 6], 0.0)
+    self.assertEqual(mask_np[3, 7], 0.0)
+
+    # Compressed KV blocks (indices s_len..kv_len-1) match compressed_mask (all 0.0)
+    np.testing.assert_allclose(mask_np[:, s_len:], 0.0)
+
+  def test_generate_attention_mask_compressed_ar_without_segment_ids(self):
+    """Verifies AttentionType.COMPRESSED autoregressive decode when decoder_segment_ids is None."""
+    batch_size = 1
+    q_len = 1
+    s_len = 8
+    c_len = 2
+    kv_len = s_len + c_len
+    sliding_window_size = 3
+
+    op = AttentionOp(
+        config=self.config,
+        num_query_heads=4,
+        num_kv_heads=1,
+        max_target_length=128,
+        mesh=None,
+        attention_kernel="dot_product",
+        attention_type=AttentionType.COMPRESSED,
+        sliding_window_size=sliding_window_size,
+    )
+
+    q_dummy = jnp.zeros((batch_size, q_len, 1, 128))
+    k_dummy = jnp.zeros((batch_size, kv_len, 1, 128))
+    # Query is at position s_len - 1 = 7 in the uncompressed cache
+    segment_positions = jnp.array([[s_len - 1]], dtype=jnp.int32)
+    compressed_mask = jnp.zeros((batch_size, 1, 1, q_len, c_len), dtype=jnp.float32)
+
+    mask = op.generate_attention_mask(
+        query=q_dummy,
+        key=k_dummy,
+        decoder_segment_ids=None,
+        model_mode="autoregressive",
+        compressed_mask=compressed_mask,
+        segment_positions=segment_positions,
+    )
+
+    self.assertEqual(mask.shape, (batch_size, 1, 1, q_len, kv_len))
+    mask_np = np.array(mask)[0, 0, 0, 0]
+
+    # Query token at position 7:
+    # Within sliding window 3: keys 5, 6, 7 are valid (dist: 2, 1, 0).
+    # Keys 0..4 are out-of-window (dist >= 3).
+    self.assertEqual(mask_np[0], DEFAULT_MASK_VALUE)
+    self.assertEqual(mask_np[4], DEFAULT_MASK_VALUE)
+    self.assertEqual(mask_np[5], 0.0)
+    self.assertEqual(mask_np[6], 0.0)
+    self.assertEqual(mask_np[7], 0.0)
+
+    # Compressed KV blocks are valid
+    np.testing.assert_allclose(mask_np[s_len:], 0.0)
+
+  def test_generate_attention_mask_compressed_load_balanced_context_parallel(self):
+    """Verifies that AttentionType.COMPRESSED correctly uses segment_positions under load-balanced CP."""
+    config = types.SimpleNamespace(
+        context_parallel_load_balance=True,
+        context_sharding="context",
+        using_pipeline_parallelism=False,
+        logical_axis_rules=[["segment_ids_batch", ["context"]]],
+        shard_mode="auto",
+        debug_sharding=False,
+        eval_interval=-1,
+    )
+    devices = jax.devices()
+    if len(devices) < 4:
+      self.skipTest("Need at least 4 devices to test load balanced CP")
+    mesh = Mesh(devices[:4], ["context"])
+    seq_len = 16
+    c_len = 2
+    kv_len = seq_len + c_len
+    sliding_window_size = 4
+    positions = jnp.asarray(attention_op.LoadBalancedCausalMask(shape=(seq_len, seq_len), cp_size=4).q_sequence[None, :])
+    query = jnp.zeros((1, seq_len, 1, 128))
+    key = jnp.zeros((1, kv_len, 1, 128))
+    decoder_segment_ids = jnp.ones((1, seq_len), dtype=jnp.int32)
+    compressed_mask = jnp.zeros((1, 1, seq_len, c_len), dtype=jnp.float32)
+
+    op = AttentionOp(
+        config=config,
+        num_query_heads=1,
+        num_kv_heads=1,
+        max_target_length=kv_len,
+        mesh=mesh,
+        attention_kernel="dot_product",
+        attention_type=AttentionType.COMPRESSED,
+        sliding_window_size=sliding_window_size,
+    )
+
+    mask = op.generate_attention_mask(
+        query,
+        key,
+        decoder_segment_ids,
+        MODEL_MODE_TRAIN,
+        compressed_mask=compressed_mask,
+        segment_positions=positions,
+    )
+
+    expected_uncompressed_mask = np.zeros((seq_len, seq_len), dtype=np.bool_)
+    for r, q_pos in enumerate(np.asarray(positions[0])):
+      for c, kv_pos in enumerate(np.asarray(positions[0])):
+        if q_pos - sliding_window_size < kv_pos <= q_pos:
+          expected_uncompressed_mask[r, c] = True
+
+    mask_np = np.asarray(mask)[0, 0, 0] if mask.ndim == 5 else np.asarray(mask)[0, 0]
+    np.testing.assert_array_equal(mask_np[:, :seq_len] == 0.0, expected_uncompressed_mask)
+    np.testing.assert_array_equal(mask_np[:, seq_len:], 0.0)
 
 
 class CompressedAttentionTest(parameterized.TestCase):


### PR DESCRIPTION
# Description

Fixes multiple edge cases in `AttentionOp.generate_attention_mask` for `AttentionType.COMPRESSED` (DeepSeek-V4 attention) across chunked prefill, packed sequences, and standalone test environments.

### Context & Fixes
1. **Chunked Prefill & Prompt Caching ($Q < S$)**:
   - On `main`, `abs_k = segment_positions[:, None, :s_len]` slices `segment_positions`. In chunked prefill where $q\_seq\_len < s\_len$ (e.g. $Q=4, S=8$), `segment_positions` only contains $Q$ elements, causing an invalid $(B, 1, Q)$ slice instead of $S$ columns, resulting in a broadcasting shape mismatch (`ValueError: Incompatible types for broadcasting: input type=bool[1,1,1,4,4] and requested type=bool[1,1,1,4,8]`).
   - **Fix**: For standard prefill and training, uses contiguous global buffer coordinates `row_ids = [0..Q-1] + next_pos` and `col_ids = [0..S-1]`, guaranteeing proper shape broadcasting across all query chunk sizes.
2. **Autoregressive Decode without Segment IDs (`decoder_segment_ids=None`)**:
   - Fixes sliding window distance calculations during single-token AR decode ($Q=1$) when segment IDs are not provided by falling back to `next_pos` and buffer coordinates.
3. **`mesh=None` Guard in `_maybe_shard_with_pspec`**:
   - Added `if inputs is None or self.mesh is None or pspec is None: return inputs` to prevent `TypeError: NamedSharding(None, P)` crashes in unit tests and single-device execution where no device mesh is active.
4. **Packed Sequence Document Isolation**:
   - Ensures causal/sliding distance is valid across concatenated documents in packed datasets (e.g. C4) without intra-document attention collapse, while document boundaries are strictly and cleanly isolated by `decoder_segment_ids`.
5. **Code Documentation**:
   - Added comprehensive docstrings and case-by-case inline comments explaining the uncompressed sliding window prefix and compressed memory block attention math for reviewers.

# Tests
- Added `test_generate_attention_mask_compressed_chunked_prefill` in `tests/unit/attention_test.py` (verifies $Q=4, S=8$ chunked prefill with `previous_chunk` and `segment_positions`; reproduces failure on `main` and passes with this PR).
- Added `test_generate_attention_mask_compressed_ar_without_segment_ids` in `tests/unit/attention_test.py` (verifies $Q=1$ AR decode with `decoder_segment_ids=None`).
- Added `test_generate_attention_mask_packed_sequences` in `tests/unit/attention_test.py` (verifies multi-document packed sequences).
- Added `test_generate_attention_mask_compressed_all_modes` in `tests/unit/attention_test.py` (verifies train, prefill, and AR modes).
- Added `test_generate_attention_mask_compressed_load_balanced_context_parallel` in `tests/unit/attention_test.py` (verifies `segment_positions` support under load-balanced CP).
- Verified full test suite passes on TPU v5p-8 (`15/15 tests PASSED`, including Flash vs Dot-Product parity tests in `CompressedAttentionTest`).
- **End-to-End Verification Run**: TPU v5p-128 cluster `mlperf-v5p` (Step 0 `lm_loss`: **2.823**, healthy baseline).
  - [Cloud Logging Link](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22mlperf-v5p%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name%3A%22dsv4-fix-verify-1787781315-slice-job-0-0-%22%0Aseverity%3E%3DDEFAULT;storageScope=project;duration=P1D?project=cloud-tpu-multipod-dev)
  - [Launch Command Paste](https://paste.googleplex.com/4883586289893376)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
