### PR TITLE
SFT Pipeline for Maxtext-Omni

### DIFF
--- a/src/maxtext/experimental/omni_poc/configs/pretrain-maxtext-omni-gemma3-qwen3-chartnet.yml
+++ b/src/maxtext/experimental/omni_poc/configs/pretrain-maxtext-omni-gemma3-qwen3-chartnet.yml
@@ -1,0 +1,88 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Step 1: Pretrain / Align the custom MLP vision projector on ChartNet (human_verified subset)
+# using dense chart analytical summaries (Chart-to-Text).
+#
+# Example command to run pretraining on TPU VM:
+# python3 -m maxtext.experimental.omni_poc.train_sft_omni \
+#   src/maxtext/experimental/omni_poc/configs/pretrain-maxtext-omni-gemma3-qwen3-chartnet.yml
+
+# Inherit model architecture (Gemma 3 4B Vision Tower + Qwen 3 4B Decoder + Custom MLP Connector)
+base_config: "../maxtext-omni-gemma3-qwen3.yml"
+
+use_sft: true
+use_tunix_gradient_accumulation: false
+use_multimodal: true
+sft_train_on_completion_only: true
+packing: false
+freeze_vision_encoder_params: true
+
+# Pretrain ONLY the custom MLP projector to align Gemma 3 vision features with Qwen 3 text space
+trainable_parameters_mask: ["custom_linear"]
+
+# Learning rate and schedule for projector alignment
+learning_rate: 2.e-4
+lr_schedule_type: 'cosine'
+warmup_steps_fraction: 0.05
+learning_rate_final_fraction: 0.1
+adamw_mask: ['.*norm.*', '.*bias.*']
+gradient_clipping_threshold: 1.0
+
+# -------------- HF pipeline (ibm-granite/ChartNet - human_verified) --------------
+# Dataset features in human_verified subset: ['id', 'image', 'code', 'csv', 'summary']
+# Prompt: 'prompt' (injected via default_prompt)
+# Completion: 'summary' (dense natural-language description of chart trends, axes, and data)
+dataset_type: hf
+tokenizer_type: "huggingface"
+tokenizer_path: "Qwen/Qwen3-4B"
+hf_path: 'ibm-granite/ChartNet'
+hf_name: 'human_verified'
+train_split: 'train'
+hf_eval_split: 'test'
+
+# Image column
+train_image_column: 'image'
+eval_image_column: 'image'
+
+# Text columns: ['prompt', 'summary']
+train_data_columns: ['prompt', 'summary']
+eval_data_columns: ['prompt', 'summary']
+default_prompt: "Summarize the key information and data trends in this chart in detail."
+
+# Initial stitched checkpoint path (or override via CLI to point to COCO step 14000)
+load_parameters_path: "gs://YOUR_BUCKET/omni_checkpoints/omni_stitched_gemma3-4b_qwen3-4b/0/items"
+base_output_directory: "gs://YOUR_BUCKET/omni-gemma3-qwen3/multimodal/pretrain_chartnet"
+run_name: "omni_pretrain_chartnet_embedder_only"
+
+# Training schedule (~3 full epochs across ~92.6k human-verified samples at global batch size 16)
+# 92,643 * 3 / 16 = 17,370 steps
+per_device_batch_size: 4
+steps: 17370
+num_epoch: 3
+checkpoint_period: 1000
+log_period: 1
+save_checkpoint_on_completion: true
+async_checkpointing: true
+
+# Evaluation (evaluates against 2,000 human_verified test split charts)
+eval_interval: 1000
+eval_steps: 50
+
+# Sequence length & attention settings
+max_prefill_predict_length: 1024
+max_target_length: 2048
+max_num_images_per_example: 1
+scan_layers: true
+attention: "dot_product"

