### PR TITLE
Add Qwen3.5 weight mapping for tpu-inference's vLLM (torchax) path

### DIFF
--- a/src/maxtext/integration/tunix/tunix_adapter.py
+++ b/src/maxtext/integration/tunix/tunix_adapter.py
@@ -144,3 +144,10 @@ class TunixMaxTextAdapter(nnx.Module):
       return {}
 
     return self._vllm_weight_mapping.lora_to_hf_mappings()
+
+  def preprocess_src_state(self):
+    """Optional state transform applied by Tunix before the key mapping (see VllmWeightMapping)."""
+    if self.use_no_op_mappings:
+      return None
+
+    return self._vllm_weight_mapping.preprocess_src_state()

--- a/src/maxtext/integration/tunix/utils.py
+++ b/src/maxtext/integration/tunix/utils.py
@@ -152,6 +152,17 @@ class VllmWeightMapping:
     else:
       return {}
 
+  def preprocess_src_state(self):
+    """Returns an optional `state -> state` transform Tunix applies before the key mapping.
+
+    Mappings whose target needs tensors fused or reordered (e.g. Qwen3.5's vLLM torchax
+    target) define it; the plain nnx-target mappings do not and return None.
+    """
+    if not self.use_standalone_mappings:
+      return None
+    fn = getattr(STANDALONE_VLLM_WEIGHT_MAPPING[self.model_name], "preprocess_src_state", None)
+    return fn(self.config) if fn else None
+
   def lora_to_hf_mappings(self):
     """Dynamically generate LoRA mappings from base model weights mappings."""
     base_mappings = self.to_hf_mapping()

--- a/src/maxtext/integration/tunix/weight_mapping/__init__.py
+++ b/src/maxtext/integration/tunix/weight_mapping/__init__.py
@@ -24,6 +24,7 @@ from maxtext.integration.tunix.weight_mapping.gpt_oss import GPT_OSS_VLLM_MAPPIN
 from maxtext.integration.tunix.weight_mapping.llama3 import LLAMA3_VLLM_MAPPING
 from maxtext.integration.tunix.weight_mapping.qwen2 import QWEN2_VLLM_MAPPING
 from maxtext.integration.tunix.weight_mapping.qwen3 import QWEN3_VLLM_MAPPING
+from maxtext.integration.tunix.weight_mapping.qwen3_5 import QWEN3_5_VLLM_MAPPING
 
 
 class StandaloneVllmWeightMapping:
@@ -34,6 +35,9 @@ class StandaloneVllmWeightMapping:
       return LLAMA3_VLLM_MAPPING
     elif name.startswith("qwen2"):
       return QWEN2_VLLM_MAPPING
+    elif name.startswith("qwen3.5"):
+      # Must precede the "qwen3" prefix check, which would otherwise swallow it.
+      return QWEN3_5_VLLM_MAPPING
     elif name.startswith("qwen3"):
       return QWEN3_VLLM_MAPPING
     elif name.startswith("gemma3"):

