### PR TITLE
ci: Add tiered timeout-minutes across core PR CI workflows

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -43,6 +43,7 @@ jobs:
   build_and_upload:
     name: Build Wheel
     runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
+    timeout-minutes: 15
     container: python:3.12-slim-bookworm
     outputs:
       maxtext_sha: ${{ steps.vars.outputs.maxtext_sha }}

--- a/.github/workflows/check_docs_build.yml
+++ b/.github/workflows/check_docs_build.yml
@@ -32,6 +32,7 @@ jobs:
   build-docs:
     name: Build Sphinx Docs
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -51,6 +51,7 @@ jobs:
   analyze_code_changes:
     name: Analyze Code Changes for Test Orchestration
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       run_tests: ${{ steps.check.outputs.run_tests }}
       run_notebooks: ${{ steps.check.outputs.run_notebooks }}
@@ -128,6 +129,7 @@ jobs:
       needs.analyze_code_changes.outputs.run_tests == 'true' &&
       needs.build_and_upload_maxtext_package.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       total_workers: ${{ steps.set-params.outputs.total_workers }}
       worker_groups: ${{ steps.set-params.outputs.worker_groups }}
@@ -304,6 +306,7 @@ jobs:
     needs: [build_and_upload_maxtext_package, gate_test_run, tpu-pretrain-tests, tpu-posttrain-tests, tpu7x-tests, gpu-tests, cpu-pretrain-tests, cpu-posttrain-tests, maxtext_tpu_pathways_unit_tests, maxtext_tpu_pathways_integration_tests, code_quality_check, docs_build_check]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check test results
         run: |
@@ -347,6 +350,7 @@ jobs:
     needs: [analyze_code_changes, build_and_upload_maxtext_package, maxtext_jupyter_notebooks]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check notebooks results
         run: |
@@ -376,6 +380,7 @@ jobs:
     needs: [gate_test_run, tpu-pretrain-tests, tpu-posttrain-tests, tpu7x-tests, gpu-tests, cpu-pretrain-tests, cpu-posttrain-tests, maxtext_jupyter_notebooks, maxtext_tpu_pathways_unit_tests, maxtext_tpu_pathways_integration_tests, code_quality_check, docs_build_check]
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       issues: write
     steps:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -28,6 +28,7 @@ jobs:
   qa:
     name: "Pre-commit Linters"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       with:

--- a/.github/workflows/run_jupyter_notebooks.yml
+++ b/.github/workflows/run_jupyter_notebooks.yml
@@ -44,6 +44,7 @@ jobs:
   discover_notebooks:
     name: Discover Notebooks to Run
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       notebooks: ${{ steps.list.outputs.notebooks }}
       count: ${{ steps.list.outputs.count }}
@@ -106,6 +107,7 @@ jobs:
       matrix:
         notebook: ${{ fromJson(needs.discover_notebooks.outputs.notebooks) }}
     runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
+    timeout-minutes: 90
     container:
       image: gcr.io/tpu-prod-env-multipod/${{ inputs.base_image }} # zizmor: ignore[unpinned-images]
       env:

--- a/.github/workflows/run_pathways_tests.yml
+++ b/.github/workflows/run_pathways_tests.yml
@@ -70,6 +70,7 @@ jobs:
   run:
     name: ${{ format('tpu-pathways-{0}', !contains(inputs.pytest_marker, 'not integration_test') && 'integration' || 'unit') }}
     runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
+    timeout-minutes: 90
     container:
       image: gcr.io/tpu-prod-env-multipod/${{ inputs.base_image }} # zizmor: ignore[unpinned-images]
       env:

--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -88,6 +88,7 @@ jobs:
   run:
     name: ${{ inputs.flavor }}
     runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
+    timeout-minutes: 90
     container:
       image: gcr.io/${{ vars.PROJECT_NAME || 'tpu-prod-env-multipod' }}/${{ inputs.base_image }} # zizmor: ignore[unpinned-images]
       env:

--- a/.github/workflows/run_tests_coordinator.yml
+++ b/.github/workflows/run_tests_coordinator.yml
@@ -61,6 +61,7 @@ jobs:
   setup-parameters:
     name: Setup Parameters
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       worker_groups: ${{ steps.set-params.outputs.worker_groups }}
       total_workers: ${{ steps.set-params.outputs.total_workers }}

--- a/.github/workflows/track_performance.yml
+++ b/.github/workflows/track_performance.yml
@@ -28,6 +28,7 @@ jobs:
   track:
     name: Track Test Duration
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:


### PR DESCRIPTION
# Description

This PR introduces explicit `timeout-minutes` settings across all core PR CI workflows in `.github/workflows/`. I saw a couple issues where an old commit blocked a PR's new commit's tests. But the old commit's tests were stuck for more than 2 hours. Cancel wasn't working, so I needed to run a force cancellation with `gh api -X POST /repos/AI-Hypercomputer/maxtext/actions/runs/32896771701/force-cancel`. Adding timeouts to try to prevent this.

Previously, workflow jobs did not define timeouts, falling back to GitHub Actions' global 360-minute (6-hour) default. When test jobs or runner containers hang or ignore cancellation signals, this causes the PR concurrency group (`MaxText Package Tests-pr-<ID>`) and dedicated hardware runner pools (TPU, GPU, CPU, buildkit) to remain blocked for hours.

A tiered timeout approach is implemented:
- **90 minutes** for hardware test runners (`run_tests_against_package.yml`, `run_pathways_tests.yml`, `run_jupyter_notebooks.yml` execution) to allow ample headroom for image pulls, XLA compilation, and suite execution while preventing 6-hour lockouts.
- **15 minutes** for fast gating & pre-test jobs (`build_package.yml`, `code_quality.yml`, `check_docs_build.yml`, `ci_pipeline.yml` orchestration, and `run_tests_coordinator.yml`) to fail fast and release runners if pre-test steps stall.

# Tests
- Verified YAML syntax and structure for all modified workflow files.
- Confirmed existing explicit timeouts (`gemini_review.yml: 30m`) remain intact.

# Checklist
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).