### PR TITLE
Integrate elastic goodput and slice efficiency into snapshotting

### DIFF
--- a/src/maxtext/common/goodput.py
+++ b/src/maxtext/common/goodput.py
@@ -42,6 +42,26 @@ RECORD_JOB_START_TIME = f"record_{GoodputEvent.JOB.value}_start_time"
 RECORD_JOB_END_TIME = f"record_{GoodputEvent.JOB.value}_end_time"
 
 
+def _construct_goodput_monitor(config, common_kwargs):
+  """Constructs a GoodputMonitor, preferring the elastic-aware monitor when applicable."""
+  if config.elastic_enabled:
+    try:
+      from maxtext.utils import elastic_utils  # pylint: disable=import-outside-toplevel
+
+      if elastic_utils.should_use_elastic(config):
+        from ml_goodput_measurement import monitoring_elastic  # pylint: disable=import-outside-toplevel
+
+        monitor = monitoring_elastic.ElasticGoodputMonitor(include_slice_efficiency=True, **common_kwargs)
+        max_logging.log(f"Goodput: using ElasticGoodputMonitor for job: {config.run_name}")
+        return monitor
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      max_logging.log(f"Goodput: could not create elastic goodput monitor, falling back to base monitor: {e}")
+
+  monitor = monitoring.GoodputMonitor(pathway_enabled=config.enable_pathways_goodput, **common_kwargs)
+  max_logging.log(f"Goodput: using GoodputMonitor for job: {config.run_name}")
+  return monitor
+
+
 @contextlib.contextmanager
 def maybe_monitor_goodput(config):
   """Monitor cumulative goodput if enabled on the lead host.
@@ -66,18 +86,20 @@ def maybe_monitor_goodput(config):
         enable_gcp_goodput_metrics=config.enable_gcp_goodput_metrics,
         enable_gcp_step_deviation_metrics=config.enable_gcp_step_deviation_metrics,
     )
-    goodput_monitor = monitoring.GoodputMonitor(
-        job_name=config.run_name,
-        logger_name=f"goodput_{config.run_name}",
-        tensorboard_dir=config.tensorboard_dir,
-        upload_interval=config.goodput_upload_interval_seconds,
-        monitoring_enabled=True,
-        pathway_enabled=config.enable_pathways_goodput,
-        include_badput_breakdown=True,
-        include_step_deviation=config.monitor_step_time_deviation,
-        step_deviation_interval_seconds=config.step_deviation_interval_seconds,
-        gcp_options=gcp_options,
-    )
+
+    common_kwargs = {
+        "job_name": config.run_name,
+        "logger_name": f"goodput_{config.run_name}",
+        "tensorboard_dir": config.tensorboard_dir,
+        "upload_interval": config.goodput_upload_interval_seconds,
+        "monitoring_enabled": True,
+        "include_badput_breakdown": True,
+        "include_step_deviation": config.monitor_step_time_deviation,
+        "step_deviation_interval_seconds": config.step_deviation_interval_seconds,
+        "gcp_options": gcp_options,
+    }
+
+    goodput_monitor = _construct_goodput_monitor(config, common_kwargs)
     goodput_monitor.start_goodput_uploader()
     max_logging.log("Started Goodput upload to Tensorboard & GCM in the background!")
     yield
@@ -121,8 +143,27 @@ def create_goodput_recorder(config):
     if config.enable_goodput_recording and jax.process_index() == 0:
       max_logging.log("[GOODPUT NO-OP] recorder skipped (decoupled stub).")
     return None
-  if config.enable_goodput_recording:
-    logger_name = f"goodput_{config.run_name}"
-    recorder = goodput.GoodputRecorder(config.run_name, logger_name, jax.process_index() == 0)
-    return recorder
-  return None
+
+  if not config.enable_goodput_recording:
+    return None
+
+  logger_name = f"goodput_{config.run_name}"
+
+  # Detect if we should use the elastic-aware recorder
+  if config.elastic_enabled:
+    try:
+      from maxtext.utils import elastic_utils  # pylint: disable=import-outside-toplevel
+
+      if elastic_utils.should_use_elastic(config):
+        from ml_goodput_measurement import goodput_elastic  # pylint: disable=import-outside-toplevel
+
+        recorder = goodput_elastic.ElasticGoodputRecorder(config.run_name, logger_name, jax.process_index() == 0)
+        elastic_utils.record_slice_state(recorder)
+        max_logging.log(f"Goodput: created ElasticGoodputRecorder for job: {config.run_name}")
+        return recorder
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      max_logging.log(f"Goodput: could not create elastic goodput recorder, falling back to base recorder: {e}")
+
+  recorder = goodput.GoodputRecorder(config.run_name, logger_name, jax.process_index() == 0)
+  max_logging.log(f"Goodput: created base GoodputRecorder for job: {config.run_name}")
+  return recorder

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -850,9 +850,7 @@ def recover(
   # Delete old iterators and loaders to release colocated python resources
   for key in ["data_iterator", "eval_data_iterator", "data_loader"]:
     if key in python_vars:
-      _logger.info(
-          "Deleting old %s to release colocated python resources...", key
-      )
+      _logger.info("Deleting old %s to release colocated python resources...", key)
       del python_vars[key]
 
   while True:
@@ -920,10 +918,8 @@ def recover(
           jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec()),
       )
 
-      params_shardings, state_mesh_shardings = (
-          sharding.maybe_update_params_sharding_with_opt(
-              config, state_mesh_shardings
-          )
+      params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(
+          config, state_mesh_shardings
       )
 
       # 3. Re-compile train and eval steps for the NEW mesh
@@ -950,9 +946,7 @@ def recover(
 
       # 4. Restore TrainState from active state (device-to-device) or host snapshot
       if active_state is not None:
-        _logger.info(
-            "[*] Resharding active state directly (device-to-device)..."
-        )
+        _logger.info("[*] Resharding active state directly (device-to-device)...")
         if isinstance(model, nn.Module):
           for_sharding_dict = {
               "step": state.step,
@@ -1036,15 +1030,11 @@ def recover(
             snapshot_loaded = True
             _logger.info("Successfully restored in-memory snapshot at step %d!", restored_step)
           except (RuntimeError, jax.errors.JaxRuntimeError) as e:
-            _logger.warning(
-                "In-memory snapshot recovery failed (%s). Falling back to persistent checkpoint.", e
-            )
+            _logger.warning("In-memory snapshot recovery failed (%s). Falling back to persistent checkpoint.", e)
 
         if not snapshot_loaded:
           if existing_checkpoint_manager is None:
-            raise RuntimeError(
-                "No snapshots or persistent checkpoints available to restore from. Cannot recover."
-            )
+            raise RuntimeError("No snapshots or persistent checkpoints available to restore from. Cannot recover.")
           _logger.info("Restoring from persistent checkpoint...")
           restored_state, _ = checkpointing.load_state_if_possible(
               existing_checkpoint_manager,
@@ -1063,8 +1053,8 @@ def recover(
               expansion_factor_real_data=config.expansion_factor_real_data,
               maxtext_config=config,
           )
-          if hasattr(restored_state, '__getitem__') and 'items' in restored_state:
-            restored_state = restored_state['items']
+          if hasattr(restored_state, "__getitem__") and "items" in restored_state:
+            restored_state = restored_state["items"]
           if isinstance(model, nn.Module):
             restored_step = int(restored_state.step)
           else:
@@ -1074,9 +1064,7 @@ def recover(
           metric_logger_instance.learning_rate_schedule = learning_rate_schedule
 
       # Update jax_device_state with the newly built JAX objects
-      if not isinstance(model, nn.Module) and isinstance(
-          restored_state, train_state_nnx.TrainStateNNX
-      ):
+      if not isinstance(model, nn.Module) and isinstance(restored_state, train_state_nnx.TrainStateNNX):
         _, restored_state = nnx.split(restored_state)
       jax_device_state["state"] = restored_state
       jax_device_state["init_rng"] = init_rng
@@ -1086,9 +1074,7 @@ def recover(
       jax_device_state["p_train_step"] = p_train_step
       jax_device_state["p_eval_step"] = p_eval_step
 
-      new_data_loader, new_data_iter, new_eval_iter = recreate_dataloaders(
-          config, mesh, recorder, rampup_manager
-      )
+      new_data_loader, new_data_iter, new_eval_iter = recreate_dataloaders(config, mesh, recorder, rampup_manager)
 
       python_vars["step"] = restored_step
       python_vars["data_loader"] = new_data_loader
@@ -1098,9 +1084,7 @@ def recover(
       python_vars["rampup_manager"] = rampup_manager
       python_vars["last_step_completion"] = datetime.datetime.now()
 
-      _logger.info(
-          "Recovery complete! Resuming safely at step %d...", restored_step
-      )
+      _logger.info("Recovery complete! Resuming safely at step %d...", restored_step)
       # State is fully restored on the new mesh: close out the "reinit" badput
       # window and log the fully-recovered slice counts.
       elastic_utils.record_elastic_reinit_end()
@@ -1113,9 +1097,7 @@ def recover(
           or is_no_replicas_err
           or elastic.is_error_due_to_slice_down(e)
       ):
-        _logger.warning(
-            "Slice state change or error caught during recovery: %s. Retrying recovery.", e
-        )
+        _logger.warning("Slice state change or error caught during recovery: %s. Retrying recovery.", e)
       else:
         raise
 
@@ -1131,9 +1113,7 @@ def train_loop(config, recorder, state=None):
   if config.elastic_enabled:
     elastic_utils.ensure_elastic_manager_initialized(config)
     elastic_manager = elastic_utils.elastic_manager
-    _logger.info(
-        "[*] Active slices at startup: %s", elastic_manager.active_slice_indices
-    )
+    _logger.info("[*] Active slices at startup: %s", elastic_manager.active_slice_indices)
     # Seed a slice-count record now that elastic_manager exists, so cumulative
     # slice-efficiency queries always have a record at/near job start to seed
     # from instead of treating the pre-first-event stretch as zero efficiency.
@@ -1163,9 +1143,7 @@ def train_loop(config, recorder, state=None):
 
         def run_setup():
           try:
-            results = train_utils.setup_train_loop(
-                config, recorder, devices=devices
-            )
+            results = train_utils.setup_train_loop(config, recorder, devices=devices)
             setup_results["results"] = results
           except Exception as e:
             setup_results["exception"] = e
@@ -1182,17 +1160,11 @@ def train_loop(config, recorder, state=None):
             new_slice = bool(elastic_manager.available_inactive_slices)
 
             if new_slice and not init_done:
-              max_logging.log(
-                  "New slice detected during initialization. Triggering retry."
-              )
-              raise pathways_manager.ScaleUpSignalError(
-                  "Scale up during initialization"
-              )
+              max_logging.log("New slice detected during initialization. Triggering retry.")
+              raise pathways_manager.ScaleUpSignalError("Scale up during initialization")
 
             if init_done and new_slice:
-              raise pathways_manager.ScaleUpSignalError(
-                  "Both events set during initialization"
-              )
+              raise pathways_manager.ScaleUpSignalError("Both events set during initialization")
 
           if init_done:
             break
@@ -1214,9 +1186,7 @@ def train_loop(config, recorder, state=None):
             state,
         ) = setup_results["results"]
 
-        init_rng = jax.device_put(
-            init_rng, jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
-        )
+        init_rng = jax.device_put(init_rng, jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec()))
         break  # Initialization succeeded!
       except (jax.errors.JaxRuntimeError, pathways_manager.ScaleUpSignalError) as e:
         is_scale_up = isinstance(e, pathways_manager.ScaleUpSignalError)
@@ -1369,10 +1339,7 @@ def train_loop(config, recorder, state=None):
       ):
         try:
           # Scale-up check at the end of the step (only if elastic snapshot)
-          if (
-              elastic_utils.elastic_snapshot(config)
-              and elastic_manager.available_inactive_slices
-          ):
+          if elastic_utils.elastic_snapshot(config) and elastic_manager.available_inactive_slices:
             elastic_utils.record_elastic_event_start(recorder, config)
             recover(
                 jax_device_state,
@@ -1388,12 +1355,9 @@ def train_loop(config, recorder, state=None):
 
         except (jax.errors.JaxRuntimeError, pathways_manager.ScaleUpSignalError) as e:
           if elastic_utils.elastic_snapshot(config) and (
-              isinstance(e, pathways_manager.ScaleUpSignalError)
-              or elastic.is_error_due_to_slice_down(e)
+              isinstance(e, pathways_manager.ScaleUpSignalError) or elastic.is_error_due_to_slice_down(e)
           ):
-            _logger.error(
-                "[!] Elastic event detected around step %d", python_vars["step"]
-            )
+            _logger.error("[!] Elastic event detected around step %d", python_vars["step"])
             elastic_utils.record_elastic_event_start(recorder, config)
             needs_recovery = True
           else:

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -868,6 +868,9 @@ def recover(
       )
       elastic_manager.active_slice_indices = all_active_slices
       jax.config.update("jax_default_device", elastic_manager.default_device)
+      # Slice topology for this recovery attempt is now known: close out the
+      # "wait" badput window and open "reinit", logging the post-wait slice counts.
+      elastic_utils.record_elastic_wait_end_and_reinit_start(recorder)
       _logger.info(
           "Active slices after recovery: %s",
           elastic_manager.active_slice_indices,
@@ -1098,6 +1101,9 @@ def recover(
       _logger.info(
           "Recovery complete! Resuming safely at step %d...", restored_step
       )
+      # State is fully restored on the new mesh: close out the "reinit" badput
+      # window and log the fully-recovered slice counts.
+      elastic_utils.record_elastic_reinit_end()
       break
 
     except (jax.errors.JaxRuntimeError, pathways_manager.ScaleUpSignalError, RuntimeError) as e:
@@ -1128,6 +1134,10 @@ def train_loop(config, recorder, state=None):
     _logger.info(
         "[*] Active slices at startup: %s", elastic_manager.active_slice_indices
     )
+    # Seed a slice-count record now that elastic_manager exists, so cumulative
+    # slice-efficiency queries always have a record at/near job start to seed
+    # from instead of treating the pre-first-event stretch as zero efficiency.
+    elastic_utils.record_slice_state(recorder)
     stop_event = threading.Event()
     monitor_thread = threading.Thread(
         target=elastic_manager._monitor_new_slices,  # pylint: disable=protected-access
@@ -1363,6 +1373,7 @@ def train_loop(config, recorder, state=None):
               elastic_utils.elastic_snapshot(config)
               and elastic_manager.available_inactive_slices
           ):
+            elastic_utils.record_elastic_event_start(recorder, config)
             recover(
                 jax_device_state,
                 python_vars,
@@ -1383,6 +1394,7 @@ def train_loop(config, recorder, state=None):
             _logger.error(
                 "[!] Elastic event detected around step %d", python_vars["step"]
             )
+            elastic_utils.record_elastic_event_start(recorder, config)
             needs_recovery = True
           else:
             # Checkpoint mode or non-elastic error: bubble to elastic_retry

--- a/src/maxtext/utils/elastic_utils.py
+++ b/src/maxtext/utils/elastic_utils.py
@@ -87,13 +87,37 @@ def restore_resharded_state(elastic_mgr: Any, mesh: Any, state: Any):
 
 
 
+def record_slice_state(recorder, active_slices_override: int | None = None) -> None:
+  """Records live slice counts and logs them to the GoodputRecorder."""
+  if (
+      recorder is None
+      or not hasattr(recorder, "record_elastic_slice_counts")
+      or not pathwaysutils.is_pathways_backend_used()
+      or elastic_manager is None
+  ):
+    return
+
+  available_slices = len(elastic.get_active_slice_indices())
+  active_slices = (
+      active_slices_override if active_slices_override is not None else len(elastic_manager.active_slice_indices)
+  )
+  total_slices = len(elastic.get_slice_to_devices(jax.devices()))
+
+  recorder.record_elastic_slice_counts(
+      available_slices=available_slices,
+      active_slices=active_slices,
+      total_slices=total_slices,
+  )
+
+
 def record_elastic_event_start(recorder, config) -> None:
   """Records start of an elastic scale up event."""
   global pending_elastic_event_type
   event_type = "elastic_scale_up" if is_scale_up_event(config) else "elastic_slice_down"
   pending_elastic_event_type = event_type
-  if recorder:
-    recorder.record_custom_badput_event_start_time(custom_badput_event_type=event_type)
+  if recorder and hasattr(recorder, "record_elastic_wait_start_time"):
+    recorder.record_elastic_wait_start_time(event_type=event_type)
+    record_slice_state(recorder, active_slices_override=0)
 
 
 def record_elastic_wait_end_and_reinit_start(recorder) -> None:
@@ -103,18 +127,20 @@ def record_elastic_wait_end_and_reinit_start(recorder) -> None:
     return
   event_type = pending_elastic_event_type
   pending_elastic_event_type = None
-  if recorder:
-    recorder.record_custom_badput_event_end_time(custom_badput_event_type=event_type)
-    recorder.record_custom_badput_event_start_time(custom_badput_event_type="elastic_reinitialization")
+  if recorder and hasattr(recorder, "record_elastic_wait_end_time"):
+    recorder.record_elastic_wait_end_time(event_type=event_type)
+    recorder.record_elastic_reinit_start_time()
+    record_slice_state(recorder)
   pending_reinit_recorder = recorder
 
 
 def record_elastic_reinit_end() -> None:
   """Records end of elastic reinitialization event."""
   global pending_reinit_recorder
-  if pending_reinit_recorder is not None:
-    pending_reinit_recorder.record_custom_badput_event_end_time(custom_badput_event_type="elastic_reinitialization")
-    pending_reinit_recorder = None
+  if pending_reinit_recorder is not None and hasattr(pending_reinit_recorder, "record_elastic_reinit_end_time"):
+    pending_reinit_recorder.record_elastic_reinit_end_time()
+    record_slice_state(pending_reinit_recorder)
+  pending_reinit_recorder = None
 
 
 def elastic_enabled(config) -> bool:

--- a/src/maxtext/utils/elastic_utils.py
+++ b/src/maxtext/utils/elastic_utils.py
@@ -97,17 +97,20 @@ def record_slice_state(recorder, active_slices_override: int | None = None) -> N
   ):
     return
 
-  available_slices = len(elastic.get_active_slice_indices())
-  active_slices = (
-      active_slices_override if active_slices_override is not None else len(elastic_manager.active_slice_indices)
-  )
-  total_slices = len(elastic.get_slice_to_devices(jax.devices()))
+  try:
+    available_slices = len(elastic.get_active_slice_indices())
+    active_slices = (
+        active_slices_override if active_slices_override is not None else len(elastic_manager.active_slice_indices)
+    )
+    total_slices = len(elastic.get_slice_to_devices(jax.devices()))
 
-  recorder.record_elastic_slice_counts(
-      available_slices=available_slices,
-      active_slices=active_slices,
-      total_slices=total_slices,
-  )
+    recorder.record_elastic_slice_counts(
+        available_slices=available_slices,
+        active_slices=active_slices,
+        total_slices=total_slices,
+    )
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    max_logging.log(f"Goodput: record_slice_state failed to record slice counts: {e}")
 
 
 def record_elastic_event_start(recorder, config) -> None:

--- a/src/maxtext/utils/elastic_utils.py
+++ b/src/maxtext/utils/elastic_utils.py
@@ -86,7 +86,6 @@ def restore_resharded_state(elastic_mgr: Any, mesh: Any, state: Any):
   return step, state
 
 
-
 def record_slice_state(recorder, active_slices_override: int | None = None) -> None:
   """Records live slice counts and logs them to the GoodputRecorder."""
   if (
@@ -216,13 +215,11 @@ def ensure_elastic_manager_initialized(config):
     if elastic_manager.active_slice_indices:
       jax.config.update("jax_default_device", elastic_manager.default_device)
 
+
 def mutate_config_for_topology(config, el_manager):
   """Dynamically mutate the config to match the degraded slice topology."""
   new_slice_count = el_manager.active_slice_count
-  max_logging.log(
-      f"[*] Dynamically mutating config.num_slices and "
-      f"config.dcn_data_parallelism to: {new_slice_count}"
-  )
+  max_logging.log(f"[*] Dynamically mutating config.num_slices and " f"config.dcn_data_parallelism to: {new_slice_count}")
   object.__setattr__(config, "num_slices", new_slice_count)
   object.__setattr__(config, "dcn_data_parallelism", new_slice_count)
 
@@ -233,10 +230,9 @@ def mutate_config_for_topology(config, el_manager):
       config.dcn_parallelism[data_axis_idx] = new_slice_count
 
   # Recalculate num_target_devices and batch sizes for the new topology
-  new_num_devices = len([
-      d for d in jax.devices() if getattr(d, "slice_index", 0) in el_manager.active_slice_indices
-  ])
+  new_num_devices = len([d for d in jax.devices() if getattr(d, "slice_index", 0) in el_manager.active_slice_indices])
   recalculate_batch_sizes(config, new_num_devices)
+
 
 def get_local_batch_size(config) -> int:
   """Returns the local batch size based on the config."""
@@ -251,9 +247,7 @@ def live_devices(config=None):
     assert elastic_manager is not None
 
     # Filter devices that are in active slices
-    active_devices = [
-        d for d in jax.devices() if d.slice_index in elastic_manager.active_slice_indices
-    ]
+    active_devices = [d for d in jax.devices() if d.slice_index in elastic_manager.active_slice_indices]
     return sorted(active_devices, key=lambda d: (d.slice_index, d.process_index))
 
   return jax.devices()
@@ -306,7 +300,9 @@ def wait_for_devices_placed(config, timeout: float = 60.0, poll_interval: float 
       active_devices = live_devices(config)
 
       if len(elastic_manager.active_slice_indices) < min_slices or not active_devices:
-        max_logging.log(f"Active slices ({len(elastic_manager.active_slice_indices)}) < min ({min_slices}). Waiting for slices...")
+        max_logging.log(
+            f"Active slices ({len(elastic_manager.active_slice_indices)}) < min ({min_slices}). Waiting for slices..."
+        )
         time.sleep(poll_interval)
         continue
 
@@ -318,7 +314,9 @@ def wait_for_devices_placed(config, timeout: float = 60.0, poll_interval: float 
       arr = jax.device_put(test_val, sharding)
       jax.block_until_ready(arr)
       arr.delete()
-      max_logging.log(f"Confirmed {len(active_devices)} devices on slices {elastic_manager.active_slice_indices} are placed and ready.")
+      max_logging.log(
+          f"Confirmed {len(active_devices)} devices on slices {elastic_manager.active_slice_indices} are placed and ready."
+      )
       return active_devices
     except Exception as e:
       max_logging.log(f"Waiting for Pathways device placement to stabilize ({e}). Retrying poll...")
@@ -447,17 +445,11 @@ def recalculate_batch_sizes(config, new_num_devices: int):
     return
   object.__setattr__(config, "num_target_devices", new_num_devices)
 
-  def calc_gbs(
-      per_device_batch_size, expansion_factor, num_devices, grad_accum_steps
-  ):
+  def calc_gbs(per_device_batch_size, expansion_factor, num_devices, grad_accum_steps):
     if per_device_batch_size < 1.0:
       mbs_load = int(num_devices * (expansion_factor if expansion_factor > 0 else 1))
     else:
-      mbs_load = int(
-          num_devices
-          * per_device_batch_size
-          * (expansion_factor if expansion_factor > 0 else 1)
-      )
+      mbs_load = int(num_devices * per_device_batch_size * (expansion_factor if expansion_factor > 0 else 1))
     mbs_train = int(num_devices * per_device_batch_size)
     gbs_load = int(mbs_load * grad_accum_steps)
     gbs_train = int(mbs_train * grad_accum_steps)
@@ -481,9 +473,7 @@ def recalculate_batch_sizes(config, new_num_devices: int):
       new_num_devices,
       1,
   )
-  object.__setattr__(
-      config, "global_batch_size_to_load_eval", gbs_load_eval
-  )
+  object.__setattr__(config, "global_batch_size_to_load_eval", gbs_load_eval)
   object.__setattr__(config, "global_batch_size_to_eval_on", gbs_eval)
   object.__setattr__(config, "micro_batch_size_to_eval_on", mbs_eval)
 
@@ -500,20 +490,14 @@ def recalculate_batch_sizes(config, new_num_devices: int):
         new_num_devices,
         config.gradient_accumulation_steps,
     )
-    object.__setattr__(
-        config, "global_batch_size_to_load_start", gbs_load_start
-    )
-    object.__setattr__(
-        config, "global_batch_size_to_load_increment", gbs_load_inc
-    )
+    object.__setattr__(config, "global_batch_size_to_load_start", gbs_load_start)
+    object.__setattr__(config, "global_batch_size_to_load_increment", gbs_load_inc)
 
     diff_batch_size = gbs_load - gbs_load_start
     if gbs_load_inc > 0:
       num_increments = diff_batch_size // gbs_load_inc
       if num_increments > 0:
-        rampup_samples_per_increment = (
-            config.global_rampup_samples / num_increments
-        )
+        rampup_samples_per_increment = config.global_rampup_samples / num_increments
         object.__setattr__(
             config,
             "rampup_samples_per_increment_to_load",
@@ -524,9 +508,7 @@ def recalculate_batch_sizes(config, new_num_devices: int):
         current_batch_size = gbs_load_start
         for _ in range(int(num_increments)):
           steps_for_this_stage = (
-              math.ceil(rampup_samples_per_increment / current_batch_size)
-              if current_batch_size > 0
-              else 0
+              math.ceil(rampup_samples_per_increment / current_batch_size) if current_batch_size > 0 else 0
           )
           total_rampup_steps += steps_for_this_stage
           current_batch_size += gbs_load_inc
@@ -535,6 +517,7 @@ def recalculate_batch_sizes(config, new_num_devices: int):
         object.__setattr__(config, "rampup_end_step", 0)
     else:
       object.__setattr__(config, "rampup_end_step", 0)
+
 
 def elastic_snapshot(config) -> bool:
   """Returns whether elastic snapshot mode is enabled."""
@@ -550,5 +533,3 @@ def maybe_bubble_elastic_exception(config, e: Exception) -> None:
   """
   if elastic_enabled(config) and isinstance(e, (jax.errors.JaxRuntimeError, manager.ScaleUpSignalError)):
     raise e
