### PR TITLE
fix(rl): Patch MoE weight tracking and adjust vLLM HBM utilization

### DIFF
--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -97,6 +97,8 @@ def _tpu_inference_compat_patches():
   orig_bulk = tunix_utils._bulk_align_and_unstack  # pylint: disable=protected-access
   orig_unstack = tunix_utils._unstack_scanned_param  # pylint: disable=protected-access
 
+  orig_moe_weights = getattr(tunix_utils, "_MOE_MLP_WEIGHTS", None)
+
   def _compat_wsc(x, shardings):
     try:
       return orig_wsc(x, shardings)
@@ -125,6 +127,10 @@ def _tpu_inference_compat_patches():
   tunix_utils._apply_dtype_cast = _no_bf16_to_f32_cast  # pylint: disable=protected-access
   tunix_utils._bulk_align_and_unstack = _compat_bulk  # pylint: disable=protected-access
   tunix_utils._unstack_scanned_param = _compat_unstack  # pylint: disable=protected-access
+
+  if orig_moe_weights is not None:
+    tunix_utils._MOE_MLP_WEIGHTS = frozenset([*orig_moe_weights, "wo"])  # pylint: disable=protected-access
+
   try:
     yield
   finally:
@@ -132,6 +138,8 @@ def _tpu_inference_compat_patches():
     tunix_utils._apply_dtype_cast = orig_apply_dtype_cast  # pylint: disable=protected-access
     tunix_utils._bulk_align_and_unstack = orig_bulk  # pylint: disable=protected-access
     tunix_utils._unstack_scanned_param = orig_unstack  # pylint: disable=protected-access
+    if orig_moe_weights is not None:
+      tunix_utils._MOE_MLP_WEIGHTS = orig_moe_weights  # pylint: disable=protected-access
 
 
 os.environ["TOKENIZERS_PARALLELISM"] = "0"

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3_rl.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3_rl.sh
@@ -48,7 +48,7 @@ python3 -m maxtext.inference.vllm_decode \
     model_name=${MODEL_NAME} \
     load_parameters_path=${SCANNED_CKPT_PATH} \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
-    hbm_utilization_vllm=0.85 \
+    hbm_utilization_vllm=0.8 \
     prompt='Suggest some famous landmarks in London.' \
     max_target_length=256 \
     max_num_batched_tokens=256 \
@@ -97,7 +97,7 @@ python3 -m maxtext.inference.vllm_decode \
     model_name=${MODEL_NAME} \
     load_parameters_path=${BASE_OUTPUT_DIRECTORY}/rl/${run_id}/checkpoints/actor/2/model_params \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
-    hbm_utilization_vllm=0.85 \
+    hbm_utilization_vllm=0.8 \
     prompt='Suggest some famous landmarks in London.' \
     max_target_length=256 \
     max_num_batched_tokens=256 \


### PR DESCRIPTION
## Description

This PR fixes a critical `ShapeMismatchError` crash during the RL Rollout weight synchronization phase for MoE models (e.g., Qwen3, Gemma4), and adjusts vLLM HBM utilization bounds to prevent memory allocation and IFRT Proxy crashes for large models.

## Root Cause

When utilizing MoE layouts (especially under GMM_v2 tiling configurations), MaxText natively exposes the `'wo'` projection weights. However, Tunix's internal parameter alignment logic (`tunix.generate.utils._MOE_MLP_WEIGHTS`) uses a strict, hardcoded `frozenset` of recognized MoE patterns that does not include `'wo'`.    
  
When the rollout engine attempts to sync weights via `intersect_trees`, Tunix throws the following error and drops the session because it doesn't recognize the token:

`tunix.generate.utils.ShapeMismatchError: Cannot align axis 1 for decoder.layers_0.moe_block.wo: ... key is not a recognized MoE pattern.`
  
Additionally, large models (like Qwen3-30B) require significant XLA temporary workspace to digest massive fused graphs and handle concurrent parameter broadcasts. 
If vLLM aggressively locks up too much HBM upon initialization, the system lacks sufficient memory for these temporary buffers, resulting in `RuntimeProgramAllocationFailure` or IFRT Proxy Stream disconnects.

## Solution

- **`train_rl.py`**: Added a safe, idempotent monkey-patch using `hasattr`. This dynamically registers `"wo"` into `tunix_utils._MOE_MLP_WEIGHTS`, ensuring the Tunix state-transfer backend properly routes the MoE projection parameter without crashing.
- **RL Configs**: Decreased `hbm_utilization_vllm` for massive topologies like Qwen3-30B to reserve an adequate physical memory buffer for XLA compiler execution and Tunix concurrent RPC bursts.

# Tests

Gemma4-26b RL: https://cloudlogging.app.goo.gl/LjE4Q9wKhcsGXXLb7

Qwen3-30b vllm_decode: https://cloudlogging.app.goo.gl/yQQcJPPyFizMqQqy8

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
