### PR TITLE
feat: Grain FileInstruction pre-extraction & GCS glob optimization

### DIFF
--- a/benchmarks/benchmark_file_instruction.py
+++ b/benchmarks/benchmark_file_instruction.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark script comparing Grain ArrayRecord initialization with vs without FileInstruction pre-extraction.
+
+Setup & Architecture:
+- Multi-Host / Pathways Setup:
+  In distributed training setups (such as Pathways single-controller with colocated Python sidecars,
+  or multi-controller McJAX clusters spanning dozens to hundreds of TPU slices), each worker process
+  independently initializes its input pipeline data source.
+- Problem (Baseline):
+  Without pre-extraction, every worker concurrently queries Google Cloud Storage (GCS)
+  to resolve file glob patterns and inspect shard footers/index metadata. At scale
+  (e.g., thousands of shards across 32+ hosts), this stampede of concurrent requests causes
+  GCS metadata rate-limiting (HTTP 429) and catastrophic startup stalls extending into 10-30+ minutes.
+- Solution (FileInstruction Optimization):
+  The coordinator inspects the dataset once and extracts lightweight `FileInstruction`
+  manifests (filename, skip, take, examples_in_shard). These pre-computed instructions are
+  distributed to all workers, allowing workers to initialize `ArrayRecordDataSource` instantly
+  in-memory with zero GCS RPCs.
+
+Benchmark Methodology:
+- Simulates concurrent worker sidecar initialization using a `ThreadPoolExecutor` to accurately
+  model the concurrent GCS traffic generated during multi-worker / multi-host startup.
+- Evaluates:
+  1. Baseline: Concurrent worker-side header inspection via `ArrayRecordDataSource(files)`.
+  2. Coordinator Pre-Extraction: One-time header inspection via `extract_file_instructions(files)`.
+  3. Optimized Workers: Concurrent worker initialization via `ArrayRecordDataSource(instructions)`.
+"""
+
+from concurrent import futures
+import time
+from absl import app
+from absl import flags
+import grain.python as grain
+from maxtext.input_pipeline.grain_data_processing import extract_file_instructions, find_data_files
+from maxtext.utils import max_logging
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string("data_pattern", None, "GCS or local ArrayRecord file pattern to benchmark", required=False)
+flags.DEFINE_integer("num_simulated_workers", 32, "Number of worker sidecars to simulate concurrently")
+
+
+def run_benchmark(data_pattern: str, num_workers: int):
+  """Measures baseline vs optimized FileInstruction initialization latency."""
+  max_logging.log(f"Starting FileInstruction benchmark on pattern: {data_pattern} with {num_workers} simulated workers.")
+
+  # 1. Baseline: Each worker independently discovers and reads arrayrecord headers concurrently
+  t0 = time.perf_counter()
+  files = find_data_files(data_pattern)
+  with futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+    _ = list(executor.map(lambda _: grain.ArrayRecordDataSource(files), range(num_workers)))
+  baseline_duration = time.perf_counter() - t0
+  max_logging.log(f"[Baseline] Worker independent concurrent init duration: {baseline_duration:.4f}s")
+
+  # 2. Optimized: Coordinator extracts FileInstructions once, workers reuse them concurrently
+  t0 = time.perf_counter()
+  instructions = extract_file_instructions(data_pattern)
+  coord_duration = time.perf_counter() - t0
+  max_logging.log(f"[Optimized] Coordinator pre-extraction duration: {coord_duration:.4f}s")
+
+  t0 = time.perf_counter()
+  with futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+    _ = list(executor.map(lambda _: grain.ArrayRecordDataSource(instructions), range(num_workers)))
+  worker_init_duration = time.perf_counter() - t0
+  max_logging.log(f"[Optimized] Worker concurrent init duration from FileInstructions: {worker_init_duration:.4f}s")
+
+  total_optimized_duration = coord_duration + worker_init_duration
+  speedup = baseline_duration / max(total_optimized_duration, 1e-6)
+  max_logging.log(f"[Summary] Total Optimized duration: {total_optimized_duration:.4f}s ({speedup:.2f}x speedup)")
+
+
+def main(argv):
+  """Entry point parsing CLI args and executing benchmark."""
+  if len(argv) > 1 and not FLAGS.data_pattern:
+    FLAGS.data_pattern = argv[1]
+  if FLAGS.data_pattern:
+    run_benchmark(FLAGS.data_pattern, FLAGS.num_simulated_workers)
+  else:
+    max_logging.log("No data_pattern supplied, skipping live GCS benchmark.")
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/src/maxtext/common/grain_utility.py
+++ b/src/maxtext/common/grain_utility.py
@@ -111,8 +111,11 @@ class GrainCheckpointable(ocp.StatefulCheckpointable):
 
     # RemoteIteratorWrapper handles checkpointing via colocated python
     if isinstance(item, RemoteIteratorWrapper):
-      item.save_state(self._step)
-      return no_op()
+
+      async def _write_remote_wrapper():
+        await asyncio.to_thread(item.save_state, self._step)
+
+      return _write_remote_wrapper()
 
     # ElasticIterator state is a single global scalar shared by all shards,
     # so we write one fixed `process_0.json` from process 0 only. This file
@@ -160,8 +163,11 @@ class GrainCheckpointable(ocp.StatefulCheckpointable):
 
     # In Pathways + colocated_python environment, RemoteIteratorWrapper handles checkpointing
     if isinstance(item, RemoteIteratorWrapper):
-      item.restore_state(self._step)
-      return no_op()
+
+      async def _read_remote_wrapper():
+        await asyncio.to_thread(item.restore_state, self._step)
+
+      return _read_remote_wrapper()
 
     # McJax and Pathways through controller cases
     # ElasticIterator: every process reads the same shared `process_0.json`.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4039,6 +4039,11 @@ class MaxTextConfig(
           "Colocated python data input is only supported with Pathways (single"
           " controller) enabled (`enable_single_controller=True`)."
       )
+    if self.colocated_python_data_input and self.grain_worker_count != 1:
+      raise ValueError(
+          "Colocated python data input (`colocated_python_data_input=True`) only supports "
+          f"`grain_worker_count=1`, got {self.grain_worker_count}."
+      )
     if self.grain_use_elastic_iterator and self.grain_file_type != "arrayrecord":
       raise ValueError(
           "`grain_use_elastic_iterator=True` only supports `grain_file_type=arrayrecord`. "

--- a/src/maxtext/input_pipeline/data_processing_utils.py
+++ b/src/maxtext/input_pipeline/data_processing_utils.py
@@ -145,17 +145,26 @@ def apply_multiprocessing_and_prefetch(dataset, config, grain_worker_count, grai
   if config.grain_use_elastic_iterator:
     # ElasticIterator applies multiprocessing itself.
     return dataset
-  multiprocessing_options = (
-      pick_performance_config(
+  if config.colocated_python_data_input and grain_worker_count != 1:
+    raise ValueError(f"Colocated python data input only supports `grain_worker_count=1`, got {grain_worker_count}.")
+  if grain_worker_count == -1:
+    if config.elastic_enabled:
+      # In elastic training, avoid pick_performance_config() benchmarking
+      # which stalls workers during slice scale-up. Default to 0 (in-process threads).
+      multiprocessing_options = grain.MultiprocessingOptions(
+          num_workers=0,
+          per_worker_buffer_size=grain_per_worker_buffer_size,
+      )
+    else:
+      multiprocessing_options = pick_performance_config(
           ds=dataset,
           ram_budget_mb=config.grain_ram_budget_mb,
           max_workers=None,
           max_buffer_size=None,
       ).multiprocessing_options
-      if grain_worker_count == -1
-      else grain.MultiprocessingOptions(
-          num_workers=grain_worker_count,
-          per_worker_buffer_size=grain_per_worker_buffer_size,
-      )
-  )
+  else:
+    multiprocessing_options = grain.MultiprocessingOptions(
+        num_workers=grain_worker_count,
+        per_worker_buffer_size=grain_per_worker_buffer_size,
+    )
   return dataset.mp_prefetch(multiprocessing_options)

--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -19,9 +19,11 @@ import glob
 import re
 from pathlib import Path
 import functools
+from typing import Any
 import ml_collections
 from concurrent import futures
 import json
+from dataclasses import asdict, dataclass
 
 import jax
 
@@ -36,6 +38,59 @@ from maxtext.input_pipeline import multihost_dataloading
 from maxtext.input_pipeline._mmap_datasource import MMapDatasetConfig, get_mmap_dataset, get_mmap_npy_dataset
 from maxtext.utils import gcs_utils
 from maxtext.utils import max_logging
+
+
+@dataclass(frozen=True)
+class FileInstruction:
+  """File instruction for Grain ArrayRecordDataSource to bypass remote index discovery."""
+
+  filename: str
+  skip: int
+  take: int
+  examples_in_shard: int
+
+  def to_dict(self):
+    return asdict(self)
+
+  @classmethod
+  def from_dict(cls, d):
+    return cls(
+        filename=d["filename"],
+        skip=d["skip"],
+        take=d["take"],
+        examples_in_shard=d.get("examples_in_shard", d["take"]),
+    )
+
+
+def extract_file_instructions(
+    pattern_or_files,
+) -> tuple[FileInstruction, ...]:
+  """Pre-resolves file paths and extracts FileInstruction metadata on the coordinator."""
+  if (
+      isinstance(pattern_or_files, (list, tuple))
+      and pattern_or_files
+      and isinstance(pattern_or_files[0], FileInstruction)
+  ):
+    return tuple(pattern_or_files)
+  files = find_data_files(pattern_or_files) if isinstance(pattern_or_files, str) else list(pattern_or_files)
+
+  # Initialize data source on coordinator once to inspect file headers
+  ds = grain.ArrayRecordDataSource(files)
+  instructions = []
+  for ri in ds._read_instructions:  # pylint: disable=protected-access
+    instructions.append(
+        FileInstruction(
+            filename=ri.filename,
+            skip=ri.start,
+            take=ri.num_records,
+            examples_in_shard=ri.num_records,
+        )
+    )
+  max_logging.log(
+      f"Extracted {len(instructions)} FileInstructions on coordinator "
+      f"(total records: {sum(inst.take for inst in instructions)})"
+  )
+  return tuple(instructions)
 
 
 def construct_hf_dataset_path(hf_path: str, hf_train_files: str | None = None, split: str = "train") -> str:
@@ -77,6 +132,11 @@ def construct_tfds_tfrecord_path(dataset_path: str, dataset_name: str, split: st
 
 def find_data_files(data_file_pattern, hf_access_token=None):
   """Find data files matching the pattern."""
+  if isinstance(data_file_pattern, (list, tuple)):
+    files = []
+    for p in data_file_pattern:
+      files.extend(find_data_files(p, hf_access_token=hf_access_token))
+    return files
   if data_file_pattern.startswith("gs://"):
     data_files = gcs_utils.gcs_glob_pattern(data_file_pattern)
   elif data_file_pattern.startswith("hf://"):
@@ -157,6 +217,28 @@ def _make_mmap_multiprocessing_options(dataset, config, grain_worker_count, grai
   return grain.MultiprocessingOptions(num_workers=grain_worker_count, per_worker_buffer_size=grain_per_worker_buffer_size)
 
 
+def _parse_mixture(pattern) -> tuple[list[Any], list[float]] | None:
+  """Returns (patterns, weights) if `pattern` is a mixture, else None."""
+  if (
+      isinstance(pattern, tuple)
+      and len(pattern) == 2
+      and isinstance(pattern[0], (list, tuple))
+      and isinstance(pattern[1], (list, tuple))
+      and len(pattern[0]) == len(pattern[1])
+  ):
+    patterns, raw_weights = pattern
+  elif isinstance(pattern, str) and ";" in pattern:
+    patterns, raw_weights = zip(*[p.split(",") for p in pattern.split(";")])
+    assert len(patterns) == len(raw_weights), "Number of data file patterns and weights must match"
+  else:
+    return None
+
+  weights = [float(w) for w in raw_weights]
+  total_weight = sum(weights)
+  weights = [round(w / total_weight, 4) for w in weights]
+  return list(patterns), weights
+
+
 def get_datasets(
     data_file_pattern,
     data_file_type,
@@ -181,11 +263,14 @@ def get_datasets(
   if data_file_type == "arrayrecord":
     # Helper function to find files, create data source, and wrap in MapDataset
     def create_dataset_from_pattern(pattern):
-      files = find_data_files(pattern, hf_access_token=hf_access_token)
       reader_options = (
           {"index_storage_option": grain_index_storage_option} if grain_index_storage_option is not None else None
       )
-      source = grain.ArrayRecordDataSource(files, reader_options=reader_options)
+      if isinstance(pattern, (list, tuple)) and pattern and isinstance(pattern[0], FileInstruction):
+        source = grain.ArrayRecordDataSource(pattern, reader_options=reader_options)
+      else:
+        files = find_data_files(pattern, hf_access_token=hf_access_token)
+        source = grain.ArrayRecordDataSource(files, reader_options=reader_options)
       return grain.MapDataset.source(source)
 
     # Handle mixture config with named datasets, allows flexibility in recovering checkpoints
@@ -220,11 +305,12 @@ def get_datasets(
 
       dataset = grain.IterDataset.mix(datasets_dict, weights_dict)
       return dataset
-    elif ";" in data_file_pattern:
-      data_file_patterns, weights = zip(*[pattern.split(",") for pattern in data_file_pattern.split(";")])
-      assert len(data_file_patterns) == len(weights), "Number of data file patterns and weights must match"
-      weights = [float(weight) for weight in weights]
-      weights = [round(weight / sum(weights), 4) for weight in weights]
+
+    mixture = _parse_mixture(data_file_pattern)
+    is_mixture = mixture is not None
+
+    if is_mixture:
+      data_file_patterns, weights = mixture
 
       # Parallelize file finding (globbing), data source creation, and dataset wrapping
       # File finding and source creation are I/O-bound operations that release the GIL
@@ -249,7 +335,7 @@ def get_datasets(
       dataset = grain.IterDataset.mix(dataset_list, weights)
       return dataset
     else:
-      # Single pattern case - no need for parallelization
+      # Single pattern case or pre-resolved FileInstruction case
       dataset = create_dataset_from_pattern(data_file_pattern)
       dataset = _apply_mapdataset_transforms(
           dataset,
@@ -804,6 +890,37 @@ def make_grain_train_iterator(
   ):
     grain_train_files = construct_tfds_tfrecord_path(config.dataset_path, config.dataset_name, config.train_split)
 
+  if (
+      config.elastic_enabled
+      and grain_train_files
+      and config.grain_file_type == "arrayrecord"
+      and not (isinstance(grain_train_files, str) and grain_train_files.startswith("hf://"))
+  ):
+    original_grain_train_files = grain_train_files
+    try:
+      if config.grain_train_mixture_config_path:
+        pass
+      else:
+        mixture = _parse_mixture(grain_train_files)
+        if mixture is not None:
+          raw_patterns, weights = mixture
+          executor = futures.ThreadPoolExecutor(max_workers=config.grain_data_source_max_workers)
+          cached_instructions_list = list(
+              executor.map(
+                  extract_file_instructions,
+                  raw_patterns,
+              )
+          )
+          executor.shutdown(wait=True)
+          grain_train_files = (cached_instructions_list, weights)
+        else:
+          grain_train_files = extract_file_instructions(grain_train_files)
+    except Exception as e:  # pylint: disable=broad-except
+      max_logging.log(
+          f"Warning: Failed to pre-extract FileInstructions on coordinator: {e}. Falling back to raw pattern."
+      )
+      grain_train_files = original_grain_train_files
+
   get_ds_fn = functools.partial(
       get_datasets,
       grain_train_files,
@@ -951,6 +1068,34 @@ def make_grain_eval_iterator(
       and config.eval_split
   ):
     grain_eval_files = construct_tfds_tfrecord_path(config.dataset_path, config.eval_dataset_name, config.eval_split)
+
+  if (
+      config.elastic_enabled
+      and grain_eval_files
+      and config.grain_file_type == "arrayrecord"
+      and not (isinstance(grain_eval_files, str) and grain_eval_files.startswith("hf://"))
+  ):
+    original_grain_eval_files = grain_eval_files
+    try:
+      mixture = _parse_mixture(grain_eval_files)
+      if mixture is not None:
+        raw_patterns, weights = mixture
+        executor = futures.ThreadPoolExecutor(max_workers=config.grain_data_source_max_workers)
+        cached_instructions_list = list(
+            executor.map(
+                extract_file_instructions,
+                raw_patterns,
+            )
+        )
+        executor.shutdown(wait=True)
+        grain_eval_files = (cached_instructions_list, weights)
+      else:
+        grain_eval_files = extract_file_instructions(grain_eval_files)
+    except Exception as e:  # pylint: disable=broad-except
+      max_logging.log(
+          f"Warning: Failed to pre-extract FileInstructions on coordinator for eval: {e}. Falling back to raw pattern."
+      )
+      grain_eval_files = original_grain_eval_files
 
   get_ds_fn = functools.partial(
       get_datasets,

--- a/src/maxtext/input_pipeline/multihost_dataloading.py
+++ b/src/maxtext/input_pipeline/multihost_dataloading.py
@@ -296,10 +296,14 @@ class RemoteIteratorWrapper:
     replicated_cpu_sharding = NamedSharding(self.cpu_mesh, PartitionSpec())
     step_array = jnp.array(step, dtype=jnp.int32)
     step_array = jax.device_put(step_array, replicated_cpu_sharding)
-    self.local_iterator.save_state(step_array)  # pyrefly: ignore[missing-attribute]
+    out = self.local_iterator.save_state(step_array)  # pyrefly: ignore[missing-attribute]
+    if hasattr(out, "block_until_ready"):
+      out.block_until_ready()
 
   def restore_state(self, step):
     replicated_cpu_sharding = NamedSharding(self.cpu_mesh, PartitionSpec())
     step_array = jnp.array(step, dtype=jnp.int32)
     step_array = jax.device_put(step_array, replicated_cpu_sharding)
-    self.local_iterator.restore_state(step_array)  # pyrefly: ignore[missing-attribute]
+    out = self.local_iterator.restore_state(step_array)  # pyrefly: ignore[missing-attribute]
+    if hasattr(out, "block_until_ready"):
+      out.block_until_ready()

--- a/src/maxtext/utils/gcs_utils.py
+++ b/src/maxtext/utils/gcs_utils.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from etils import epath
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+import re
 
 import yaml
 
@@ -223,7 +224,9 @@ def gcs_glob_pattern(pattern):
   """
   storage_client = storage.Client()
   bucket_name, glob_pattern = parse_gcs_bucket_and_prefix(pattern)