-
-

--- a/tests/unit/elastic_utils_test.py
+++ b/tests/unit/elastic_utils_test.py
@@ -508,6 +508,19 @@ class ElasticUtilsTest(parameterized.TestCase):
 
     fake_recorder.record_elastic_slice_counts.assert_not_called()
 
+  def test_record_slice_state_handles_health_check_failure(self):
+    """A health-check failure must not propagate."""
+    elastic_utils.elastic_manager = self.fake_manager
+    elastic_utils.elastic.get_active_slice_indices = Mock(
+        side_effect=MockJaxRuntimeError("unrecognized backend error")
+    )
+    fake_recorder = Mock()
+
+    # Should not raise.
+    elastic_utils.record_slice_state(fake_recorder)
+
+    fake_recorder.record_elastic_slice_counts.assert_not_called()
+
   def test_record_slice_state_noop_no_elastic_manager(self):
     """Tests that record_slice_state no-ops when elastic_manager is uninitialized."""
     elastic_utils.elastic_manager = None

--- a/tests/unit/elastic_utils_test.py
+++ b/tests/unit/elastic_utils_test.py
@@ -75,7 +75,7 @@ class ElasticUtilsTest(parameterized.TestCase):
     self.fake_logging = create_autospec(self.original_max_logging)
     self.fake_jax = create_autospec(self.original_jax)
     self.fake_manager = create_autospec(self.original_manager_class, instance=True)