--- a/src/maxtext/experimental/omni_poc/configs/sft-maxtext-omni-gemma3-qwen3.yml
+++ b/src/maxtext/experimental/omni_poc/configs/sft-maxtext-omni-gemma3-qwen3.yml
@@ -1,0 +1,68 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example command to run SFT on TPU VM:
+# python3 -m maxtext.experimental.omni_poc.train_sft_omni \
+#   src/maxtext/experimental/omni_poc/configs/sft-maxtext-omni-gemma3-qwen3.yml
+
+# Inherit model architecture from maxtext-omni-gemma3-qwen3.yml
+
+base_config: "../maxtext-omni-gemma3-qwen3.yml"
+
+use_sft: true
+use_tunix_gradient_accumulation: false
+use_multimodal: true
+sft_train_on_completion_only: true
+packing: false
+freeze_vision_encoder_params: true
+learning_rate: 2.e-4
+
+# Train ONLY the custom MLP projector by freezing all other parameters
+trainable_parameters_mask: ["custom_linear"]
+
+# -------------- HF pipeline --------------
+dataset_type: hf
+tokenizer_type: "huggingface"
+tokenizer_path: "Qwen/Qwen3-4B"
+hf_path: 'HuggingFaceM4/ChartQA'
+train_split: 'train'
+hf_eval_split: 'val'
+train_data_columns: ['query', 'label']
+eval_data_columns: ['query', 'label']
+
+# Checkpoint paths (override via CLI for your bucket)
+load_parameters_path: "gs://YOUR_BUCKET/omni_checkpoints/omni_stitched_gemma3-4b_qwen3-4b/0/items"
+base_output_directory: "gs://YOUR_BUCKET/sft_multimodal_omni_output"
+run_name: "sft_omni_chartqa"
+
+# Training schedule (5 epochs = 8840 steps, 1 epoch = 1768 steps)
+per_device_batch_size: 4
+num_epoch: 5
+steps: 8841
+checkpoint_period: 500
+log_period: 1
+save_checkpoint_on_completion: true
+async_checkpointing: true
+
+# Evaluation settings
+eval_interval: 500
+eval_steps: 50
+
+# Sequence length & attention settings
+max_prefill_predict_length: 1024
+max_target_length: 1600
+max_num_images_per_example: 1
+scan_layers: true
+attention: "dot_product"
+