--- a/src/maxtext/integration/tunix/weight_mapping/qwen3_5.py
+++ b/src/maxtext/integration/tunix/weight_mapping/qwen3_5.py
@@ -1,0 +1,337 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Weight mapping from MaxText's Qwen3.5 (text) model to tpu-inference's vLLM (torchax) Qwen3.5.
+
+Unlike the dense mappings in this package, the target here is not a JAX/nnx model but the
+vLLM (PyTorch) implementation that tpu-inference runs through torchax. That runner keeps
+its weights in an internal, tensor-parallelism-dependent layout, so the contract used
+here is vLLM's *canonical* parameter layout (what ``model.named_parameters()`` holds on
+a single GPU at TP=1):
+
+  * linear kernels are ``[out, in]``;
+  * ``self_attn.qkv_proj.weight`` is ``[q | k | v]`` with each KV head once (``q`` carries
+    the attention output gate, i.e. ``num_heads * 2 * head_dim`` rows);
+  * ``linear_attn.in_proj_qkvz.weight`` is ``[q | k | v | z]``, ``in_proj_ba.weight`` is
+    ``[b | a]`` (HF / vLLM order, not MaxText's per-key-head interleaving);
+  * ``conv1d.weight`` is ``[channels, 1, kernel]``;
+  * routed experts are ``w13_weight = [E, 2F, D]`` (gate rows first) and
+    ``w2_weight = [E, D, F]``; the shared expert is ``gate_up_proj = [2F, D]``.
+
+tpu-inference (``VllmModelWrapper.load_canonical_weights``) converts canonical arrays into
+its internal layout, so this mapping needs no knowledge of TP size, KV-head replication
+or the MoE backend. Tunix drives it from ``VllmSampler.update_params``.
+
+Because Tunix's key mapping is one-to-one, every MaxText parameter that has to be *fused*
+or *reordered* is handled in ``preprocess_src_state`` (which returns a flat dict of
+canonical arrays keyed by MaxText-side names), and ``to_hf_mapping`` is then a pure
+rename. Both scanned (inhomogeneous ``layers.layer_{b}`` blocks) and unscanned
+(``layers_{i}``) MaxText parameter trees are accepted.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Mapping, Optional
+
+import jax
+import jax.numpy as jnp
+
+
+# Regexes matched against the canonical vLLM parameter names. `(\d+)` captures the layer
+# index that fills the `*` of the MaxText-side key; the optional `language_model.` prefix
+# covers both `Qwen3_5MoeForConditionalGeneration` and the text-only `...ForCausalLM`.
+_LM = r"(?:language_model\.)?"
+_LAYER = _LM + r"model\.layers\.(\d+)\."
+
+
+def _tgt(rest: str) -> str:
+  return _LAYER + rest
+
+
+@dataclass
+class QWEN3_5_VLLM_MAPPING:
+  """Mapping MaxText Qwen3.5 weights to tpu-inference vLLM (torchax) Qwen3.5 weights."""
+
+  @staticmethod
+  def to_hf_mapping():
+    """Maps MaxText-side keys (after `preprocess_src_state`) to canonical vLLM parameter names.
+
+    The second tuple element is the sharding hint Tunix expects; no entry carries a
+    `layer` axis because `preprocess_src_state` already unstacks scanned layers.
+    """
+    return {
+        "base.token_embedder.embedding": (_LM + r"model\.embed_tokens\.weight", ("model", None)),
+        "base.decoder.decoder_norm.scale": (_LM + r"model\.norm\.weight", (None,)),
+        "base.decoder.logits_dense.kernel": (_LM + r"lm_head\.weight", ("model", None)),
+        # Per-layer norms
+        "base.decoder.layers.*.input_layernorm.scale": (_tgt(r"input_layernorm\.weight"), (None,)),
+        "base.decoder.layers.*.post_attention_layernorm.scale": (
+            _tgt(r"post_attention_layernorm\.weight"),
+            (None,),
+        ),
+        # Full (gated) attention layers
+        "base.decoder.layers.*.attention.qkv_proj": (_tgt(r"self_attn\.qkv_proj\.weight"), ("model", None)),
+        "base.decoder.layers.*.attention.o_proj": (_tgt(r"self_attn\.o_proj\.weight"), (None, "model")),
+        "base.decoder.layers.*.attention.query_norm.scale": (_tgt(r"self_attn\.q_norm\.weight"), (None,)),
+        "base.decoder.layers.*.attention.key_norm.scale": (_tgt(r"self_attn\.k_norm\.weight"), (None,)),
+        # Gated DeltaNet (linear attention) layers
+        "base.decoder.layers.*.attention.in_proj_qkvz": (_tgt(r"linear_attn\.in_proj_qkvz\.weight"), ("model", None)),
+        "base.decoder.layers.*.attention.in_proj_ba": (_tgt(r"linear_attn\.in_proj_ba\.weight"), ("model", None)),
+        "base.decoder.layers.*.attention.conv1d": (_tgt(r"linear_attn\.conv1d\.weight"), (None, None, None)),
+        "base.decoder.layers.*.attention.A_log": (_tgt(r"linear_attn\.A_log"), (None,)),
+        "base.decoder.layers.*.attention.dt_bias": (_tgt(r"linear_attn\.dt_bias"), (None,)),
+        "base.decoder.layers.*.attention.norm": (_tgt(r"linear_attn\.norm\.weight"), (None,)),
+        "base.decoder.layers.*.attention.gdn_out_proj": (_tgt(r"linear_attn\.out_proj\.weight"), (None, "model")),
+        # MoE
+        "base.decoder.layers.*.mlp.gate": (_tgt(r"mlp\.gate\.weight"), (None, None)),
+        "base.decoder.layers.*.mlp.experts.w13": (
+            _tgt(r"mlp\.experts(?:\.routed_experts)?\.w13_weight"),
+            ("expert", "model", None),
+        ),
+        "base.decoder.layers.*.mlp.experts.w2": (
+            _tgt(r"mlp\.experts(?:\.routed_experts)?\.w2_weight"),
+            ("expert", None, "model"),
+        ),
+        "base.decoder.layers.*.mlp.shared_expert.gate_up_proj": (
+            _tgt(r"mlp\.shared_expert\.gate_up_proj\.weight"),
+            ("model", None),
+        ),
+        "base.decoder.layers.*.mlp.shared_expert.down_proj": (
+            _tgt(r"mlp\.shared_expert\.down_proj\.weight"),
+            (None, "model"),
+        ),
+        "base.decoder.layers.*.mlp.shared_expert_gate": (_tgt(r"mlp\.shared_expert_gate\.weight"), (None, None)),
+    }
+
+  @staticmethod
+  def to_hf_hook_fns():
+    """All layout transformations happen in `preprocess_src_state`."""
+    return {}
+
+  @staticmethod
+  def to_hf_transpose_keys():
+    return {}
+
+  @staticmethod
+  def lora_to_hf_mappings():
+    return None
+
+  @staticmethod
+  def preprocess_src_state(hf_config: Optional[Mapping[str, Any]] = None) -> Callable[[Any], Dict[str, jax.Array]]:
+    """Returns the function that turns a MaxText state into canonical vLLM arrays.
+
+    Args:
+      hf_config: optional HF config dict (``text_config`` is honoured) used for the GDN
+        head geometry. Without it the geometry is inferred from parameter shapes,
+        assuming ``linear_key_head_dim == linear_value_head_dim`` (true for Qwen3.5).
+    """
+    return lambda state: qwen3_5_maxtext_to_vllm_canonical(state, hf_config)
+
+
+# ----------------------------------------------------------------------------------- #
+# Canonicalization
+# ----------------------------------------------------------------------------------- #
+
+_UNSCANNED = re.compile(r"^decoder\.layers_(\d+)\.(.+)$")
+_SCANNED_BLOCK = re.compile(r"^decoder\.layers\.layer_(\d+)\.(.+)$")
+_SCAN_AXIS = 1  # MaxText stacks scanned layer parameters on axis 1.
+
+
+def _flatten(state: Any) -> Dict[str, jax.Array]:
+  """Flattens an nnx.State / dict / pytree of MaxText params to {dotted_key: array}."""
+  if hasattr(state, "flat_state"):
+    items = state.flat_state()
+  elif isinstance(state, Mapping) and all(isinstance(k, str) for k in state):
+    items = state.items()
+  else:
+    leaves = jax.tree_util.tree_flatten_with_path(state)[0]
+    items = [(tuple(getattr(k, "key", getattr(k, "name", getattr(k, "idx", k))) for k in path), v) for path, v in leaves]
+  out = {}
+  for key, val in items:
+    key = key if isinstance(key, str) else ".".join(str(k) for k in key)
+    val = getattr(val, "value", val)
+    if val is None or not hasattr(val, "shape"):
+      continue
+    out[key] = val
+  return out
+
+
+def _normalize_key(key: str) -> Optional[str]:
+  """Strips wrapper prefixes (`base.`, `params.params.`, ...) down to the MaxText param path."""
+  for anchor in ("decoder.", "token_embedder."):
+    idx = key.find(anchor)
+    if idx >= 0:
+      return key[idx:]
+  return None
+
+
+def _gdn_geometry(hf_config: Optional[Mapping[str, Any]], layer: Mapping[str, jax.Array]):
+  """(H_k, H_v, D_k, D_v) of the Gated DeltaNet block."""
+  if hf_config:
+    cfg = hf_config.get("text_config", hf_config)
+    keys = ("linear_num_key_heads", "linear_num_value_heads", "linear_key_head_dim", "linear_value_head_dim")
+    if all(k in cfg for k in keys):
+      return tuple(int(cfg[k]) for k in keys)
+  h_v = layer["attention.A_log"].shape[0]
+  d_v = layer["attention.norm.rms_norm.scale"].shape[0]
+  qkvz_out = layer["attention.in_proj_qkvz.kernel"].shape[1]
+  d_k = d_v
+  h_k = (qkvz_out - 2 * h_v * d_v) // (2 * d_k)
+  assert h_k * d_k * 2 + 2 * h_v * d_v == qkvz_out, (
+      f"cannot infer GDN geometry from in_proj_qkvz {layer['attention.in_proj_qkvz.kernel'].shape}"
+  )
+  return h_k, h_v, d_k, d_v
+
+
+def _canonicalize_layer(layer: Mapping[str, jax.Array], hf_config) -> Dict[str, jax.Array]:
+  """MaxText per-layer params (keys relative to the layer) -> canonical vLLM arrays."""
+  out: Dict[str, jax.Array] = {}
+
+  out["input_layernorm.scale"] = layer["input_layernorm.scale"]
+  out["post_attention_layernorm.scale"] = layer["post_attention_layernorm.scale"]
+
+  if "attention.in_proj_qkvz.kernel" in layer:
+    # --- Gated DeltaNet. MaxText stores in_proj_qkvz per key head as
+    # [q_h | k_h | v_h(0..V/K) | z_h(0..V/K)] and in_proj_ba as [b_h | a_h]; vLLM wants
+    # [Q | K | V | Z] and [B | A] (see QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN in
+    # checkpoint_conversion/utils/param_mapping.py).
+    h_k, h_v, d_k, d_v = _gdn_geometry(hf_config, layer)
+    v_per_k = h_v // h_k
+    qkvz = layer["attention.in_proj_qkvz.kernel"]  # [D, H_k * block]
+    d_model = qkvz.shape[0]
+    block = 2 * d_k + 2 * v_per_k * d_v
+    t = jnp.transpose(qkvz).reshape(h_k, block, d_model)
+    q = t[:, :d_k].reshape(h_k * d_k, d_model)
+    k = t[:, d_k : 2 * d_k].reshape(h_k * d_k, d_model)
+    v = t[:, 2 * d_k : 2 * d_k + v_per_k * d_v].reshape(h_v * d_v, d_model)
+    z = t[:, 2 * d_k + v_per_k * d_v :].reshape(h_v * d_v, d_model)
+    out["attention.in_proj_qkvz"] = jnp.concatenate([q, k, v, z], axis=0)
+
+    ba = jnp.transpose(layer["attention.in_proj_ba.kernel"]).reshape(h_k, 2 * v_per_k, d_model)
+    b = ba[:, :v_per_k].reshape(h_v, d_model)
+    a = ba[:, v_per_k:].reshape(h_v, d_model)
+    out["attention.in_proj_ba"] = jnp.concatenate([b, a], axis=0)
+
+    out["attention.conv1d"] = jnp.transpose(layer["attention.conv1d.kernel"], (2, 1, 0))  # [K,1,C] -> [C,1,K]
+    out["attention.A_log"] = layer["attention.A_log"]
+    out["attention.dt_bias"] = layer["attention.dt_bias"]
+    out["attention.norm"] = layer["attention.norm.rms_norm.scale"]
+    out["attention.gdn_out_proj"] = jnp.transpose(layer["attention.out_proj.kernel"])
+  else:
+    # --- Full attention with output gate: MaxText query kernel is [D, H, 2*Dh] (q and
+    # gate per head, HF order), key/value are [D, H_kv, Dh].
+    q = layer["attention.attention.query.kernel"]
+    k = layer["attention.attention.key.kernel"]
+    v = layer["attention.attention.value.kernel"]
+    d_model = q.shape[0]
+    qkv = [jnp.transpose(x.reshape(d_model, -1)) for x in (q, k, v)]
+    out["attention.qkv_proj"] = jnp.concatenate(qkv, axis=0)
+    out["attention.o_proj"] = jnp.transpose(layer["attention.attention.out.kernel"])
+    out["attention.query_norm.scale"] = layer["attention.attention.query_norm.scale"]
+    out["attention.key_norm.scale"] = layer["attention.attention.key_norm.scale"]
+
+  # --- MoE: MaxText experts are [E, D, F] / [E, F, D]; vLLM wants [E, 2F, D] / [E, D, F].
+  out["mlp.gate"] = jnp.transpose(layer["mlp.routed_experts.gate.kernel"])
+  w13 = jnp.concatenate([layer["mlp.routed_experts.wi_0"], layer["mlp.routed_experts.wi_1"]], axis=-1)
+  out["mlp.experts.w13"] = jnp.swapaxes(w13, 1, 2)
+  out["mlp.experts.w2"] = jnp.swapaxes(layer["mlp.routed_experts.wo"], 1, 2)
+  gate_up = jnp.concatenate([layer["mlp.shared_expert.wi_0.kernel"], layer["mlp.shared_expert.wi_1.kernel"]], axis=-1)
+  out["mlp.shared_expert.gate_up_proj"] = jnp.transpose(gate_up)
+  out["mlp.shared_expert.down_proj"] = jnp.transpose(layer["mlp.shared_expert.wo.kernel"])
+  out["mlp.shared_expert_gate"] = jnp.transpose(layer["mlp.shared_expert_gate.kernel"])
+  return out
+
+
+def _mesh_of(arrays) -> Optional[jax.sharding.Mesh]:
+  """The mesh the (jax) source arrays live on, or None for host/numpy inputs."""
+  for arr in arrays:
+    sharding = getattr(arr, "sharding", None)
+    if isinstance(sharding, jax.sharding.NamedSharding):
+      return sharding.mesh
+  return None
+
+
+def _even_sharding(mesh: jax.sharding.Mesh, shape) -> jax.sharding.NamedSharding:
+  """Shards the first dimension divisible by the device count over the whole mesh (else replicates)."""
+  n = mesh.size
+  spec = [None] * len(shape)
+  for i, dim in enumerate(shape):
+    if dim % n == 0 and dim >= n:
+      spec[i] = tuple(mesh.axis_names)
+      break
+  return jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(*spec))
+
+
+def _materialize(fn: Callable[[Any], Dict[str, jax.Array]], args: Any) -> Dict[str, jax.Array]:
+  """Runs `fn(args)` under jit with every output evenly sharded on the source mesh.
+
+  Eager execution lets XLA pick the output shardings, and reshapes/transposes of
+  fsdp-sharded kernels readily come back replicated -- a full canonical copy per
+  device does not fit next to the trainer and sampler weights.
+  """
+  mesh = _mesh_of(jax.tree_util.tree_leaves(args))
+  if mesh is None:
+    return fn(args)
+  shapes = jax.eval_shape(fn, args)
+  out_shardings = {k: _even_sharding(mesh, v.shape) for k, v in shapes.items()}
+  return jax.jit(fn, out_shardings=out_shardings)(args)
+
+
+def qwen3_5_maxtext_to_vllm_canonical(state: Any, hf_config: Optional[Mapping[str, Any]] = None) -> Dict[str, jax.Array]:
+  """Converts a MaxText Qwen3.5 param tree into canonical vLLM arrays.
+
+  Returns a flat dict keyed by the MaxText-side names used in `to_hf_mapping`
+  (``base.decoder.layers.{i}....``), one entry per (unstacked) layer.
+  """
+  flat = _flatten(state)
+  layers: Dict[int, Dict[str, jax.Array]] = {}
+  globals_: Dict[str, jax.Array] = {}
+  scanned_blocks: Dict[int, Dict[str, jax.Array]] = {}
+
+  for key, val in flat.items():
+    norm = _normalize_key(key)
+    if norm is None:
+      continue
+    if m := _UNSCANNED.match(norm):
+      layers.setdefault(int(m.group(1)), {})[m.group(2)] = val
+    elif m := _SCANNED_BLOCK.match(norm):
+      scanned_blocks.setdefault(int(m.group(1)), {})[m.group(2)] = val
+    elif norm.startswith("decoder.layers"):
+      raise NotImplementedError(f"unexpected MaxText layer parameter layout: {key}")
+    else:
+      globals_[norm] = val
+
+  if scanned_blocks:
+    # Inhomogeneous scan: block b holds layers b, b+n, b+2n, ... stacked on _SCAN_AXIS.
+    n_blocks = max(scanned_blocks) + 1
+    for b, params in scanned_blocks.items():
+      n_rep = next(iter(params.values())).shape[_SCAN_AXIS]
+      for j in range(n_rep):
+        layers[b + n_blocks * j] = {k: jnp.take(v, j, axis=_SCAN_AXIS) for k, v in params.items()}
+
+  out: Dict[str, jax.Array] = {}
+  canonicalize = lambda params: _canonicalize_layer(params, hf_config)  # pylint: disable=unnecessary-lambda-assignment
+  for i, params in sorted(layers.items()):
+    for name, arr in _materialize(canonicalize, params).items():
+      out[f"base.decoder.layers.{i}.{name}"] = arr
+
+  out["base.token_embedder.embedding"] = globals_["token_embedder.embedding"]
+  out["base.decoder.decoder_norm.scale"] = globals_["decoder.decoder_norm.scale"]
+  out.update(
+      _materialize(
+          lambda g: {"base.decoder.logits_dense.kernel": jnp.transpose(g["decoder.logits_dense.kernel"])},
+          {"decoder.logits_dense.kernel": globals_["decoder.logits_dense.kernel"]},
+      )
+  )
+  return out