-    self.fake_manager.available_inactive_slices = set()    # Configure default behaviors if needed
+    self.fake_manager.available_inactive_slices = set()  # Configure default behaviors if needed
     self.fake_pathwaysutils.is_pathways_backend_used.return_value = True
     self.fake_jax.process_index.return_value = 0
     self.fake_manager.slice_to_devices = {0: [FakeDevice(slice_index=0)]}
@@ -390,9 +390,7 @@ class ElasticUtilsTest(parameterized.TestCase):
 
     elastic_utils.record_elastic_event_start(fake_recorder, config)
 
-    fake_recorder.record_elastic_wait_start_time.assert_called_once_with(
-        event_type="elastic_slice_down"
-    )
+    fake_recorder.record_elastic_wait_start_time.assert_called_once_with(event_type="elastic_slice_down")
     self.assertEqual(elastic_utils.pending_elastic_event_type, "elastic_slice_down")
 
   def test_record_elastic_event_start_scale_up(self):
@@ -404,9 +402,7 @@ class ElasticUtilsTest(parameterized.TestCase):
 
     elastic_utils.record_elastic_event_start(fake_recorder, config)
 
-    fake_recorder.record_elastic_wait_start_time.assert_called_once_with(
-        event_type="elastic_scale_up"
-    )
+    fake_recorder.record_elastic_wait_start_time.assert_called_once_with(event_type="elastic_scale_up")
 
   def test_record_elastic_wait_end_and_reinit_start_noop_on_first_attempt(self):
     """Tests recording elastic event end and elastic reinit start."""