--- a/src/maxtext/experimental/omni_poc/tests/compare_sft_checkpoint_test.py
+++ b/src/maxtext/experimental/omni_poc/tests/compare_sft_checkpoint_test.py
@@ -1,0 +1,295 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This is NOT an unit test.
+
+Sanity check utility to verify parameter freezing and training after SFT.
+
+1. Loads the original stitched checkpoint.
+2. Loads the SFT-trained checkpoint (auto-discovered or specified).
+3. Compares the parameter PyTrees to verify that:
+   - Custom MLP vision projector weights were updated (trained).
+   - Vision encoder and LLM backbone weights are 100% identical (frozen).
+
+Example usage:
+  python3 -m maxtext.experimental.omni_poc.tests.compare_sft_checkpoint_test \
+      src/maxtext/experimental/omni_poc/configs/sft-maxtext-omni-gemma3-qwen3.yml \
+      load_parameters_path=gs://YOUR_BUCKET/omni_checkpoints/omni_stitched_gemma3-4b_qwen3-4b/0/items \
+      base_output_directory=gs://YOUR_BUCKET/sft_multimodal_omni_output \
+      run_name=sft_omni_chartqa
+"""
+
+import os
+import sys
+from typing import Any, Optional, Sequence
+
+from absl import app, flags
+from etils import epath
+import jax
+import jax.numpy as jnp
+
+from maxtext.common import checkpointing
+from maxtext.configs import pyconfig
+from maxtext.utils import max_utils, maxtext_utils, model_creation_utils
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
+
+FLAGS = flags.FLAGS
+
+
+def _define_flag(fn, name, default, help_str):
+  """Defines an ABSL flag if it hasn't already been registered."""
+  if name not in FLAGS:
+    fn(name, default, help_str)
+
+
+_define_flag(
+    flags.DEFINE_string,
+    "config_path",
+    os.path.join(MAXTEXT_PKG_DIR, "experimental", "omni_poc", "configs", "sft-maxtext-omni-gemma3-qwen3.yml"),
+    "Path to the config YAML file.",
+)
+_define_flag(
+    flags.DEFINE_string,
+    "stitched_checkpoint_path",
+    "",
+    "Path to original stitched checkpoint directory (defaults to load_parameters_path from config).",
+)
+_define_flag(
+    flags.DEFINE_string,
+    "sft_checkpoint_path",
+    "",
+    "Path to SFT trained checkpoint directory (defaults to latest checkpoint in base_output_directory/run_name).",
+)
+
+
+def _format_path(key_path) -> str:
+  """Formats a JAX PyTree key path into a readable slash-separated string."""
+  parts = []
+  for k in key_path:
+    if hasattr(k, "key"):
+      parts.append(str(k.key))
+    elif hasattr(k, "name"):
+      parts.append(str(k.name))
+    elif hasattr(k, "idx"):
+      parts.append(str(k.idx))
+    else:
+      parts.append(str(k))
+  return "/".join(parts)
+
+
+def resolve_sft_checkpoint_path(config: Any, explicit_path: str = "") -> str:
+  """Finds the latest SFT checkpoint step directory if not explicitly provided."""
+  if explicit_path:
+    return explicit_path
+  ckpt_dir = epath.Path(config.base_output_directory) / config.run_name / "checkpoints"
+  if ckpt_dir.exists():
+    step_dirs = [d.name for d in ckpt_dir.iterdir() if d.name.isdigit() and d.is_dir()]
+    if step_dirs:
+      latest_step = max(step_dirs, key=int)
+      return str(ckpt_dir / latest_step / "items")
+  raise ValueError(f"No valid SFT checkpoint steps found in {ckpt_dir}.")
+
+
+def compare_checkpoints(
+    config: Any,
+    stitched_checkpoint_path: Optional[str] = None,
+    sft_checkpoint_path: Optional[str] = None,
+) -> bool:
+  """Compares stitched checkpoint against SFT checkpoint and verifies freezing.
+
+  Args:
+    config: The MaxText configuration object.
+    stitched_checkpoint_path: Path to original pre-SFT stitched checkpoint.
+    sft_checkpoint_path: Path to post-SFT checkpoint (or None for auto-discovery).
+
+  Returns:
+    True if only trainable projector MLP parameters changed and all other weights
+    are 100% identical. False otherwise.
+  """
+  stitched_path = stitched_checkpoint_path or getattr(config, "load_parameters_path", "")
+  if not stitched_path:
+    raise ValueError("stitched_checkpoint_path or load_parameters_path must be provided.")
+
+  sft_path = resolve_sft_checkpoint_path(config, sft_checkpoint_path or "")
+
+  print("=" * 80)
+  print(f"  Stitched Original Checkpoint: {stitched_path}")
+  print(f"  SFT Trained Checkpoint:       {sft_path}")
+  print("=" * 80)
+
+  mesh = maxtext_utils.get_mesh_from_config(config)
+  with jax.set_mesh(mesh):
+    model = model_creation_utils.from_config(config, mesh=mesh)
+    abstract_vars = maxtext_utils.get_abstract_param(model, config)
+    target_params_abstract = max_utils.unbox_logicallypartioned(abstract_vars["params"])
+
+    # Load original stitched checkpoint
+    stitched_loaded = checkpointing.load_params_from_path(
+        stitched_path,
+        {"params": target_params_abstract},
+        config.checkpoint_storage_concurrent_gb,
+        use_ocdbt=config.checkpoint_storage_use_ocdbt,
+        use_zarr3=config.checkpoint_storage_use_zarr3,
+    )
+    stitched_params = stitched_loaded.get("params", stitched_loaded)
+
+    # Load SFT trained checkpoint
+    sft_loaded = checkpointing.load_params_from_path(
+        sft_path,
+        {"params": target_params_abstract},
+        config.checkpoint_storage_concurrent_gb,
+        use_ocdbt=config.checkpoint_storage_use_ocdbt,
+        use_zarr3=config.checkpoint_storage_use_zarr3,
+    )
+    sft_params = sft_loaded.get("params", sft_loaded)
+
+  stitched_leaves = {_format_path(k): v for k, v in jax.tree_util.tree_leaves_with_path(stitched_params)}
+  sft_leaves = {_format_path(k): v for k, v in jax.tree_util.tree_leaves_with_path(sft_params)}
+
+  # Validate trainable parameter mask (ensure this test runs only on masked training runs)
+  trainable_masks = getattr(config, "trainable_parameters_mask", None)
+  if not trainable_masks:
+    print(
+        "Error: 'trainable_parameters_mask' is empty or not provided. "
+        "This test specifically verifies custom MLP projector training with frozen encoder and decoder. "
+        "Exiting."
+    )
+    return False
+  elif isinstance(trainable_masks, str):
+    trainable_masks = [trainable_masks]
+
+  def _is_trainable(path: str) -> bool:
+    """Returns True if the tensor path matches any trainable mask pattern."""
+    return any(mask in path for mask in trainable_masks)
+
+  stats = {
+      "Vision Encoder": {"total": 0, "identical": 0, "different": 0, "expected": "FROZEN"},
+      "Projector MLP": {"total": 0, "identical": 0, "different": 0, "expected": "TRAINED"},
+      "LLM Backbone": {"total": 0, "identical": 0, "different": 0, "expected": "FROZEN"},
+  }
+  projector_diffs = []
+  unexpected_diffs = []
+
+  # Go through all parameter tensors and compare weights before vs after SFT
+  sft_keys = set(sft_leaves.keys())
+  stitched_keys = set(stitched_leaves.keys())
+  if sft_keys != stitched_keys:
+    missing_in_sft = stitched_keys - sft_keys
+    missing_in_stitched = sft_keys - stitched_keys
+    if missing_in_sft:
+      print(f"Error: Parameters in stitched but missing in SFT checkpoint: {missing_in_sft}")
+    if missing_in_stitched:
+      print(f"Error: Parameters in SFT but missing in stitched checkpoint: {missing_in_stitched}")
+    return False
+  # Go through all parameter tensors and compare weights before vs after SFT
+  for path, sft_arr in sft_leaves.items():
+    stitched_arr = stitched_leaves[path]
+
+    if _is_trainable(path):
+      cat = "Projector MLP"
+    elif path.startswith("vision_encoder"):
+      cat = "Vision Encoder"
+    else:
+      cat = "LLM Backbone"
+
+    # Compute maximum absolute difference between checkpoints
+    diff = jnp.max(jnp.abs(sft_arr.astype(jnp.float32) - stitched_arr.astype(jnp.float32)))
+    max_abs_diff = float(diff)
+    is_identical = max_abs_diff == 0.0
+
+    stats[cat]["total"] += 1
+    if is_identical:
+      stats[cat]["identical"] += 1
+    else:
+      stats[cat]["different"] += 1
+      if cat == "Projector MLP":
+        projector_diffs.append((path, max_abs_diff))
+      else:
+        unexpected_diffs.append((path, max_abs_diff))
+
+  # Test summary
+  print("\n" + "-" * 60)
+  print("Checkpoint Freezing & Training Verification:")
+  print("-" * 60)
+
+  all_passed = True
+  for cat, data in stats.items():
+    if data["expected"] == "FROZEN":
+      passed = data["different"] == 0 and data["total"] > 0
+      detail = f"{data['identical']}/{data['total']} tensors frozen"
+    else:
+      passed = data["different"] > 0 and data["total"] > 0
+      max_diff_val = max((d for _, d in projector_diffs), default=0.0)
+      detail = f"{data['different']}/{data['total']} tensors updated (max diff: {max_diff_val:.6f})"
+
+    if not passed:
+      all_passed = False
+    tag = "PASS" if passed else "FAIL"
+    print(f"  [{tag}] {cat:<15}: {detail}")
+
+  print("-" * 60)
+  if unexpected_diffs:
+    print("Unexpected changes in frozen weights:")
+    for path, d in unexpected_diffs:
+      print(f"    - {path}: diff={d:.6f}")
+    print("-" * 60)
+
+  return all_passed
+
+
+def main(argv: Sequence[str]) -> None:
+  argv = list(argv)
+
+  # Find YAML config path from CLI arguments or default flag
+  config_path = None
+  for a in argv[1:]:
+    if a.endswith(".yml") or a.endswith(".yaml"):
+      config_path = a
+      break
+
+  if not config_path:
+    config_path = FLAGS.config_path
+    argv.insert(1, config_path)
+
+  # Set required flags for checkpoint inspection
+  if not any(a.startswith("override_model_config=") for a in argv):
+    argv.append("override_model_config=True")
+  if not any(a.startswith("skip_jax_distributed_system=") for a in argv):
+    argv.append("skip_jax_distributed_system=True")
+  if not any(a.startswith("ici_fsdp_parallelism=") for a in argv):
+    argv.append("ici_fsdp_parallelism=1")
+  if not any(a.startswith("ici_tensor_parallelism=") for a in argv):
+    argv.append("ici_tensor_parallelism=-1")
+
+  config = pyconfig.initialize(
+      argv,
+      override_model_config=True,
+      skip_jax_distributed_system=True,
+      log_config=False,
+  )
+
+  passed = compare_checkpoints(
+      config=config,
+      stitched_checkpoint_path=FLAGS.stitched_checkpoint_path or getattr(config, "load_parameters_path", ""),
+      sft_checkpoint_path=FLAGS.sft_checkpoint_path,
+  )
+
+  # Exit with non-zero code if frozen weights changed or projector wasn't updated
+  if not passed:
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/src/maxtext/experimental/omni_poc/train_sft_omni.py
+++ b/src/maxtext/experimental/omni_poc/train_sft_omni.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Experimental SFT training runner for Omni (Gemma 3 + Qwen 3).
+
+Executes native MaxText SFT training with multimodal data processing and
+trainable parameter masking to fine-tune the custom MLP vision projector.
+
+Example usage:
+  python3 -m maxtext.experimental.omni_poc.train_sft_omni \
+    src/maxtext/experimental/omni_poc/configs/sft-maxtext-omni-gemma3-qwen3.yml \
+    load_parameters_path=gs://YOUR_BUCKET/path/to/checkpoint/items \
+    base_output_directory=gs://YOUR_BUCKET/output_directory \
+    run_name=my_omni_sft_run
+"""
+
+import maxtext
+# Eagerly initialize core MaxText C++ and model dependencies before train.py
+_ = (maxtext.Mesh, maxtext.pyconfig, maxtext.models, maxtext.model_creation_utils)
+
+from typing import Sequence
+from absl import app
+from maxtext.trainers.pre_train.train import get_train_func, initialize
+
+from maxtext.common.goodput import (
+    RECORD_JOB_START_TIME,
+    maybe_monitor_goodput,
+    record_goodput,
+)
+
+
+def main(argv: Sequence[str]) -> None:
+  """Runs the native SFT training loop for Omni."""
+  argv = list(argv)
+  if "use_sft=True" not in argv and not any(a.startswith("use_sft=") for a in argv):
+    argv.append("use_sft=True")
+  if "use_tunix_gradient_accumulation=False" not in argv and not any(
+      a.startswith("use_tunix_gradient_accumulation=") for a in argv
+  ):
+    argv.append("use_tunix_gradient_accumulation=False")
+  if "override_model_config=True" not in argv and not any(a.startswith("override_model_config=") for a in argv):
+    argv.append("override_model_config=True")
+
+  # Initialize config and goodput recorder using native SFT initialization
+  mt_config, goodput_recorder = initialize(argv)
+
+  # Run native SFT training loop (code derived from train_sft_native.py)
+  record_goodput(goodput_recorder, RECORD_JOB_START_TIME)
+  train_func = get_train_func(mt_config, goodput_recorder, argv)
+  with maybe_monitor_goodput(mt_config):
+    train_func()
+
+
+if __name__ == "__main__":
+  app.run(main)


### PR DESCRIPTION
# Description

This PR introduces the native Supervised Fine-Tuning (SFT) training runner and checkpoint verification utilities for hybrid multimodal Omni models (Gemma 3 Vision + Qwen 3 LLM).

Specifically:
- **Two-Stage Multimodal Training Configurations**:
  1. **Stage 1 (Pretrain / Projector Alignment)**: `pretrain-maxtext-omni-gemma3-qwen3-chartnet.yml` for pretraining the randomly initialized MLP connector on chart data (ChartNet).
  2. **Stage 2 (Downstream SFT)**: `sft-maxtext-omni-gemma3-qwen3.yml` for visual question-answering fine-tuning (ChartQA) starting from an aligned checkpoint.
  - Both configs are trained using `train_sft_omni.py`
- **Checkpoint Freezing Verification**: A test utility `compare_sft_checkpoint_test.py` that loads the base stitched checkpoint alongside the SFT-trained checkpoint, comparing all parameter PyTree leaves to mathematically verify that only projector weights changed while frozen encoder/decoder weights remained 100% identical.

This is Step 5 of a 5-step Proof-of-Concept for any-to-any multimodal alignment in MaxText. The overall goal is to align pretrained vision encoders with text-only LLMs by connecting the two with a dynamically configured adaptation layer, special tokenizer mapping for visual placeholder tokens, and training only the MLP using supervised fine tuning.

---

# Files

1. **Omni SFT Training Runner**
   - `src/maxtext/experimental/omni_poc/train_sft_omni.py`
     - Implements native SFT training loop execution for Omni models.

2. **Checkpoint Freezing & Weight Comparison Test**
   - `src/maxtext/experimental/omni_poc/tests/compare_sft_checkpoint_test.py`
     - Test to load and compare pre-SFT vs post-SFT checkpoints, validating that `Vision Encoder` and `LLM Backbone` parameters remain frozen while `Projector MLP` parameters are updated.

3. **Training Configurations**
   - `src/maxtext/experimental/omni_poc/configs/pretrain-maxtext-omni-gemma3-qwen3-chartnet.yml`
     - Configuration for pretraining on ChartNet dataset.
   - `src/maxtext/experimental/omni_poc/configs/sft-maxtext-omni-gemma3-qwen3.yml`
     - Configuration for SFT on ChartQA dataset.

---

# Example Usage

## Two-Stage Training Example

```bash
# Stage 1: Pretrain Projector Alignment on ChartNet
python3 -m maxtext.experimental.omni_poc.train_sft_omni \
  src/maxtext/experimental/omni_poc/configs/pretrain-maxtext-omni-gemma3-qwen3-chartnet.yml \
  load_parameters_path=gs://YOUR_BUCKET/path/to/stitched/checkpoint/items \
  base_output_directory=gs://YOUR_BUCKET/pretrain_output \
  run_name=my_chartnet_pretrain 

# Stage 2: SFT Fine-Tuning on ChartQA
python3 -m maxtext.experimental.omni_poc.train_sft_omni \
  src/maxtext/experimental/omni_poc/configs/sft-maxtext-omni-gemma3-qwen3.yml \
  load_parameters_path=gs://YOUR_BUCKET/pretrain_output/my_chartnet_pretrain/checkpoints/100/items \
  base_output_directory=gs://YOUR_BUCKET/sft_output \
  run_name=my_chartqa_sft 
```

---

# Training Execution & Verification

## 1. Stage 1: Pretraining on ChartNet
```bash
export PYTHONPATH=src:$PYTHONPATH

python3 -m maxtext.experimental.omni_poc.train_sft_omni \
  src/maxtext/experimental/omni_poc/configs/pretrain-maxtext-omni-gemma3-qwen3-chartnet.yml \
  load_parameters_path="gs://yuchenhou-maxtext-logs/omni_checkpoints/omni_stitched_gemma3-4b_qwen3-4b/0/items" \
  base_output_directory="gs://yuchenhou-maxtext-logs/omni-gemma3-qwen3/multimodal/pretrain_chartnet" \
  run_name="omni_pretrain_chartnet_100step" \
  steps=100 \
  checkpoint_period=100 \
  eval_interval=0
```

## 2. Stage 2: SFT on ChartQA
```bash
export PYTHONPATH=src:$PYTHONPATH

python3 -m maxtext.experimental.omni_poc.train_sft_omni \
  src/maxtext/experimental/omni_poc/configs/sft-maxtext-omni-gemma3-qwen3.yml \
  load_parameters_path="gs://yuchenhou-maxtext-logs/omni-gemma3-qwen3/multimodal/pretrain_chartnet/omni_pretrain_chartnet_100step/checkpoints/99/items" \
  base_output_directory="gs://yuchenhou-maxtext-logs/omni-gemma3-qwen3/multimodal/sft_chartqa" \
  run_name="omni_sft_chartqa_100step" \
  steps=100 \
  checkpoint_period=100 \
  save_checkpoint_on_completion=true \
  eval_interval=0 \
  eval_steps=0
```

### Training Output:
```text
I0825 23:09:57.545643 139925043539072 metric_logger.py:230] completed step: 0, seconds: 77.607, TFLOP/s/device: 2.739, Tokens/s/device: 105.558, total_weights: 6413, loss: 1.372, lm_loss: 1.372, perplexity: 3.942
I0825 23:10:00.088244 139925043539072 metric_logger.py:230] completed step: 1, seconds: 7.287, TFLOP/s/device: 29.169, Tokens/s/device: 1124.246, total_weights: 6845, loss: 1.435, lm_loss: 1.435, perplexity: 4.198
I0825 23:10:02.636908 139925043539072 metric_logger.py:230] completed step: 2, seconds: 1.408, TFLOP/s/device: 150.968, Tokens/s/device: 5818.645, total_weights: 6478, loss: 1.344, lm_loss: 1.344, perplexity: 3.834
I0825 23:10:05.185393 139925043539072 metric_logger.py:230] completed step: 3, seconds: 1.380, TFLOP/s/device: 154.072, Tokens/s/device: 5938.289, total_weights: 7299, loss: 1.274, lm_loss: 1.274, perplexity: 3.577
```

---

# Tests

## Checkpoint Freezing Verification Test
Verify that only the custom MLP projector was trained and all encoder/decoder weights remained strictly frozen:
```bash
export PYTHONPATH=src:$PYTHONPATH

python3 -m maxtext.experimental.omni_poc.tests.compare_sft_checkpoint_test \
  src/maxtext/experimental/omni_poc/configs/sft-maxtext-omni-gemma3-qwen3.yml \
  load_parameters_path="gs://yuchenhou-maxtext-logs/omni_checkpoints/omni_stitched_gemma3-4b_qwen3-4b/0/items" \
  base_output_directory="gs://yuchenhou-maxtext-logs/omni-gemma3-qwen3/multimodal/sft_chartqa" \
  run_name="omni_sft_chartqa_100step"
```

### Verification Output:
```text
================================================================================
  Stitched Original Checkpoint: gs://yuchenhou-maxtext-logs/omni_checkpoints/omni_stitched_gemma3-4b_qwen3-4b/0/items
  SFT Trained Checkpoint:       gs://yuchenhou-maxtext-logs/omni-gemma3-qwen3/multimodal/sft_chartqa/omni_sft_chartqa_100step/checkpoints/99/items
================================================================================

------------------------------------------------------------
Checkpoint Freezing & Training Verification:
------------------------------------------------------------
  [PASS] Vision Encoder : 437/437 tensors frozen
  [PASS] Projector MLP  : 6/6 tensors updated (max diff: 0.010238)
  [PASS] LLM Backbone   : 13/13 tensors frozen
------------------------------------------------------------
```

---

# Quick Evaluation

Quick sample generation check with `decode_omni`:
```bash
export PYTHONPATH=src:$PYTHONPATH

python3 -m maxtext.experimental.omni_poc.utils.decode_omni \
  --config_path="src/maxtext/experimental/omni_poc/maxtext-omni-gemma3-qwen3.yml" \
  --checkpoint_path="gs://yuchenhou-maxtext-logs/omni-gemma3-qwen3/multimodal/sft_chartqa/omni_sft_chartqa_100step/checkpoints/99/items" \
  --num_samples=2 \
  --max_new_tokens=128
```

### Evaluation Output:
After 100 steps of training
```text
Sample 1 (Index 1309):
  Question: What was the average annual total income per household of those in the top decile group?
  Ground Truth: ['186600']
  Model Response: 125.66

Sample 2 (Index 228):
  Question: Which gender is represented by the red color line?
  Ground Truth: ['Male']
  Model Response: Female
```

---

# Step-by-Step Objectives
- [PR 4485](https://github.com/google/maxtext/pull/4485) Multi-Directory Checkpoint Restoration: Implemented selective sub-tree parameter loading using Orbax such that we can initialize a multimodal model with parameters from multiple checkpoints.
- [PR 4593](https://github.com/google/maxtext/pull/4593) Dynamic MLP Connector: Add omni modal adapter layer (MLP) to connect vision tower output to the LLM decoder.
- [PR 4746](https://github.com/google/maxtext/pull/4746) and [PR 4839](https://github.com/google/maxtext/pull/4839) Special Tokenizer & Placeholder Masking: Add special token `<|image_pad|>` to tokenizer and ensure correct masking in the decoder.
- [PR 4864](https://github.com/AI-Hypercomputer/maxtext/pull/4864) COCO-Narratives Data Pipeline Processing.
- **[Current] SFT Training & Checkpoint Verification**.
- SFT Evaluation & Benchmarking.

---

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