--- a/tests/post_training/integration/qwen3_5_vllm_weight_sync_check.py
+++ b/tests/post_training/integration/qwen3_5_vllm_weight_sync_check.py
@@ -1,0 +1,239 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Manual TPU check: MaxText Qwen3.5 -> tpu-inference (vLLM/torchax) weight sync.
+
+Two runs on the same 8-chip host:
+
+  # 1. Reference: load Qwen/Qwen3.5-35B-A3B from the HF checkpoint on the torchax path,
+  #    dump the runner state + greedy generations.
+  python qwen3_5_vllm_weight_sync_check.py dump --out /some/dir
+
+  # 2. Load the MaxText checkpoint, start Tunix's VllmSampler with dummy weights, run
+  #    update_params() (MaxText mapping -> canonical vLLM layout -> tpu-inference
+  #    load_canonical_weights), and compare every tensor + generations against the dump.
+  python qwen3_5_vllm_weight_sync_check.py sync --out /some/dir --rl-yml src/maxtext/configs/post_train/rl.yml
+
+Requires tpu-inference with `VllmModelWrapper.load_canonical_weights`, Tunix with the
+torchax branch of `VllmSampler.update_params`, and `MODEL_IMPL_TYPE=vllm`,
+`VLLM_ENABLE_V1_MULTIPROCESSING=0` in the environment.
+"""
+
+import tpu_inference  # noqa: F401  pylint: disable=unused-import  # must precede jax
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import numpy as np
+import jax
+from flax import nnx
+from transformers import AutoTokenizer
+from vllm import LLM, SamplingParams
+
+from maxtext.configs import pyconfig, types
+from maxtext.utils import model_creation_utils
+from tunix.generate import mappings, vllm_sampler
+
+MODEL = "Qwen/Qwen3.5-35B-A3B"
+CKPT = "gs://maxtext-model-checkpoints/qwen3.5-35b-a3b/unscanned/0/items"
+PROMPTS = [
+    "The capital of France is",
+    "Janet's ducks lay 16 eggs per day. She eats three for breakfast every morning and bakes muffins for her "
+    "friends every day with four. She sells the remainder at the farmers market daily for $2 per fresh duck egg. "
+    "How much in dollars does she make every day at the farmers market? Answer:",
+    "def fibonacci(n):",
+    "In 1492, Columbus",
+]
+ENGINE_KWARGS = dict(
+    model=MODEL,
+    dtype="bfloat16",
+    max_model_len=2048,
+    max_num_seqs=8,
+    max_num_batched_tokens=2048,
+    language_model_only=True,
+    limit_mm_per_prompt={"image": 0, "video": 0},
+    enable_prefix_caching=False,
+    disable_log_stats=True,
+)
+SAMPLING = SamplingParams(temperature=0.0, max_tokens=32, logprobs=1)
+
+
+def log(*a):
+  print("[sync-check]", *a, flush=True)
+
+
+def _to_numpy(arr):
+  return np.asarray(jax.device_get(arr))
+
+
+def _load_npy(path):
+  import ml_dtypes  # pylint: disable=import-outside-toplevel
+
+  arr = np.load(path)
+  if arr.dtype.kind == "V" and arr.dtype.itemsize == 2:
+    arr = arr.view(ml_dtypes.bfloat16)
+  return arr
+
+
+def _generate(llm):
+  outs = llm.generate(PROMPTS, SAMPLING)
+  gens = []
+  for p, o in zip(PROMPTS, outs):
+    c = o.outputs[0]
+    gens.append({"prompt": p, "text": c.text, "token_ids": list(c.token_ids)})
+    log(repr(p[:40]), "->", repr(c.text[:100]))
+  return gens
+
+
+def dump(out):
+  os.makedirs(os.path.join(out, "arrays"), exist_ok=True)
+  llm = LLM(tensor_parallel_size=8, gpu_memory_utilization=0.45, **ENGINE_KWARGS)
+  state = llm.llm_engine.model_executor.driver_worker.model_runner.state
+  meta = []
+  for name in sorted(state):
+    arr = state[name]
+    meta.append({"name": name, "shape": [int(s) for s in arr.shape], "dtype": str(arr.dtype)})
+    np.save(os.path.join(out, "arrays", name + ".npy"), _to_numpy(arr))
+  json.dump(meta, open(os.path.join(out, "vllm_state_meta.json"), "w"), indent=1)
+  json.dump(_generate(llm), open(os.path.join(out, "vllm_ref_generations.json"), "w"), indent=1)
+  log(f"dumped {len(meta)} tensors to {out}")
+
+
+def sync(out, rl_yml, random_init=False):
+  t0 = time.time()
+  argv = [
+      "",
+      rl_yml,
+      "model_name=qwen3.5-35b-a3b",
+      f"load_parameters_path={CKPT}",
+      f"tokenizer_path={MODEL}",
+      "run_name=qwen35_vllm_sync_check",
+      "scan_layers=false",
+      "use_pathways=false",
+      "checkpoint_storage_use_ocdbt=true",
+      "checkpoint_storage_use_zarr3=true",
+      "convert_checkpoint_if_possible=false",
+      "dtype=bfloat16",
+      "weight_dtype=bfloat16",
+      "max_target_length=512",
+      "per_device_batch_size=1",
+      "log_config=false",
+  ]
+  config = pyconfig.initialize(argv, config_class=types.RLConfig)
+  adapter, mt_mesh = model_creation_utils.from_pretrained(config, devices=jax.devices(), wrap_with_tunix_adapter=True)
+  log(f"MaxText model loaded in {time.time() - t0:.0f}s")
+
+  # Like train_rl: the rollout mesh keeps the trainer's device order so single-host
+  # jax.device_put can reshard between the MaxText and vLLM meshes.
+  rollout_mesh = jax.sharding.Mesh(mt_mesh.devices.flatten().reshape(1, -1), ("data", "model"))
+  cfg = vllm_sampler.VllmConfig(
+      mesh=rollout_mesh,
+      tensor_parallel_size=8,
+      data_parallel_size=1,
+      mapping_config=mappings.MappingConfig.build(mapping_obj=adapter),
+      init_with_random_weights=random_init,
+      hbm_utilization=0.3,
+      engine_kwargs=dict(ENGINE_KWARGS),
+  )
+  sampler = vllm_sampler.VllmSampler(AutoTokenizer.from_pretrained(MODEL), cfg)
+  runner = sampler._model_runner  # pylint: disable=protected-access
+
+  inproc_ref = None
+  if not random_init:
+    # Same process, same engine configuration (KV-cache size, buckets): generations with the
+    # HF weights are the exact reference for the post-sync generations. Cross-process
+    # references (the dump) can legitimately differ by a greedy tie-break because the engine
+    # configuration differs.
+    log("in-process reference generations with the HF weights:")
+    inproc_ref = [g["token_ids"] for g in _generate(sampler.llm)]
+    key = jax.random.PRNGKey(0)
+    for name in sorted(runner.state):
+      old = runner.state[name]
+      if name.rsplit(".", 1)[-1].startswith("_") or "rotary_emb" in name:
+        continue
+      key, sub = jax.random.split(key)
+      new = jax.device_put((jax.random.normal(sub, old.shape, jax.numpy.float32) * 0.02).astype(old.dtype), old.sharding)
+      new.block_until_ready()
+      runner.state[name] = new
+      old.delete()
+    runner.state_leaves = runner.state
+    log("weights overwritten with on-device random values; generations now:")
+    _generate(sampler.llm)
+
+  t0 = time.time()
+  sampler.update_params(nnx.state(adapter))
+  jax.block_until_ready(list(runner.state.values()))
+  log(f"update_params done in {time.time() - t0:.1f}s")
+
+  ok = True
+  meta_path = os.path.join(out, "vllm_state_meta.json")
+  if os.path.exists(meta_path):
+    diffs, worst = [], (0.0, None)
+    for m in json.load(open(meta_path)):
+      name = m["name"]
+      ref = _load_npy(os.path.join(out, "arrays", name + ".npy"))
+      got = _to_numpy(runner.state[name])
+      if got.shape != ref.shape or got.dtype != ref.dtype:
+        diffs.append((name, f"{got.shape}/{got.dtype} vs {ref.shape}/{ref.dtype}"))
+        continue
+      d = float(np.abs(got.astype(np.float32) - ref.astype(np.float32)).max())
+      worst = max(worst, (d, name))
+      # Attention scale scalars and the rotary cos/sin cache are computed by the sampler, not synced.
+      if d != 0.0 and not name.endswith("_scale") and "rotary_emb" not in name:
+        diffs.append((name, f"maxabs {d:.3g}"))
+    log(f"worst tensor diff vs HF-loaded model: {worst[0]:.3g} at {worst[1]}; {len(diffs)} tensors differ")
+    for n, why in diffs[:20]:
+      log("   ", n, why)
+    ok &= not diffs
+  log("generations after the sync:")
+  gens = _generate(sampler.llm)
+  ref_path = os.path.join(out, "vllm_ref_generations.json")
+  if os.path.exists(ref_path):
+    ref = json.load(open(ref_path))
+    same = sum(g["token_ids"] == r["token_ids"] for g, r in zip(gens, ref))
+    log(f"greedy generations identical to the dumped (separate-process) reference: {same}/{len(ref)}")
+    if inproc_ref is None:
+      ok &= same == len(ref)
+  if inproc_ref is not None:
+    same = sum(g["token_ids"] == r for g, r in zip(gens, inproc_ref))
+    log(f"greedy generations identical to the in-process HF-weight reference: {same}/{len(inproc_ref)}")
+    ok &= same == len(inproc_ref)
+  log("RESULT", "PASS" if ok else "FAIL")
+  return ok
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("mode", choices=["dump", "sync"])
+  parser.add_argument("--out", required=True)
+  parser.add_argument("--rl-yml", default="src/maxtext/configs/post_train/rl.yml")
+  parser.add_argument(
+      "--random-init",
+      action="store_true",
+      help="start the sampler from vLLM's dummy loader (slow CPU init, ~17 min for 35B) instead of "
+      "loading the HF weights, capturing in-process reference generations and overwriting the "
+      "weights with on-device random values",
+  )
+  args = parser.parse_args()
+  if args.mode == "dump":
+    dump(args.out)
+  else:
+    sys.exit(0 if sync(args.out, args.rl_yml, random_init=args.random_init) else 1)
+
+
+if __name__ == "__main__":
+  main()

--- a/tests/post_training/unit/qwen3_5_vllm_weight_mapping_test.py
+++ b/tests/post_training/unit/qwen3_5_vllm_weight_mapping_test.py
@@ -1,0 +1,199 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for the MaxText Qwen3.5 -> vLLM (torchax) weight mapping.
+
+The canonical re-layouts are cross-checked against MaxText's own HF export hooks
+(`QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(saving_to_hf=True)`), and the mapping is checked
+to cover every produced tensor and to resolve real vLLM parameter names uniquely.
+"""
+
+import re
+import unittest
+from types import SimpleNamespace
+
+import pytest
+
+import numpy as np
+
+from maxtext.checkpoint_conversion.utils.param_mapping import QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN
+from maxtext.integration.tunix.weight_mapping import StandaloneVllmWeightMapping
+from maxtext.integration.tunix.weight_mapping.qwen3 import QWEN3_VLLM_MAPPING
+from maxtext.integration.tunix.weight_mapping.qwen3_5 import (
+    QWEN3_5_VLLM_MAPPING,
+    qwen3_5_maxtext_to_vllm_canonical,
+)
+
+
+pytestmark = [pytest.mark.post_training]
+
+# Tiny geometry: 8 layers in cycles of 4 (layers 3 and 7 are full attention).
+D, H, HD, HKV = 64, 4, 16, 2
+HK, HV, DK, DV = 4, 8, 8, 8
+E, F, V, K = 6, 24, 100, 4
+N_LAYERS = 8
+HF_CFG = {
+    "text_config": {
+        "linear_num_key_heads": HK,
+        "linear_num_value_heads": HV,
+        "linear_key_head_dim": DK,
+        "linear_value_head_dim": DV,
+        "num_hidden_layers": N_LAYERS,
+    }
+}
+
+
+def _make_state(rng):
+  def r(*shape):
+    return rng.standard_normal(shape).astype(np.float32)
+
+  state = {
+      "params.params.token_embedder.embedding": r(V, D),
+      "params.params.decoder.decoder_norm.scale": r(D),
+      "params.params.decoder.logits_dense.kernel": r(D, V),
+  }
+  for i in range(N_LAYERS):
+    p = f"params.params.decoder.layers_{i}."
+    state[p + "input_layernorm.scale"] = r(D)
+    state[p + "post_attention_layernorm.scale"] = r(D)
+    if i % 4 == 3:
+      state[p + "attention.attention.query.kernel"] = r(D, H, 2 * HD)
+      state[p + "attention.attention.key.kernel"] = r(D, HKV, HD)
+      state[p + "attention.attention.value.kernel"] = r(D, HKV, HD)
+      state[p + "attention.attention.out.kernel"] = r(H * HD, D)
+      state[p + "attention.attention.query_norm.scale"] = r(HD)
+      state[p + "attention.attention.key_norm.scale"] = r(HD)
+    else:
+      state[p + "attention.in_proj_qkvz.kernel"] = r(D, HK * (2 * DK + 2 * (HV // HK) * DV))
+      state[p + "attention.in_proj_ba.kernel"] = r(D, 2 * HV)
+      state[p + "attention.conv1d.kernel"] = r(K, 1, 2 * HK * DK + HV * DV)
+      state[p + "attention.A_log"] = r(HV)
+      state[p + "attention.dt_bias"] = r(HV)
+      state[p + "attention.norm.rms_norm.scale"] = r(DV)
+      state[p + "attention.out_proj.kernel"] = r(HV * DV, D)
+    state[p + "mlp.routed_experts.gate.kernel"] = r(D, E)
+    state[p + "mlp.routed_experts.wi_0"] = r(E, D, F)
+    state[p + "mlp.routed_experts.wi_1"] = r(E, D, F)
+    state[p + "mlp.routed_experts.wo"] = r(E, F, D)
+    state[p + "mlp.shared_expert.wi_0.kernel"] = r(D, F)
+    state[p + "mlp.shared_expert.wi_1.kernel"] = r(D, F)
+    state[p + "mlp.shared_expert.wo.kernel"] = r(F, D)
+    state[p + "mlp.shared_expert_gate.kernel"] = r(D, 1)
+  return state
+
+
+class Qwen35VllmWeightMappingTest(unittest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.state = _make_state(np.random.default_rng(0))
+    self.out = qwen3_5_maxtext_to_vllm_canonical(self.state, HF_CFG)
+
+  def test_registry_prefers_qwen3_5_over_qwen3(self):
+    self.assertIs(StandaloneVllmWeightMapping()["qwen3.5-35b-a3b"], QWEN3_5_VLLM_MAPPING)
+    self.assertIs(StandaloneVllmWeightMapping()["qwen3-8b"], QWEN3_VLLM_MAPPING)
+
+  def test_geometry_inferred_from_shapes_matches_config(self):
+    inferred = qwen3_5_maxtext_to_vllm_canonical(self.state, None)
+    self.assertEqual(set(inferred), set(self.out))
+    for k in self.out:
+      np.testing.assert_array_equal(np.asarray(inferred[k]), np.asarray(self.out[k]), err_msg=k)
+
+  def test_relayouts_match_maxtext_hf_export_hooks(self):
+    hooks = QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(
+        HF_CFG,
+        SimpleNamespace(inhomogeneous_layer_cycle_interval=4, use_multimodal=False),
+        scan_layers=False,
+        saving_to_hf=True,
+    )
+    s = self.state
+    p0, p3 = "params-decoder-layers_0-", "params-decoder-layers_3-"
+    l0, l3 = "params.params.decoder.layers_0.", "params.params.decoder.layers_3."
+
+    qkv, z = hooks[p0 + "attention-in_proj_qkvz-kernel"](s[l0 + "attention.in_proj_qkvz.kernel"])
+    np.testing.assert_array_equal(np.asarray(self.out["base.decoder.layers.0.attention.in_proj_qkvz"]), np.concatenate([qkv, z], 0))
+    b, a = hooks[p0 + "attention-in_proj_ba-kernel"](s[l0 + "attention.in_proj_ba.kernel"])
+    np.testing.assert_array_equal(np.asarray(self.out["base.decoder.layers.0.attention.in_proj_ba"]), np.concatenate([b, a], 0))
+    conv = hooks[p0 + "attention-conv1d-kernel"](s[l0 + "attention.conv1d.kernel"])
+    np.testing.assert_array_equal(np.asarray(self.out["base.decoder.layers.0.attention.conv1d"]), conv)
+
+    q = hooks[p3 + "attention-attention-query-kernel"](s[l3 + "attention.attention.query.kernel"], (H * 2 * HD, D))
+    k = hooks[p3 + "attention-attention-key-kernel"](s[l3 + "attention.attention.key.kernel"], (HKV * HD, D))
+    v = hooks[p3 + "attention-attention-value-kernel"](s[l3 + "attention.attention.value.kernel"], (HKV * HD, D))
+    np.testing.assert_array_equal(np.asarray(self.out["base.decoder.layers.3.attention.qkv_proj"]), np.concatenate([q, k, v], 0))
+    o = hooks[p3 + "attention-attention-out-kernel"](s[l3 + "attention.attention.out.kernel"], (D, H * HD))
+    np.testing.assert_array_equal(np.asarray(self.out["base.decoder.layers.3.attention.o_proj"]), o)
+
+    gu = hooks[(p0 + "mlp-routed_experts-wi_0", p0 + "mlp-routed_experts-wi_1")](
+        (s[l0 + "mlp.routed_experts.wi_0"], s[l0 + "mlp.routed_experts.wi_1"])
+    )
+    self.assertEqual(gu.shape, (E, 2 * F, D))
+    np.testing.assert_array_equal(np.asarray(self.out["base.decoder.layers.0.mlp.experts.w13"]), gu)
+    dn = hooks[p0 + "mlp-routed_experts-wo"](s[l0 + "mlp.routed_experts.wo"])
+    self.assertEqual(dn.shape, (E, D, F))
+    np.testing.assert_array_equal(np.asarray(self.out["base.decoder.layers.0.mlp.experts.w2"]), dn)
+
+  def test_canonical_vllm_layouts(self):
+    out = self.out
+    self.assertEqual(out["base.decoder.logits_dense.kernel"].shape, (V, D))
+    self.assertEqual(out["base.decoder.layers.0.mlp.gate"].shape, (E, D))
+    self.assertEqual(out["base.decoder.layers.0.mlp.shared_expert.gate_up_proj"].shape, (2 * F, D))
+    self.assertEqual(out["base.decoder.layers.0.mlp.shared_expert.down_proj"].shape, (D, F))
+    self.assertEqual(out["base.decoder.layers.0.mlp.shared_expert_gate"].shape, (1, D))
+    self.assertEqual(out["base.decoder.layers.0.attention.gdn_out_proj"].shape, (D, HV * DV))
+    # shared expert gate_up is [gate | up] rows, i.e. wi_0 first.
+    np.testing.assert_array_equal(
+        np.asarray(out["base.decoder.layers.0.mlp.shared_expert.gate_up_proj"])[:F],
+        self.state["params.params.decoder.layers_0.mlp.shared_expert.wi_0.kernel"].T,
+    )
+
+  def test_mapping_covers_all_produced_keys_and_resolves_vllm_names(self):
+    mapping = QWEN3_5_VLLM_MAPPING.to_hf_mapping()
+    src_patterns = [re.compile("^" + re.escape(s).replace(r"\*", r"(\d+)") + "$") for s in mapping]
+    for key in self.out:
+      self.assertTrue(any(p.match(key) for p in src_patterns), f"produced key without mapping: {key}")
+    for s in mapping:
+      gdn = any(t in s for t in ("in_proj", "gdn", "A_log", "dt_bias", "attention.norm", "conv1d"))
+      concrete = s.replace("*", "0" if gdn else "3")
+      self.assertIn(concrete, self.out, f"mapping source never produced: {s}")
+
+    vllm_names = [
+        "language_model.model.layers.0.linear_attn.in_proj_qkvz.weight",
+        "language_model.model.layers.0.linear_attn.A_log",
+        "language_model.model.layers.3.self_attn.qkv_proj.weight",
+        "language_model.model.layers.0.mlp.experts.routed_experts.w13_weight",
+        "model.layers.0.mlp.experts.w2_weight",
+        "language_model.lm_head.weight",
+        "language_model.model.embed_tokens.weight",
+    ]
+    for n in vllm_names:
+      hits = [(s, m) for s, (t, _) in mapping.items() if (m := re.compile("^" + t + "$").match(n))]
+      self.assertEqual(len(hits), 1, (n, hits))
+      self.assertEqual(len(hits[0][1].groups()), 1 if ".layers." in n else 0, n)
+
+  def test_scanned_blocks_give_same_result(self):
+    scanned = {k: v for k, v in self.state.items() if "decoder.layers_" not in k}
+    for b in range(4):
+      for name in [k for k in self.state if f"decoder.layers_{b}." in k]:
+        rest = name.split(f"decoder.layers_{b}.")[1]
+        stacked = np.stack([self.state[f"params.params.decoder.layers_{b + 4 * j}.{rest}"] for j in range(2)], axis=1)
+        scanned[f"params.params.decoder.layers.layer_{b}.{rest}"] = stacked
+    out_scanned = qwen3_5_maxtext_to_vllm_canonical(scanned, HF_CFG)
+    self.assertEqual(set(out_scanned), set(self.out))
+    for k in self.out:
+      np.testing.assert_array_equal(np.asarray(out_scanned[k]), np.asarray(self.out[k]), err_msg=k)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary

Weight mapping from MaxText's Qwen3.5 (text) model to tpu-inference's native Qwen3.5, which runs on the vLLM (torchax) path, for RL weight sync through Tunix's `VllmSampler.update_params`.

- `src/maxtext/integration/tunix/weight_mapping/qwen3_5.py`: `QWEN3_5_VLLM_MAPPING`. The target is vLLM's canonical TP=1 parameter layout (module paths such as `language_model.model.layers.N.self_attn.qkv_proj.weight`); tpu-inference converts canonical arrays into its tp/backend-dependent internal layout (`VllmModelWrapper.load_canonical_weights`, companion PR), so the mapping knows nothing about TP size, KV-head replication or the MoE backend.
- Tunix's key mapping is one-to-one, so every fusion/reorder lives in `preprocess_src_state`: GDN per-key-head interleaved `in_proj_qkvz`/`in_proj_ba` → `[Q|K|V|Z]`/`[B|A]`, `query`/`key`/`value` → `qkv_proj` (q keeps the attention output gate), `wi_0`/`wi_1` → `w13_weight`, shared-expert `gate_up_proj`, `conv1d [K,1,C] → [C,1,K]`, transposes. `to_hf_mapping` is then a regex rename (targets match both `language_model.model.layers.N…` and `model.layers.N…`, and `experts(.routed_experts)?.w13_weight`). Unscanned (`layers_{i}`) and inhomogeneous scanned (`layers.layer_{b}`) parameter trees are accepted; the GDN geometry comes from the HF config or is inferred from shapes. Each layer is materialized under `jax.jit` with even `out_shardings` on the source mesh (eager execution on fsdp-sharded kernels came back replicated and did not fit next to the trainer and sampler weights).
- `preprocess_src_state` is plumbed through `VllmWeightMapping` and `TunixMaxTextAdapter` (Tunix's `MappingConfig.build/from_model` pick it up).
- Registry fix: `StandaloneVllmWeightMapping` now checks the `qwen3.5` prefix before `qwen3`, which used to swallow it and silently return the dense Qwen3 mapping.

## Testing

- `tests/post_training/unit/qwen3_5_vllm_weight_mapping_test.py` (CPU): re-layouts cross-checked against MaxText's own HF export hooks (`QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(saving_to_hf=True)`), geometry inference, mapping coverage and target-regex resolution against real vLLM names, scanned vs unscanned equivalence.
- `tests/post_training/integration/qwen3_5_vllm_weight_sync_check.py` (manual, TPU): `dump` loads Qwen/Qwen3.5-35B-A3B from HF on the torchax path and records the runner state + greedy generations; `sync` loads `gs://maxtext-model-checkpoints/qwen3.5-35b-a3b/unscanned/0/items` (bf16), starts Tunix's `VllmSampler`, captures in-process reference generations with the HF weights, overwrites all weights with random values (or `--random-init` for vLLM's dummy loader), runs `update_params`, and compares every tensor and the generations.
- Result on v7x-8 (TP=8, bf16): all 613 weight tensors bit-identical to the HF-loaded model; greedy generations 4/4 identical to the in-process HF-weight reference; `update_params` ~150 s (first call, JIT-dominated).
- Same result (4/4 identical generations) with the production Qwen3.5 serving configuration on the sampler side (TP=8, `--enable-expert-parallel`, `enable_dp_attention` + `attn_dp_size=4`, prefix caching, async scheduling, chunked prefill, production env/LIBTPU flags): the mapping is unchanged, tpu-inference produces the EP/attn-DP layouts.

Companion PRs: vllm-project/tpu-inference#3477 (`load_canonical_weights`), google/tunix#2014 (`VllmSampler.update_params` torchax branch).