@@ -426,9 +422,7 @@ class ElasticUtilsTest(parameterized.TestCase):
 
     elastic_utils.record_elastic_wait_end_and_reinit_start(fake_recorder)
 
-    fake_recorder.record_elastic_wait_end_time.assert_called_once_with(
-        event_type="elastic_slice_down"
-    )
+    fake_recorder.record_elastic_wait_end_time.assert_called_once_with(event_type="elastic_slice_down")
     fake_recorder.record_elastic_reinit_start_time.assert_called_once_with()
     self.assertIs(elastic_utils.pending_reinit_recorder, fake_recorder)
     self.assertIsNone(elastic_utils.pending_elastic_event_type)
@@ -465,9 +459,7 @@ class ElasticUtilsTest(parameterized.TestCase):
     finally:
       elastic_utils.elastic.get_slice_to_devices = original_get_slice_to_devices
 
-    fake_recorder.record_elastic_slice_counts.assert_called_once_with(
-        available_slices=2, active_slices=1, total_slices=2
-    )
+    fake_recorder.record_elastic_slice_counts.assert_called_once_with(available_slices=2, active_slices=1, total_slices=2)
 
   def test_record_slice_state_active_slices_override(self):
     """Tests that an explicit active_slices_override is forwarded instead of the live count."""
