### PR TITLE
Add ChartNet SFT configuration and support

### DIFF
--- a/src/maxtext/configs/post_train/sft-vision-chartnet.yml
+++ b/src/maxtext/configs/post_train/sft-vision-chartnet.yml
@@ -1,0 +1,44 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+base_config: "base.yml"
+
+use_sft: true
+use_tunix_gradient_accumulation: true
+use_multimodal: true
+# For vision, the prompt contains image, we only train on completion tokens
+sft_train_on_completion_only: true
+packing: false  # multimodal packing is not supported yet
+freeze_vision_encoder_params: true
+learning_rate: 2.e-5
+
+# -------------- HF pipeline (ibm-granite/ChartNet) --------------
+# Available subsets in ibm-granite/ChartNet: 'human_verified', 'core', 'core_permissive',
+# 'reasoning', 'grounded_qa'
+# Prompt: 'prompt' (injected via default_prompt)
+# Completion: 'summary' (dense natural-language description of chart trends, axes, and data)
+dataset_type: hf
+hf_path: 'ibm-granite/ChartNet'
+hf_name: 'human_verified'
+train_split: 'train'
+hf_eval_split: 'test'
+
+# Image column
+train_image_column: 'image'
+eval_image_column: 'image'
+
+# Text columns: ['prompt', 'summary']
+train_data_columns: ['prompt', 'summary']
+eval_data_columns: ['prompt', 'summary']
+default_prompt: "Summarize the key information and data trends in this chart in detail."

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -126,7 +126,12 @@ def reformat_prompt(
 
 def reformat_response(example, column, model_name):
   """reformat response for multimodal SFT"""
-  example[column] = mm_processor.reformat_response(example[column][0], model_name)
+  val = example[column]
+  if not val:
+    raise ValueError(f"Response column '{column}' cannot be empty or None: {val}")
+  response = val[0] if isinstance(val, (list, tuple)) else val
+
+  example[column] = mm_processor.reformat_response(response, model_name)
   return example
 
 

--- a/tests/unit/multimodal_utils_test.py
+++ b/tests/unit/multimodal_utils_test.py
@@ -21,6 +21,7 @@ import numpy as np
 from maxtext.common.common_types import DecoderBlockType, VisionEncoderBlockType
 from maxtext.configs import pyconfig
 from maxtext.utils.globals import MAXTEXT_REPO_ROOT
+from maxtext.input_pipeline import input_pipeline_utils
 from maxtext.multimodal import processor as mm_processor
 from maxtext.multimodal import utils as mm_utils
 from maxtext.multimodal import processor_gemma3
@@ -389,6 +390,27 @@ class TestMultimodalProcessorRouting(unittest.TestCase):
     self.assertEqual(mm_processor.reformat_response("Hello world", "gemma3-4b"), "Hello world<end_of_turn>")
     # Multimodal Llama 4 model should append <|eot|>
     self.assertEqual(mm_processor.reformat_response("Hello world", "llama4-17b-16e"), "Hello world<|eot|>")
+
+  def test_input_pipeline_reformat_response_string_and_list(self):
+    # Test list response column (e.g. ChartQA where label = ['186600'])
+    ex_list = {"label": ["186600"]}
+    res_list = input_pipeline_utils.reformat_response(ex_list, "label", "maxtext-omni-gemma3-qwen3")
+    self.assertEqual(res_list["label"], "186600<|im_end|>")
+
+    # Test string response column (e.g. ChartNet where summary = 'This is a chart summary.')
+    ex_str = {"summary": "This is a chart summary."}
+    res_str = input_pipeline_utils.reformat_response(ex_str, "summary", "maxtext-omni-gemma3-qwen3")
+    self.assertEqual(res_str["summary"], "This is a chart summary.<|im_end|>")
+
+    # Test empty list and tuple raise ValueError
+    with self.assertRaises(ValueError):
+      input_pipeline_utils.reformat_response({"label": []}, "label", "maxtext-omni-gemma3-qwen3")
+    # Test empty string raises ValueError
+    with self.assertRaises(ValueError):
+      input_pipeline_utils.reformat_response({"summary": ""}, "summary", "maxtext-omni-gemma3-qwen3")
+    # Test None raises ValueError
+    with self.assertRaises(ValueError):
+      input_pipeline_utils.reformat_response({"label": None}, "label", "maxtext-omni-gemma3-qwen3")
 
   def test_reformat_prompt_text_only_fallback(self):
     # Text-only models should return prompt unchanged


### PR DESCRIPTION
# Description

This PR introduces post-training Supervised Fine-Tuning support for the **`ChartNet`** dataset into MaxText's native vision SFT pipeline.


# Files

1. **Vision SFT Dataset Configuration**
   - `src/maxtext/configs/post_train/sft-vision-chartnet.yml`
     - Introduces native vision SFT configuration for the `ibm-granite/ChartNet` dataset.
     - Configures input/target feature mappings: loads visual inputs from the `image` column, injects instructional prompts via `default_prompt`, and dense chart analytical descriptions from `summary`.

2. **Multimodal Input Pipeline Utilities**
   - `src/maxtext/input_pipeline/input_pipeline_utils.py`
     - Adds type inspection (`isinstance(example[column], (list, tuple))`) to support both sequence-based target completions (such as ChartQA's `['186600']`) and raw string completions (such as ChartNet's `summary`).
     - Adds explicit `ValueError` validation to guard against empty sequences (`[]`) or `None` target fields.

3. **Unit Tests**
   - `tests/unit/multimodal_utils_test.py`
     - Adds unit tests to verify response formatting for string and list targets.



# Tests

## Pre-SFT Baseline Inference
Run baseline multimodal inference on Gemma 3 4B before fine-tuning:

```bash
python3 -m maxtext.inference.decode \
    src/maxtext/configs/base.yml \
    model_name=gemma3-4b \
    tokenizer_path=google/gemma-3-4b-it \
    tokenizer_type=huggingface \
    load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/gemma3-4b-processor/0/items \
    per_device_batch_size=1 \
    run_name=gemma3_4b_chartnet_pre_sft \
    max_prefill_predict_length=1024 \
    max_target_length=2048 \
    steps=1 \
    async_checkpointing=false \
    scan_layers=false \
    use_multimodal=true \
    prompt='Describe the image' \
    image_path=tests/assets/test_image.jpg \
    attention=dot_product \
    skip_jax_distributed_system=true
```

### Pre-SFT Output:
```text
Input `<start_of_turn>user
\n\nDescribe the image<end_of_turn>
<start_of_turn>model
` -> `Here's a description of the image:

The image is a wide-angle shot of Seattle, Washington. The dominant feature is the Space Needle, a distinctive landmark that rises above the city's skyline. 

Behind the Space Needle, there's a dense collection of skyscrapers and other buildings, creating a layered urban landscape. In the distance, partially obscured by clouds, are the snow-capped peaks of the Cascade Mountains. 

The sky is a bright blue, dotted with fluffy white clouds. The foreground is filled with greenery, suggesting that the photo was taken from an elevated position overlooking the city. 

Overall, the image captures the beauty and scale of Seattle, highlighting its iconic landmarks and its proximity to the majestic Cascade Mountains. 

Do you want me to focus on a specific aspect of the image, like the Space Needle or the mountains?`
```

## Vision SFT Training on ChartNet
Run native SFT fine-tuning on `ibm-granite/ChartNet` (`human_verified` subset):

```bash
python3 -m maxtext.trainers.post_train.sft.train_sft_native \
    src/maxtext/configs/post_train/sft-vision-chartnet.yml \
    model_name=gemma3-4b \
    tokenizer_path=google/gemma-3-4b-it \
    tokenizer_type=huggingface \
    load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/gemma3-4b-processor/0/items \
    base_output_directory=gs://yuchenhou-maxtext-logs/gemma3-4b/multimodal/sft \
    run_name=gemma3_4b_sft_chartnet \
    per_device_batch_size=1 \
    max_prefill_predict_length=1024 \
    max_target_length=2048 \
    steps=101 \
    checkpoint_period=20 \
    scan_layers=false \
    async_checkpointing=false \
    save_checkpoint_on_completion=true \
    log_period=1 \
    eval_interval=10 \
    eval_steps=2 \
    gcs_metrics=true \
    float32_qk_product=true \
    float32_logits=true \
    attention=dot_product \
    sharding_tolerance=0.05 \
    checkpoint_storage_use_zarr3=false \
    checkpoint_storage_use_ocdbt=false \
    enable_single_controller=false \
    grain_worker_count=0
```

[Log link](https://paste.googleplex.com/4885969224990720). Model training behavior is expected and losses decrease steadily without error.



## Post-SFT Inference Verification
Run decode with the fine-tuned checkpoint at step 100:

```bash
python3 -m maxtext.inference.decode \
    src/maxtext/configs/base.yml \
    model_name=gemma3-4b \
    tokenizer_path=google/gemma-3-4b-it \
    tokenizer_type=huggingface \
    load_parameters_path=gs://yuchenhou-maxtext-logs/gemma3-4b/multimodal/sft/gemma3_4b_sft_chartnet/checkpoints/100/items \
    per_device_batch_size=1 \
    run_name=gemma3_4b_chartnet_post_sft \
    max_prefill_predict_length=1024 \
    max_target_length=2048 \
    steps=1 \
    async_checkpointing=false \
    scan_layers=false \
    use_multimodal=true \
    prompt='Describe the image' \
    image_path=tests/assets/test_image.jpg \
    attention=dot_product \
    skip_jax_distributed_system=true
```

### Post-SFT Output:
```text
Input `<start_of_turn>user
\n\nDescribe the image<end_of_turn>
<start_of_turn>model
` -> `The image is a panoramic view of Seattle, Washington, with the iconic Space Needle prominently featured at the top. The skyline is dominated by a mix of modern and older buildings, with the Space Needle standing out as the tallest structure. The buildings are primarily in shades of blue, gray, and brown, indicating a mix of architectural styles. The Space Needle itself is a striking white structure with a circular top, providing a clear contrast against the blue sky. The background shows a mountain range, with the snow-capped peaks visible in the distance. This mountain range adds a sense of depth to the image, making the skyline more dynamic. The foreground features a green hill, which helps to separate the buildings from the background, enhancing the overall visual appeal. The image uses a clear and crisp style, with a slight blue tint that helps to make the buildings stand out. The composition is well-balanced, with the Space Needle positioned at the top and the mountain range in the background, creating a harmonious and visually engaging scene.`
```

## Additional Unit Tests

```bash
PYTHONPATH=src python3 -m unittest tests/unit/multimodal_utils_test.py
```

```text
----------------------------------------------------------------------
Ran 25 tests in 7.336s

OK
```


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
