### PR TITLE
Update Qwen3.5 scan-remat pattern by re-using Qwen3-Next's nested block scan

### DIFF
--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -881,113 +881,81 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
   }
 
   if scan_layers:
-    # 2. Scan over block cycles
-    for block_idx in range(layer_cycle_interval):
-      hf_indices = list(range(block_idx, num_main_layers, layer_cycle_interval))
-      prefix = f"params-decoder-layers-layer_{block_idx}"
+    # 2. Scanned blocks. One block covers a single period of the hybrid attention
+    # pattern: `layer_cycle_interval - 1` linear-attention (GatedDeltaNet) layers
+    # run as an inner scan, then one full-attention layer. The resulting params are:
+    #   layers-local_layers-*  -> nested [block][local]  (doubly scanned)
+    #   layers-global_layer-*  -> flat [block]           (block scan only; the
+    #     length-1 _scan_global_layer scan is a runtime memory boundary, not a
+    #     param stack)
+    # Qwen3.5 stores its routed experts fused, so unlike Qwen3-Next there is no
+    # extra per-expert axis to nest.
+    # Qwen3NextScannableBlock requires the full-attention layer to be last in the
+    # period, so the local positions are 0..cycle-2 and the global position is
+    # cycle-1.
+    num_blocks = num_main_layers // layer_cycle_interval
+    local_positions = list(range(layer_cycle_interval - 1))
+    global_position = layer_cycle_interval - 1
 