@@ -485,9 +477,7 @@ class ElasticUtilsTest(parameterized.TestCase):
     finally:
       elastic_utils.elastic.get_slice_to_devices = original_get_slice_to_devices
 
-    fake_recorder.record_elastic_slice_counts.assert_called_once_with(
-        available_slices=2, active_slices=0, total_slices=2
-    )
+    fake_recorder.record_elastic_slice_counts.assert_called_once_with(available_slices=2, active_slices=0, total_slices=2)
 
   def test_record_slice_state_noop_recorder_missing_attr(self):
     """Tests that record_slice_state no-ops for a recorder without record_elastic_slice_counts."""
@@ -511,9 +501,7 @@ class ElasticUtilsTest(parameterized.TestCase):
   def test_record_slice_state_handles_health_check_failure(self):
     """A health-check failure must not propagate."""
     elastic_utils.elastic_manager = self.fake_manager
-    elastic_utils.elastic.get_active_slice_indices = Mock(
-        side_effect=MockJaxRuntimeError("unrecognized backend error")
-    )
+    elastic_utils.elastic.get_active_slice_indices = Mock(side_effect=MockJaxRuntimeError("unrecognized backend error"))
     fake_recorder = Mock()
 
     # Should not raise.
@@ -544,9 +532,7 @@ class ElasticUtilsTest(parameterized.TestCase):
     self.fake_manager.active_slice_indices = {0}
     elastic_utils.elastic.get_active_slice_indices = Mock(return_value={0})
     original_get_slice_to_devices = elastic_utils.elastic.get_slice_to_devices
-    elastic_utils.elastic.get_slice_to_devices = Mock(
-        return_value={0: [FakeDevice(slice_index=0)]}
-    )
+    elastic_utils.elastic.get_slice_to_devices = Mock(return_value={0: [FakeDevice(slice_index=0)]})
     fake_recorder = Mock()
     config = FakeConfig()
 
@@ -557,12 +543,8 @@ class ElasticUtilsTest(parameterized.TestCase):
     finally:
       elastic_utils.elastic.get_slice_to_devices = original_get_slice_to_devices
 
-    fake_recorder.record_elastic_wait_start_time.assert_called_once_with(
-        event_type="elastic_slice_down"
-    )
-    fake_recorder.record_elastic_wait_end_time.assert_called_once_with(
-        event_type="elastic_slice_down"
-    )
+    fake_recorder.record_elastic_wait_start_time.assert_called_once_with(event_type="elastic_slice_down")
+    fake_recorder.record_elastic_wait_end_time.assert_called_once_with(event_type="elastic_slice_down")
     fake_recorder.record_elastic_reinit_start_time.assert_called_once_with()
     fake_recorder.record_elastic_reinit_end_time.assert_called_once_with()
     # active_slices=0 is forced on event start (we've lost/are waiting on slices),

