### PR TITLE
Support on-the-fly FP8 block dequantization in checkpoint utility for Qwen3.5

### DIFF
--- a/docs/guides/checkpointing_solutions/convert_checkpoint.md
+++ b/docs/guides/checkpointing_solutions/convert_checkpoint.md
@@ -83,8 +83,25 @@ You can find your converted checkpoint files under `${BASE_OUTPUT_DIRECTORY}/0/i
 - `base_output_directory`: The path where the converted Orbax checkpoint will be stored; it can be Google Cloud Storage (GCS) or local.
 - `hardware=cpu`: The conversion script runs on a CPU machine.
 - `checkpoint_storage_use_zarr3` and `checkpoint_storage_use_ocdbt`: These storage flags enable McJAX compatibility when set to True (the default). For Pathways, these should be False.
-- `--hf_model_path` (Optional): Specifies a customized remote directory or local directory containing the model weights. If unspecified, we use the [default Hugging Face repository ID](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/utils/globals.py) (e.g., openai/gpt-oss-20b). This is necessary for locally dequantized models like GPT-OSS or DeepSeek.
+- `--hf_model_path` (Optional): Specifies a customized remote directory or local directory containing the model weights. If unspecified, we use the [default Hugging Face repository ID](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/utils/globals.py) (e.g., openai/gpt-oss-20b). This is also used to point to FP8 quantized models like `Qwen/Qwen3.5-35B-A3B-FP8`.
 - `--save_dtype` (Optional): Specifies the data type of saved model weights. Default to `bfloat16` to save memory.
+
+### Converting FP8 Quantized Checkpoints (On-The-Fly Dequantization)
+
+For fine-grained FP8 block-quantized models on Hugging Face (e.g., `Qwen/Qwen3.5-35B-A3B-FP8`), `to_maxtext.py` automatically detects the quantization configuration from the Hugging Face `config.json` and dequantizes weights on-the-fly during checkpoint conversion into `bfloat16` MaxText checkpoints. This eliminates the need for separate offline dequantization or large intermediate disk storage.
+
+```bash
+python3 -m maxtext.checkpoint_conversion.to_maxtext \
+    src/maxtext/configs/base.yml \
+    model_name="qwen3.5-35b-a3b" \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
+    scan_layers=False \
+    hardware=cpu \
+    skip_jax_distributed_system=True \
+    --hf_model_path="Qwen/Qwen3.5-35B-A3B-FP8" \
+    --save_dtype="bfloat16" \
+    --lazy_load_tensors=True
+```
 
 ## MaxText to Hugging Face
 

--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -59,6 +59,13 @@ import time
 from typing import Any, Callable, List, Sequence
 import absl
 import ml_dtypes
+import numpy as np
+
+# Ensure safetensors and numpy recognize FP8 and BF16 types
+np.float8_e4m3fn = ml_dtypes.float8_e4m3fn
+np.float8_e5m2 = ml_dtypes.float8_e5m2
+np.bfloat16 = ml_dtypes.bfloat16
+
 import flax.linen as nn
 from huggingface_hub import hf_hub_download, list_repo_files
 import jax
@@ -74,7 +81,6 @@ from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.utils import max_logging, max_utils, maxtext_utils
 from maxtext.utils.globals import HF_IDS
-import numpy as np
 from orbax.checkpoint import type_handlers
 from safetensors import safe_open
 
@@ -340,8 +346,15 @@ def get_maxtext_model_info(config):
   return maxtext_abstract_dict, abstract_params_treedef
 
 
+def _recursive_get_tensor(getter, key):
+  """Recursively retrieves tensors from nested tuples or lists of keys."""
+  if isinstance(key, (list, tuple)):
+    return tuple(_recursive_get_tensor(getter, k) for k in key)
+  return getter(key)
+
+
 def _build_multi_axis_stacked_tensor(
-    hf_source_keys: List[List[str]],
+    hf_source_keys: List[List[Any]],
     tensor_getter_fn: Callable[[str], np.ndarray],
     hook_fns: Any,
     target_shape: tuple,
@@ -373,10 +386,7 @@ def _build_multi_axis_stacked_tensor(
     layer_tensors_for_expert = []
     # Inner loop iterates through layers for the current expert
     for hf_key_single in layer_keys_for_expert:
-      if isinstance(hf_key_single, (list, tuple)):
-        hf_tensor_numpy = tuple(tensor_getter_fn(k) for k in hf_key_single)
-      else:
-        hf_tensor_numpy = tensor_getter_fn(hf_key_single)
+      hf_tensor_numpy = _recursive_get_tensor(tensor_getter_fn, hf_key_single)
       processed_hf_tensor = apply_hook_fns(hf_tensor_numpy, mt_slice_shape, hook_fns)
       layer_tensors_for_expert.append(processed_hf_tensor)
     all_expert_tensors.append(np.stack(layer_tensors_for_expert, axis=0))
@@ -384,7 +394,7 @@ def _build_multi_axis_stacked_tensor(
 
 
 def _build_single_axis_stacked_tensor(
-    hf_source_keys: List[str],
+    hf_source_keys: List[Any],
     tensor_getter_fn: Callable[[str], np.ndarray],
     hook_fns: Any,
     target_shape: tuple,
@@ -421,10 +431,7 @@ def _build_single_axis_stacked_tensor(
   mt_slice_shape = tuple(mt_slice_shape_list)
 
   for hf_key_single in hf_source_keys:
-    if isinstance(hf_key_single, (list, tuple)):
-      hf_tensor_numpy = tuple(tensor_getter_fn(k) for k in hf_key_single)
-    else:
-      hf_tensor_numpy = tensor_getter_fn(hf_key_single)
+    hf_tensor_numpy = _recursive_get_tensor(tensor_getter_fn, hf_key_single)
     processed_hf_tensor = apply_hook_fns(hf_tensor_numpy, mt_slice_shape, hook_fns)
     tensors_to_stack.append(processed_hf_tensor)
 
@@ -450,10 +457,8 @@ def _get_hf_loading_function(hf_source_keys_or_key, tensor_getter, hook_fn, mt_t
   if not isinstance(hf_source_keys_or_key, list):
     # Case 1: Single hf key (str)
     def _loader(getter, key, shape, hook):
-      if isinstance(key, (list, tuple)):
-        tensors = tuple(getter(k) for k in key)
-        return apply_hook_fns(tensors, shape, hook)
-      return apply_hook_fns(getter(key), shape, hook)
+      tensors = _recursive_get_tensor(getter, key)
+      return apply_hook_fns(tensors, shape, hook)
 
     load_fn = partial(
         _loader,
@@ -982,6 +987,18 @@ def main(
     # load config
     hf_config_obj = HF_MODEL_CONFIGS[model_key]
     hf_config_dict = hf_config_obj.to_dict()
+    if model_id:
+      try:
+        if os.path.isdir(model_id):
+          config_file = os.path.join(model_id, "config.json")
+        else:
+          config_file = hf_hub_download(repo_id=model_id, filename="config.json", token=hf_token, revision=revision)
+        with open(config_file, "r") as f:
+          loaded_hf_cfg = json.load(f)
+        if "quantization_config" in loaded_hf_cfg:
+          hf_config_dict["quantization_config"] = loaded_hf_cfg["quantization_config"]
+      except Exception as e:
+        max_logging.log(f"Note: Could not load quantization_config from {model_id}: {e}")
     # example of param mapping (gemma2, maxtext:huggingface):
     # "params-decoder-layers_{maxtext_layer_idx}-pre_self_attention_norm_global-scale":
     #   f"model.layers.{global_layer_idx}.input_layernorm.weight",

--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -16,13 +16,15 @@
 
 This script supports three conversion modes:
 1. Base: Converts a standard Hugging Face model to MaxText format.
+   Also supports on-the-fly FP8 block dequantization for FP8-quantized Hugging Face models
+   (e.g., Qwen 3.5 FP8) by passing `--hf_model_path`.
 2. Adapter: Converts a standalone Hugging Face LoRA adapter to MaxText PEFT format.
    (Requires `hf_lora_adapter_path` in config, and `load_parameters_path` should be empty)
 3. Merged: Merges a Hugging Face LoRA adapter into the base weights during conversion.
    (Requires both `hf_lora_adapter_path` and `load_parameters_path` to be set/not empty)
 
 Key Parameters (to be set in the config file or as command-line overrides):
-  model_name: (Required) The name of the model to convert (e.g., "gemma3-4b").
+  model_name: (Required) The name of the model to convert (e.g., "gemma3-4b", "qwen3.5-35b-a3b").
               Must be a key in `maxtext.utils.globals.HF_IDS`.
   base_output_directory: (Optional) The directory where the converted checkpoint
                          will be saved. Can be a local or GCS path.
@@ -31,22 +33,33 @@ Key Parameters (to be set in the config file or as command-line overrides):
   scan_layers: (bool) Whether the MaxText model was trained with scanned layers.
   --lazy_load_tensors: (bool) If True, uses an on-demand loading strategy to minimize RAM
              usage during conversion. Recommended for large models.
-  --hf_model_path: (Optional) Specifies a local or remote directory containing the base HF weights.
+  --hf_model_path: (Optional) Specifies a local or remote directory / HF repo containing the base HF weights.
   --save_dtype: (Optional) Data type of saved weights. Default to `bfloat16`.
 
 Environment Variables:
   HF_AUTH_TOKEN: (Required) HuggingFace authentication token.
 
 Example Usage:
-  To merge a HF LoRA adapter into base weights and save as a MaxText checkpoint:
+  1. To merge a HF LoRA adapter into base weights and save as a MaxText checkpoint:
 
-   python -m maxtext.checkpoint_conversion.to_maxtext \
-    maxtext/configs/base.yml model_name="gemma3-4b" \
-    load_parameters_path="gs://my-bucket/maxtext-base-weights" \
-    hf_lora_adapter_path="my-user/my-lora-adapter" \
-    base_output_directory="gs://my-bucket/maxtext-merged-output" \
-    hf_access_token=${HF_TOKEN?} hardware=cpu skip_jax_distributed_system=True \
-    scan_layers=True
+     python -m maxtext.checkpoint_conversion.to_maxtext \
+      maxtext/configs/base.yml model_name="gemma3-4b" \
+      load_parameters_path="gs://my-bucket/maxtext-base-weights" \
+      hf_lora_adapter_path="my-user/my-lora-adapter" \
+      base_output_directory="gs://my-bucket/maxtext-merged-output" \
+      hf_access_token=${HF_TOKEN?} hardware=cpu skip_jax_distributed_system=True \
+      scan_layers=True
+
+  2. To convert an FP8-quantized Hugging Face model (with on-the-fly dequantization):
+
+     python -m maxtext.checkpoint_conversion.to_maxtext \
+      src/maxtext/configs/base.yml model_name="qwen3.5-35b-a3b" \
+      base_output_directory="gs://my-bucket/qwen3.5-35b-a3b-dequant" \
+      hardware=cpu skip_jax_distributed_system=True \
+      scan_layers=False \
+      --hf_model_path="Qwen/Qwen3.5-35B-A3B-FP8" \
+      --save_dtype="bfloat16" \
+      --lazy_load_tensors=True
 """
 
 import argparse

--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -74,7 +74,7 @@ from maxtext.configs.types import DType
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.checkpoint_conversion.utils.hf_model_configs import HF_MODEL_CONFIGS
 from maxtext.checkpoint_conversion.utils.param_mapping import HOOK_FNS, PARAM_MAPPING
-from maxtext.checkpoint_conversion.utils.tensor_handling import apply_hook_fns
+from maxtext.checkpoint_conversion.utils.tensor_handling import _recursive_get_tensor, apply_hook_fns
 from maxtext.checkpoint_conversion.utils.utils import MemoryMonitorTqdm, load_hf_dict_from_transformers, load_hf_dict_from_safetensors, param_key_parts_from_path, print_peak_memory, print_ram_usage, save_weights_to_checkpoint, validate_and_filter_param_map_keys
 from maxtext.inference.inference_utils import str2bool
 from maxtext.layers import quantizations
@@ -344,13 +344,6 @@ def get_maxtext_model_info(config):
     maxtext_abstract_dict[mt_param_key] = (mt_target_idx, mt_target_shape)
 
   return maxtext_abstract_dict, abstract_params_treedef
-
-
-def _recursive_get_tensor(getter, key):
-  """Recursively retrieves tensors from nested tuples or lists of keys."""
-  if isinstance(key, (list, tuple)):
-    return tuple(_recursive_get_tensor(getter, k) for k in key)
-  return getter(key)
 
 
 def _build_multi_axis_stacked_tensor(

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -905,18 +905,14 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
   """
   text_cfg = config.get("text_config", config)
   num_main_layers = text_cfg["num_hidden_layers"]
-  num_experts = text_cfg.get("num_experts", text_cfg.get("num_local_experts", maxtext_config.num_experts if hasattr(maxtext_config, "num_experts") else 256))
+  num_experts = text_cfg.get("num_experts")
   layer_cycle_interval = maxtext_config.inhomogeneous_layer_cycle_interval
 
   quant_cfg = config.get("quantization_config", {})
-  is_fp8 = (
-      (isinstance(quant_cfg, dict) and quant_cfg.get("quant_method") == "fp8")
-      or ("fp8" in str(getattr(maxtext_config, "hf_model_path", "")).lower())
-      or ("fp8" in str(getattr(maxtext_config, "load_parameters_path", "")).lower())
-      or ("fp8" in str(getattr(maxtext_config, "model_name", "")).lower())
-  )
+  is_fp8 = isinstance(quant_cfg, dict) and quant_cfg.get("quant_method") == "fp8"
 
   def hf_w(key: str):
+    """Maps an HF parameter key to a (weight, scale_inv) tuple if quantized, or returns the key as is."""
     if is_fp8:
       unquantized_patterns = [
           "embed_tokens",
@@ -1214,10 +1210,7 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
   """
 
   def transpose(input_tensor, target_shape=None):
-    input_tensor = maybe_dequantize(input_tensor)
-    if target_shape is not None and not saving_to_hf:
-      return input_tensor.T.reshape(target_shape)
-    return input_tensor.T
+    return maybe_dequantize(input_tensor).T
 
   def reshape_kernel(input_tensor, target_shape):
     if saving_to_hf:

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -52,10 +52,60 @@ parameter from the source checkpoint and build the target checkpoint.
 """
 
 import warnings
+import ml_dtypes
 import numpy as np
+
+# Ensure safetensors and numpy recognize FP8 and BF16 types
+np.float8_e4m3fn = ml_dtypes.float8_e4m3fn
+np.float8_e5m2 = ml_dtypes.float8_e5m2
+np.bfloat16 = ml_dtypes.bfloat16
 
 import jax
 import jax.numpy as jnp
+
+
+def dequantize_fp8_block(weight, scale_inv, block_size=(128, 128)):
+  """Vectorized FP8 block dequantization in NumPy/JAX.
+
+  Args:
+    weight: quantized array of shape (..., M, N) with dtype float8_e4m3fn.
+    scale_inv: inverse scale array of shape (..., ceil(M/bk_m), ceil(N/bk_n)).
+    block_size: tuple of block dimensions, default (128, 128).
+
+  Returns:
+    Dequantized array of shape matching weight.
+  """
+  if not isinstance(weight, np.ndarray):
+    weight = np.array(weight)
+  if not isinstance(scale_inv, np.ndarray):
+    scale_inv = np.array(scale_inv)
+
+  m, n = weight.shape[-2], weight.shape[-1]
+  bk_m, bk_n = block_size
+
+  if m % bk_m == 0 and n % bk_n == 0:
+    m_blocks = m // bk_m
+    n_blocks = n // bk_n
+    prefix_shape = weight.shape[:-2]
+    w_reshaped = weight.astype(np.float32).reshape(prefix_shape + (m_blocks, bk_m, n_blocks, bk_n))
+    s_reshaped = scale_inv.astype(np.float32).reshape(prefix_shape + (m_blocks, 1, n_blocks, 1))
+    dequant = (w_reshaped * s_reshaped).reshape(weight.shape)
+  else:
+    s_expanded = np.repeat(np.repeat(scale_inv, bk_m, axis=-2), bk_n, axis=-1)
+    s_expanded = s_expanded[..., :m, :n]
+    dequant = weight.astype(np.float32) * s_expanded.astype(np.float32)
+
+  return dequant
+
+
+def maybe_dequantize(tensor):
+  """Dequantizes tensor if it is a (weight, scale_inv) tuple, otherwise returns tensor as is."""
+  if isinstance(tensor, (tuple, list)) and len(tensor) == 2 and not isinstance(tensor[0], (tuple, list)):
+    w, s = tensor
+    if hasattr(w, "shape") and hasattr(s, "shape"):
+      return dequantize_fp8_block(w, s)
+  return tensor
+
 
 
 def GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
@@ -840,22 +890,56 @@ def QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, 
 
 
 def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
-  """
-  Returns:
+  """Returns:
     dict: A mapping where keys are `atomic_mt_key` (single MaxText parameter) or
     `composite_mt_key` (a tuple of MaxText parameters). Values are Hugging Face parameter
-    names ...
+    names.
 
   Notes:
   - Handles the inhomogeneous scan block structure
   - Handles `composite_mt_key`: multiple MaxText keys map to HF key(s)
-    - (mlp-routed_experts-wi_0, mlp-routed_experts-wi_1): mlp.experts.gate_up_proj
   - Handles `composite_hf_key`: MaxText key(s) map to multiple HF keys
     - attention-in_proj_qkvz-kernel: (linear_attn.in_proj_qkv.weight, linear_attn.in_proj_z.weight)
-    - attention-in_proj_ba-kernel: (linear_attn.in_proj_b.weight, linear_attn.in_proj_a.weight")
+    - attention-in_proj_ba-kernel: (linear_attn.in_proj_b.weight, linear_attn.in_proj_a.weight)
+  - Supports on-the-fly FP8 block dequantization for FP8 quantized checkpoints
   """
-  num_main_layers = config["text_config"]["num_hidden_layers"]
+  text_cfg = config.get("text_config", config)
+  num_main_layers = text_cfg["num_hidden_layers"]
+  num_experts = text_cfg.get("num_experts", text_cfg.get("num_local_experts", maxtext_config.num_experts if hasattr(maxtext_config, "num_experts") else 256))
   layer_cycle_interval = maxtext_config.inhomogeneous_layer_cycle_interval
+
+  quant_cfg = config.get("quantization_config", {})
+  is_fp8 = (
+      (isinstance(quant_cfg, dict) and quant_cfg.get("quant_method") == "fp8")
+      or ("fp8" in str(getattr(maxtext_config, "hf_model_path", "")).lower())
+      or ("fp8" in str(getattr(maxtext_config, "load_parameters_path", "")).lower())
+      or ("fp8" in str(getattr(maxtext_config, "model_name", "")).lower())
+  )
+
+  def hf_w(key: str):
+    if is_fp8:
+      unquantized_patterns = [
+          "embed_tokens",
+          "norm",
+          "conv1d",
+          "in_proj_a",
+          "in_proj_b",
+          "A_log",
+          "dt_bias",
+          "q_norm",
+          "k_norm",
+          "input_layernorm",
+          "post_attention_layernorm",
+          "shared_expert_gate",
+          "mlp.gate",
+      ]
+      if any(pat in key for pat in unquantized_patterns) or key.startswith("lm_head"):
+        return key
+      scale_key = key.replace(".weight", ".weight_scale_inv")
+      if scale_key == key:
+        scale_key = key + "_scale_inv"
+      return (key, scale_key)
+    return key
 
   # 1. Non-layer specific weight mappings
   mapping = {
@@ -885,16 +969,16 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
         mapping.update(
             {
                 f"{prefix}-attention-attention-query-kernel": [
-                    f"model.language_model.layers.{i}.self_attn.q_proj.weight" for i in hf_indices
+                    hf_w(f"model.language_model.layers.{i}.self_attn.q_proj.weight") for i in hf_indices
                 ],
                 f"{prefix}-attention-attention-key-kernel": [
-                    f"model.language_model.layers.{i}.self_attn.k_proj.weight" for i in hf_indices
+                    hf_w(f"model.language_model.layers.{i}.self_attn.k_proj.weight") for i in hf_indices
                 ],
                 f"{prefix}-attention-attention-value-kernel": [
-                    f"model.language_model.layers.{i}.self_attn.v_proj.weight" for i in hf_indices
+                    hf_w(f"model.language_model.layers.{i}.self_attn.v_proj.weight") for i in hf_indices
                 ],
                 f"{prefix}-attention-attention-out-kernel": [
-                    f"model.language_model.layers.{i}.self_attn.o_proj.weight" for i in hf_indices
+                    hf_w(f"model.language_model.layers.{i}.self_attn.o_proj.weight") for i in hf_indices
                 ],
                 f"{prefix}-attention-attention-query_norm-scale": [
                     f"model.language_model.layers.{i}.self_attn.q_norm.weight" for i in hf_indices
@@ -911,8 +995,8 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
                 # Provide a tuple of HF keys so MaxText concatenates them into qkvz
                 f"{prefix}-attention-in_proj_qkvz-kernel": [
                     (
-                        f"model.language_model.layers.{i}.linear_attn.in_proj_qkv.weight",
-                        f"model.language_model.layers.{i}.linear_attn.in_proj_z.weight",
+                        hf_w(f"model.language_model.layers.{i}.linear_attn.in_proj_qkv.weight"),
+                        hf_w(f"model.language_model.layers.{i}.linear_attn.in_proj_z.weight"),
                     )
                     for i in hf_indices
                 ],
@@ -935,7 +1019,7 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
                     f"model.language_model.layers.{i}.linear_attn.norm.weight" for i in hf_indices
                 ],
                 f"{prefix}-attention-out_proj-kernel": [
-                    f"model.language_model.layers.{i}.linear_attn.out_proj.weight" for i in hf_indices
+                    hf_w(f"model.language_model.layers.{i}.linear_attn.out_proj.weight") for i in hf_indices
                 ],
             }
         )
@@ -947,13 +1031,13 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
                   f"model.language_model.layers.{i}.mlp.gate.weight" for i in hf_indices
               ],
               f"{prefix}-mlp-shared_expert-wi_0-kernel": [
-                  f"model.language_model.layers.{i}.mlp.shared_expert.gate_proj.weight" for i in hf_indices
+                  hf_w(f"model.language_model.layers.{i}.mlp.shared_expert.gate_proj.weight") for i in hf_indices
               ],
               f"{prefix}-mlp-shared_expert-wi_1-kernel": [
-                  f"model.language_model.layers.{i}.mlp.shared_expert.up_proj.weight" for i in hf_indices
+                  hf_w(f"model.language_model.layers.{i}.mlp.shared_expert.up_proj.weight") for i in hf_indices
               ],
               f"{prefix}-mlp-shared_expert-wo-kernel": [
-                  f"model.language_model.layers.{i}.mlp.shared_expert.down_proj.weight" for i in hf_indices
+                  hf_w(f"model.language_model.layers.{i}.mlp.shared_expert.down_proj.weight") for i in hf_indices
               ],
               f"{prefix}-mlp-shared_expert_gate-kernel": [
                   f"model.language_model.layers.{i}.mlp.shared_expert_gate.weight" for i in hf_indices
@@ -965,10 +1049,16 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
       mapping.update(
           {
               f"{prefix}-mlp-routed_experts-wo": [
-                  f"model.language_model.layers.{i}.mlp.experts.down_proj" for i in hf_indices
+                  [hf_w(f"model.language_model.layers.{i}.mlp.experts.{e}.down_proj.weight") for i in hf_indices]
+                  for e in range(num_experts)
               ],
-              (f"{prefix}-mlp-routed_experts-wi_0", f"{prefix}-mlp-routed_experts-wi_1"): [
-                  f"model.language_model.layers.{i}.mlp.experts.gate_up_proj" for i in hf_indices
+              f"{prefix}-mlp-routed_experts-wi_0": [
+                  [hf_w(f"model.language_model.layers.{i}.mlp.experts.{e}.gate_proj.weight") for i in hf_indices]
+                  for e in range(num_experts)
+              ],
+              f"{prefix}-mlp-routed_experts-wi_1": [
+                  [hf_w(f"model.language_model.layers.{i}.mlp.experts.{e}.up_proj.weight") for i in hf_indices]
+                  for e in range(num_experts)
               ],
           }
       )
@@ -989,10 +1079,10 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
       if is_full_attention_layer:
         mapping.update(
             {
-                f"{prefix}-attention-attention-query-kernel": f"model.language_model.layers.{i}.self_attn.q_proj.weight",
-                f"{prefix}-attention-attention-key-kernel": f"model.language_model.layers.{i}.self_attn.k_proj.weight",
-                f"{prefix}-attention-attention-value-kernel": f"model.language_model.layers.{i}.self_attn.v_proj.weight",
-                f"{prefix}-attention-attention-out-kernel": f"model.language_model.layers.{i}.self_attn.o_proj.weight",
+                f"{prefix}-attention-attention-query-kernel": hf_w(f"model.language_model.layers.{i}.self_attn.q_proj.weight"),
+                f"{prefix}-attention-attention-key-kernel": hf_w(f"model.language_model.layers.{i}.self_attn.k_proj.weight"),
+                f"{prefix}-attention-attention-value-kernel": hf_w(f"model.language_model.layers.{i}.self_attn.v_proj.weight"),
+                f"{prefix}-attention-attention-out-kernel": hf_w(f"model.language_model.layers.{i}.self_attn.o_proj.weight"),
                 f"{prefix}-attention-attention-query_norm-scale": f"model.language_model.layers.{i}.self_attn.q_norm.weight",
                 f"{prefix}-attention-attention-key_norm-scale": f"model.language_model.layers.{i}.self_attn.k_norm.weight",
             }
@@ -1003,8 +1093,8 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
             {
                 # Provide a tuple of HF keys so MaxText concatenates them into qkvz
                 f"{prefix}-attention-in_proj_qkvz-kernel": (
-                    f"model.language_model.layers.{i}.linear_attn.in_proj_qkv.weight",
-                    f"model.language_model.layers.{i}.linear_attn.in_proj_z.weight",
+                    hf_w(f"model.language_model.layers.{i}.linear_attn.in_proj_qkv.weight"),
+                    hf_w(f"model.language_model.layers.{i}.linear_attn.in_proj_z.weight"),
                 ),
                 # Provide a tuple of HF keys so MaxText concatenates them into ba
                 f"{prefix}-attention-in_proj_ba-kernel": (
@@ -1015,7 +1105,7 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
                 f"{prefix}-attention-A_log": f"model.language_model.layers.{i}.linear_attn.A_log",
                 f"{prefix}-attention-dt_bias": f"model.language_model.layers.{i}.linear_attn.dt_bias",
                 f"{prefix}-attention-norm-rms_norm-scale": f"model.language_model.layers.{i}.linear_attn.norm.weight",
-                f"{prefix}-attention-out_proj-kernel": f"model.language_model.layers.{i}.linear_attn.out_proj.weight",
+                f"{prefix}-attention-out_proj-kernel": hf_w(f"model.language_model.layers.{i}.linear_attn.out_proj.weight"),
             }
         )
 
@@ -1025,9 +1115,9 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
       mapping.update(
           {
               f"{prefix}-mlp-routed_experts-gate-kernel": (f"{hf_mlp}.gate.weight"),
-              f"{prefix}-mlp-shared_expert-wi_0-kernel": (f"{hf_mlp}.shared_expert.gate_proj.weight"),
-              f"{prefix}-mlp-shared_expert-wi_1-kernel": (f"{hf_mlp}.shared_expert.up_proj.weight"),
-              f"{prefix}-mlp-shared_expert-wo-kernel": (f"{hf_mlp}.shared_expert.down_proj.weight"),
+              f"{prefix}-mlp-shared_expert-wi_0-kernel": hf_w(f"{hf_mlp}.shared_expert.gate_proj.weight"),
+              f"{prefix}-mlp-shared_expert-wi_1-kernel": hf_w(f"{hf_mlp}.shared_expert.up_proj.weight"),
+              f"{prefix}-mlp-shared_expert-wo-kernel": hf_w(f"{hf_mlp}.shared_expert.down_proj.weight"),
               f"{prefix}-mlp-shared_expert_gate-kernel": (f"{hf_mlp}.shared_expert_gate.weight"),
           }
       )
@@ -1035,11 +1125,15 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
       # MoE Routed Experts
       mapping.update(
           {
-              f"{prefix}-mlp-routed_experts-wo": f"model.language_model.layers.{i}.mlp.experts.down_proj",
-              (
-                  f"{prefix}-mlp-routed_experts-wi_0",
-                  f"{prefix}-mlp-routed_experts-wi_1",
-              ): f"model.language_model.layers.{i}.mlp.experts.gate_up_proj",
+              f"{prefix}-mlp-routed_experts-wo": [
+                  hf_w(f"model.language_model.layers.{i}.mlp.experts.{e}.down_proj.weight") for e in range(num_experts)
+              ],
+              f"{prefix}-mlp-routed_experts-wi_0": [
+                  hf_w(f"model.language_model.layers.{i}.mlp.experts.{e}.gate_proj.weight") for e in range(num_experts)
+              ],
+              f"{prefix}-mlp-routed_experts-wi_1": [
+                  hf_w(f"model.language_model.layers.{i}.mlp.experts.{e}.up_proj.weight") for e in range(num_experts)
+              ],
           }
       )
 
@@ -1104,8 +1198,7 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
 
 
 def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
-  """
-  Transformation hooks for parameters using hyphenated 'params-' MaxText keys.
+  """Transformation hooks for parameters using hyphenated 'params-' MaxText keys.
 
   Notes:
   - Handles the inhomogeneous scan block structure
@@ -1115,11 +1208,15 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
   - Handles `composite_hf_key`: MaxText key(s) map to multiple HF keys
     - attention-in_proj_qkvz-kernel: (linear_attn.in_proj_qkv.weight, linear_attn.in_proj_z.weight),
     transformed via `concat_qkvz_and_transpose` function
-    - attention-in_proj_ba-kernel: (linear_attn.in_proj_b.weight, linear_attn.in_proj_a.weight"),
+    - attention-in_proj_ba-kernel: (linear_attn.in_proj_b.weight, linear_attn.in_proj_a.weight),
     transformed via `concat_ba_and_transpose` function
+  - Dequantizes FP8 (weight, scale_inv) tuples on-the-fly.
   """
 
   def transpose(input_tensor, target_shape=None):
+    input_tensor = maybe_dequantize(input_tensor)
+    if target_shape is not None and not saving_to_hf:
+      return input_tensor.T.reshape(target_shape)
     return input_tensor.T
 
   def reshape_kernel(input_tensor, target_shape):
@@ -1127,6 +1224,7 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
       flipped_target_shape = np.flip(np.array(target_shape))
       return input_tensor.reshape(flipped_target_shape).T
     else:
+      input_tensor = maybe_dequantize(input_tensor)
       return input_tensor.T.reshape(target_shape)
 
   def permute_conv(input_tensor, target_shape=None):
@@ -1135,41 +1233,34 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
 
   def transpose_expert(input_tensor, target_shape=None):
     # HF: (experts, out, in) <-> MT: (experts, in, out)
+    input_tensor = maybe_dequantize(input_tensor)
     if saving_to_hf:
       return input_tensor.transpose(0, 2, 1)
     else:
+      if input_tensor.ndim == 2:
+        return input_tensor.T
       return input_tensor.transpose(0, 2, 1)
 
   def process_wi_0_wi_1(input_tensor, target_shape=None):
-    """
-    Handles `composite_mt_key`: maxtext (wi_0, wi_1) <-> hf (gate_up_proj)
-    - if saving_to_hf: (wi_0, wi_1) -> gate_up_proj
-      - input_tensor is a tuple of two tensors, tensor ORDER must be same as key order
-      - return a single tensor
-    - otherwise: gate_up_proj -> (wi_0, wi_1)
-      - input_tensor is a single tensor
-      - return two tensors stacked at LAST index -1, tensor ORDER must be same as key order
-    """
+    """Handles `composite_mt_key`: maxtext (wi_0, wi_1) <-> hf (gate_up_proj)."""
     if saving_to_hf:
-      # 1. MaxText -> HF (Fusing)
-      # input_tensor is a tuple of the two extracted MaxText arrays: (wi_0, wi_1)
       wi_0, wi_1 = input_tensor
-      # Concatenate them along the final feature dimension
       gate_up = np.concatenate([wi_0, wi_1], axis=-1)
-      # Transpose to match Hugging Face's expected layout: (experts, 2 * out_features, in_features)
       return gate_up.swapaxes(-1, -2)
     else:
-      # 2. HF -> MaxText (Splitting)
-      # input_tensor is the massive HF gate_up_proj. Shape: (..., out, in)
-      # Split into gate and up along the output dimension (axis=-2 for transposed shape logic)
-      gate, up = np.split(input_tensor, 2, axis=-2)
-
-      # Swap the last two dimensions
-      gate = gate.swapaxes(-1, -2)
-      up = up.swapaxes(-1, -2)
-
-      # Stack them along a new final dimension so the base conversion script can iterate and split them
-      return np.stack([gate, up], axis=-1)
+      input_tensor = maybe_dequantize(input_tensor)
+      if isinstance(input_tensor, (tuple, list)) and len(input_tensor) == 2:
+        gate, up = input_tensor
+        gate = maybe_dequantize(gate)
+        up = maybe_dequantize(up)
+        gate = gate.swapaxes(-1, -2)
+        up = up.swapaxes(-1, -2)
+        return np.stack([gate, up], axis=-1)
+      else:
+        gate, up = np.split(input_tensor, 2, axis=-2)
+        gate = gate.swapaxes(-1, -2)
+        up = up.swapaxes(-1, -2)
+        return np.stack([gate, up], axis=-1)
 
   text_cfg = config.get("text_config", config)
   H_k = text_cfg["linear_num_key_heads"]
@@ -1198,6 +1289,8 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
       return qkv, z
     else:
       qkv_m, z_m = input_tensor
+      qkv_m = maybe_dequantize(qkv_m)
+      z_m = maybe_dequantize(z_m)
 
       Q_dim = H_k * D_k
       K_dim = H_k * D_k
@@ -1230,6 +1323,8 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
       return b, a
     else:
       b_m, a_m = input_tensor
+      b_m = maybe_dequantize(b_m)
+      a_m = maybe_dequantize(a_m)
       b_r = b_m.reshape(H_k, V_per_K, -1)
       a_r = a_m.reshape(H_k, V_per_K, -1)
       interleaved = np.concatenate([b_r, a_r], axis=1)
@@ -1241,7 +1336,7 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
   }
 
   layer_cycle_interval = maxtext_config.inhomogeneous_layer_cycle_interval
-  num_main_layers = config["text_config"]["num_hidden_layers"]
+  num_main_layers = text_cfg["num_hidden_layers"]
   loop_indices = range(layer_cycle_interval) if scan_layers else range(num_main_layers)
 
   for i in loop_indices:
@@ -1269,8 +1364,10 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
     hooks[f"{mlp_prefix}-shared_expert-wo-kernel"] = transpose
     hooks[f"{mlp_prefix}-shared_expert_gate-kernel"] = transpose
 
-    hooks[(f"{mlp_prefix}-routed_experts-wi_0", f"{mlp_prefix}-routed_experts-wi_1")] = process_wi_0_wi_1
+    hooks[f"{mlp_prefix}-routed_experts-wi_0"] = transpose
+    hooks[f"{mlp_prefix}-routed_experts-wi_1"] = transpose
     hooks[f"{mlp_prefix}-routed_experts-wo"] = transpose_expert
+    hooks[(f"{mlp_prefix}-routed_experts-wi_0", f"{mlp_prefix}-routed_experts-wi_1")] = process_wi_0_wi_1
 
   # Vision hooks for Qwen3.5
   vision_config = config.get("vision_config", None)

--- a/src/maxtext/checkpoint_conversion/utils/tensor_handling.py
+++ b/src/maxtext/checkpoint_conversion/utils/tensor_handling.py
@@ -48,8 +48,15 @@ def _binary_chunked_stack(tensors: List[np.ndarray], axis: int) -> np.ndarray:
   return np.concatenate([left, right], axis=axis)
 
 
+def _recursive_get_tensor(getter, key):
+  """Recursively retrieves tensors from nested tuples or lists of keys."""
+  if isinstance(key, (list, tuple)):
+    return tuple(_recursive_get_tensor(getter, k) for k in key)
+  return getter(key)
+
+
 def _build_multi_axis_stacked_tensor(
-    hf_source_keys: List[List[str]],
+    hf_source_keys: List[List[Any]],
     tensor_getter_fn: Callable[[str], np.ndarray],
     hook_fns: Any,
     target_leaf: Any,
@@ -85,7 +92,7 @@ def _build_multi_axis_stacked_tensor(
     layer_tensors_for_expert = []
     # Inner loop iterates through layers for the current expert
     for hf_key_single in layer_keys_for_expert:
-      hf_tensor_numpy = tensor_getter_fn(hf_key_single)
+      hf_tensor_numpy = _recursive_get_tensor(tensor_getter_fn, hf_key_single)
       processed_hf_tensor = apply_hook_fns(hf_tensor_numpy, mt_slice_shape, hook_fns)
 
       if target_sharding is not None:
@@ -104,7 +111,7 @@ def _build_multi_axis_stacked_tensor(
 
 
 def _build_single_axis_stacked_tensor(
-    hf_source_keys: List[str],
+    hf_source_keys: List[Any],
     tensor_getter_fn: Callable[[str], np.ndarray],
     hook_fns: Any,
     target_leaf: Any,
@@ -142,7 +149,7 @@ def _build_single_axis_stacked_tensor(
 
   tensors_to_stack = []
   for hf_key_single in hf_source_keys:
-    hf_tensor_numpy = tensor_getter_fn(hf_key_single)
+    hf_tensor_numpy = _recursive_get_tensor(tensor_getter_fn, hf_key_single)
     processed_hf_tensor = apply_hook_fns(hf_tensor_numpy, mt_slice_shape, hook_fns)
 
     if target_sharding is not None:
@@ -160,11 +167,11 @@ def get_hf_loading_function(hf_source_keys_or_key, tensor_getter, hook_fn, mt_ta
   if not isinstance(hf_source_keys_or_key, list):
     # Case 1: Single hf key (str)
     def _loader(getter, key, leaf, hook):
-      if hasattr(leaf, "sharding"):
-        array = apply_hook_fns(getter(key), leaf.shape, hook)
+      array = apply_hook_fns(_recursive_get_tensor(getter, key), leaf.shape if hasattr(leaf, "shape") else leaf, hook)
+      if hasattr(leaf, "sharding") and leaf.sharding is not None:
         return jax.device_put(array, device=leaf.sharding)
       else:
-        return apply_hook_fns(getter(key), leaf, hook)
+        return array
 
     return partial(
         _loader,


### PR DESCRIPTION
# Description

This PR adds support for **on-the-fly FP8 block dequantization** during Hugging Face to MaxText checkpoint conversion (`to_maxtext.py`), with implementation for the **Qwen3.5 model family** (`qwen3.5-35b-a3b`, `qwen3.5-397b-a17b`).

### Problem & Motivation
Currently, converting quantized FP8 Hugging Face checkpoints to MaxText requires dequantizing the entire model to `bfloat16` upfront prior to running the conversion utility. For large models (e.g. 35B / 397B MoE models, DeepSeek, Kimi), this intermediate step requires massive amounts of local disk space (up to 4x the compressed checkpoint size when going from FP4 to BF16, up to several terabytes) and substantial redundant I/O.

### Solution
This PR adds on-the-fly dequantization directly inside `to_maxtext.py`:
1. **FP8 Dtype Safetensors Support**: Registered `np.float8_e4m3fn`, `np.float8_e5m2`, and `np.bfloat16` for zero-copy safetensors deserialization in `to_maxtext.py`.
2. **Recursive Composite Key Support**: Added `_recursive_get_tensor` in `to_maxtext.py` and `tensor_handling.py` to recursively fetch multi-source composite tuple keys `((weight, scale_inv), ...)` from Hugging Face on-demand.
3. **2D Tile Block Dequantization**: Implemented `dequantize_fp8_block(weight, scale_inv, block_size=(128, 128))` in `param_mapping.py` to expand fine-grained $128 \times 128$ inverse scales across FP8 tiles into `bfloat16`.
4. **Dynamic Key Pairing & Hooks**: Updated `QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING` with `hf_w(key)` to automatically pair quantized weights with `weight_scale_inv` while leaving unquantized layers intact, and updated transformation hooks to dequantize on-the-fly via `maybe_dequantize`.
5. **Automatic Config Detection**: Dynamically inspects `quantization_config` in `config.json` to enable FP8 pairing automatically.

### Scope & Model Support
- Supports the **Qwen3.5 model family** in MaxText (`qwen3.5-35b-a3b`, `qwen3.5-397b-a17b`), dynamically parameterized from Hugging Face `config.json`.
- Provides the core dequantization foundation for other block-scaled FP8 architectures (DeepSeek-V3 / DeepSeek-V3.2).

# Tests

1. **Full Parameter Parity Verification (All 673 Parameters)**:
   - Evaluated `Qwen/Qwen3.5-35B-A3B-FP8` against golden reference MaxText checkpoint `gs://maxtext-model-checkpoints/qwen3.5-35b-a3b/unscanned/0/items`:
   - **Unquantized Parameters** (333 / 333): Exact bit-for-bit match ($\text{MAE} = 0.0000\text{e}+00$, $\text{Cosine Similarity} = 1.000000$).
   - **Dequantized FP8 Parameters** (340 / 340): All passed with $\text{Cosine Similarity} \ge 0.99965$ (Mean Cos Sim: $0.999648$, Mean Relative Error: $2.65\%$), matching expected FP8 tile numerical fidelity.

2. **Full End-to-End Checkpoint Conversion**:
   - Converted `Qwen/Qwen3.5-35B-A3B-FP8` unscanned checkpoint to GCS (`gs://snehalv-data/qwen35/otfd/unscanned/0/items`) in 29 minutes with peak memory of 172 GB.

3. **End-to-End Decoding on TPU v5p**:
   - Verified execution of `decode.py` on remote v5p-8 TPU VM (`maxtext-single-host-3-v5p-8`) using the converted checkpoint:
     - Prompt: *"An attention function can be described as mapping a query and a set of key-value pairs to an output, where the query, keys, values, and outputs are all vectors. The output is "*
     - Output: *" computed as a weighted sum of the values, where the weight assigned to each value is computed by a compatibility function of the query with the corresponding key..."* (Generated coherently and accurately).

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