-  blobs = storage_client.list_blobs(bucket_name, match_glob=glob_pattern)
+
+  literal_prefix = re.split(r"[*?\[]", glob_pattern, maxsplit=1)[0]
+  blobs = storage_client.list_blobs(bucket_name, prefix=literal_prefix or None, match_glob=glob_pattern)
   data_files = [f"gs://{bucket_name}/{blob.name}" for blob in blobs]
   return data_files
 

--- a/tests/unit/file_instruction_test.py
+++ b/tests/unit/file_instruction_test.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Grain FileInstruction extraction and dataset integration."""
+
+from types import SimpleNamespace
+from unittest import mock
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from maxtext.input_pipeline.data_processing_utils import apply_multiprocessing_and_prefetch
+from maxtext.input_pipeline.grain_data_processing import (
+    FileInstruction,
+    _parse_mixture,
+    extract_file_instructions,
+)
+
+
+class FileInstructionTest(parameterized.TestCase):
+
+  def test_file_instruction_dataclass(self):
+    fi = FileInstruction(filename="gs://test-bucket/data.arrayrecord", skip=0, take=100, examples_in_shard=100)
+    self.assertEqual(fi.filename, "gs://test-bucket/data.arrayrecord")
+    self.assertEqual(fi.skip, 0)
+    self.assertEqual(fi.take, 100)
+    self.assertEqual(fi.examples_in_shard, 100)
+
+    d = fi.to_dict()
+    self.assertEqual(
+        d,
+        {
+            "filename": "gs://test-bucket/data.arrayrecord",
+            "skip": 0,
+            "take": 100,
+            "examples_in_shard": 100,
+        },
+    )
+
+    restored = FileInstruction.from_dict(d)
+    self.assertEqual(restored, fi)
+
+  @mock.patch("maxtext.input_pipeline.grain_data_processing.find_data_files")
+  @mock.patch("grain.python.ArrayRecordDataSource")
+  def test_extract_file_instructions(self, mock_ds_cls, mock_find_files):
+    mock_find_files.return_value = ["gs://bucket/shard_000.arrayrecord", "gs://bucket/shard_001.arrayrecord"]
+
+    mock_ri1 = mock.MagicMock()
+    mock_ri1.filename = "gs://bucket/shard_000.arrayrecord"
+    mock_ri1.start = 0
+    mock_ri1.num_records = 50
+
+    mock_ri2 = mock.MagicMock()
+    mock_ri2.filename = "gs://bucket/shard_001.arrayrecord"
+    mock_ri2.start = 0
+    mock_ri2.num_records = 75
+
+    mock_ds_instance = mock.MagicMock()
+    mock_ds_instance._read_instructions = [mock_ri1, mock_ri2]  # pylint: disable=protected-access
+    mock_ds_cls.return_value = mock_ds_instance
+
+    instructions = extract_file_instructions("gs://bucket/*.arrayrecord")
+    self.assertEqual(len(instructions), 2)
+    self.assertEqual(instructions[0].filename, "gs://bucket/shard_000.arrayrecord")
+    self.assertEqual(instructions[0].take, 50)
+    self.assertEqual(instructions[1].filename, "gs://bucket/shard_001.arrayrecord")
+    self.assertEqual(instructions[1].take, 75)
+
+  def test_extract_file_instructions_passthrough(self):
+    existing = (
+        FileInstruction("gs://bucket/shard_000.arrayrecord", 0, 50, 50),
+        FileInstruction("gs://bucket/shard_001.arrayrecord", 0, 75, 75),
+    )
+    result = extract_file_instructions(existing)
+    self.assertEqual(result, existing)
+
+  @mock.patch("maxtext.input_pipeline.grain_data_processing.find_data_files")
+  @mock.patch("grain.python.ArrayRecordDataSource")
+  def test_extract_file_instructions_list_input(self, mock_ds_cls, mock_find_files):
+    mock_find_files.side_effect = lambda x: [x] if isinstance(x, str) else list(x)
+
+    mock_ri = mock.MagicMock()
+    mock_ri.filename = "gs://bucket/shard_000.arrayrecord"
+    mock_ri.start = 0
+    mock_ri.num_records = 100
+
+    mock_ds_instance = mock.MagicMock()
+    mock_ds_instance._read_instructions = [mock_ri]  # pylint: disable=protected-access
+    mock_ds_cls.return_value = mock_ds_instance
+
+    instructions = extract_file_instructions(["gs://bucket/shard_000.arrayrecord"])
+    self.assertEqual(len(instructions), 1)
+    self.assertEqual(instructions[0].filename, "gs://bucket/shard_000.arrayrecord")
+
+  def test_parse_mixture_string(self):
+    mixture = _parse_mixture("gs://bucket/data1.arrayrecord,0.7;gs://bucket/data2.arrayrecord,0.3")
+    self.assertIsNotNone(mixture)
+    patterns, weights = mixture
+    self.assertEqual(patterns, ["gs://bucket/data1.arrayrecord", "gs://bucket/data2.arrayrecord"])
+    self.assertEqual(weights, [0.7, 0.3])
+
+  def test_parse_mixture_pre_extracted_tuple(self):
+    inst1 = [FileInstruction("f1.arrayrecord", 0, 10, 10)]
+    inst2 = [FileInstruction("f2.arrayrecord", 0, 20, 20)]
+    mixture = _parse_mixture(((inst1, inst2), [0.4, 0.6]))
+    self.assertIsNotNone(mixture)
+    patterns, weights = mixture
+    self.assertEqual(patterns, [inst1, inst2])
+    self.assertEqual(weights, [0.4, 0.6])
+
+  def test_parse_mixture_single_pattern_returns_none(self):
+    self.assertIsNone(_parse_mixture("gs://bucket/*.arrayrecord"))
+    self.assertIsNone(_parse_mixture(["gs://bucket/f1.arrayrecord", "gs://bucket/f2.arrayrecord"]))
+    self.assertIsNone(_parse_mixture(None))
+
+  def test_colocated_python_unexpected_worker_count_raises(self):
+    mock_dataset = mock.MagicMock()
+    config = SimpleNamespace(
+        grain_use_elastic_iterator=False,
+        colocated_python_data_input=True,
+        elastic_enabled=False,
+    )
+    with self.assertRaisesRegex(ValueError, "Colocated python data input only supports `grain_worker_count=1`"):
+      apply_multiprocessing_and_prefetch(mock_dataset, config, grain_worker_count=2, grain_per_worker_buffer_size=1)
+
+    with self.assertRaisesRegex(ValueError, "Colocated python data input only supports `grain_worker_count=1`"):
+      apply_multiprocessing_and_prefetch(mock_dataset, config, grain_worker_count=-1, grain_per_worker_buffer_size=1)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
# Description

- Pre-extract FileInstruction metadata on coordinator once to bypass worker sidecar GCS ArrayRecord index inspection storms at scale.
- Extract literal prefix in GCS glob pattern matching to avoid scanning entire buckets.
- Skip pick_performance_config() stalls in colocated python and elastic modes.
- Add block_until_ready() sync and threadpool execution to RemoteIteratorWrapper save_state and restore_state.
- Add unit tests (tests/unit/file_instruction_test.py) and benchmark harness.


Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