--- a/tests/unit/elastic_utils_test.py
+++ b/tests/unit/elastic_utils_test.py
@@ -390,8 +390,8 @@ class ElasticUtilsTest(parameterized.TestCase):
 
     elastic_utils.record_elastic_event_start(fake_recorder, config)
 
-    fake_recorder.record_custom_badput_event_start_time.assert_called_once_with(
-        custom_badput_event_type="elastic_slice_down"
+    fake_recorder.record_elastic_wait_start_time.assert_called_once_with(
+        event_type="elastic_slice_down"
     )
     self.assertEqual(elastic_utils.pending_elastic_event_type, "elastic_slice_down")
 
@@ -404,8 +404,8 @@ class ElasticUtilsTest(parameterized.TestCase):
 
     elastic_utils.record_elastic_event_start(fake_recorder, config)
 
-    fake_recorder.record_custom_badput_event_start_time.assert_called_once_with(
-        custom_badput_event_type="elastic_scale_up"
+    fake_recorder.record_elastic_wait_start_time.assert_called_once_with(
+        event_type="elastic_scale_up"
     )
 
   def test_record_elastic_wait_end_and_reinit_start_noop_on_first_attempt(self):
@@ -415,8 +415,8 @@ class ElasticUtilsTest(parameterized.TestCase):
 
     elastic_utils.record_elastic_wait_end_and_reinit_start(fake_recorder)
 
-    fake_recorder.record_custom_badput_event_end_time.assert_not_called()
-    fake_recorder.record_custom_badput_event_start_time.assert_not_called()
+    fake_recorder.record_elastic_wait_end_time.assert_not_called()
+    fake_recorder.record_elastic_reinit_start_time.assert_not_called()
     self.assertIsNone(elastic_utils.pending_reinit_recorder)
 
   def test_record_elastic_wait_end_and_reinit_start(self):
@@ -426,12 +426,10 @@ class ElasticUtilsTest(parameterized.TestCase):
 
     elastic_utils.record_elastic_wait_end_and_reinit_start(fake_recorder)
 
-    fake_recorder.record_custom_badput_event_end_time.assert_called_once_with(
-        custom_badput_event_type="elastic_slice_down"
+    fake_recorder.record_elastic_wait_end_time.assert_called_once_with(
+        event_type="elastic_slice_down"
     )
-    fake_recorder.record_custom_badput_event_start_time.assert_called_once_with(
-        custom_badput_event_type="elastic_reinitialization"
-    )
+    fake_recorder.record_elastic_reinit_start_time.assert_called_once_with()
     self.assertIs(elastic_utils.pending_reinit_recorder, fake_recorder)
     self.assertIsNone(elastic_utils.pending_elastic_event_type)
 
@@ -442,9 +440,7 @@ class ElasticUtilsTest(parameterized.TestCase):
 
     elastic_utils.record_elastic_reinit_end()
 
-    fake_recorder.record_custom_badput_event_end_time.assert_called_once_with(
-        custom_badput_event_type="elastic_reinitialization"
-    )
+    fake_recorder.record_elastic_reinit_end_time.assert_called_once_with()
     self.assertIsNone(elastic_utils.pending_reinit_recorder)
 
   def test_record_elastic_reinit_end_on_cold_start(self):
@@ -452,6 +448,116 @@ class ElasticUtilsTest(parameterized.TestCase):
     elastic_utils.pending_reinit_recorder = None
 
     elastic_utils.record_elastic_reinit_end()
+
+  def test_record_slice_state_calls_recorder(self):
+    """Tests that record_slice_state computes and forwards the right slice counts."""
+    elastic_utils.elastic_manager = self.fake_manager
+    self.fake_manager.active_slice_indices = {0}
+    elastic_utils.elastic.get_active_slice_indices = Mock(return_value={0, 1})
+    original_get_slice_to_devices = elastic_utils.elastic.get_slice_to_devices
+    elastic_utils.elastic.get_slice_to_devices = Mock(
+        return_value={0: [FakeDevice(slice_index=0)], 1: [FakeDevice(slice_index=1)]}
+    )
+    fake_recorder = Mock()
+
+    try:
+      elastic_utils.record_slice_state(fake_recorder)
+    finally:
+      elastic_utils.elastic.get_slice_to_devices = original_get_slice_to_devices
+
+    fake_recorder.record_elastic_slice_counts.assert_called_once_with(
+        available_slices=2, active_slices=1, total_slices=2
+    )
+
+  def test_record_slice_state_active_slices_override(self):
+    """Tests that an explicit active_slices_override is forwarded instead of the live count."""
+    elastic_utils.elastic_manager = self.fake_manager
+    self.fake_manager.active_slice_indices = {0, 1}
+    elastic_utils.elastic.get_active_slice_indices = Mock(return_value={0, 1})
+    original_get_slice_to_devices = elastic_utils.elastic.get_slice_to_devices
+    elastic_utils.elastic.get_slice_to_devices = Mock(
+        return_value={0: [FakeDevice(slice_index=0)], 1: [FakeDevice(slice_index=1)]}
+    )
+    fake_recorder = Mock()
+
+    try:
+      elastic_utils.record_slice_state(fake_recorder, active_slices_override=0)
+    finally:
+      elastic_utils.elastic.get_slice_to_devices = original_get_slice_to_devices
+
+    fake_recorder.record_elastic_slice_counts.assert_called_once_with(
+        available_slices=2, active_slices=0, total_slices=2
+    )
+
+  def test_record_slice_state_noop_recorder_missing_attr(self):
+    """Tests that record_slice_state no-ops for a recorder without record_elastic_slice_counts."""
+    elastic_utils.elastic_manager = self.fake_manager
+    fake_recorder = Mock(spec=[])
+
+    elastic_utils.record_slice_state(fake_recorder)
+
+    self.assertFalse(hasattr(fake_recorder, "record_elastic_slice_counts"))
+
+  def test_record_slice_state_noop_not_pathways(self):
+    """Tests that record_slice_state no-ops when not on the Pathways backend."""
+    elastic_utils.elastic_manager = self.fake_manager
+    elastic_utils.pathwaysutils.is_pathways_backend_used.return_value = False
+    fake_recorder = Mock()
+
+    elastic_utils.record_slice_state(fake_recorder)
+
+    fake_recorder.record_elastic_slice_counts.assert_not_called()
+
+  def test_record_slice_state_noop_no_elastic_manager(self):
+    """Tests that record_slice_state no-ops when elastic_manager is uninitialized."""
+    elastic_utils.elastic_manager = None
+    fake_recorder = Mock()
+
+    elastic_utils.record_slice_state(fake_recorder)
+
+    fake_recorder.record_elastic_slice_counts.assert_not_called()
+
+  def test_record_slice_state_noop_recorder_none(self):
+    """Tests that record_slice_state no-ops when the recorder is None."""
+    elastic_utils.elastic_manager = self.fake_manager
+
+    # Should not raise.
+    elastic_utils.record_slice_state(None)
+
+  def test_elastic_event_lifecycle_records_slice_counts(self):
+    """End-to-end: start -> wait-end/reinit-start -> reinit-end each log slice counts."""
+    elastic_utils.elastic_manager = self.fake_manager
+    self.fake_manager.available_inactive_slices = set()
+    self.fake_manager.active_slice_indices = {0}
+    elastic_utils.elastic.get_active_slice_indices = Mock(return_value={0})
+    original_get_slice_to_devices = elastic_utils.elastic.get_slice_to_devices
+    elastic_utils.elastic.get_slice_to_devices = Mock(
+        return_value={0: [FakeDevice(slice_index=0)]}
+    )
+    fake_recorder = Mock()
+    config = FakeConfig()
+
+    try:
+      elastic_utils.record_elastic_event_start(fake_recorder, config)
+      elastic_utils.record_elastic_wait_end_and_reinit_start(fake_recorder)
+      elastic_utils.record_elastic_reinit_end()
+    finally:
+      elastic_utils.elastic.get_slice_to_devices = original_get_slice_to_devices
+
+    fake_recorder.record_elastic_wait_start_time.assert_called_once_with(
+        event_type="elastic_slice_down"
+    )
+    fake_recorder.record_elastic_wait_end_time.assert_called_once_with(
+        event_type="elastic_slice_down"
+    )
+    fake_recorder.record_elastic_reinit_start_time.assert_called_once_with()
+    fake_recorder.record_elastic_reinit_end_time.assert_called_once_with()
+    # active_slices=0 is forced on event start (we've lost/are waiting on slices),
+    # then reflects the live count once wait ends and once reinit ends.
+    self.assertEqual(
+        [c.kwargs["active_slices"] for c in fake_recorder.record_elastic_slice_counts.call_args_list],
+        [0, 1, 1],
+    )
 
   def test_ensure_elastic_manager_initialized_readonly_config(self):
     """Tests that ensure_elastic_manager_initialized works with read-only config."""

--- a/tests/unit/goodput_utils_test.py
+++ b/tests/unit/goodput_utils_test.py
@@ -159,10 +159,13 @@ class GoodputUtilsTest(unittest.TestCase):
     mock_cloud_logger.return_value = mock.MagicMock()
     elastic_config = self._make_elastic_config("runner_test_elastic")
 
-    with mock.patch(
-        "maxtext.utils.elastic_utils.pathwaysutils.is_pathways_backend_used",
-        return_value=True,
-    ), mock.patch("maxtext.utils.elastic_utils.record_slice_state") as mock_seed:
+    with (
+        mock.patch(
+            "maxtext.utils.elastic_utils.pathwaysutils.is_pathways_backend_used",
+            return_value=True,
+        ),
+        mock.patch("maxtext.utils.elastic_utils.record_slice_state") as mock_seed,
+    ):
       recorder = create_goodput_recorder(elastic_config)
 
     from ml_goodput_measurement import goodput_elastic  # pylint: disable=g-import-not-at-top
@@ -176,12 +179,15 @@ class GoodputUtilsTest(unittest.TestCase):
     mock_cloud_logger.return_value = mock.MagicMock()
     elastic_config = self._make_elastic_config("runner_test_elastic_fallback")
 
-    with mock.patch(
-        "maxtext.utils.elastic_utils.pathwaysutils.is_pathways_backend_used",
-        return_value=True,
-    ), mock.patch(
-        "ml_goodput_measurement.goodput_elastic.ElasticGoodputRecorder",
-        side_effect=RuntimeError("boom"),
+    with (
+        mock.patch(
+            "maxtext.utils.elastic_utils.pathwaysutils.is_pathways_backend_used",
+            return_value=True,
+        ),
+        mock.patch(
+            "ml_goodput_measurement.goodput_elastic.ElasticGoodputRecorder",
+            side_effect=RuntimeError("boom"),
+        ),
     ):
       recorder = create_goodput_recorder(elastic_config)
 
@@ -206,9 +212,10 @@ class GoodputUtilsTest(unittest.TestCase):
     elastic_config = self._make_elastic_config("runner_test_monitor_elastic")
     common_kwargs = {"job_name": "test"}
 
-    with mock.patch(
-        "maxtext.utils.elastic_utils.should_use_elastic", return_value=True
-    ), mock.patch("ml_goodput_measurement.monitoring_elastic.ElasticGoodputMonitor") as mock_elastic_monitor:
+    with (
+        mock.patch("maxtext.utils.elastic_utils.should_use_elastic", return_value=True),
+        mock.patch("ml_goodput_measurement.monitoring_elastic.ElasticGoodputMonitor") as mock_elastic_monitor,
+    ):
       mock_elastic_monitor.return_value = mock.MagicMock()
       monitor = _construct_goodput_monitor(elastic_config, common_kwargs)
 
@@ -231,12 +238,14 @@ class GoodputUtilsTest(unittest.TestCase):
     elastic_config = self._make_elastic_config("runner_test_monitor_elastic_fallback")
     common_kwargs = {"job_name": "test"}
 
-    with mock.patch(
-        "maxtext.utils.elastic_utils.should_use_elastic", return_value=True
-    ), mock.patch(
-        "ml_goodput_measurement.monitoring_elastic.ElasticGoodputMonitor",
-        side_effect=RuntimeError("boom"),
-    ), mock.patch("ml_goodput_measurement.monitoring.GoodputMonitor") as mock_monitor:
+    with (
+        mock.patch("maxtext.utils.elastic_utils.should_use_elastic", return_value=True),
+        mock.patch(
+            "ml_goodput_measurement.monitoring_elastic.ElasticGoodputMonitor",
+            side_effect=RuntimeError("boom"),
+        ),
+        mock.patch("ml_goodput_measurement.monitoring.GoodputMonitor") as mock_monitor,
+    ):
       mock_monitor.return_value = mock.MagicMock()
       monitor = _construct_goodput_monitor(elastic_config, common_kwargs)
 

--- a/tests/unit/goodput_utils_test.py
+++ b/tests/unit/goodput_utils_test.py
@@ -24,6 +24,7 @@ from maxtext.common.goodput import (
     GoodputEvent,
     RECORD_JOB_END_TIME,
     RECORD_JOB_START_TIME,
+    _construct_goodput_monitor,
     create_goodput_recorder,
     maybe_monitor_goodput,
     maybe_record_goodput,
@@ -140,6 +141,107 @@ class GoodputUtilsTest(unittest.TestCase):
 
     mock_record_job_start_time.assert_called_once()
     mock_record_job_end_time.assert_not_called()
+
+  def _make_elastic_config(self, run_name):
+    return pyconfig.initialize(
+        [None, get_test_config_path()],
+        base_output_directory=get_test_base_output_directory(),
+        run_name=run_name,
+        enable_checkpointing=False,
+        enable_goodput_recording=True,
+        elastic_enabled=True,
+        enable_single_controller=True,
+    )
+
+  @mock.patch("google.cloud.logging.Client")
+  def test_create_goodput_recorder_elastic(self, mock_cloud_logger):
+    """create_goodput_recorder builds an ElasticGoodputRecorder and seeds slice state."""
+    mock_cloud_logger.return_value = mock.MagicMock()
+    elastic_config = self._make_elastic_config("runner_test_elastic")
+
+    with mock.patch(
+        "maxtext.utils.elastic_utils.pathwaysutils.is_pathways_backend_used",
+        return_value=True,
+    ), mock.patch("maxtext.utils.elastic_utils.record_slice_state") as mock_seed:
+      recorder = create_goodput_recorder(elastic_config)
+
+    from ml_goodput_measurement import goodput_elastic  # pylint: disable=g-import-not-at-top
+
+    self.assertIsInstance(recorder, goodput_elastic.ElasticGoodputRecorder)
+    mock_seed.assert_called_once_with(recorder)
+
+  @mock.patch("google.cloud.logging.Client")
+  def test_create_goodput_recorder_elastic_fallback_on_error(self, mock_cloud_logger):
+    """Falls back to the base GoodputRecorder if elastic recorder construction raises."""
+    mock_cloud_logger.return_value = mock.MagicMock()
+    elastic_config = self._make_elastic_config("runner_test_elastic_fallback")
+
+    with mock.patch(
+        "maxtext.utils.elastic_utils.pathwaysutils.is_pathways_backend_used",
+        return_value=True,
+    ), mock.patch(
+        "ml_goodput_measurement.goodput_elastic.ElasticGoodputRecorder",
+        side_effect=RuntimeError("boom"),
+    ):
+      recorder = create_goodput_recorder(elastic_config)
+
+    from ml_goodput_measurement import goodput as base_goodput  # pylint: disable=g-import-not-at-top
+
+    self.assertIs(type(recorder), base_goodput.GoodputRecorder)
+
+  def test_create_goodput_recorder_not_elastic_when_backend_absent(self):
+    """elastic_enabled=True alone isn't enough: falls back without the Pathways backend."""
+    elastic_config = self._make_elastic_config("runner_test_elastic_no_pathways")
+
+    with mock.patch("google.cloud.logging.Client") as mock_cloud_logger:
+      mock_cloud_logger.return_value = mock.MagicMock()
+      recorder = create_goodput_recorder(elastic_config)
+
+    from ml_goodput_measurement import goodput as base_goodput  # pylint: disable=g-import-not-at-top
+
+    self.assertIs(type(recorder), base_goodput.GoodputRecorder)
+
+  def test_construct_goodput_monitor_elastic(self):
+    """_construct_goodput_monitor prefers ElasticGoodputMonitor when elastic training applies."""
+    elastic_config = self._make_elastic_config("runner_test_monitor_elastic")
+    common_kwargs = {"job_name": "test"}
+
+    with mock.patch(
+        "maxtext.utils.elastic_utils.should_use_elastic", return_value=True
+    ), mock.patch("ml_goodput_measurement.monitoring_elastic.ElasticGoodputMonitor") as mock_elastic_monitor:
+      mock_elastic_monitor.return_value = mock.MagicMock()
+      monitor = _construct_goodput_monitor(elastic_config, common_kwargs)
+
+    mock_elastic_monitor.assert_called_once_with(include_slice_efficiency=True, **common_kwargs)
+    self.assertIs(monitor, mock_elastic_monitor.return_value)
+
+  def test_construct_goodput_monitor_non_elastic(self):
+    """_construct_goodput_monitor uses the base GoodputMonitor when elastic training is off."""
+    common_kwargs = {"job_name": "test"}
+
+    with mock.patch("ml_goodput_measurement.monitoring.GoodputMonitor") as mock_monitor:
+      mock_monitor.return_value = mock.MagicMock()
+      monitor = _construct_goodput_monitor(self.config, common_kwargs)
+
+    mock_monitor.assert_called_once_with(pathway_enabled=self.config.enable_pathways_goodput, **common_kwargs)
+    self.assertIs(monitor, mock_monitor.return_value)
+
+  def test_construct_goodput_monitor_elastic_fallback_on_error(self):
+    """Falls back to the base GoodputMonitor if elastic monitor construction raises."""
+    elastic_config = self._make_elastic_config("runner_test_monitor_elastic_fallback")
+    common_kwargs = {"job_name": "test"}
+
+    with mock.patch(
+        "maxtext.utils.elastic_utils.should_use_elastic", return_value=True
+    ), mock.patch(
+        "ml_goodput_measurement.monitoring_elastic.ElasticGoodputMonitor",
+        side_effect=RuntimeError("boom"),
+    ), mock.patch("ml_goodput_measurement.monitoring.GoodputMonitor") as mock_monitor:
+      mock_monitor.return_value = mock.MagicMock()
+      monitor = _construct_goodput_monitor(elastic_config, common_kwargs)
+
+    mock_monitor.assert_called_once_with(pathway_enabled=elastic_config.enable_pathways_goodput, **common_kwargs)
+    self.assertIs(monitor, mock_monitor.return_value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This change integrates elastic goodput and slice efficiency into snapshotting.

Following changes are  ported from main inside this PR:

- PR 4840: "Add a new goodput elastic utils function record_slice_state()"
GitHub Commit: [c1572ad0abe6c449aca9e2577003ded11aa07205](https://github.com/AI-Hypercomputer/maxtext/commit/c1572ad0abe6c449aca9e2577003ded11aa07205)

- PR 4846: "Add more elasticity goodput tests" (also contains the elastic_utils fix in the same commit)
GitHub Commit: [cbdde3833e7d86c555212006cd3f3bd39318f051](https://github.com/AI-Hypercomputer/maxtext/commit/cbdde3833e7d86c555212006cd3f3bd39318f051) 

- Unit tests

New changes in this PR (not from main):

- ElasticRecorder API integration into snapshotting version of `train.py`



The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/552616060

# Tests

- All simulated tests 72/72 Passed
- Small E2E single host run with elasticity enabled.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