-      # Layer norms
-      mapping[f"{prefix}-input_layernorm-scale"] = [  # pyrefly: ignore[bad-assignment]
-          f"model.language_model.layers.{i}.input_layernorm.weight" for i in hf_indices
+    def hf_layer(block_idx, position, suffix):
+      return f"model.language_model.layers.{block_idx * layer_cycle_interval + position}.{suffix}"
+
+    # (maxtext subkey, hf suffix) pairs shared by both the local and global layers.
+    # A tuple of suffixes means MaxText concatenates the HF tensors into one kernel.
+    shared_specs = [
+        ("input_layernorm-scale", "input_layernorm.weight"),
+        ("post_attention_layernorm-scale", "post_attention_layernorm.weight"),
+        ("mlp-routed_experts-gate-kernel", "mlp.gate.weight"),
+        ("mlp-shared_expert-wi_0-kernel", "mlp.shared_expert.gate_proj.weight"),
+        ("mlp-shared_expert-wi_1-kernel", "mlp.shared_expert.up_proj.weight"),
+        ("mlp-shared_expert-wo-kernel", "mlp.shared_expert.down_proj.weight"),
+        ("mlp-shared_expert_gate-kernel", "mlp.shared_expert_gate.weight"),
+        ("mlp-routed_experts-wo", "mlp.experts.down_proj"),
+    ]
+    # Linear (GatedDeltaNet) attention: only ever on the local layers.
+    local_specs = shared_specs + [
+        ("attention-in_proj_qkvz-kernel", ("linear_attn.in_proj_qkv.weight", "linear_attn.in_proj_z.weight")),
+        ("attention-in_proj_ba-kernel", ("linear_attn.in_proj_b.weight", "linear_attn.in_proj_a.weight")),
+        ("attention-conv1d-kernel", "linear_attn.conv1d.weight"),
+        ("attention-A_log", "linear_attn.A_log"),
+        ("attention-dt_bias", "linear_attn.dt_bias"),
+        ("attention-norm-rms_norm-scale", "linear_attn.norm.weight"),
+        ("attention-out_proj-kernel", "linear_attn.out_proj.weight"),
+    ]
+    # Full attention: only ever on the global layer.
+    global_specs = shared_specs + [
+        ("attention-attention-query-kernel", "self_attn.q_proj.weight"),
+        ("attention-attention-key-kernel", "self_attn.k_proj.weight"),
+        ("attention-attention-value-kernel", "self_attn.v_proj.weight"),
+        ("attention-attention-out-kernel", "self_attn.o_proj.weight"),
+        ("attention-attention-query_norm-scale", "self_attn.q_norm.weight"),
+        ("attention-attention-key_norm-scale", "self_attn.k_norm.weight"),
+    ]
+
+    def hf_entry(block_idx, position, suffix):
+      """One HF reference: a tuple of suffixes stays a tuple of HF keys to concatenate."""
+      if isinstance(suffix, tuple):
+        return tuple(hf_layer(block_idx, position, s) for s in suffix)
+      return hf_layer(block_idx, position, suffix)
+
+    local_prefix = "params-decoder-layers-local_layers"
+    for subkey, suffix in local_specs:
+      mapping[f"{local_prefix}-{subkey}"] = [  # pyrefly: ignore[bad-assignment, no-matching-overload]
+          [hf_entry(b, p, suffix) for p in local_positions] for b in range(num_blocks)
       ]
-      mapping[f"{prefix}-post_attention_layernorm-scale"] = [  # pyrefly: ignore[bad-assignment]
-          f"model.language_model.layers.{i}.post_attention_layernorm.weight" for i in hf_indices
+    # Fused gate_up_proj feeds both wi_0 and wi_1, so it is keyed by the pair.
+    mapping[(f"{local_prefix}-mlp-routed_experts-wi_0", f"{local_prefix}-mlp-routed_experts-wi_1")] = [
+        [hf_layer(b, p, "mlp.experts.gate_up_proj") for p in local_positions] for b in range(num_blocks)
+    ]
+
+    global_prefix = "params-decoder-layers-global_layer"
+    for subkey, suffix in global_specs:
+      mapping[f"{global_prefix}-{subkey}"] = [  # pyrefly: ignore[bad-assignment, no-matching-overload]
+          hf_entry(b, global_position, suffix) for b in range(num_blocks)
       ]
-
-      # Handle Interleaved Attention (Linear vs Full)
-      is_full_attention_layer = (block_idx + 1) % layer_cycle_interval == 0
-
-      if is_full_attention_layer:
-        mapping.update(  # pyrefly: ignore[no-matching-overload]
-            {
-                f"{prefix}-attention-attention-query-kernel": [
-                    f"model.language_model.layers.{i}.self_attn.q_proj.weight" for i in hf_indices
-                ],
-                f"{prefix}-attention-attention-key-kernel": [
-                    f"model.language_model.layers.{i}.self_attn.k_proj.weight" for i in hf_indices
-                ],
-                f"{prefix}-attention-attention-value-kernel": [
-                    f"model.language_model.layers.{i}.self_attn.v_proj.weight" for i in hf_indices
-                ],
-                f"{prefix}-attention-attention-out-kernel": [
-                    f"model.language_model.layers.{i}.self_attn.o_proj.weight" for i in hf_indices
-                ],
-                f"{prefix}-attention-attention-query_norm-scale": [
-                    f"model.language_model.layers.{i}.self_attn.q_norm.weight" for i in hf_indices
-                ],
-                f"{prefix}-attention-attention-key_norm-scale": [
-                    f"model.language_model.layers.{i}.self_attn.k_norm.weight" for i in hf_indices
-                ],
-            }
-        )
-      else:
-        # Linear/Hybrid Attention Block
-        mapping.update(  # pyrefly: ignore[no-matching-overload]
-            {
-                # Provide a tuple of HF keys so MaxText concatenates them into qkvz
-                f"{prefix}-attention-in_proj_qkvz-kernel": [
-                    (
-                        f"model.language_model.layers.{i}.linear_attn.in_proj_qkv.weight",
-                        f"model.language_model.layers.{i}.linear_attn.in_proj_z.weight",
-                    )
-                    for i in hf_indices
-                ],
-                # Provide a tuple of HF keys so MaxText concatenates them into ba
-                f"{prefix}-attention-in_proj_ba-kernel": [
-                    (
-                        f"model.language_model.layers.{i}.linear_attn.in_proj_b.weight",
-                        f"model.language_model.layers.{i}.linear_attn.in_proj_a.weight",
-                    )
-                    for i in hf_indices
-                ],
-                f"{prefix}-attention-conv1d-kernel": [
-                    f"model.language_model.layers.{i}.linear_attn.conv1d.weight" for i in hf_indices
-                ],
-                f"{prefix}-attention-A_log": [f"model.language_model.layers.{i}.linear_attn.A_log" for i in hf_indices],
-                f"{prefix}-attention-dt_bias": [
-                    f"model.language_model.layers.{i}.linear_attn.dt_bias" for i in hf_indices
-                ],
-                f"{prefix}-attention-norm-rms_norm-scale": [
-                    f"model.language_model.layers.{i}.linear_attn.norm.weight" for i in hf_indices
-                ],
-                f"{prefix}-attention-out_proj-kernel": [
-                    f"model.language_model.layers.{i}.linear_attn.out_proj.weight" for i in hf_indices
-                ],
-            }
-        )
-
-      # 3. Handle MLP: Gates and Shared Experts
-      mapping.update(  # pyrefly: ignore[no-matching-overload]
-          {
-              f"{prefix}-mlp-routed_experts-gate-kernel": [
-                  f"model.language_model.layers.{i}.mlp.gate.weight" for i in hf_indices
-              ],
-              f"{prefix}-mlp-shared_expert-wi_0-kernel": [
-                  f"model.language_model.layers.{i}.mlp.shared_expert.gate_proj.weight" for i in hf_indices
-              ],
-              f"{prefix}-mlp-shared_expert-wi_1-kernel": [
-                  f"model.language_model.layers.{i}.mlp.shared_expert.up_proj.weight" for i in hf_indices
-              ],
-              f"{prefix}-mlp-shared_expert-wo-kernel": [
-                  f"model.language_model.layers.{i}.mlp.shared_expert.down_proj.weight" for i in hf_indices
-              ],
-              f"{prefix}-mlp-shared_expert_gate-kernel": [
-                  f"model.language_model.layers.{i}.mlp.shared_expert_gate.weight" for i in hf_indices
-              ],
-          }
-      )
-
-      # 4. Handle MoE Routed Experts
-      mapping.update(  # pyrefly: ignore[no-matching-overload]
-          {
-              f"{prefix}-mlp-routed_experts-wo": [
-                  f"model.language_model.layers.{i}.mlp.experts.down_proj" for i in hf_indices
-              ],
-              (f"{prefix}-mlp-routed_experts-wi_0", f"{prefix}-mlp-routed_experts-wi_1"): [
-                  f"model.language_model.layers.{i}.mlp.experts.gate_up_proj" for i in hf_indices
-              ],
-          }
-      )
+    mapping[(f"{global_prefix}-mlp-routed_experts-wi_0", f"{global_prefix}-mlp-routed_experts-wi_1")] = [
+        hf_layer(b, global_position, "mlp.experts.gate_up_proj") for b in range(num_blocks)
+    ]
   else:
     # Unscanned layer mapping
     for i in range(num_main_layers):
@@ -1258,17 +1226,21 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
 
   layer_cycle_interval = maxtext_config.inhomogeneous_layer_cycle_interval
   num_main_layers = config["text_config"]["num_hidden_layers"]
-  loop_indices = range(layer_cycle_interval) if scan_layers else range(num_main_layers)
+  # Scanned blocks expose two prefixes -- the stacked local (linear-attention) layers
+  # and the single global (full-attention) layer -- rather than one prefix per position
+  # in the cycle. Unscanned models keep one prefix per decoder layer.
+  if scan_layers:
+    layer_prefixes = [
+        ("params-decoder-layers-local_layers", False),
+        ("params-decoder-layers-global_layer", True),
+    ]
+  else:
+    layer_prefixes = [
+        (f"params-decoder-layers_{i}", (i % layer_cycle_interval + 1) % layer_cycle_interval == 0)
+        for i in range(num_main_layers)
+    ]
 
-  for i in loop_indices:
-    if scan_layers:
-      prefix = f"params-decoder-layers-layer_{i}"
-      block_idx = i
-    else:
-      prefix = f"params-decoder-layers_{i}"
-      block_idx = i % layer_cycle_interval
-    is_full_attention_layer = (block_idx + 1) % layer_cycle_interval == 0
-
+  for prefix, is_full_attention_layer in layer_prefixes:
     if is_full_attention_layer:
       for key in ["query", "key", "value", "out"]:
         hooks[f"{prefix}-attention-attention-{key}-kernel"] = reshape_kernel  # pyrefly: ignore[bad-assignment]

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -881,18 +881,8 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
   }
 
   if scan_layers:
-    # 2. Scanned blocks. One block covers a single period of the hybrid attention
-    # pattern: `layer_cycle_interval - 1` linear-attention (GatedDeltaNet) layers
-    # run as an inner scan, then one full-attention layer. The resulting params are:
-    #   layers-local_layers-*  -> nested [block][local]  (doubly scanned)
-    #   layers-global_layer-*  -> flat [block]           (block scan only; the
-    #     length-1 _scan_global_layer scan is a runtime memory boundary, not a
-    #     param stack)
-    # Qwen3.5 stores its routed experts fused, so unlike Qwen3-Next there is no
-    # extra per-expert axis to nest.
-    # Qwen3NextScannableBlock requires the full-attention layer to be last in the
-    # period, so the local positions are 0..cycle-2 and the global position is
-    # cycle-1.
+    # The length-1 _scan_global_layer scan is a memory boundary, not a param stack, so
+    # global_layer params stay flat [block] while local_layers nest [block][local].
     num_blocks = num_main_layers // layer_cycle_interval
     local_positions = list(range(layer_cycle_interval - 1))
     global_position = layer_cycle_interval - 1
@@ -900,8 +890,6 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
     def hf_layer(block_idx, position, suffix):
       return f"model.language_model.layers.{block_idx * layer_cycle_interval + position}.{suffix}"
 
-    # (maxtext subkey, hf suffix) pairs shared by both the local and global layers.
-    # A tuple of suffixes means MaxText concatenates the HF tensors into one kernel.
     shared_specs = [
         ("input_layernorm-scale", "input_layernorm.weight"),
         ("post_attention_layernorm-scale", "post_attention_layernorm.weight"),
@@ -912,7 +900,6 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
         ("mlp-shared_expert_gate-kernel", "mlp.shared_expert_gate.weight"),
         ("mlp-routed_experts-wo", "mlp.experts.down_proj"),
     ]
-    # Linear (GatedDeltaNet) attention: only ever on the local layers.
     local_specs = shared_specs + [
         ("attention-in_proj_qkvz-kernel", ("linear_attn.in_proj_qkv.weight", "linear_attn.in_proj_z.weight")),
         ("attention-in_proj_ba-kernel", ("linear_attn.in_proj_b.weight", "linear_attn.in_proj_a.weight")),
@@ -922,7 +909,6 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
         ("attention-norm-rms_norm-scale", "linear_attn.norm.weight"),
         ("attention-out_proj-kernel", "linear_attn.out_proj.weight"),
     ]
-    # Full attention: only ever on the global layer.
     global_specs = shared_specs + [
         ("attention-attention-query-kernel", "self_attn.q_proj.weight"),
         ("attention-attention-key-kernel", "self_attn.k_proj.weight"),
@@ -943,7 +929,6 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
       mapping[f"{local_prefix}-{subkey}"] = [  # pyrefly: ignore[bad-assignment, no-matching-overload]
           [hf_entry(b, p, suffix) for p in local_positions] for b in range(num_blocks)
       ]
-    # Fused gate_up_proj feeds both wi_0 and wi_1, so it is keyed by the pair.
     mapping[(f"{local_prefix}-mlp-routed_experts-wi_0", f"{local_prefix}-mlp-routed_experts-wi_1")] = [
         [hf_layer(b, p, "mlp.experts.gate_up_proj") for p in local_positions] for b in range(num_blocks)
     ]
@@ -1226,9 +1211,6 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
 
   layer_cycle_interval = maxtext_config.inhomogeneous_layer_cycle_interval
   num_main_layers = config["text_config"]["num_hidden_layers"]
-  # Scanned blocks expose two prefixes -- the stacked local (linear-attention) layers
-  # and the single global (full-attention) layer -- rather than one prefix per position
-  # in the cycle. Unscanned models keep one prefix per decoder layer.
   if scan_layers:
     layer_prefixes = [
         ("params-decoder-layers-local_layers", False),

--- a/src/maxtext/checkpoint_conversion/utils/tensor_handling.py
+++ b/src/maxtext/checkpoint_conversion/utils/tensor_handling.py
@@ -63,9 +63,6 @@ def stacked_axes(mt_key: str, config, depth: int) -> tuple:
     routed experts): the expert axis still leads, giving
     ``(0, param_scan_axis, param_scan_axis + 1)``.
   """
-  # A tuple is the composite-MaxText-key convention (e.g. Qwen3.5's fused
-  # gate_up_proj feeding wi_0 and wi_1); every component shares the same prefix,
-  # so the first one decides the layout.
   if isinstance(mt_key, tuple) and mt_key:
     mt_key = mt_key[0]
   if isinstance(mt_key, str) and "-local_layers" in mt_key:

--- a/src/maxtext/checkpoint_conversion/utils/tensor_handling.py
+++ b/src/maxtext/checkpoint_conversion/utils/tensor_handling.py
@@ -63,6 +63,11 @@ def stacked_axes(mt_key: str, config, depth: int) -> tuple:
     routed experts): the expert axis still leads, giving
     ``(0, param_scan_axis, param_scan_axis + 1)``.
   """
+  # A tuple is the composite-MaxText-key convention (e.g. Qwen3.5's fused
+  # gate_up_proj feeding wi_0 and wi_1); every component shares the same prefix,
+  # so the first one decides the layout.
+  if isinstance(mt_key, tuple) and mt_key:
+    mt_key = mt_key[0]
   if isinstance(mt_key, str) and "-local_layers" in mt_key:
     param_scan_axis = config.param_scan_axis
     nested_axes = (param_scan_axis, param_scan_axis + 1)

--- a/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
@@ -30,7 +30,7 @@ import logging
 import re
 import time
 import traceback
-from typing import Any, Optional, Tuple
+from typing import Any, NamedTuple, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -189,25 +189,61 @@ def _find_scanned_layer_idx(key_tuple, container_names=("layers", "scanned_block
   return -1, None
 
 
-def _find_qwen_scanned_layer_idx(key_tuple):
-  """Finds a Qwen scanned block path like `layers.layer_0` or `layers.moe_block`."""
+# `Qwen3NextScannableBlock` (shared by Qwen3-Next and Qwen3.5) nests two scans:
+# the cycle's linear-attention layers share a single `local_layers` module, with
+# blocks on `scan_axis` and the cycle slot on `scan_axis + 1`, while the trailing
+# full-attention layer sits in `global_layer` with blocks on `scan_axis` alone.
+_QWEN_NESTED_LOCAL = "local_layers"
+_QWEN_NESTED_GLOBAL = "global_layer"
+
+
+class _QwenScannedRef(NamedTuple):
+  """Where a scanned Qwen parameter sits, and how it maps onto cycle slots.
+
+  `slot_idx` is the parameter's fixed position in the layer cycle. It is None
+  for the two nested containers: `local_layers` spans several slots, read off
+  `scan_axis + 1` rather than off the key, and `global_layer` always takes
+  whichever slot closes the cycle.
+  """
+
+  container_idx: int  # Position of "layers" in the key tuple, or -1 for no match.
+  slot_idx: Optional[int]
+  consumed: int  # Key elements the container occupies.
+  nested: bool  # Slots are stacked on `scan_axis + 1`.
+  trailing: bool  # Occupies the last slot of the cycle.
+
+
+_NO_QWEN_SCAN = _QwenScannedRef(-1, -1, 0, False, False)
+
+
+def _find_qwen_scanned_layer_idx(key_tuple) -> _QwenScannedRef:
+  """Finds a Qwen scanned block path like `layers.local_layers` or `layers.layer_0`."""
   for i in range(len(key_tuple) - 1):
     if key_tuple[i] != "layers" or not isinstance(key_tuple[i + 1], str):
       continue
-    if key_tuple[i + 1].startswith("layers_"):
+    name = key_tuple[i + 1]
+    if name.startswith("layers_"):
       continue
-    match = re.fullmatch(r"layer_(\d+)", key_tuple[i + 1])
+    if name == _QWEN_NESTED_LOCAL:
+      return _QwenScannedRef(i, None, 2, True, False)
+    if name == _QWEN_NESTED_GLOBAL:
+      return _QwenScannedRef(i, None, 2, False, True)
+    match = re.fullmatch(r"layer_(\d+)", name)
     if match:
-      return i, int(match.group(1)), 2
-    return i, 0, 1
-  return -1, -1, 0
+      return _QwenScannedRef(i, int(match.group(1)), 2, False, False)
+    return _QwenScannedRef(i, 0, 1, False, False)
+  return _NO_QWEN_SCAN
 
 
 def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Optional[int] = None):
   """Unroll Qwen's heterogeneous or homogeneous scanned blocks for an unscanned MaxText target.
 
-  Qwen 3 Next/3.5 training stores a repeating layer cycle as
-  `decoder.layers.layer_{slot}`, with repetitions stacked on `scan_axis`.
+  Qwen 3 Next/3.5 training stores a repeating layer cycle under a nested scan:
+  `decoder.layers.local_layers` holds the cycle's linear-attention layers with
+  repetitions on `scan_axis` and the cycle slot on `scan_axis + 1`, and
+  `decoder.layers.global_layer` holds the trailing full-attention layer with
+  repetitions on `scan_axis` alone. Trainer states predating that layout, which
+  kept one `decoder.layers.layer_{slot}` module per slot, are still accepted.
   Qwen 3 base training stores homogeneous layers as `decoder.layers.*` stacked on `scan_axis`.
   The inference model stores every layer as a direct decoder attribute named
   `layers_{global_index}`. Tunix's generic direct-sync mapper cannot bridge
@@ -234,18 +270,37 @@ def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Opt
   scanned_keys = []
   slot_indices = set()
   scan_lengths = set()
+  local_widths = set()
+  has_trailing = False
   for key, value in flat_w.items():
-    container_idx, slot_idx, consumed = _find_qwen_scanned_layer_idx(key)
-    if container_idx == -1 or "dropout" in key or "rngs" in key:
+    ref = _find_qwen_scanned_layer_idx(key)
+    if ref.container_idx == -1 or "dropout" in key or "rngs" in key:
       continue
-    if not hasattr(value, "shape") or len(value.shape) <= scan_axis:
+    # A nested `local_layers` parameter carries its cycle slots on the axis just
+    # past the block axis, so it needs one dimension more than a flat one.
+    min_ndim = scan_axis + 2 if ref.nested else scan_axis + 1
+    if not hasattr(value, "shape") or len(value.shape) < min_ndim:
       raise ValueError(f"Qwen scanned parameter {'.'.join(map(str, key))} has no scan axis {scan_axis}: {value!r}")
-    scanned_keys.append((key, value, container_idx, slot_idx, consumed))
-    slot_indices.add(slot_idx)
+    scanned_keys.append((key, value, ref))
     scan_lengths.add(value.shape[scan_axis])
+    if ref.nested:
+      local_widths.add(value.shape[scan_axis + 1])
+      slot_indices.update(range(value.shape[scan_axis + 1]))
+    elif ref.trailing:
+      has_trailing = True
+    else:
+      slot_indices.add(ref.slot_idx)
 
   if not scanned_keys:
     return weights
+
+  if len(local_widths) > 1:
+    raise ValueError(f"Qwen nested `local_layers` parameters disagree on cycle width: {sorted(local_widths)}")
+  # `global_layer` closes the cycle, so its slot is whatever follows the local
+  # ones. Resolved here because the key alone does not carry the index.
+  trailing_slot = (max(slot_indices) + 1) if slot_indices else 0
+  if has_trailing:
+    slot_indices.add(trailing_slot)
 
   if pattern_length is None:
     expected_slots = set(range(max(slot_indices) + 1))
@@ -260,16 +315,26 @@ def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Opt
     raise ValueError(f"Qwen scanned parameters disagree on scan length: {sorted(scan_lengths)}")
 
   scan_length = scan_lengths.pop()
-  scanned_key_paths = {key for key, _, _, _, _ in scanned_keys}
+  scanned_key_paths = {key for key, _, _ in scanned_keys}
   new_flat_w = {key: value for key, value in flat_w.items() if key not in scanned_key_paths}
 
-  for key, value, container_idx, slot_idx, consumed in scanned_keys:
-    prefix = key[:container_idx]
-    suffix = key[container_idx + consumed :]
+  for key, value, ref in scanned_keys:
+    prefix = key[: ref.container_idx]
+    suffix = key[ref.container_idx + ref.consumed :]
+    # `local_layers` supplies several cycle slots from one tensor; every other
+    # container supplies exactly one, at a slot fixed above.
+    if ref.nested:
+      slots = tuple(range(value.shape[scan_axis + 1]))
+    else:
+      slots = (trailing_slot if ref.trailing else ref.slot_idx,)
     for repetition in range(scan_length):
-      global_idx = repetition * pattern_length + slot_idx
-      new_key = prefix + (f"layers_{global_idx}",) + suffix
-      new_flat_w[new_key] = jnp.take(value, repetition, axis=scan_axis)
+      block = jnp.take(value, repetition, axis=scan_axis)
+      for local_idx, slot_idx in enumerate(slots):
+        global_idx = repetition * pattern_length + slot_idx
+        new_key = prefix + (f"layers_{global_idx}",) + suffix
+        # Taking the block collapses `scan_axis`, so the nested slot axis has
+        # shifted down into it.
+        new_flat_w[new_key] = jnp.take(block, local_idx, axis=scan_axis) if ref.nested else block
 
   logging.info(
       "MaxTextVllmSampler: unrolled %d Qwen tensor components across %d layers for direct MaxText weight sync.",

--- a/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
@@ -189,28 +189,18 @@ def _find_scanned_layer_idx(key_tuple, container_names=("layers", "scanned_block
   return -1, None
 
 
-# `Qwen3NextScannableBlock` (shared by Qwen3-Next and Qwen3.5) nests two scans:
-# the cycle's linear-attention layers share a single `local_layers` module, with
-# blocks on `scan_axis` and the cycle slot on `scan_axis + 1`, while the trailing
-# full-attention layer sits in `global_layer` with blocks on `scan_axis` alone.
 _QWEN_NESTED_LOCAL = "local_layers"
 _QWEN_NESTED_GLOBAL = "global_layer"
 
 
 class _QwenScannedRef(NamedTuple):
-  """Where a scanned Qwen parameter sits, and how it maps onto cycle slots.
+  """Where a scanned Qwen parameter sits, and how it maps onto cycle slots."""
 
-  `slot_idx` is the parameter's fixed position in the layer cycle. It is None
-  for the two nested containers: `local_layers` spans several slots, read off
-  `scan_axis + 1` rather than off the key, and `global_layer` always takes
-  whichever slot closes the cycle.
-  """
-
-  container_idx: int  # Position of "layers" in the key tuple, or -1 for no match.
+  container_idx: int
   slot_idx: Optional[int]
-  consumed: int  # Key elements the container occupies.
-  nested: bool  # Slots are stacked on `scan_axis + 1`.
-  trailing: bool  # Occupies the last slot of the cycle.
+  consumed: int
+  nested: bool
+  trailing: bool
 
 
 _NO_QWEN_SCAN = _QwenScannedRef(-1, -1, 0, False, False)
@@ -238,12 +228,8 @@ def _find_qwen_scanned_layer_idx(key_tuple) -> _QwenScannedRef:
 def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Optional[int] = None):
   """Unroll Qwen's heterogeneous or homogeneous scanned blocks for an unscanned MaxText target.
 
-  Qwen 3 Next/3.5 training stores a repeating layer cycle under a nested scan:
-  `decoder.layers.local_layers` holds the cycle's linear-attention layers with
-  repetitions on `scan_axis` and the cycle slot on `scan_axis + 1`, and
-  `decoder.layers.global_layer` holds the trailing full-attention layer with
-  repetitions on `scan_axis` alone. Trainer states predating that layout, which
-  kept one `decoder.layers.layer_{slot}` module per slot, are still accepted.
+  Qwen 3 Next/3.5 training nests two scans: `decoder.layers.local_layers` holds the cycle's linear-attention
+  layers with the slot on `scan_axis + 1`, and `decoder.layers.global_layer` holds the trailing full-attention layer.
   Qwen 3 base training stores homogeneous layers as `decoder.layers.*` stacked on `scan_axis`.
   The inference model stores every layer as a direct decoder attribute named
   `layers_{global_index}`. Tunix's generic direct-sync mapper cannot bridge
@@ -276,8 +262,6 @@ def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Opt
     ref = _find_qwen_scanned_layer_idx(key)
     if ref.container_idx == -1 or "dropout" in key or "rngs" in key:
       continue
-    # A nested `local_layers` parameter carries its cycle slots on the axis just
-    # past the block axis, so it needs one dimension more than a flat one.
     min_ndim = scan_axis + 2 if ref.nested else scan_axis + 1
     if not hasattr(value, "shape") or len(value.shape) < min_ndim:
       raise ValueError(f"Qwen scanned parameter {'.'.join(map(str, key))} has no scan axis {scan_axis}: {value!r}")
@@ -296,8 +280,6 @@ def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Opt
 
   if len(local_widths) > 1:
     raise ValueError(f"Qwen nested `local_layers` parameters disagree on cycle width: {sorted(local_widths)}")
-  # `global_layer` closes the cycle, so its slot is whatever follows the local
-  # ones. Resolved here because the key alone does not carry the index.
   trailing_slot = (max(slot_indices) + 1) if slot_indices else 0
   if has_trailing:
     slot_indices.add(trailing_slot)
@@ -321,8 +303,6 @@ def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Opt
   for key, value, ref in scanned_keys:
     prefix = key[: ref.container_idx]
     suffix = key[ref.container_idx + ref.consumed :]
-    # `local_layers` supplies several cycle slots from one tensor; every other
-    # container supplies exactly one, at a slot fixed above.
     if ref.nested:
       slots = tuple(range(value.shape[scan_axis + 1]))
     else:
@@ -332,8 +312,7 @@ def unroll_qwen_scanned_weights(weights, scan_axis: int = 1, pattern_length: Opt
       for local_idx, slot_idx in enumerate(slots):
         global_idx = repetition * pattern_length + slot_idx
         new_key = prefix + (f"layers_{global_idx}",) + suffix
-        # Taking the block collapses `scan_axis`, so the nested slot axis has
-        # shifted down into it.
+        # Taking the block collapsed `scan_axis`, so the nested slot axis has shifted down into it.
         new_flat_w[new_key] = jnp.take(block, local_idx, axis=scan_axis) if ref.nested else block
 
   logging.info(

--- a/src/maxtext/integration/vllm/weight_converter.py
+++ b/src/maxtext/integration/vllm/weight_converter.py
@@ -482,6 +482,9 @@ class _PlanEntry:
   # Index along the scan axis, or None when the source is already per-layer.
   slice_index: Optional[int]
   op: str  # "identity" | "slice" | "fuse_moe"
+  # Index along the nested cycle-slot axis (`scan_axis + 1`), or None when the
+  # source stacks blocks alone. Only `local_layers` sources carry one.
+  local_index: Optional[int] = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -506,21 +509,25 @@ class _PlanGroup:
   # Dot-joined source path, precomputed for diagnostics and for the
   # leaf-name check inside `_align_per_axis`.
   source_path: str
+  # Shared by every entry in the group: see `_PlanEntry.local_index`.
+  local_index: Optional[int] = None
 
 
 def _group_plan(plan: List[_PlanEntry]) -> List[_PlanGroup]:
   """Collapses per-leaf plan entries into one group per source parameter.
 
-  Entries are grouped by `(source_keys, op)`. Target shape is deliberately
-  *not* part of the key: every rollout layer reading a given scanned source
-  must share a shape, and if two did not, the bulk unstack would produce the
-  wrong shape for one of them -- which `convert()`'s post-execution shape
-  check catches loudly rather than silently writing incorrect weights.
+  Entries are grouped by `(source_keys, op, local_index)`. Target shape is
+  deliberately *not* part of the key: every rollout layer reading a given
+  scanned source must share a shape, and if two did not, the bulk unstack would
+  produce the wrong shape for one of them -- which `convert()`'s post-execution
+  shape check catches loudly rather than silently writing incorrect weights.
+  `local_index` *is* part of the key, because one nested `local_layers` source
+  feeds a different set of rollout layers at each cycle slot.
   """
   grouped: Dict[Tuple[Any, ...], List[_PlanEntry]] = {}
   order: List[Tuple[Any, ...]] = []
   for entry in plan:
-    key = (entry.source_keys, entry.op)
+    key = (entry.source_keys, entry.op, entry.local_index)
     if key not in grouped:
       grouped[key] = []
       order.append(key)
@@ -529,11 +536,12 @@ def _group_plan(plan: List[_PlanEntry]) -> List[_PlanGroup]:
   groups: List[_PlanGroup] = []
   for key in order:
     entries = grouped[key]
-    source_keys, op = key
+    source_keys, op, local_index = key
     groups.append(
         _PlanGroup(
             source_keys=source_keys,
             op=op,
+            local_index=local_index,
             targets=tuple(
                 (e.slice_index, e.target_key)
                 # `identity` entries carry no index; -1 keeps the sort key
@@ -691,18 +699,29 @@ class MaxTextToMaxTextConverter:
   # -------------------------------------------------------------- #
   def _scanned_candidates(
       self, key_tuple: Tuple[Any, ...], prefix_len: int, suffix_start: int, slot: int
-  ) -> List[Tuple[Any, ...]]:
-    """Source keys that could hold the scanned form of a target layer key."""
+  ) -> List[Tuple[Tuple[Any, ...], Optional[int]]]:
+    """Source keys that could hold the scanned form of a target layer key.
+
+    Each candidate is paired with the index to take along the nested cycle-slot
+    axis, or None when the source stacks blocks alone. `Qwen3NextScannableBlock`
+    nests two scans: the cycle's linear-attention layers share one
+    `local_layers` module whose slot sits on `scan_axis + 1`, while the trailing
+    full-attention layer sits in `global_layer` with no slot axis at all.
+    """
     prefix, suffix = key_tuple[:prefix_len], key_tuple[suffix_start:]
     if self.cycle > 1:
-      # Inhomogeneous: `Qwen3_5ScannableBlock` holds `layer_0..layer_{C-1}`.
-      return [
-          prefix + ("layers", f"layer_{slot}") + suffix,
-          prefix + ("layers", str(slot)) + suffix,
-          prefix + ("layers", slot) + suffix,
+      if slot == self.cycle - 1:
+        candidates = [(prefix + ("layers", "global_layer") + suffix, None)]
+      else:
+        candidates = [(prefix + ("layers", "local_layers") + suffix, slot)]
+      # Trainer states predating the nested scan kept one module per slot.
+      return candidates + [
+          (prefix + ("layers", f"layer_{slot}") + suffix, None),
+          (prefix + ("layers", str(slot)) + suffix, None),
+          (prefix + ("layers", slot) + suffix, None),
       ]
     # Homogeneous: a single scanned `layers` container.
-    return [prefix + ("layers",) + suffix]
+    return [(prefix + ("layers",) + suffix, None)]
 
   def _build_plan(
       self,
@@ -740,18 +759,19 @@ class MaxTextToMaxTextConverter:
       candidates = self._scanned_candidates(tgt_key, prefix_len, suffix_start, slot)
 
       # 2. Scanned source, sliced at this block index.
-      matched = next((c for c in candidates if c in src_flat), None)
+      matched = next(((c, li) for c, li in candidates if c in src_flat), None)
       if matched is not None:
-        plan.append(_PlanEntry(tgt_key, (matched,), block, "slice"))
-        consumed.add(matched)
+        matched_key, local_index = matched
+        plan.append(_PlanEntry(tgt_key, (matched_key,), block, "slice", local_index))
+        consumed.add(matched_key)
         continue
 
       # 3. Rollout pre-fuses MoE `wi`; trainer still has `wi_0`/`wi_1`.
       if tgt_key and tgt_key[-1] == "wi":
-        for cand in candidates:
+        for cand, local_index in candidates:
           wi_0, wi_1 = cand[:-1] + ("wi_0",), cand[:-1] + ("wi_1",)
           if wi_0 in src_flat and wi_1 in src_flat:
-            plan.append(_PlanEntry(tgt_key, (wi_0, wi_1), block, "fuse_moe"))
+            plan.append(_PlanEntry(tgt_key, (wi_0, wi_1), block, "fuse_moe", local_index))
             consumed.update((wi_0, wi_1))
             break
         else:
@@ -862,15 +882,37 @@ class MaxTextToMaxTextConverter:
       )
 
     if group.op == "fuse_moe":
-      wi_0, wi_1 = (_apply_dtype_cast(src_flat[k], first_tgt.dtype, path) for k in group.source_keys)
+      wi_0, wi_1 = (
+          self._take_cycle_slot(_apply_dtype_cast(src_flat[k], first_tgt.dtype, path), group) for k in group.source_keys
+      )
       self._check_scan_axis(wi_0, path)
       per_block = self._fuse_moe_bulk(wi_0, wi_1, first_tgt, path)
     else:  # "slice"
       val = _apply_dtype_cast(src_flat[group.source_keys[0]], first_tgt.dtype, path)
+      val = self._take_cycle_slot(val, group)
       self._check_scan_axis(val, path)
       per_block = _bulk_align_and_unstack(val, self.scan_axis, first_tgt, path)
 
     return [(tgt_key, per_block[idx]) for idx, tgt_key in group.targets]
+
+  def _take_cycle_slot(self, val, group: _PlanGroup):
+    """Drops the nested cycle-slot axis from a `local_layers` source.
+
+    Everything downstream expects blocks on `scan_axis` and no other stacked
+    axis, so the slot is selected here -- once per group, before the bulk
+    alignment and unstack, rather than once per target layer.
+    """
+    if group.local_index is None:
+      return val
+    slot_axis = self.scan_axis + 1
+    if val.ndim <= slot_axis or val.shape[slot_axis] <= group.local_index:
+      raise ConversionPlanError(
+          f"Expected a nested cycle-slot axis holding at least "
+          f"{group.local_index + 1} slots on axis {slot_axis} of "
+          f"{group.source_path}, found shape {val.shape}. Check "
+          "param_scan_axis and inhomogeneous_layer_cycle_interval."
+      )
+    return jnp.take(val, group.local_index, axis=slot_axis)
 
   def _check_scan_axis(self, val, path: str) -> None:
     if val.shape[self.scan_axis] != self.num_blocks:

--- a/src/maxtext/integration/vllm/weight_converter.py
+++ b/src/maxtext/integration/vllm/weight_converter.py
@@ -482,8 +482,6 @@ class _PlanEntry:
   # Index along the scan axis, or None when the source is already per-layer.
   slice_index: Optional[int]
   op: str  # "identity" | "slice" | "fuse_moe"
-  # Index along the nested cycle-slot axis (`scan_axis + 1`), or None when the
-  # source stacks blocks alone. Only `local_layers` sources carry one.
   local_index: Optional[int] = None
 
 
@@ -509,7 +507,6 @@ class _PlanGroup:
   # Dot-joined source path, precomputed for diagnostics and for the
   # leaf-name check inside `_align_per_axis`.
   source_path: str
-  # Shared by every entry in the group: see `_PlanEntry.local_index`.
   local_index: Optional[int] = None
 
 
@@ -521,8 +518,6 @@ def _group_plan(plan: List[_PlanEntry]) -> List[_PlanGroup]:
   scanned source must share a shape, and if two did not, the bulk unstack would
   produce the wrong shape for one of them -- which `convert()`'s post-execution
   shape check catches loudly rather than silently writing incorrect weights.
-  `local_index` *is* part of the key, because one nested `local_layers` source
-  feeds a different set of rollout layers at each cycle slot.
   """
   grouped: Dict[Tuple[Any, ...], List[_PlanEntry]] = {}
   order: List[Tuple[Any, ...]] = []
@@ -702,11 +697,7 @@ class MaxTextToMaxTextConverter:
   ) -> List[Tuple[Tuple[Any, ...], Optional[int]]]:
     """Source keys that could hold the scanned form of a target layer key.
 
-    Each candidate is paired with the index to take along the nested cycle-slot
-    axis, or None when the source stacks blocks alone. `Qwen3NextScannableBlock`
-    nests two scans: the cycle's linear-attention layers share one
-    `local_layers` module whose slot sits on `scan_axis + 1`, while the trailing
-    full-attention layer sits in `global_layer` with no slot axis at all.
+    Each candidate is paired with the index to take along the nested cycle-slot axis, or None when there is none.
     """
     prefix, suffix = key_tuple[:prefix_len], key_tuple[suffix_start:]
     if self.cycle > 1:
@@ -896,12 +887,7 @@ class MaxTextToMaxTextConverter:
     return [(tgt_key, per_block[idx]) for idx, tgt_key in group.targets]
 
   def _take_cycle_slot(self, val, group: _PlanGroup):
-    """Drops the nested cycle-slot axis from a `local_layers` source.
-
-    Everything downstream expects blocks on `scan_axis` and no other stacked
-    axis, so the slot is selected here -- once per group, before the bulk
-    alignment and unstack, rather than once per target layer.
-    """
+    """Drops the nested cycle-slot axis from a `local_layers` source."""
     if group.local_index is None:
       return val
     slot_axis = self.scan_axis + 1

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -1085,8 +1085,8 @@ class Decoder(nn.Module):
               kv_caches=kv_caches,
               attention_metadata=attention_metadata,
           )
-        elif cfg.decoder_block == DecoderBlockType.QWEN3_NEXT:
-          y = self._apply_qwen3_next_scanned_blocks(
+        elif cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
+          y = self._apply_qwen3_hybrid_scanned_blocks(
               y,
               decoder_segment_ids,
               decoder_positions,
@@ -1449,7 +1449,7 @@ class Decoder(nn.Module):
 
     return y
 
-  def _apply_qwen3_next_scanned_blocks(
+  def _apply_qwen3_hybrid_scanned_blocks(
       self,
       y,
       decoder_segment_ids,
@@ -1461,10 +1461,15 @@ class Decoder(nn.Module):
       kv_caches=None,
       attention_metadata=None,
   ):
-    """Applies Qwen3-Next scanned decoder blocks, handling main scan and remainders."""
+    """Applies Qwen3-Next/Qwen3.5 scanned decoder blocks, handling main scan and remainders."""
 
     cfg = self.config
     mesh = self.mesh
+    ScannableBlockToLinen = (
+        qwen3_5.Qwen3_5ScannableBlockToLinen
+        if cfg.decoder_block == DecoderBlockType.QWEN3_5
+        else qwen3.Qwen3NextScannableBlockToLinen
+    )
 
     # Define the repeating pattern length and calculate how many full blocks to scan
     block_pattern_len = cfg.inhomogeneous_layer_cycle_interval
@@ -1472,7 +1477,6 @@ class Decoder(nn.Module):
     remainder_layers = cfg.num_decoder_layers % block_pattern_len
 
     if num_full_blocks > 0:
-      ScannableBlockToLinen = qwen3.Qwen3NextScannableBlockToLinen
       policy = self.get_remat_policy()
 
       kv_cache_scanned = maxtext_utils.prepare_kv_caches_for_scan(
@@ -1536,7 +1540,7 @@ class Decoder(nn.Module):
     if remainder_layers > 0:
       start_idx = cfg.num_decoder_layers - remainder_layers
       remainder_kv = tuple(kv_caches[start_idx:]) if kv_caches is not None else None
-      y_and_kv = qwen3.Qwen3NextScannableBlockToLinen(
+      y_and_kv = ScannableBlockToLinen(
           config=cfg,
           mesh=mesh,
           quant=self.quant,

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -2620,6 +2620,19 @@ class RoutedMoE(nnx.Module):
           logical_axes=gate_logits_logical_axes,
       )
 
+    if jnp.dtype(self.weight_dtype) == jnp.dtype(self.dtype):
+      # Keep the FSDP all-gather below inside the decoder loop. Under a scanned decoder the
+      # kernels arrive as a per-layer dynamic-slice of a stacked, fsdp-sharded param, and the
+      # pspecs above have the fsdp axis stripped so XLA inserts the all-gather right here.
+      # With nothing in between, XLA rewrites all_gather(dynamic_slice(w)) into
+      # dynamic_slice(all_gather(w)); that gather is loop invariant, so it is hoisted out of
+      # the scan and every layer's gathered expert kernel is live at once
+      # (num_layers * num_experts * embed * mlp * dtype bytes -- 51 GB for qwen3-next-80b).
+      # The `jnp.asarray(kernel, self.dtype)` cast in __call__ normally sits between the two
+      # and blocks the rewrite; when weight_dtype == dtype it is an identity, so pin the
+      # gather here instead. Only needed in that case, as the barrier costs a few percent of
+      # peak memory when XLA is otherwise free to schedule around the cast.
+      w0_kernel, w1_kernel, wo_kernel = jax.lax.optimization_barrier((w0_kernel, w1_kernel, wo_kernel))
     w0_kernel = self._maybe_shard_with_pspec(w0_kernel, w0_pspec)
     w1_kernel = self._maybe_shard_with_pspec(w1_kernel, w1_pspec)
     wo_kernel = self._maybe_shard_with_pspec(wo_kernel, wo_pspec)

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -2621,17 +2621,8 @@ class RoutedMoE(nnx.Module):
       )
 
     if jnp.dtype(self.weight_dtype) == jnp.dtype(self.dtype):
-      # Keep the FSDP all-gather below inside the decoder loop. Under a scanned decoder the
-      # kernels arrive as a per-layer dynamic-slice of a stacked, fsdp-sharded param, and the
-      # pspecs above have the fsdp axis stripped so XLA inserts the all-gather right here.
-      # With nothing in between, XLA rewrites all_gather(dynamic_slice(w)) into
-      # dynamic_slice(all_gather(w)); that gather is loop invariant, so it is hoisted out of
-      # the scan and every layer's gathered expert kernel is live at once
-      # (num_layers * num_experts * embed * mlp * dtype bytes -- 51 GB for qwen3-next-80b).
-      # The `jnp.asarray(kernel, self.dtype)` cast in __call__ normally sits between the two
-      # and blocks the rewrite; when weight_dtype == dtype it is an identity, so pin the
-      # gather here instead. Only needed in that case, as the barrier costs a few percent of
-      # peak memory when XLA is otherwise free to schedule around the cast.
+      # Without this, XLA rewrites all_gather(dynamic_slice(w)) into dynamic_slice(all_gather(w)) and hoists the
+      # gather out of the scanned decoder, keeping every layer's experts live; the dtype cast normally blocks that.
       w0_kernel, w1_kernel, wo_kernel = jax.lax.optimization_barrier((w0_kernel, w1_kernel, wo_kernel))
     w0_kernel = self._maybe_shard_with_pspec(w0_kernel, w0_pspec)
     w1_kernel = self._maybe_shard_with_pspec(w1_kernel, w1_pspec)

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -230,6 +230,43 @@ class NNXDecoderLayer(nnx.Module):
       return layer_output, kv_cache
 
 
+def forced_routed_experts_per_layer(forced_routed_experts: jax.Array, num_layers: int) -> jax.Array:
+  """Normalizes a batch's forced_routed_experts to a per-decoder-layer stack.
+
+  Every supported architecture is homogeneous-MoE, so the layer axis is simply
+  the decoder layer index.
+
+  Args:
+    forced_routed_experts: `[batch, seq, num_layers, top_k]` (per-layer) or
+      `[batch, seq, top_k]` (broadcast to every layer).
+    num_layers: Total decoder layers.
+
+  Returns:
+    Array shaped `[num_layers, batch, seq, top_k]`.
+
+  Raises:
+    ValueError: If forced_routed_experts is not 3D or 4D, or its layer axis
+      does not match `num_layers`.
+  """
+  fre = forced_routed_experts
+  if fre.ndim not in (3, 4):
+    raise ValueError(
+        "forced_routed_experts must be [batch, seq, top_k] (3D, broadcast to"
+        " every layer) or [batch, seq, num_layers, top_k] (4D, per-layer); got"
+        f" ndim={fre.ndim} with shape {fre.shape}."
+    )
+  if fre.ndim == 4:
+    if fre.shape[2] != num_layers:
+      raise ValueError(
+          "forced_routed_experts layer axis must equal the number of decoder"
+          f" layers ({num_layers}); got {fre.shape[2]} (shape {fre.shape})."
+      )
+    # [batch, seq, num_layers, top_k] -> [num_layers, batch, seq, top_k]
+    return jnp.moveaxis(fre, 2, 0)
+  # [batch, seq, top_k]: same forced routing for every layer.
+  return jnp.broadcast_to(fre[None], (num_layers,) + fre.shape)
+
+
 def reshape_forced_routed_experts_for_scan(
     forced_routed_experts: jax.Array,
     num_layers: int,
@@ -239,8 +276,7 @@ def reshape_forced_routed_experts_for_scan(
   """Reshapes a batch's forced_routed_experts into jax.lax.scan's xs layout.
 
   The outer scan runs `scan_length` iterations, each covering a cycle of
-  `layers_per_cycle` decoder layers. Every supported architecture is
-  homogeneous-MoE, so the layer axis is simply the decoder layer index.
+  `layers_per_cycle` decoder layers.
 
   Args:
     forced_routed_experts: `[batch, seq, num_layers, top_k]` (per-layer) or
@@ -255,19 +291,7 @@ def reshape_forced_routed_experts_for_scan(
   Raises:
     ValueError: If forced_routed_experts is not 3D or 4D.
   """
-  fre = forced_routed_experts
-  if fre.ndim not in (3, 4):
-    raise ValueError(
-        "forced_routed_experts must be [batch, seq, top_k] (3D, broadcast to"
-        " every layer) or [batch, seq, num_layers, top_k] (4D, per-layer); got"
-        f" ndim={fre.ndim} with shape {fre.shape}."
-    )
-  if fre.ndim == 4:
-    # [batch, seq, num_layers, top_k] -> [num_layers, batch, seq, top_k]
-    fre = jnp.moveaxis(fre, 2, 0)
-  else:
-    # [batch, seq, top_k]: same forced routing for every layer.
-    fre = jnp.broadcast_to(fre[None], (num_layers,) + fre.shape)
+  fre = forced_routed_experts_per_layer(forced_routed_experts, num_layers)
   return jnp.reshape(fre, (scan_length, layers_per_cycle) + fre.shape[1:])
 
 
@@ -2420,10 +2444,34 @@ class NNXDecoder(nnx.Module):
     Layers past the last whole block are applied afterwards, in a short
     remainder block, so a layer count that is not a multiple of the cycle keeps
     all its layers.
+
+    Forced routing (router replay) is sliced per decoder layer here and handed
+    to each block as its own `[block_length, batch, seq, top_k]` stack, which
+    the block then splits between its local scan and its global layer.
     """
     cfg = self.config
     block_length = cfg.inhomogeneous_layer_cycle_interval
     scan_length = cfg.num_decoder_layers // block_length
+    num_scanned_layers = scan_length * block_length
+
+    layer_kwargs = dict(layer_kwargs)
+    forced_routed_experts = layer_kwargs.pop("forced_routed_experts", None)
+    forced_routed_experts_scanned = None
+    remainder_forced_routed_experts = None
+    if forced_routed_experts is not None:
+      if kv_caches is not None:
+        # The kv-cache path below unrolls into _apply_layers_sequentially, which
+        # threads either kv caches or scan xs, not both.
+        raise NotImplementedError(
+            "Forced routing is not supported together with externally-managed (vLLM) kv_caches in scanned layers."
+        )
+      per_layer = forced_routed_experts_per_layer(forced_routed_experts, cfg.num_decoder_layers)
+      if scan_length > 0:
+        forced_routed_experts_scanned = jnp.reshape(
+            per_layer[:num_scanned_layers], (scan_length, block_length) + per_layer.shape[1:]
+        )
+      remainder_forced_routed_experts = per_layer[num_scanned_layers:]
+
     if scan_length > 0:
       grouped_kv_caches = maxtext_utils.prepare_kv_caches_for_scan(kv_caches, scan_length, block_length, stack=False)
       y, self.layers, _ = self._apply_layers_sequentially(
@@ -2433,19 +2481,22 @@ class NNXDecoder(nnx.Module):
           length=scan_length,
           kv_caches_stacked=grouped_kv_caches,
           skip_block_remat=True,
+          forced_routed_experts_scanned=forced_routed_experts_scanned,
           **layer_kwargs,
       )
       maxtext_utils.update_kv_caches_after_scan(kv_caches, grouped_kv_caches, scan_length, block_length, stacked=False)
 
     num_remaining_layers = cfg.num_decoder_layers % block_length
     if num_remaining_layers > 0:
+      if remainder_forced_routed_experts is not None:
+        layer_kwargs["forced_routed_experts"] = remainder_forced_routed_experts
       y = self._apply_remainder_block(
           self.layers_remainder,
           y,
           layer_args,
           layer_kwargs,
           kv_caches=kv_caches,
-          start_idx=scan_length * block_length,
+          start_idx=num_scanned_layers,
           num_remaining_layers=num_remaining_layers,
       )
     return y

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -271,6 +271,13 @@ def reshape_forced_routed_experts_for_scan(
   return jnp.reshape(fre, (scan_length, layers_per_cycle) + fre.shape[1:])
 
 
+def _qwen3_hybrid_block_class(config):
+  """Returns the nested-scan block class for a Qwen3-Next-style hybrid decoder."""
+  if config.decoder_block == DecoderBlockType.QWEN3_5:
+    return qwen3_5.Qwen3_5ScannableBlock
+  return qwen3.Qwen3NextScannableBlock
+
+
 def deepstack_process(hidden_states, bidirectional_mask, visual_embeds):
   """Process deepstack visual embeddings by adding them to hidden states at visual token positions.
 
@@ -480,7 +487,9 @@ class NNXDecoder(nnx.Module):
     self.is_gemma3 = self.config.decoder_block == DecoderBlockType.GEMMA3
     self.is_gemma4 = self.config.decoder_block == DecoderBlockType.GEMMA4
     self.is_gemma4_small = self.config.decoder_block == DecoderBlockType.GEMMA4_SMALL
-    self.is_qwen3_next = self.config.decoder_block == DecoderBlockType.QWEN3_NEXT
+    # Qwen3-Next and Qwen3.5 share the same hybrid attention period, so they share
+    # the same nested-scan block structure.
+    self.is_qwen3_hybrid = self.config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5)
 
     if config.mhc_expansion_rate > 1 and config.decoder_block == DecoderBlockType.DEEPSEEK4:
       self.hc_head = mhc.DeepSeek4HyperHead(
@@ -591,8 +600,8 @@ class NNXDecoder(nnx.Module):
       self._init_scanned_gemma3(decoder_block_classes, rngs, mesh)
     elif self.is_gemma4:
       self._init_scanned_gemma4(decoder_block_classes, rngs, mesh)
-    elif self.is_qwen3_next:
-      self._init_scanned_qwen3_next(rngs, mesh)
+    elif self.is_qwen3_hybrid:
+      self._init_scanned_qwen3_hybrid(rngs, mesh)
     else:
       self._init_scanned_generic(decoder_block_classes, rngs)
 
@@ -763,8 +772,8 @@ class NNXDecoder(nnx.Module):
         rngs=rngs,
     )
 
-  def _init_scanned_qwen3_next(self, rngs, mesh):
-    """Initializes scanned Qwen3-Next blocks with per-layer (rather than per-block) remat.
+  def _init_scanned_qwen3_hybrid(self, rngs, mesh):
+    """Initializes scanned Qwen3-Next/Qwen3.5 blocks with per-layer (rather than per-block) remat.
 
     Mirrors _init_scanned_gemma4: each block covers one period of the hybrid
     attention pattern and rematerializes its own sub-layers, so the outer apply
@@ -773,13 +782,14 @@ class NNXDecoder(nnx.Module):
     keep producing the same parameter tree.
     """
     config = self.config
+    block_cls = _qwen3_hybrid_block_class(config)
     block_length = config.inhomogeneous_layer_cycle_interval
     scan_length = config.num_decoder_layers // block_length
     num_remaining_layers = config.num_decoder_layers % block_length
     policy = self.get_remat_policy()
     if scan_length > 0:
       self.layers = self._create_scanned_layers(
-          qwen3.Qwen3NextScannableBlock,
+          block_cls,
           length=scan_length,
           metadata_axis_name="layers",
           rngs=rngs,
@@ -790,7 +800,7 @@ class NNXDecoder(nnx.Module):
     if num_remaining_layers > 0:
       # The remainder starts on a period boundary, so it holds only the leading
       # linear-attention layers of a period -- the full-attention layer is last.
-      self.layers_remainder = qwen3.Qwen3NextScannableBlock(
+      self.layers_remainder = block_cls(
           config=config,
           mesh=mesh,
           quant=self.quant,
@@ -2021,8 +2031,8 @@ class NNXDecoder(nnx.Module):
               layer_kwargs,
               kv_caches=kv_caches,
           )
-        elif self.is_qwen3_next:
-          y = self._apply_qwen3_next_scanned_blocks(
+        elif self.is_qwen3_hybrid:
+          y = self._apply_qwen3_hybrid_scanned_blocks(
               y,
               layer_args,
               layer_kwargs,
@@ -2393,8 +2403,8 @@ class NNXDecoder(nnx.Module):
 
     return y
 
-  def _apply_qwen3_next_scanned_blocks(self, y, layer_args, layer_kwargs, kv_caches=None):
-    """Applies the Qwen3-Next scanned blocks.
+  def _apply_qwen3_hybrid_scanned_blocks(self, y, layer_args, layer_kwargs, kv_caches=None):
+    """Applies the Qwen3-Next / Qwen3.5 scanned blocks.
 
     Qwen3NextScannableBlock rematerializes its own sub-layers (a scan over the
     linear-attention layers plus a trip-count-one scan over the full-attention

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -511,8 +511,6 @@ class NNXDecoder(nnx.Module):
     self.is_gemma3 = self.config.decoder_block == DecoderBlockType.GEMMA3
     self.is_gemma4 = self.config.decoder_block == DecoderBlockType.GEMMA4
     self.is_gemma4_small = self.config.decoder_block == DecoderBlockType.GEMMA4_SMALL
-    # Qwen3-Next and Qwen3.5 share the same hybrid attention period, so they share
-    # the same nested-scan block structure.
     self.is_qwen3_hybrid = self.config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5)
 
     if config.mhc_expansion_rate > 1 and config.decoder_block == DecoderBlockType.DEEPSEEK4:
@@ -2444,10 +2442,6 @@ class NNXDecoder(nnx.Module):
     Layers past the last whole block are applied afterwards, in a short
     remainder block, so a layer count that is not a multiple of the cycle keeps
     all its layers.
-
-    Forced routing (router replay) is sliced per decoder layer here and handed
-    to each block as its own `[block_length, batch, seq, top_k]` stack, which
-    the block then splits between its local scan and its global layer.
     """
     cfg = self.config
     block_length = cfg.inhomogeneous_layer_cycle_interval
@@ -2460,8 +2454,7 @@ class NNXDecoder(nnx.Module):
     remainder_forced_routed_experts = None
     if forced_routed_experts is not None:
       if kv_caches is not None:
-        # The kv-cache path below unrolls into _apply_layers_sequentially, which
-        # threads either kv caches or scan xs, not both.
+        # _apply_layers_sequentially threads either kv caches or scan xs, not both.
         raise NotImplementedError(
             "Forced routing is not supported together with externally-managed (vLLM) kv_caches in scanned layers."
         )

--- a/src/maxtext/layers/nnx_scan.py
+++ b/src/maxtext/layers/nnx_scan.py
@@ -96,7 +96,8 @@ def apply_scanned_layers(
     *,
     length: int,
     param_scan_axis: int,
-    apply_fn: Callable[[nnx.Module, Any], Any],
+    apply_fn: Callable[..., Any],
+    xs: Any | None = None,
     remat: bool = False,
     remat_policy: Callable[..., Any] | None = None,
     prevent_cse: bool = True,
@@ -108,6 +109,11 @@ def apply_scanned_layers(
   defines the model-specific module invocation and must return the next carry.
   ``remat`` is separate from ``remat_policy`` because ``None`` is JAX's full
   rematerialization policy, not an indication that rematerialization is off.
+
+  ``xs`` is an optional pytree of per-layer inputs whose leaves have a leading
+  axis of ``length``; each iteration's slice is passed to ``apply_fn`` as a
+  third argument. Callers that pass no ``xs`` keep the two-argument ``apply_fn``
+  signature.
 
   Externally managed per-layer state, such as KV caches, is not supported by
   this scan path.
@@ -170,14 +176,19 @@ def apply_scanned_layers(
     return leaf
 
   def scan_body(current_carry, scanned_state):
-    current_params, current_rest = scanned_state
+    if xs is None:
+      current_params, current_rest = scanned_state
+      apply_args = ()
+    else:
+      current_params, current_rest, current_xs = scanned_state
+      apply_args = (current_xs,)
     current_params = jax.tree.map(
         _strip_scan_metadata,
         current_params,
         is_leaf=lambda x: hasattr(x, "replace") and hasattr(x, "value"),
     )
     current_layer = nnx.merge(layer_graphdef, current_params, current_rest)
-    next_carry = apply_fn(current_layer, current_carry)
+    next_carry = apply_fn(current_layer, current_carry, *apply_args)
     # Drop the parameters that were carried in: ``jax.lax.scan`` stacks every
     # output, so returning them would materialize a second copy of the stacked
     # layer weights. Parameters created inside the body are still returned.
@@ -188,9 +199,8 @@ def apply_scanned_layers(
     return next_carry, (new_params, updated_rest)
 
   scan_fn = jax.checkpoint(scan_body, policy=remat_policy, prevent_cse=prevent_cse) if remat else scan_body
-  final_carry, (scanned_new_params, scanned_rest) = jax.lax.scan(
-      scan_fn, carry, (params, rest), length=length, unroll=unroll
-  )
+  scan_xs = (params, rest) if xs is None else (params, rest, xs)
+  final_carry, (scanned_new_params, scanned_rest) = jax.lax.scan(scan_fn, carry, scan_xs, length=length, unroll=unroll)
 
   if param_scan_axis != 0:
     scanned_new_params = jax.tree.map(lambda x: jnp.moveaxis(x, 0, param_scan_axis), scanned_new_params)

--- a/src/maxtext/layers/nnx_scan.py
+++ b/src/maxtext/layers/nnx_scan.py
@@ -110,11 +110,6 @@ def apply_scanned_layers(
   ``remat`` is separate from ``remat_policy`` because ``None`` is JAX's full
   rematerialization policy, not an indication that rematerialization is off.
 
-  ``xs`` is an optional pytree of per-layer inputs whose leaves have a leading
-  axis of ``length``; each iteration's slice is passed to ``apply_fn`` as a
-  third argument. Callers that pass no ``xs`` keep the two-argument ``apply_fn``
-  signature.
-
   Externally managed per-layer state, such as KV caches, is not supported by
   this scan path.
 

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -1350,11 +1350,7 @@ class Qwen3NextScannableBlock(nnx.Module):
       self.global_layer = None
 
   def _make_decoder_layer(self, *, layer_idx, is_full_attention_layer, rngs):
-    """Builds one sub-layer of the block.
-
-    Subclasses for architectures that share this block structure (e.g. Qwen3.5)
-    override this to swap in their own decoder layer class.
-    """
+    """Builds one sub-layer of the block."""
     return Qwen3NextDecoderLayer(
         config=self.config,
         mesh=self.mesh,
@@ -1384,8 +1380,7 @@ class Qwen3NextScannableBlock(nnx.Module):
         return self._run_layer(layer, carry, layer_kwargs)[0]
 
     else:
-      # Router replay: one slice of forced routing per local layer, fed through
-      # the scan's xs so each iteration sees its own layer's expert indices.
+
       def apply_fn(layer, carry, routing):
         return self._run_layer(layer, carry, layer_kwargs, forced_routed_experts=routing)[0]
 
@@ -1611,11 +1606,6 @@ class Qwen3NextDecoderLayer(nnx.Module):
 
     self.mlp = self._make_mlp(rngs=rngs)
 
-  # The three factories below are the only places a sibling architecture that reuses
-  # this layer (Qwen3.5) has to diverge, so they are overridable hooks rather than
-  # inline constructor calls. `__init__` binds what they return to `attention` and
-  # `mlp`, which are checkpoint parameter paths, so an override has to keep the
-  # sub-module's own parameter names too.
   def _make_full_attention(self, *, rngs: nnx.Rngs):
     """Builds the full-attention sub-block used on the last layer of every cycle."""
     return Qwen3NextFullAttention(
@@ -1707,8 +1697,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
 
     # We sow the load balancing loss so it can be collected and added to the total loss
     # during training.
-    # Assigned rather than sown: `sow` appends to a tuple, so the layer's Intermediate
-    # structure would grow on every call, which a `jax.lax.scan` body cannot express.
+    # Assigned, not sown: `sow` appends, so Intermediate would grow per call, which a scan body cannot express.
     if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
       self.moe_lb_loss = nnx.Intermediate(load_balance_loss)
 

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -1365,9 +1365,9 @@ class Qwen3NextScannableBlock(nnx.Module):
         rngs=rngs,
     )
 
-  def _run_layer(self, layer, y, layer_kwargs, kv_cache=None):
+  def _run_layer(self, layer, y, layer_kwargs, kv_cache=None, forced_routed_experts=None):
     """Invokes one Qwen3NextDecoderLayer, returning (output, updated_kv_cache)."""
-    out = layer(y, **layer_kwargs, kv_cache=kv_cache)
+    out = layer(y, **layer_kwargs, kv_cache=kv_cache, forced_routed_experts=forced_routed_experts)
     return out if isinstance(out, tuple) else (out, None)
 
   @property
@@ -1375,21 +1375,30 @@ class Qwen3NextScannableBlock(nnx.Module):
     """Whether the block rematerializes its own layers."""
     return self.apply_internal_remat and self.config.remat_policy != "none"
 
-  def _scan_local_layers(self, y, layer_kwargs):
+  def _scan_local_layers(self, y, layer_kwargs, forced_routed_experts=None):
     """Runs the local (linear attention / GatedDeltaNet) layers via a per-layer rematerialized jax.lax.scan."""
     remat = self._remat_enabled
+    if forced_routed_experts is None:
+      apply_fn = lambda layer, carry: self._run_layer(layer, carry, layer_kwargs)[0]
+    else:
+      # Router replay: one slice of forced routing per local layer, fed through
+      # the scan's xs so each iteration sees its own layer's expert indices.
+      def apply_fn(layer, carry, routing):
+        return self._run_layer(layer, carry, layer_kwargs, forced_routed_experts=routing)[0]
+
     return nnx_scan.apply_scanned_layers(
         self.local_layers,
         y,
         length=self.num_local,
         param_scan_axis=self.config.param_scan_axis,
-        apply_fn=lambda layer, carry: self._run_layer(layer, carry, layer_kwargs)[0],
+        apply_fn=apply_fn,
+        xs=forced_routed_experts,
         remat=remat,
         remat_policy=self.remat_policy_fn if remat else None,
         prevent_cse=maxtext_utils.should_prevent_cse_in_remat(self.config) if remat else True,
     )
 
-  def _scan_global_layer(self, y, layer_kwargs):
+  def _scan_global_layer(self, y, layer_kwargs, forced_routed_experts=None):
     """Runs the single global-attention layer inside a length-1 jax.lax.scan."""
     cfg = self.config
     graphdef_g, intermediate_g, other_g = nnx.split(self.global_layer, nnx.Intermediate, ...)
@@ -1398,7 +1407,9 @@ class Qwen3NextScannableBlock(nnx.Module):
     def run_global_layer(carry, intermediate_slice):
       hidden_states, other = carry
       layer = nnx.merge(graphdef_g, intermediate_slice, other)
-      new_hidden_states = self._run_layer(layer, hidden_states, layer_kwargs)[0]
+      new_hidden_states = self._run_layer(
+          layer, hidden_states, layer_kwargs, forced_routed_experts=forced_routed_experts
+      )[0]
       _, new_intermediate, new_other = nnx.split(layer, nnx.Intermediate, ...)
       return (new_hidden_states, new_other), new_intermediate
 
@@ -1428,7 +1439,7 @@ class Qwen3NextScannableBlock(nnx.Module):
     nnx.update(self.global_layer, final_other, intermediate_state)
     return y
 
-  def _forward_with_external_kv_cache(self, y, kv_cache, layer_kwargs):
+  def _forward_with_external_kv_cache(self, y, kv_cache, layer_kwargs, forced_routed_experts=None):
     """Runs the block with externally-supplied per-layer kv caches.
 
     Inference KV caches are a Python list of per-layer entries, so this path
@@ -1446,7 +1457,8 @@ class Qwen3NextScannableBlock(nnx.Module):
         current_state = jax.tree.map(lambda x, i=i: x[i], state)
         layer = nnx.merge(graphdef, current_params, current_state)
         current_kv = kv_cache[i] if (kv_cache is not None and i < len(kv_cache)) else None
-        y, new_kv = self._run_layer(layer, y, layer_kwargs, current_kv)
+        current_routing = None if forced_routed_experts is None else forced_routed_experts[i]
+        y, new_kv = self._run_layer(layer, y, layer_kwargs, current_kv, forced_routed_experts=current_routing)
         updated_kvs.append(new_kv)
         # Collect only non-Param state: parameters are read-only here, so stacking
         # them back would allocate a second copy of every layer weight. Non-Param
@@ -1458,7 +1470,8 @@ class Qwen3NextScannableBlock(nnx.Module):
 
     if self.global_layer is not None:
       global_kv = kv_cache[self.num_local] if (kv_cache is not None and self.num_local < len(kv_cache)) else None
-      y, new_kv = self._run_layer(self.global_layer, y, layer_kwargs, global_kv)
+      global_routing = None if forced_routed_experts is None else forced_routed_experts[self.num_local]
+      y, new_kv = self._run_layer(self.global_layer, y, layer_kwargs, global_kv, forced_routed_experts=global_routing)
       updated_kvs.append(new_kv)
 
     return y, tuple(updated_kvs)
@@ -1474,11 +1487,15 @@ class Qwen3NextScannableBlock(nnx.Module):
       slot: None | int = None,
       kv_cache=None,
       attention_metadata=None,
+      forced_routed_experts=None,
   ) -> tuple[Array, None]:
     """Applies the block of decoder layers to the input carry.
 
     Args:
       carry: The input tensor from the previous scan iteration.
+      forced_routed_experts: Optional router replay indices for this block,
+        shaped `[num_of_layers, batch, seq, top_k]` -- one slice per sub-layer,
+        in block order (the local layers first, the full-attention layer last).
       # ... other arguments are broadcasted to each iteration.
 
     Returns:
@@ -1499,14 +1516,22 @@ class Qwen3NextScannableBlock(nnx.Module):
         "attention_metadata": attention_metadata,
     }
 
+    if forced_routed_experts is not None and forced_routed_experts.shape[0] != self.num_of_layers:
+      raise ValueError(
+          f"forced_routed_experts must carry one slice per sub-layer of the block: expected leading axis "
+          f"{self.num_of_layers}, got {forced_routed_experts.shape[0]} (shape {forced_routed_experts.shape})."
+      )
+
     if kv_cache is not None:
-      return self._forward_with_external_kv_cache(inputs, kv_cache, layer_kwargs)
+      return self._forward_with_external_kv_cache(inputs, kv_cache, layer_kwargs, forced_routed_experts)
 
     y = inputs
     if self.local_layers is not None:
-      y = self._scan_local_layers(y, layer_kwargs)
+      local_routing = None if forced_routed_experts is None else forced_routed_experts[: self.num_local]
+      y = self._scan_local_layers(y, layer_kwargs, local_routing)
     if self.global_layer is not None:
-      y = self._scan_global_layer(y, layer_kwargs)
+      global_routing = None if forced_routed_experts is None else forced_routed_experts[self.num_local]
+      y = self._scan_global_layer(y, layer_kwargs, global_routing)
 
     if cfg.scan_layers:
       return y, None
@@ -1568,20 +1593,9 @@ class Qwen3NextDecoderLayer(nnx.Module):
 
     # Conditionally instantiate either the Linear Attention or Full Attention block.
     if is_full_attention_layer:
-      self.attention = Qwen3NextFullAttention(
-          config=cfg,
-          mesh=self.mesh,
-          quant=self.quant,
-          model_mode=model_mode,
-          layer_idx=self.layer_idx,
-          rngs=rngs,
-      )
+      self.attention = self._make_full_attention(rngs=rngs)
     else:
-      batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
-      dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
-      self.attention = Qwen3NextGatedDeltaNet(
-          config=cfg, inputs_shape=dummy_inputs_shape, mesh=self.mesh, dtype=cfg.dtype, model_mode=model_mode, rngs=rngs
-      )
+      self.attention = self._make_linear_attention(rngs=rngs)
 
     # Second LayerNorm, applied before the MoE block.
     self.post_attention_layernorm = Qwen3NextRMSNorm(
@@ -1592,8 +1606,41 @@ class Qwen3NextDecoderLayer(nnx.Module):
         rngs=rngs,
     )
 
-    # Instantiate our `Qwen3NextSparseMoeBlock`.
-    self.mlp = Qwen3NextSparseMoeBlock(config=cfg, mesh=self.mesh, quant=self.quant, rngs=rngs)
+    self.mlp = self._make_mlp(rngs=rngs)
+
+  # The three factories below are the only places a sibling architecture that reuses
+  # this layer (Qwen3.5) has to diverge, so they are overridable hooks rather than
+  # inline constructor calls. `__init__` binds what they return to `attention` and
+  # `mlp`, which are checkpoint parameter paths, so an override has to keep the
+  # sub-module's own parameter names too.
+  def _make_full_attention(self, *, rngs: nnx.Rngs):
+    """Builds the full-attention sub-block used on the last layer of every cycle."""
+    return Qwen3NextFullAttention(
+        config=self.config,
+        mesh=self.mesh,
+        quant=self.quant,
+        model_mode=self.model_mode,
+        layer_idx=self.layer_idx,
+        rngs=rngs,
+    )
+
+  def _make_linear_attention(self, *, rngs: nnx.Rngs):
+    """Builds the linear-attention (GatedDeltaNet) sub-block used on all other layers."""
+    cfg = self.config
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(cfg, self.model_mode)
+    dummy_inputs_shape = (batch_size, seq_len, cfg.emb_dim)
+    return Qwen3NextGatedDeltaNet(
+        config=cfg,
+        inputs_shape=dummy_inputs_shape,
+        mesh=self.mesh,
+        dtype=cfg.dtype,
+        model_mode=self.model_mode,
+        rngs=rngs,
+    )
+
+  def _make_mlp(self, *, rngs: nnx.Rngs):
+    """Builds the sparse MoE block."""
+    return Qwen3NextSparseMoeBlock(config=self.config, mesh=self.mesh, quant=self.quant, rngs=rngs)
 
   def __call__(
       self,
@@ -1606,6 +1653,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
       slot: None | int = None,
       kv_cache: None | dict[str, Array] = None,
       attention_metadata: None | dict[str, Any] = None,
+      forced_routed_experts: jnp.ndarray | None = None,
   ):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):
@@ -1648,10 +1696,16 @@ class Qwen3NextDecoderLayer(nnx.Module):
     hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
 
     # Instantiate and call our `Qwen3NextSparseMoeBlock`.
-    mlp_output, load_balance_loss = self.mlp(hidden_states, deterministic=deterministic)
+    mlp_output, load_balance_loss = self.mlp(
+        hidden_states,
+        deterministic=deterministic,
+        forced_routed_experts=forced_routed_experts,
+    )
 
     # We sow the load balancing loss so it can be collected and added to the total loss
     # during training.
+    # Assigned rather than sown: `sow` appends to a tuple, so the layer's Intermediate
+    # structure would grow on every call, which a `jax.lax.scan` body cannot express.
     if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
       self.moe_lb_loss = nnx.Intermediate(load_balance_loss)
 

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -1379,7 +1379,10 @@ class Qwen3NextScannableBlock(nnx.Module):
     """Runs the local (linear attention / GatedDeltaNet) layers via a per-layer rematerialized jax.lax.scan."""
     remat = self._remat_enabled
     if forced_routed_experts is None:
-      apply_fn = lambda layer, carry: self._run_layer(layer, carry, layer_kwargs)[0]
+
+      def apply_fn(layer, carry):
+        return self._run_layer(layer, carry, layer_kwargs)[0]
+
     else:
       # Router replay: one slice of forced routing per local layer, fed through
       # the scan's xs so each iteration sees its own layer's expert indices.

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -1327,11 +1327,7 @@ class Qwen3NextScannableBlock(nnx.Module):
 
     if self.num_local > 0:
       self.local_layers = nnx_scan.create_scanned_layers(
-          lambda layer_rngs: Qwen3NextDecoderLayer(
-              config=self.config,
-              mesh=self.mesh,
-              model_mode=self.model_mode,
-              quant=self.quant,
+          lambda layer_rngs: self._make_decoder_layer(
               layer_idx=0,
               is_full_attention_layer=False,
               rngs=layer_rngs,
@@ -1345,17 +1341,29 @@ class Qwen3NextScannableBlock(nnx.Module):
       self.local_layers = None
 
     if self.num_global > 0:
-      self.global_layer = Qwen3NextDecoderLayer(
-          config=self.config,
-          mesh=self.mesh,
-          quant=self.quant,
-          model_mode=self.model_mode,
+      self.global_layer = self._make_decoder_layer(
           layer_idx=full_attention_offset,
           is_full_attention_layer=True,
           rngs=self.rngs,
       )
     else:
       self.global_layer = None
+
+  def _make_decoder_layer(self, *, layer_idx, is_full_attention_layer, rngs):
+    """Builds one sub-layer of the block.
+
+    Subclasses for architectures that share this block structure (e.g. Qwen3.5)
+    override this to swap in their own decoder layer class.
+    """
+    return Qwen3NextDecoderLayer(
+        config=self.config,
+        mesh=self.mesh,
+        model_mode=self.model_mode,
+        quant=self.quant,
+        layer_idx=layer_idx,
+        is_full_attention_layer=is_full_attention_layer,
+        rngs=rngs,
+    )
 
   def _run_layer(self, layer, y, layer_kwargs, kv_cache=None):
     """Invokes one Qwen3NextDecoderLayer, returning (output, updated_kv_cache)."""

--- a/src/maxtext/models/qwen3_5.py
+++ b/src/maxtext/models/qwen3_5.py
@@ -16,22 +16,14 @@
 # pylint: disable=arguments-differ
 # pylint: disable=no-name-in-module
 
-from typing import Any, cast
-
-from jax.sharding import Mesh
-import jax.numpy as jnp
-
-from flax import linen as nn
 from flax import nnx
 
-from maxtext.common.common_types import Config, Array
 from maxtext.layers import initializers as max_initializers
 from maxtext.layers import nnx_wrappers
-from maxtext.layers.normalizations import Qwen3NextRMSNorm
-from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.utils import max_utils
 
 from maxtext.models.qwen3 import (
+    Qwen3NextDecoderLayer,
     Qwen3NextGatedDeltaNet,
     Qwen3NextFullAttention,
     Qwen3NextScannableBlock,
@@ -78,11 +70,15 @@ class Qwen3_5ScannableBlock(Qwen3NextScannableBlock):
     )
 
 
-class Qwen3_5DecoderLayer(nnx.Module):
-  """
-  This layer is a hybrid, capable of functioning as either:
-  1. A standard attention + MoE layer.
-  2. A linear attention + MoE layer.
+class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
+  """Qwen3.5 hybrid decoder layer.
+
+  Qwen3.5's decoder layer is structurally identical to Qwen3-Next's -- norm,
+  either full or linear attention, norm, sparse MoE, with residuals around the
+  attention and MoE halves -- so the whole forward pass is inherited. Only the
+  sub-block factories are overridden, to build the Qwen3.5 sub-classes. The
+  attribute names (`input_layernorm`, `attention`, `post_attention_layernorm`,
+  `mlp`) are therefore shared, and so are the checkpoint parameter paths.
 
   Attributes:
     config: The model configuration object.
@@ -92,144 +88,31 @@ class Qwen3_5DecoderLayer(nnx.Module):
     quant: Optional quantization configuration.
   """
 
-  def __init__(
-      self,
-      config: Config,
-      mesh: Mesh,
-      model_mode: str,
-      layer_idx: int,
-      quant: None | Quant = None,
-      *,
-      is_full_attention_layer: bool | None = None,
-      rngs: nnx.Rngs,
-  ):
-    self.config = config
-    self.mesh = mesh
-    self.model_mode = model_mode
-    self.layer_idx = layer_idx
-    self.quant = quant
+  def _make_full_attention(self, *, rngs: nnx.Rngs):
+    return Qwen3_5FullAttention(
+        config=self.config,
+        mesh=self.mesh,
+        quant=self.quant,
+        model_mode=self.model_mode,
+        layer_idx=self.layer_idx,
+        rngs=rngs,
+    )
+
+  def _make_linear_attention(self, *, rngs: nnx.Rngs):
     cfg = self.config
-    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
-
-    # First LayerNorm, applied before the attention block.
-    self.input_layernorm = Qwen3NextRMSNorm(
-        num_features=cfg.emb_dim,
-        epsilon=cfg.normalization_layer_epsilon,
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(cfg, self.model_mode)
+    dummy_inputs_shape = (batch_size, seq_len, cfg.emb_dim)
+    return Qwen3_5GatedDeltaNet(
+        config=cfg,
+        inputs_shape=dummy_inputs_shape,
+        mesh=self.mesh,
         dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
+        model_mode=self.model_mode,
         rngs=rngs,
     )
 
-    # Determine the type of attention mechanism for the current layer. A scanned block
-    # knows each sub-layer's role up front and passes it explicitly, because inside a
-    # scan the layer's position is not recoverable from layer_idx.
-    if is_full_attention_layer is None:
-      is_full_attention_layer = (self.layer_idx + 1) % cfg.inhomogeneous_layer_cycle_interval == 0
-    self.is_full_attention_layer = is_full_attention_layer
-
-    # Conditionally instantiate either the Linear Attention or Full Attention block.
-    if is_full_attention_layer:
-      self.attention = Qwen3_5FullAttention(
-          config=cfg,
-          mesh=self.mesh,
-          quant=self.quant,
-          model_mode=model_mode,
-          layer_idx=self.layer_idx,
-          rngs=rngs,
-      )
-    else:
-      batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
-      dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
-      self.attention = Qwen3_5GatedDeltaNet(
-          config=cfg, inputs_shape=dummy_inputs_shape, mesh=self.mesh, dtype=cfg.dtype, model_mode=model_mode, rngs=rngs
-      )
-
-    # Second LayerNorm, applied before the MoE block.
-    self.post_attention_layernorm = Qwen3NextRMSNorm(
-        num_features=cfg.emb_dim,
-        epsilon=cfg.normalization_layer_epsilon,
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        rngs=rngs,
-    )
-
-    # Instantiate our `Qwen3_5SparseMoEBlock`.
-    self.mlp = Qwen3_5SparseMoEBlock(config=cfg, mesh=self.mesh, quant=self.quant, rngs=rngs)
-
-  def __call__(
-      self,
-      inputs: jnp.ndarray,
-      decoder_segment_ids: None | jnp.ndarray,
-      decoder_positions: None | jnp.ndarray,
-      deterministic: bool,
-      model_mode: str,
-      previous_chunk=None,
-      slot: None | int = None,
-      kv_cache: None | dict[str, Array] = None,
-      attention_metadata: None | dict[str, Any] = None,
-      forced_routed_experts: jnp.ndarray | None = None,
-  ):
-    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
-    if isinstance(inputs, tuple):
-      inputs = inputs[0]
-    residual = inputs
-
-    # First LayerNorm, applied before the attention block.
-    hidden_states = self.input_layernorm(inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
-
-    # Conditionally apply either the Linear Attention or Full Attention block.
-    if isinstance(self.attention, Qwen3_5FullAttention):
-      attention_output, new_kv_cache = cast(Qwen3_5FullAttention, self.attention)(
-          hidden_states,
-          decoder_segment_ids,
-          decoder_positions,
-          deterministic,
-          model_mode,
-          kv_cache=kv_cache,
-          attention_metadata=attention_metadata,
-      )
-    else:
-      attention_output, new_kv_cache = cast(Qwen3_5GatedDeltaNet, self.attention)(
-          hidden_states,
-          model_mode=model_mode,
-          kv_cache=kv_cache,
-          decoder_segment_ids=decoder_segment_ids,
-          attention_metadata=attention_metadata,
-      )
-
-    # First residual connection after attention
-    hidden_states = residual + attention_output
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
-
-    # Prepare for the MoE block by capturing the new residual
-    residual = hidden_states
-
-    # Second LayerNorm, applied before the MoE block.
-    hidden_states = self.post_attention_layernorm(hidden_states)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
-
-    # Instantiate and call our `Qwen3_5SparseMoEBlock`.
-    mlp_output, load_balance_loss = self.mlp(
-        hidden_states,
-        deterministic=deterministic,
-        forced_routed_experts=forced_routed_experts,
-    )
-
-    # We sow the load balancing loss so it can be collected and added to the total loss
-    # during training.
-    # Assigned rather than sown: `sow` appends to a tuple, so the layer's Intermediate
-    # structure would grow on every call, which a `jax.lax.scan` body cannot express.
-    if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
-      self.moe_lb_loss = nnx.Intermediate(load_balance_loss)
-
-    # Final residual connection (after the MoE block)
-    layer_output = residual + mlp_output
-    layer_output = nn.with_logical_constraint(
-        layer_output,
-        self.activation_axis_names,
-    )
-    return layer_output, new_kv_cache
+  def _make_mlp(self, *, rngs: nnx.Rngs):
+    return Qwen3_5SparseMoEBlock(config=self.config, mesh=self.mesh, quant=self.quant, rngs=rngs)
 
 
 Qwen3_5DecoderLayerToLinen = nnx_wrappers.to_linen_class(

--- a/src/maxtext/models/qwen3_5.py
+++ b/src/maxtext/models/qwen3_5.py
@@ -49,14 +49,7 @@ class Qwen3_5SparseMoEBlock(Qwen3NextSparseMoeBlock):
 
 
 class Qwen3_5ScannableBlock(Qwen3NextScannableBlock):
-  """Scanned Structure for Text-only Architecture, explicitly invoking Qwen3_5 layers.
-
-  Qwen3.5 repeats the same hybrid attention period as Qwen3-Next -- several
-  GatedDeltaNet layers followed by one full-attention layer -- so it reuses
-  Qwen3-Next's hierarchical nested scans (an inner scan over the homogeneous
-  linear-attention layers plus a trip-count-one scan over the full-attention
-  layer) and only swaps in the Qwen3.5 decoder layer.
-  """
+  """Scanned Structure for Text-only Architecture, explicitly invoking Qwen3_5 layers."""
 
   def _make_decoder_layer(self, *, layer_idx, is_full_attention_layer, rngs):
     return Qwen3_5DecoderLayer(
@@ -72,13 +65,6 @@ class Qwen3_5ScannableBlock(Qwen3NextScannableBlock):
 
 class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
   """Qwen3.5 hybrid decoder layer.
-
-  Qwen3.5's decoder layer is structurally identical to Qwen3-Next's -- norm,
-  either full or linear attention, norm, sparse MoE, with residuals around the
-  attention and MoE halves -- so the whole forward pass is inherited. Only the
-  sub-block factories are overridden, to build the Qwen3.5 sub-classes. The
-  attribute names (`input_layernorm`, `attention`, `post_attention_layernorm`,
-  `mlp`) are therefore shared, and so are the checkpoint parameter paths.
 
   Attributes:
     config: The model configuration object.

--- a/src/maxtext/models/qwen3_5.py
+++ b/src/maxtext/models/qwen3_5.py
@@ -34,6 +34,7 @@ from maxtext.utils import max_utils
 from maxtext.models.qwen3 import (
     Qwen3NextGatedDeltaNet,
     Qwen3NextFullAttention,
+    Qwen3NextScannableBlock,
     Qwen3NextSparseMoeBlock,
 )
 
@@ -55,63 +56,26 @@ class Qwen3_5SparseMoEBlock(Qwen3NextSparseMoeBlock):
   """Shares same MoE code as Qwen3-Next"""
 
 
-class Qwen3_5ScannableBlock(nnx.Module):
-  """Scanned Structure for Text-only Architecture, explicitly invoking Qwen3_5 layers."""
+class Qwen3_5ScannableBlock(Qwen3NextScannableBlock):
+  """Scanned Structure for Text-only Architecture, explicitly invoking Qwen3_5 layers.
 
-  def __init__(self, config: Config, mesh: Mesh, model_mode: str, quant=None, *, rngs: nnx.Rngs):
-    self.config = config
-    self.mesh = mesh
-    self.model_mode = model_mode
-    self.quant = quant
-    self.rngs = rngs
-    cfg = self.config
+  Qwen3.5 repeats the same hybrid attention period as Qwen3-Next -- several
+  GatedDeltaNet layers followed by one full-attention layer -- so it reuses
+  Qwen3-Next's hierarchical nested scans (an inner scan over the homogeneous
+  linear-attention layers plus a trip-count-one scan over the full-attention
+  layer) and only swaps in the Qwen3.5 decoder layer.
+  """
 
-    # Explicitly instantiate Qwen3_5DecoderLayer here
-    for i in range(cfg.inhomogeneous_layer_cycle_interval):
-      layer_rngs = self.rngs.fork()
-      layer_name = f"layer_{i}"
-      layer = Qwen3_5DecoderLayer(
-          config=self.config,
-          mesh=self.mesh,
-          quant=self.quant,
-          model_mode=self.model_mode,
-          layer_idx=i,
-          rngs=layer_rngs,
-      )
-      setattr(self, layer_name, layer)
-
-  def __call__(
-      self,
-      carry: jnp.ndarray,
-      decoder_segment_ids: None | jnp.ndarray,
-      decoder_positions: None | jnp.ndarray,
-      deterministic: bool,
-      model_mode: str,
-      previous_chunk=None,
-      slot: None | int = None,
-      forced_routed_experts: jnp.ndarray | None = None,
-  ) -> tuple[Array, None]:
-    cfg = self.config
-    x = carry
-
-    for i in range(cfg.inhomogeneous_layer_cycle_interval):
-      layer = getattr(self, f"layer_{i}")
-      # forced_routed_experts, when present, is shaped
-      # [inhomogeneous_layer_cycle_interval, batch, seq, top_k]: one slice per
-      # sub-layer in this cycle (see nnx_decoders.py's scan wiring).
-      layer_forced_routed_experts = forced_routed_experts[i] if forced_routed_experts is not None else None
-      x, _ = layer(
-          x,
-          decoder_segment_ids,
-          decoder_positions,
-          deterministic,
-          model_mode,
-          previous_chunk,
-          slot,
-          forced_routed_experts=layer_forced_routed_experts,
-      )
-
-    return x, None
+  def _make_decoder_layer(self, *, layer_idx, is_full_attention_layer, rngs):
+    return Qwen3_5DecoderLayer(
+        config=self.config,
+        mesh=self.mesh,
+        model_mode=self.model_mode,
+        quant=self.quant,
+        layer_idx=layer_idx,
+        is_full_attention_layer=is_full_attention_layer,
+        rngs=rngs,
+    )
 
 
 class Qwen3_5DecoderLayer(nnx.Module):
@@ -129,7 +93,15 @@ class Qwen3_5DecoderLayer(nnx.Module):
   """
 
   def __init__(
-      self, config: Config, mesh: Mesh, model_mode: str, layer_idx: int, quant: None | Quant = None, *, rngs: nnx.Rngs
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: str,
+      layer_idx: int,
+      quant: None | Quant = None,
+      *,
+      is_full_attention_layer: bool | None = None,
+      rngs: nnx.Rngs,
   ):
     self.config = config
     self.mesh = mesh
@@ -148,8 +120,12 @@ class Qwen3_5DecoderLayer(nnx.Module):
         rngs=rngs,
     )
 
-    # Determine the type of attention mechanism for the current layer.
-    is_full_attention_layer = (self.layer_idx + 1) % cfg.inhomogeneous_layer_cycle_interval == 0
+    # Determine the type of attention mechanism for the current layer. A scanned block
+    # knows each sub-layer's role up front and passes it explicitly, because inside a
+    # scan the layer's position is not recoverable from layer_idx.
+    if is_full_attention_layer is None:
+      is_full_attention_layer = (self.layer_idx + 1) % cfg.inhomogeneous_layer_cycle_interval == 0
+    self.is_full_attention_layer = is_full_attention_layer
 
     # Conditionally instantiate either the Linear Attention or Full Attention block.
     if is_full_attention_layer:
@@ -242,8 +218,10 @@ class Qwen3_5DecoderLayer(nnx.Module):
 
     # We sow the load balancing loss so it can be collected and added to the total loss
     # during training.
+    # Assigned rather than sown: `sow` appends to a tuple, so the layer's Intermediate
+    # structure would grow on every call, which a `jax.lax.scan` body cannot express.
     if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
-      self.sow(nnx.Intermediate, "moe_lb_loss", load_balance_loss)
+      self.moe_lb_loss = nnx.Intermediate(load_balance_loss)
 
     # Final residual connection (after the MoE block)
     layer_output = residual + mlp_output

--- a/tests/post_training/unit/vllm_rollout_unroll_test.py
+++ b/tests/post_training/unit/vllm_rollout_unroll_test.py
@@ -225,6 +225,65 @@ class QwenScannedWeightsUnrollTest(unittest.TestCase):
     self.assertEqual(validate_direct_sync_layer_coverage(unrolled, target), 4)
 
   @pytest.mark.cpu_only
+  def test_unrolls_the_nested_local_and_global_block_scan(self):
+    """Qwen3-Next and Qwen3.5 nest the cycle's local layers into one module.
+
+    `local_layers` stacks blocks on `scan_axis` and the cycle slot on
+    `scan_axis + 1`; `global_layer` holds the trailing full-attention layer on
+    the block axis alone. Together they must still unroll to a dense
+    `layers_{global_idx}` run, with each slot landing on its own layer.
+    """
+    num_blocks, num_local = 2, 3
+    cycle = num_local + 1
+    local_probe = np.zeros((2, num_blocks, num_local, 1), dtype=np.float32)
+    global_probe = np.zeros((2, num_blocks, 1), dtype=np.float32)
+    for block in range(num_blocks):
+      for slot in range(num_local):
+        local_probe[:, block, slot, :] = block * cycle + slot
+      global_probe[:, block, :] = block * cycle + num_local
+    weights = MockWeights(
+        {
+            "base": {
+                "decoder": {
+                    "layers": {
+                        "local_layers": {"probe": local_probe},
+                        "global_layer": {"probe": global_probe},
+                    },
+                    "decoder_norm": {"scale": np.ones(2)},
+                }
+            }
+        }
+    )
+
+    unrolled = unroll_qwen_scanned_weights(weights)
+
+    decoder = unrolled["base"]["decoder"]
+    for layer_idx in range(num_blocks * cycle):
+      self.assertIn(f"layers_{layer_idx}", decoder)
+      np.testing.assert_array_equal(
+          decoder[f"layers_{layer_idx}"]["probe"],
+          np.full((2, 1), layer_idx, dtype=np.float32),
+      )
+    np.testing.assert_array_equal(decoder["decoder_norm"]["scale"], np.ones(2))
+    target = {
+        "model": {
+            "decoder": {
+                f"layers_{layer_idx}": {"probe": np.zeros((2, 1), dtype=np.float32)}
+                for layer_idx in range(num_blocks * cycle)
+            }
+        }
+    }
+    self.assertEqual(validate_direct_sync_layer_coverage(unrolled, target), num_blocks * cycle)
+
+  @pytest.mark.cpu_only
+  def test_rejects_nested_local_layers_without_a_cycle_slot_axis(self):
+    """A `local_layers` tensor missing its slot axis must not be read as flat."""
+    weights = MockWeights({"decoder": {"layers": {"local_layers": {"probe": np.ones((2, 2))}}}})
+
+    with self.assertRaisesRegex(ValueError, "has no scan axis"):
+      unroll_qwen_scanned_weights(weights)
+
+  @pytest.mark.cpu_only
   def test_correctly_unrolls_homogeneous_scanned_weights(self):
     """Verify homogeneous scanned layers (LLaMA, Qwen Base) unroll to layers_{global_idx}."""
     # 4 layers stacked on scan_axis=1 (feature_dim=2, num_layers=4, hidden=1)

--- a/tests/post_training/unit/vllm_rollout_unroll_test.py
+++ b/tests/post_training/unit/vllm_rollout_unroll_test.py
@@ -226,13 +226,7 @@ class QwenScannedWeightsUnrollTest(unittest.TestCase):
 
   @pytest.mark.cpu_only
   def test_unrolls_the_nested_local_and_global_block_scan(self):
-    """Qwen3-Next and Qwen3.5 nest the cycle's local layers into one module.
-
-    `local_layers` stacks blocks on `scan_axis` and the cycle slot on
-    `scan_axis + 1`; `global_layer` holds the trailing full-attention layer on
-    the block axis alone. Together they must still unroll to a dense
-    `layers_{global_idx}` run, with each slot landing on its own layer.
-    """
+    """Nested `local_layers` plus `global_layer` unroll to a dense `layers_{global_idx}` run."""
     num_blocks, num_local = 2, 3
     cycle = num_local + 1
     local_probe = np.zeros((2, num_blocks, num_local, 1), dtype=np.float32)

--- a/tests/post_training/unit/weight_converter_test.py
+++ b/tests/post_training/unit/weight_converter_test.py
@@ -119,6 +119,24 @@ def _source_tree(fused_moe_on_target: bool):
   }
 
 
+def _nested_source_tree(fused_moe_on_target: bool):
+  """Trainer state in the nested-scan layout `Qwen3NextScannableBlock` produces.
+
+  Same values as `_source_tree`, restacked the way the shared Qwen3-Next block
+  stores them: slots `0..C-2` share one `local_layers` module with the cycle
+  slot on `SCAN_AXIS + 1`, and slot `C-1` becomes `global_layer` with the block
+  axis alone. Converting either tree must yield the same rollout weights.
+  """
+  legacy = _source_tree(fused_moe_on_target)["base"]["decoder"]["layers"]
+  local_slots = [legacy[f"layer_{slot}"] for slot in range(CYCLE - 1)]
+  tree = _source_tree(fused_moe_on_target)
+  tree["base"]["decoder"]["layers"] = {
+      "local_layers": jax.tree.map(lambda *slots: jnp.stack(slots, axis=SCAN_AXIS + 1), *local_slots),
+      "global_layer": legacy[f"layer_{CYCLE - 1}"],
+  }
+  return tree
+
+
 def _target_tree(moe_intermediate=MOE_DIM, fused=True, wo_intermediate=MOE_DIM):
   """Rollout state: unrolled `layers_{0..7}`, optionally fused MoE.
 
@@ -189,6 +207,34 @@ class ScannedToUnrolledMappingTest(unittest.TestCase):
         np.asarray(out["token_embedder"]["embedding"]),
         np.asarray(_arr(16, EMB)),
     )
+
+  def test_nested_scan_layout_converts_identically(self):
+    """Qwen3.5 moved onto Qwen3-Next's nested block scan.
+
+    The cycle's linear-attention layers now live in one `local_layers` module
+    with the slot on `SCAN_AXIS + 1` instead of one module per slot, so the
+    converter has to read that layout too -- and read it to the same answer.
+    """
+    target = _target_tree()
+    legacy = traverse_util.flatten_dict(MaxTextToMaxTextConverter(_config()).convert(_source_tree(True), target))
+    nested = traverse_util.flatten_dict(MaxTextToMaxTextConverter(_config()).convert(_nested_source_tree(True), target))
+    self.assertEqual(set(legacy), set(nested))
+    for key, want in legacy.items():
+      np.testing.assert_array_equal(
+          np.asarray(nested[key]),
+          np.asarray(want),
+          err_msg=f"{'.'.join(map(str, key))} differs between the per-slot and nested layouts",
+      )
+
+  def test_nested_local_layers_shorter_than_the_cycle_is_rejected(self):
+    """A `local_layers` axis that cannot cover every slot must not slice silently."""
+    source = _nested_source_tree(True)
+    local = source["base"]["decoder"]["layers"]["local_layers"]
+    local["input_layernorm"]["scale"] = jnp.take(
+        local["input_layernorm"]["scale"], jnp.arange(CYCLE - 2), axis=SCAN_AXIS + 1
+    )
+    with self.assertRaisesRegex(ConversionPlanError, "nested cycle-slot axis"):
+      MaxTextToMaxTextConverter(_config()).convert(source, _target_tree())
 
   def test_plan_is_built_once_and_reused(self):
     converter = MaxTextToMaxTextConverter(_config())

--- a/tests/post_training/unit/weight_converter_test.py
+++ b/tests/post_training/unit/weight_converter_test.py
@@ -120,13 +120,7 @@ def _source_tree(fused_moe_on_target: bool):
 
 
 def _nested_source_tree(fused_moe_on_target: bool):
-  """Trainer state in the nested-scan layout `Qwen3NextScannableBlock` produces.
-
-  Same values as `_source_tree`, restacked the way the shared Qwen3-Next block
-  stores them: slots `0..C-2` share one `local_layers` module with the cycle
-  slot on `SCAN_AXIS + 1`, and slot `C-1` becomes `global_layer` with the block
-  axis alone. Converting either tree must yield the same rollout weights.
-  """
+  """Trainer state in the nested-scan layout `Qwen3NextScannableBlock` produces."""
   legacy = _source_tree(fused_moe_on_target)["base"]["decoder"]["layers"]
   local_slots = [legacy[f"layer_{slot}"] for slot in range(CYCLE - 1)]
   tree = _source_tree(fused_moe_on_target)
@@ -209,12 +203,7 @@ class ScannedToUnrolledMappingTest(unittest.TestCase):
     )
 
   def test_nested_scan_layout_converts_identically(self):
-    """Qwen3.5 moved onto Qwen3-Next's nested block scan.
-
-    The cycle's linear-attention layers now live in one `local_layers` module
-    with the slot on `SCAN_AXIS + 1` instead of one module per slot, so the
-    converter has to read that layout too -- and read it to the same answer.
-    """
+    """The nested-scan layout converts to the same rollout weights as the per-slot layout."""
     target = _target_tree()
     legacy = traverse_util.flatten_dict(MaxTextToMaxTextConverter(_config()).convert(_source_tree(True), target))
     nested = traverse_util.flatten_dict(MaxTextToMaxTextConverter(_config()).convert(_nested_source_tree(True), target))

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -460,6 +460,8 @@ def test_sparse_matmul_repairs_batch_specs_only_without_expert_parallelism(exper
       mesh=SimpleNamespace(shape={"fsdp": 32, "expert": expert_parallelism}),
       rngs=object(),
       get_expert_parallelism_size=lambda: expert_parallelism,
+      weight_dtype=jnp.float32,
+      dtype=jnp.bfloat16,
   )
   original_batch_partition = "fsdp" if expert_parallelism == 1 else ("fsdp", "expert")
   fake_moe._logical_to_mesh_axes = lambda logical_axes: P(  # pylint: disable=protected-access
@@ -500,6 +502,94 @@ def test_sparse_matmul_repairs_batch_specs_only_without_expert_parallelism(exper
   assert captured["in_specs"][2] is None
   assert captured["in_specs"][9] is None
   assert captured["out_specs"][0] == P(batch_partition, None, None)
+
+
+@pytest.mark.parametrize(
+    ("weight_dtype", "dtype", "expect_barrier"),
+    (
+        (jnp.bfloat16, jnp.bfloat16, True),
+        (jnp.float32, jnp.float32, True),
+        (jnp.float32, jnp.bfloat16, False),
+    ),
+)
+def test_sparse_matmul_pins_expert_kernel_all_gather_when_the_upcast_is_an_identity(weight_dtype, dtype, expect_barrier):
+  """Sparse MoE keeps the FSDP kernel gather from being hoisted out of a scanned decoder.
+
+  The kernel pspecs drop the fsdp axis so XLA emits the all-gather at the sharding
+  constraint. Under a scanned decoder the kernels are a per-layer dynamic-slice of a
+  stacked param, and with nothing between the slice and the collective XLA turns
+  all_gather(dynamic_slice(w)) into the loop-invariant dynamic_slice(all_gather(w)) and
+  hoists it, making every layer's gathered expert kernel live at once. The
+  `jnp.asarray(kernel, dtype)` upcast usually separates them; when weight_dtype == dtype
+  it is an identity, so an optimization barrier has to stand in for it.
+  """
+  fake_moe = SimpleNamespace(
+      config=SimpleNamespace(
+          shard_exp_on_fsdp=False,
+          use_2d_fsdp_sharding=False,
+          shard_embed_moe_on_fsdp=False,
+          model_name="qwen3.5-35b-a3b",
+          check_vma=False,
+          moe_fsdp_use_two_stage_all_gather=False,
+      ),
+      mesh=SimpleNamespace(shape={"fsdp": 32, "expert": 1}),
+      rngs=object(),
+      get_expert_parallelism_size=lambda: 1,
+      weight_dtype=weight_dtype,
+      dtype=dtype,
+  )
+  fake_moe._logical_to_mesh_axes = lambda logical_axes: P(  # pylint: disable=protected-access
+      *("fsdp" if axis == "activation_batch" else None for axis in logical_axes)
+  )
+  sharded = []
+
+  def record_shard(value, _pspec, **_kwargs):
+    sharded.append(value)
+    return value
+
+  fake_moe._maybe_shard_with_pspec = record_shard  # pylint: disable=protected-access
+
+  w0 = SimpleNamespace(shape=(256, 2048, 512))
+  w1 = SimpleNamespace(shape=(256, 2048, 512))
+  wo = SimpleNamespace(shape=(256, 512, 2048))
+  barriered = tuple(SimpleNamespace(shape=w.shape) for w in (w0, w1, wo))
+
+  def fake_shard_map(function, *, mesh, in_specs, out_specs, check_vma):
+    del function, mesh, in_specs, out_specs, check_vma
+    return lambda x, *_args: (x, None, None)
+
+  with (
+      mock.patch.object(jax, "shard_map", side_effect=fake_shard_map),
+      mock.patch.object(jax.lax, "optimization_barrier", return_value=barriered) as barrier,
+  ):
+    moe.RoutedMoE.sparse_matmul(
+        fake_moe,
+        SimpleNamespace(shape=(4, 1024, 2048)),
+        SimpleNamespace(shape=(4, 1024, 256)),
+        None,
+        w0,
+        w1,
+        wo,
+        None,
+        None,
+        None,
+    )
+
+  # Identity, not equality: the stand-in kernels all share a shape, so SimpleNamespace
+  # equality cannot tell a barrier output from the raw kernel it replaced.
+  def was_sharded(value):
+    return any(value is candidate for candidate in sharded)
+
+  if expect_barrier:
+    assert barrier.call_count == 1
+    assert all(a is b for a, b in zip(barrier.call_args.args[0], (w0, w1, wo), strict=True))
+    # The constraint must consume the barrier's outputs; a barrier whose results are
+    # dropped still lets XLA reorder the gather above the per-layer slice.
+    assert all(was_sharded(kernel) for kernel in barriered)
+    assert not any(was_sharded(kernel) for kernel in (w0, w1, wo))
+  else:
+    barrier.assert_not_called()
+    assert all(was_sharded(kernel) for kernel in (w0, w1, wo))
 
 
 class RoutedMoeTest(parameterized.TestCase):

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -513,16 +513,7 @@ def test_sparse_matmul_repairs_batch_specs_only_without_expert_parallelism(exper
     ),
 )
 def test_sparse_matmul_pins_expert_kernel_all_gather_when_the_upcast_is_an_identity(weight_dtype, dtype, expect_barrier):
-  """Sparse MoE keeps the FSDP kernel gather from being hoisted out of a scanned decoder.
-
-  The kernel pspecs drop the fsdp axis so XLA emits the all-gather at the sharding
-  constraint. Under a scanned decoder the kernels are a per-layer dynamic-slice of a
-  stacked param, and with nothing between the slice and the collective XLA turns
-  all_gather(dynamic_slice(w)) into the loop-invariant dynamic_slice(all_gather(w)) and
-  hoists it, making every layer's gathered expert kernel live at once. The
-  `jnp.asarray(kernel, dtype)` upcast usually separates them; when weight_dtype == dtype
-  it is an identity, so an optimization barrier has to stand in for it.
-  """
+  """Sparse MoE keeps the FSDP kernel gather from being hoisted out of a scanned decoder."""
   fake_moe = SimpleNamespace(
       config=SimpleNamespace(
           shard_exp_on_fsdp=False,
@@ -575,16 +566,12 @@ def test_sparse_matmul_pins_expert_kernel_all_gather_when_the_upcast_is_an_ident
         None,
     )
 
-  # Identity, not equality: the stand-in kernels all share a shape, so SimpleNamespace
-  # equality cannot tell a barrier output from the raw kernel it replaced.
   def was_sharded(value):
     return any(value is candidate for candidate in sharded)
 
   if expect_barrier:
     assert barrier.call_count == 1
     assert all(a is b for a, b in zip(barrier.call_args.args[0], (w0, w1, wo), strict=True))
-    # The constraint must consume the barrier's outputs; a barrier whose results are
-    # dropped still lets XLA reorder the gather above the per-layer slice.
     assert all(was_sharded(kernel) for kernel in barriered)
     assert not any(was_sharded(kernel) for kernel in (w0, w1, wo))
   else:

--- a/tests/unit/nnx_decoders_test.py
+++ b/tests/unit/nnx_decoders_test.py
@@ -52,7 +52,7 @@ from maxtext.layers.attentions import Attention
 from maxtext.layers.embeddings import Embed
 from maxtext.layers.nnx_decoders import NNXDecoder, NNXDecoderLayer, deepstack_process
 from maxtext.layers.normalizations import RMSNorm
-from maxtext.models import gemma4, gemma4_small, qwen3
+from maxtext.models import gemma4, gemma4_small, qwen3, qwen3_5
 from maxtext.models.gpt3 import Gpt3LayerNorm
 from maxtext.models.llama2 import LlamaDecoderLayer
 from maxtext.utils import maxtext_utils, maxtext_utils_nnx
@@ -894,26 +894,29 @@ _QWEN3_NEXT_CONFIG = {
 }
 
 
-def _build_qwen3_next_block(layer_idx_offset=0, **overrides):
-  """Builds one Qwen3-Next scannable block; overrides go to the config."""
-  cfg = _make_config(**{**_QWEN3_NEXT_CONFIG, **overrides})
-  block = qwen3.Qwen3NextScannableBlock(
-      config=cfg,
-      mesh=_make_mesh(cfg),
-      model_mode=MODEL_MODE_TRAIN,
-      layer_idx_offset=layer_idx_offset,
-      rngs=nnx.Rngs(0),
-  )
-  return cfg, block
-
-
 class TestQwen3NextScannableBlock(unittest.TestCase):
   """Tests Qwen3-Next's nested local(scan)/global(length-1 scan) decoder block."""
+
+  MODEL_CONFIG = _QWEN3_NEXT_CONFIG
+  BLOCK_CLS = qwen3.Qwen3NextScannableBlock
+
+  @classmethod
+  def _build(cls, layer_idx_offset=0, **overrides):
+    """Builds one scannable block; overrides go to the config, layer_idx_offset to the block."""
+    cfg = _make_config(**{**cls.MODEL_CONFIG, **overrides})
+    block = cls.BLOCK_CLS(
+        config=cfg,
+        mesh=_make_mesh(cfg),
+        model_mode=MODEL_MODE_TRAIN,
+        layer_idx_offset=layer_idx_offset,
+        rngs=nnx.Rngs(0),
+    )
+    return cfg, block
 
   @classmethod
   def setUpClass(cls):
     """Builds the block once; it costs several seconds and no test here mutates it."""
-    cls.cfg, cls.block = _build_qwen3_next_block()
+    cls.cfg, cls.block = cls._build()
 
   def _inputs(self, cfg):
     inputs = jax.random.normal(jax.random.PRNGKey(1), (1, cfg.max_target_length, cfg.emb_dim), dtype=jnp.float32)
@@ -972,16 +975,18 @@ class TestQwen3NextScannableBlock(unittest.TestCase):
     local-scan-then-global would silently reorder the model, so it is rejected.
     """
     with self.assertRaisesRegex(ValueError, "full-attention layer last"):
-      _build_qwen3_next_block(layer_idx_offset=1)
+      self._build(layer_idx_offset=1)
 
 
 class TestNNXDecoderQwen3Next(unittest.TestCase):
   """Tests the NNXDecoder-level wiring of the Qwen3-Next scanned blocks."""
 
+  MODEL_CONFIG = _QWEN3_NEXT_CONFIG
+
   def _build(self, num_decoder_layers, **overrides):
     """Builds a scanned Qwen3-Next decoder and its shared embedding."""
     cfg = _make_config(
-        **{**_QWEN3_NEXT_CONFIG, "base_num_decoder_layers": num_decoder_layers, "scan_layers": True, **overrides}
+        **{**self.MODEL_CONFIG, "base_num_decoder_layers": num_decoder_layers, "scan_layers": True, **overrides}
     )
     mesh = _make_mesh(cfg)
     decoder = NNXDecoder(config=cfg, mesh=mesh, model_mode=MODEL_MODE_TRAIN, rngs=nnx.Rngs(params=0, dropout=1))
@@ -1074,6 +1079,8 @@ class TestQwen3NextDecoderParity(unittest.TestCase):
   conversion on whichever side the mapping was not written against.
   """
 
+  MODEL_CONFIG = _QWEN3_NEXT_CONFIG
+
   def _param_tree(self, num_decoder_layers, pure_nnx_decoder):
     """Returns {parameter key: shape} for the chosen decoder implementation."""
     # pylint: disable=import-outside-toplevel
@@ -1081,7 +1088,7 @@ class TestQwen3NextDecoderParity(unittest.TestCase):
 
     cfg = _make_config(
         **{
-            **_QWEN3_NEXT_CONFIG,
+            **self.MODEL_CONFIG,
             "base_num_decoder_layers": num_decoder_layers,
             "scan_layers": True,
             "pure_nnx_decoder": pure_nnx_decoder,
@@ -1097,6 +1104,42 @@ class TestQwen3NextDecoderParity(unittest.TestCase):
     """6 layers is one whole period plus a two-layer remainder, which both decoders
     have to put in a `layers_remainder` block rather than spell out layer by layer."""
     self.assertEqual(self._param_tree(6, True), self._param_tree(6, False))
+
+
+# Qwen3.5 repeats Qwen3-Next's hybrid attention period and reuses its scannable
+# block, so it gets the same coverage over its own layer classes and config.
+_QWEN3_5_CONFIG = {
+    **_QWEN3_NEXT_CONFIG,
+    "run_name": "qwen3_5_scannable_block_test",
+    "model_name": "qwen3.5-35b-a3b",
+    # Qwen3.5 uses MRoPE, whose sections must cover rotary_dim / 2 frequencies. The
+    # shipped [11, 11, 10] is sized for the real head_dim (256), not this tiny one
+    # (32 * partial_rotary_factor 0.25 / 2 = 4).
+    "mrope_section": [2, 1, 1],
+}
+
+
+class TestQwen3_5ScannableBlock(TestQwen3NextScannableBlock):
+  """Runs the Qwen3-Next scannable-block tests against Qwen3.5's block."""
+
+  MODEL_CONFIG = _QWEN3_5_CONFIG
+  BLOCK_CLS = qwen3_5.Qwen3_5ScannableBlock
+
+  def test_block_uses_qwen3_5_layers(self):
+    """The block must build Qwen3.5 decoder layers, not Qwen3-Next ones."""
+    self.assertIsInstance(self.block.global_layer, qwen3_5.Qwen3_5DecoderLayer)
+
+
+class TestNNXDecoderQwen3_5(TestNNXDecoderQwen3Next):
+  """Runs the NNXDecoder wiring tests against Qwen3.5."""
+
+  MODEL_CONFIG = _QWEN3_5_CONFIG
+
+
+class TestQwen3_5DecoderParity(TestQwen3NextDecoderParity):
+  """Runs the Linen/NNX parameter-tree parity tests against Qwen3.5."""
+
+  MODEL_CONFIG = _QWEN3_5_CONFIG
 
 
 class TestNNXDecoderDeepseekAndGemma4(unittest.TestCase):

--- a/tests/unit/nnx_decoders_test.py
+++ b/tests/unit/nnx_decoders_test.py
@@ -902,7 +902,7 @@ class TestQwen3NextScannableBlock(unittest.TestCase):
 
   @classmethod
   def _build(cls, layer_idx_offset=0, **overrides):
-    """Builds one scannable block; overrides go to the config, layer_idx_offset to the block."""
+    """Builds one scannable block; overrides go to the config."""
     cfg = _make_config(**{**cls.MODEL_CONFIG, **overrides})
     block = cls.BLOCK_CLS(
         config=cfg,
@@ -1123,15 +1123,11 @@ class TestQwen3NextDecoderParity(unittest.TestCase):
     self.assertEqual(self._param_tree(6, True), self._param_tree(6, False))
 
 
-# Qwen3.5 repeats Qwen3-Next's hybrid attention period and reuses its scannable
-# block, so it gets the same coverage over its own layer classes and config.
 _QWEN3_5_CONFIG = {
     **_QWEN3_NEXT_CONFIG,
     "run_name": "qwen3_5_scannable_block_test",
     "model_name": "qwen3.5-35b-a3b",
-    # Qwen3.5 uses MRoPE, whose sections must cover rotary_dim / 2 frequencies. The
-    # shipped [11, 11, 10] is sized for the real head_dim (256), not this tiny one
-    # (32 * partial_rotary_factor 0.25 / 2 = 4).
+    # MRoPE sections must cover rotary_dim / 2, which is 4 here, not the shipped [11, 11, 10].
     "mrope_section": [2, 1, 1],
 }
 

--- a/tests/unit/nnx_decoders_test.py
+++ b/tests/unit/nnx_decoders_test.py
@@ -977,6 +977,23 @@ class TestQwen3NextScannableBlock(unittest.TestCase):
     with self.assertRaisesRegex(ValueError, "full-attention layer last"):
       self._build(layer_idx_offset=1)
 
+  def test_rejects_forced_routing_that_does_not_cover_every_sub_layer(self):
+    """Router replay is sliced per sub-layer, so a mismatched leading axis must not be broadcast."""
+    cfg, block = self.cfg, self.block
+    inputs, segment_ids, positions = self._inputs(cfg)
+    forced_routed_experts = jnp.zeros(
+        (block.num_of_layers + 1, 1, cfg.max_target_length, cfg.num_experts_per_tok), dtype=jnp.int32
+    )
+    with self.assertRaisesRegex(ValueError, "one slice per sub-layer"):
+      block(
+          inputs,
+          segment_ids,
+          positions,
+          True,
+          MODEL_MODE_TRAIN,
+          forced_routed_experts=forced_routed_experts,
+      )
+
 
 class TestNNXDecoderQwen3Next(unittest.TestCase):
   """Tests the NNXDecoder-level wiring of the Qwen3-Next scanned blocks."""

--- a/tests/unit/param_mapping_test.py
+++ b/tests/unit/param_mapping_test.py
@@ -24,6 +24,7 @@ pytestmark = [pytest.mark.decoupled_target]
 
 from maxtext.checkpoint_conversion.to_maxtext import _build_multi_axis_stacked_tensor
 from maxtext.checkpoint_conversion.utils import param_mapping
+from maxtext.checkpoint_conversion.utils import tensor_handling
 from maxtext.checkpoint_conversion.utils.utils import process_maxtext_param
 
 
@@ -141,6 +142,65 @@ class ParamMappingTest(unittest.TestCase):
     global_experts = mapping[f"{global_prefix}-mlp-routed_experts-wi_0"]
     self.assertEqual(len(global_experts), num_experts)
     self.assertEqual(len(global_experts[0]), num_blocks)
+
+  def test_qwen3_5_mapping_scanned(self):
+    """Qwen3.5 reuses Qwen3-Next's nested block scan, but stores its routed experts fused."""
+    num_layers, cycle = 8, 4
+    config = {"text_config": {"num_hidden_layers": num_layers}}
+    maxtext_config = mock.Mock()
+    maxtext_config.inhomogeneous_layer_cycle_interval = cycle
+    maxtext_config.use_multimodal = False
+    mapping = param_mapping.QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=True)
+
+    num_blocks, num_local = num_layers // cycle, cycle - 1
+    local_prefix = "params-decoder-layers-local_layers"
+    global_prefix = "params-decoder-layers-global_layer"
+    # Linear attention only exists on the local layers, full attention only on the global one.
+    self.assertIn(f"{local_prefix}-attention-in_proj_qkvz-kernel", mapping)
+    self.assertIn(f"{global_prefix}-attention-attention-query-kernel", mapping)
+    self.assertNotIn(f"{global_prefix}-attention-in_proj_qkvz-kernel", mapping)
+    self.assertNotIn(f"{local_prefix}-attention-attention-query-kernel", mapping)
+
+    # local_layers values are nested [block][local]; global_layer is flat over blocks.
+    # A tuple of HF names is a composite source the hook fuses, not a stacking axis.
+    local_val = mapping[f"{local_prefix}-attention-in_proj_qkvz-kernel"]
+    self.assertEqual(len(local_val), num_blocks)
+    self.assertEqual(len(local_val[0]), num_local)
+    self.assertEqual(
+        local_val[0][0],
+        (
+            "model.language_model.layers.0.linear_attn.in_proj_qkv.weight",
+            "model.language_model.layers.0.linear_attn.in_proj_z.weight",
+        ),
+    )
+    global_val = mapping[f"{global_prefix}-attention-attention-query-kernel"]
+    self.assertEqual(len(global_val), num_blocks)
+    # The full-attention layer is last in the period.
+    self.assertEqual(global_val[0], f"model.language_model.layers.{cycle - 1}.self_attn.q_proj.weight")
+
+    # Fused experts: one HF tensor feeds both wi_0 and wi_1, so it is keyed by the pair
+    # and carries no extra per-expert axis (unlike Qwen3-Next).
+    fused_local = mapping[(f"{local_prefix}-mlp-routed_experts-wi_0", f"{local_prefix}-mlp-routed_experts-wi_1")]
+    self.assertEqual(len(fused_local), num_blocks)
+    self.assertEqual(len(fused_local[0]), num_local)
+    self.assertEqual(fused_local[0][0], "model.language_model.layers.0.mlp.experts.gate_up_proj")
+    fused_global = mapping[(f"{global_prefix}-mlp-routed_experts-wi_0", f"{global_prefix}-mlp-routed_experts-wi_1")]
+    self.assertEqual(len(fused_global), num_blocks)
+
+  def test_qwen3_5_composite_key_uses_the_nested_scan_axes(self):
+    """A composite (tuple) MaxText key must still be recognised as a nested block scan.
+
+    Qwen3.5's fused gate_up_proj is keyed by the (wi_0, wi_1) pair, so a layout
+    check that only looks at `str` keys would place the (blocks, local) axes at
+    the leading positions and silently transpose the weights.
+    """
+    cfg = mock.Mock()
+    cfg.param_scan_axis = 1
+    local_key = "params-decoder-layers-local_layers-mlp-routed_experts-wi_0"
+    self.assertEqual(
+        tensor_handling.stacked_axes((local_key, local_key.replace("wi_0", "wi_1")), cfg, depth=2),
+        tensor_handling.stacked_axes(local_key, cfg, depth=2),
+    )
 
   @staticmethod
   def _indices_from_name(name):

--- a/tests/unit/param_mapping_test.py
+++ b/tests/unit/param_mapping_test.py
@@ -155,14 +155,11 @@ class ParamMappingTest(unittest.TestCase):
     num_blocks, num_local = num_layers // cycle, cycle - 1
     local_prefix = "params-decoder-layers-local_layers"
     global_prefix = "params-decoder-layers-global_layer"
-    # Linear attention only exists on the local layers, full attention only on the global one.
     self.assertIn(f"{local_prefix}-attention-in_proj_qkvz-kernel", mapping)
     self.assertIn(f"{global_prefix}-attention-attention-query-kernel", mapping)
     self.assertNotIn(f"{global_prefix}-attention-in_proj_qkvz-kernel", mapping)
     self.assertNotIn(f"{local_prefix}-attention-attention-query-kernel", mapping)
 
-    # local_layers values are nested [block][local]; global_layer is flat over blocks.
-    # A tuple of HF names is a composite source the hook fuses, not a stacking axis.
     local_val = mapping[f"{local_prefix}-attention-in_proj_qkvz-kernel"]
     self.assertEqual(len(local_val), num_blocks)
     self.assertEqual(len(local_val[0]), num_local)
@@ -175,11 +172,8 @@ class ParamMappingTest(unittest.TestCase):
     )
     global_val = mapping[f"{global_prefix}-attention-attention-query-kernel"]
     self.assertEqual(len(global_val), num_blocks)
-    # The full-attention layer is last in the period.
     self.assertEqual(global_val[0], f"model.language_model.layers.{cycle - 1}.self_attn.q_proj.weight")
 
-    # Fused experts: one HF tensor feeds both wi_0 and wi_1, so it is keyed by the pair
-    # and carries no extra per-expert axis (unlike Qwen3-Next).
     fused_local = mapping[(f"{local_prefix}-mlp-routed_experts-wi_0", f"{local_prefix}-mlp-routed_experts-wi_1")]
     self.assertEqual(len(fused_local), num_blocks)
     self.assertEqual(len(fused_local[0]), num_local)
@@ -188,12 +182,7 @@ class ParamMappingTest(unittest.TestCase):
     self.assertEqual(len(fused_global), num_blocks)
 
   def test_qwen3_5_composite_key_uses_the_nested_scan_axes(self):
-    """A composite (tuple) MaxText key must still be recognised as a nested block scan.
-
-    Qwen3.5's fused gate_up_proj is keyed by the (wi_0, wi_1) pair, so a layout
-    check that only looks at `str` keys would place the (blocks, local) axes at
-    the leading positions and silently transpose the weights.
-    """
+    """A composite (tuple) MaxText key must still be recognised as a nested block scan."""
     cfg = mock.Mock()
     cfg.param_scan_axis = 1
     local_key = "params-decoder-layers-local_layers-mlp-routed_experts-wi_0"

--- a/tests/unit/router_replay_test.py
+++ b/tests/unit/router_replay_test.py
@@ -704,11 +704,7 @@ class TrainerRouterReplayTest(unittest.TestCase):
     )
 
   def test_per_layer_routing_reaches_the_scan_remainder_block(self):
-    """Layers past the last whole cycle live in a separate remainder block.
-
-    With 3 layers and a cycle of 2 the scan covers layers 0-1 and layer 2 is
-    applied afterwards, so the remainder needs its own slice of the routing.
-    """
+    """Layers past the last whole cycle live in a separate remainder block."""
     seq_len, batch_size, top_k, num_experts = 8, 1, 2, 4
     cycle_interval, layers = 2, 3
     cfg = self._qwen35_cfg(
@@ -721,8 +717,6 @@ class TrainerRouterReplayTest(unittest.TestCase):
         num_decoder_layers=layers,
         inhomogeneous_layer_cycle_interval=cycle_interval,
     )
-    # Only the trailing (remainder) layer's routing differs between a and b, so
-    # the losses can only diverge if the remainder block replays its own slice.
     shared = jnp.zeros((batch_size, seq_len, layers, top_k), dtype=jnp.int32)
     a = shared.at[:, :, -1, :].set(1)
     b = shared.at[:, :, -1, :].set(3)

--- a/tests/unit/router_replay_test.py
+++ b/tests/unit/router_replay_test.py
@@ -703,6 +703,31 @@ class TrainerRouterReplayTest(unittest.TestCase):
         "qwen3.5 scanned per-layer",
     )
 
+  def test_per_layer_routing_reaches_the_scan_remainder_block(self):
+    """Layers past the last whole cycle live in a separate remainder block.
+
+    With 3 layers and a cycle of 2 the scan covers layers 0-1 and layer 2 is
+    applied afterwards, so the remainder needs its own slice of the routing.
+    """
+    seq_len, batch_size, top_k, num_experts = 8, 1, 2, 4
+    cycle_interval, layers = 2, 3
+    cfg = self._qwen35_cfg(
+        seq_len,
+        batch_size,
+        num_experts,
+        top_k,
+        "test_router_replay_scan_remainder",
+        base_num_decoder_layers=layers,
+        num_decoder_layers=layers,
+        inhomogeneous_layer_cycle_interval=cycle_interval,
+    )
+    # Only the trailing (remainder) layer's routing differs between a and b, so
+    # the losses can only diverge if the remainder block replays its own slice.
+    shared = jnp.zeros((batch_size, seq_len, layers, top_k), dtype=jnp.int32)
+    a = shared.at[:, :, -1, :].set(1)
+    b = shared.at[:, :, -1, :].set(3)
+    self._assert_routing_is_load_bearing(cfg, seq_len, batch_size, a, b, "qwen3.5 scan remainder")
+
   def test_loss_fn_with_forced_routed_experts_gemma4(self):
     """Gemma4 is supported unscanned only (its scanned path raises), and it is
 


### PR DESCRIPTION
## What

Extends the Qwen3-Next scanned-block work from #4964 to **Qwen3.5**.

Qwen3.5 repeats the exact same hybrid attention period as Qwen3-Next — `inhomogeneous_layer_cycle_interval = 4`, i.e. three GatedDeltaNet layers followed by one full-attention layer — so rather than porting the logic, this makes Qwen3.5 reuse it.

The two architectures now share the **decoder layer** as well as the block. `Qwen3_5DecoderLayer` subclasses `Qwen3NextDecoderLayer` and overrides only three factory hooks — `_make_full_attention`, `_make_linear_attention`, `_make_mlp` — so the forward pass, both LayerNorms, the residual structure, the `is_full_attention_layer` derivation and the MoE load-balance handling are inherited rather than duplicated. The hooks keep the submodule attribute names (`input_layernorm`, `attention`, `post_attention_layernorm`, `mlp`), so the checkpoint parameter paths are identical either way. `Qwen3_5ScannableBlock` likewise subclasses `Qwen3NextScannableBlock` and overrides only `_make_decoder_layer`.

`models/qwen3_5.py` goes from 266 to 127 lines. Qwen3.5 picks up the inner scan over the homogeneous linear-attention layers, the trip-count-one `lax.scan` scheduling barrier around the full-attention layer, and per-sub-layer remat, for free.

## Changes

- **`models/qwen3.py`** — extract sub-block construction from `Qwen3NextDecoderLayer.__init__` into `_make_full_attention()` / `_make_linear_attention()` / `_make_mlp()`, and layer construction from `Qwen3NextScannableBlock.__init__` into `_make_decoder_layer()`. These are the only points a sibling architecture has to diverge at. Also threads `forced_routed_experts` through the layer and the block (see below). No behavior change for Qwen3-Next.
- **`models/qwen3_5.py`** — `Qwen3_5DecoderLayer` and `Qwen3_5ScannableBlock` become thin subclasses that override the hooks. `Qwen3NextDecoderLayer` gains an explicit `is_full_attention_layer` kwarg, because inside a scan a sub-layer's position in the cycle is not recoverable from `layer_idx`; it still falls back to the `(layer_idx + 1) % cycle == 0` derivation when unscanned. The MoE load-balance loss is assigned rather than `sow`-n — `sow` appends to a tuple, so the layer's `Intermediate` structure grows on every call, which a `lax.scan` body cannot express.
- **`layers/decoders.py`, `layers/nnx_decoders.py`** — route `QWEN3_5` through the shared hybrid path. `_init_scanned_qwen3_next` / `_apply_qwen3_next_scanned_blocks` are renamed to `..._qwen3_hybrid_...` and pick the block class by `decoder_block`, including for `layers_remainder`. `forced_routed_experts_per_layer()` is factored out of `reshape_forced_routed_experts_for_scan()` so the hybrid path can slice routing per sub-layer.
- **`layers/nnx_scan.py`** — `apply_scanned_layers()` gains an optional `xs` pytree of per-layer scan inputs. Callers that pass no `xs` keep the two-argument `apply_fn` signature; Gemma4, the only other caller, is unchanged.
- **`layers/moe.py`** — hold the FSDP expert-kernel all-gather inside the decoder loop when `weight_dtype == dtype`. Not part of the port; it is a pre-existing bug in the scanned MoE path that this PR would otherwise widen to Qwen3.5. See [The `weight_dtype=bfloat16` blow-up](#the-weight_dtypebfloat16-blow-up-and-its-fix) below.
- **`checkpoint_conversion/utils/param_mapping.py`** — remap Qwen3.5's scanned checkpoint mapping from the old per-cycle-position `layers-layer_{i}` prefixes to the `local_layers` / `global_layer` tree, mirroring what #4964 did for Qwen3-Next. Local layers nest `[block][local]`, the global layer is flat `[block]`.
- **`checkpoint_conversion/utils/tensor_handling.py`** — `stacked_axes()` was guarded on `isinstance(mt_key, str)`, so Qwen3.5's composite `(wi_0, wi_1)` key (fed by one fused HF `gate_up_proj` tensor) fell through to the leading-axis MoE layout instead of the nested-scan layout and would have silently transposed those weights. Tuple keys now resolve via their first component.
- **`integration/vllm/weight_converter.py`, `integration/vllm/maxtext_vllm_rollout.py`** — teach the RL rollout weight sync to read the nested tree (see below).

## Results

AOT `temp_size_in_bytes` per device, using the config from `train_compile_test.py::test_qwen3_5` (`per_device_batch_size=1`, `max_target_length=1024`, `sparse_matmul`, `megablox`, `attention=flash`, `use_tokamax_splash`, `remat_policy=full` — the `base.yml` default — on both sides). Both sides freshly compiled against `main` @ `457040f7`:

| model | topology | before | after | delta |
|---|---|---|---|---|
| qwen3.5-35b-a3b | tpu7x-16 | 30.36 GB | **25.13 GB** | −17.2% ✅ |
| qwen3.5-35b-a3b | tpu7x-8 | 43.61 GB | 44.11 GB | +1.1% |
| qwen3.5-397b-a17b | v5p-512 | 75.62 GB | **46.01 GB** | −39.2% ✅ |
| qwen3.5-397b-a17b | v5p-128 | 128.05 GB (OOM) | 116.25 GB (OOM) | −9% |

Exact bytes: 35b/tpu7x-16 `30359507040 → 25132249440`; 35b/tpu7x-8 `43612869024 → 44113347456`; 397b/v5p-512 `75622737696 → 46011566848`. The 397b/v5p-128 OOM row is the original pre-rebase measurement and was not re-run.

**The saving is a roughly constant 5–7 GB, not a constant percentage.** Sweeping device count on identical silicon (qwen3.5-35b-a3b, tpu7x-N):

| devices | before | after | delta |
|---|---|---|---|
| 8 | 43.61 GB | 44.11 GB | +0.50 GB |
| 16 | 30.36 GB | 25.13 GB | −5.23 GB |
| 32 | 21.50 GB | 15.42 GB | −6.08 GB |
| 64 | 19.81 GB | 14.70 GB | −5.11 GB |
| 128 | 15.59 GB | 8.51 GB | −7.08 GB |

What shrinks with device count is the *baseline*, not the saving. The FSDP-sharded share of the working set falls as 1/N, while what this PR removes does not shard at all: `sparse_matmul` deliberately strips `fsdp` from the expert-kernel pspecs, so the gathered per-device MoE kernels are full size on every chip, and block-level remat keeps all four sub-layers' worth of them co-live. Per-sub-layer remat keeps one. The same absolute saving is therefore 17% of a 30 GB budget and 45% of a 16 GB one.

The cross-generation control agrees: v5p-128 and tpu7x-64 are both 64 JAX devices (v5p slice names count TensorCores) and start from quite different baselines — 16.16 GB and 19.81 GB — yet save 5.129 GB and 5.105 GB, within 0.5% of each other. v5p-512 (256 devices) saves 5.25 GB, 11.99 → 6.74 GB.

`argument_size_in_bytes` is unchanged in both directions (26.01 GB at 35b/tpu7x-16, 18.61 GB at 397b/v5p-512). Generated code size roughly halves on *every* row, including the ones where temp memory does not move — that is the nested scan replacing an unrolled cycle, and it is topology-independent: 35b/tpu7x-8 205 → 99 MB, 35b/tpu7x-16 210 → 99 MB, 397b/v5p-512 320 → 163 MB.

Real training on a v7-8 (qwen3.5-35b-a3b, synthetic data, `ici_fsdp_parallelism=8`, `per_device_batch_size=1`, `max_target_length=1024`, 6 steps) converges on both sides with matching loss curves (step 5: 7.056 before, 7.072 after — RNG-fork differences only). Memory there is a wash, 40.6 → 41.1 GB estimated temp, consistent with the tpu7x-8 row.

**The layer-sharing refactor is free.** Recompiling qwen3.5-35b-a3b at tpu7x-16 after collapsing `Qwen3_5DecoderLayer` onto `Qwen3NextDecoderLayer` and threading router replay gives `temp_size_in_bytes=25132249440`, `generated_code_size_in_bytes=99265536` — byte-identical to the build before the refactor.

## Test plan

All CPU-only, run individually against this branch:

| suite | result |
|---|---|
| `tests/unit/nnx_decoders_test.py` | 65 passed, 2 skipped (`-k Qwen3`: 17 passed, up from 7 on `main`) |
| `tests/unit/moe_test.py` | 38 passed, 40 skipped (TPU-only) |
| `tests/unit/router_replay_test.py` | 38 passed, 1 skipped |
| `tests/unit/nnx_scan_test.py` | 4 passed |
| `tests/unit/param_mapping_test.py` | 30 passed |
| `tests/post_training/unit/weight_converter_test.py` | 27 passed |

- The three Qwen3-Next test classes in `nnx_decoders_test.py` are parameterized by class attributes so the Qwen3.5 subclasses reuse them: nested-scan output matches a sequential unroll numerically, and the Linen and NNX parameter trees match, both for a whole number of periods and with a remainder. New: a block given forced routing that does not cover every sub-layer must raise.
- `moe_test.py` adds `test_sparse_matmul_pins_expert_kernel_all_gather_when_the_upcast_is_an_identity`, parameterized over `(bf16, bf16)`, `(f32, f32)` and `(f32, bf16)`. It asserts the barrier is applied exactly when the upcast is an identity, and — by object identity, since the stand-in kernels share a shape — that the sharding constraint consumes the barrier's outputs rather than the raw kernels, so a barrier whose results are dropped does not pass. Both matching-dtype cases fail without the `moe.py` change.
- `param_mapping_test.py` covers the `local_layers` / `global_layer` mapping shape and the composite-key axis fix.
- `router_replay_test.py` adds a case for the scan **remainder** block, where only the trailing layer's routing differs between two runs, so the losses can diverge only if the remainder replays its own slice. Reverting the `qwen3.py` / `nnx_scan.py` / `nnx_decoders.py` changes fails `test_loss_fn_with_forced_routed_experts_scanned_qwen3_5` and `test_per_layer_routing_is_not_broadcast_scanned`.
- `weight_converter_test.py` adds a nested-layout source tree and asserts it converts **byte-identically** to the per-slot layout, plus a truncated cycle-slot axis being rejected. Both fail if the `weight_converter.py` change is reverted.
- `tests/post_training/unit/vllm_rollout_unroll_test.py` adds a nested `local_layers` + `global_layer` unroll case and a missing-slot-axis rejection. This file needs `vllm` installed to import the module under test, so it was verified in CI-equivalent form by executing the unroll helpers in isolation: the nested layout produces a dense `layers_{0..7}` with every slot on its own layer, and the legacy per-slot and homogeneous paths are unchanged. The same check fails against `main`.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
