### PR TITLE
Use native block-sparse attention for indexer mask under CP

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -3868,6 +3868,15 @@ class MaxTextConfig(
         raise ValueError(
             "Sparse indexer is only supported with dot_product attention or flash attention with tokamax splash."
         )
+      if (
+          self.attention == "flash"
+          and self.context_parallel_strategy == "all_gather"
+          and self.ici_context_parallelism * self.dcn_context_parallelism > 1
+          and self.attention_sink
+      ):
+        raise ValueError(
+            "Sparse indexer with all-gather context parallelism for flash attention does not support attention sinks."
+        )
       if self.indexer_loss_scaling_factor > 0.0 and self.indexer_topk >= self.max_target_length:
         raise ValueError(
             f"`indexer_topk` ({self.indexer_topk}) must be < `max_target_length` ({self.max_target_length}) "

--- a/src/maxtext/kernels/attention/jax_flash_attention.py
+++ b/src/maxtext/kernels/attention/jax_flash_attention.py
@@ -42,10 +42,13 @@ def flash_attention_block_masked(
     segment_ids: SegmentIds | None,
     block_kv: int,
     block_q: int,
-    mask: mask_lib.Mask,
+    mask: mask_lib.Mask | jax.Array,
     mask_value: float,
     cap: Optional[float] = None,
     save_residuals: bool = False,
+    logits_dtype: jax.typing.DTypeLike = jnp.bfloat16,
+    loop_unroll: int | bool = True,
+    fuse_logits: bool = True,
 ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, Tuple[jnp.ndarray, jnp.ndarray]]]:
   """Computes masked flash attention using block-sparse masking.
 
@@ -62,12 +65,22 @@ def flash_attention_block_masked(
       other. It stores the segment ids of the query and key/value sequences.
     block_kv: Block size for the key/value sequence dimension.
     block_q: Block size for the query sequence dimension.
-    mask: The full attention mask with shape of (q_seq_len, kv_seq_len). This
-      mask will be used for all batches.
+    mask: The full attention mask. A rank-2 mask with shape
+      (q_seq_len, kv_seq_len) is shared by every batch item. A rank-3 mask with
+      shape (batch_size, q_seq_len, kv_seq_len) supplies an independent mask
+      for each batch item.
     mask_value: The value to use for masked-out attention scores.
     cap: Optional cap for attention logits. This helps to prevent extremely
       large logits: capped_logits = jnp.tanh(logits / attn_logits_soft_cap) *
       attn_logits_soft_cap
+    logits_dtype: Preferred element type for the fused query-key product that
+      forms the attention probabilities; pass the query dtype when
+      full-precision logits are required.
+    loop_unroll: Unroll setting for the block loops; True fully unrolls, which
+      is prohibitive for long sequences with a runtime mask.
+    fuse_logits: Wrap the logits computation in a must-fuse XLA metadata call.
+      The wrapper does not support reverse-mode differentiation inside a
+      sharded computation; pass False when gradients are required.
     save_residuals: Whether to save residuals. If True, returns a tuple of
       (output, dict=(logsumexp, max_logits)). Both `logsumexp` and `max_logits`
       are of shape (batch_size, num_kv_heads, num_q_heads // num_kv_heads,
@@ -94,14 +107,25 @@ def flash_attention_block_masked(
       )
   )
 
+  if q_seq_len % block_q != 0:
+    raise ValueError(f"q_seq_len {q_seq_len} must be divisible by block_q {block_q}")
+  if kv_seq_len % block_kv != 0:
+    raise ValueError(f"kv_seq_len {kv_seq_len} must be divisible by block_kv {block_kv}")
+
   # Calculate the number of key/value and query blocks.
   num_kv_blocks = kv_seq_len // block_kv
   num_q_blocks = q_seq_len // block_q
 
   mask_array = mask[:, :]
-  # Before applying the segment mask, we need to broadcast the mask in batch
-  # dimension since we have same logic for all batches.
-  mask_full = jnp.broadcast_to(mask_array[None, :, :], (batch_size, q_seq_len, kv_seq_len))
+  if mask_array.ndim == 2:
+    # A rank-2 mask is shared by every item in the batch.
+    mask_full = jnp.broadcast_to(mask_array[None, :, :], (batch_size, q_seq_len, kv_seq_len))
+  else:
+    if mask_array.shape != (batch_size, q_seq_len, kv_seq_len):
+      raise ValueError(
+          f"Batched attention mask must have shape {(batch_size, q_seq_len, kv_seq_len)}, got {mask_array.shape}."
+      )
+    mask_full = mask_array
 
   if segment_ids is not None:
     segment_ids_q = segment_ids.q[:, :, None]
@@ -200,7 +224,7 @@ def flash_attention_block_masked(
               "bxhqc,bxkc->bxhqk",
               q_slice,
               k_j_slice,
-              preferred_element_type=jnp.bfloat16,
+              preferred_element_type=logits_dtype,
           )
           if cap is not None:
             s_i_j = jnp.tanh(s_i_j / cap)
@@ -209,7 +233,10 @@ def flash_attention_block_masked(
           p_i_j = jnp.exp(s_i_j - m_i_j[..., None])
           return p_i_j
 
-        p_i_j = must_fuse_call("1")(fuse_this)(q_slice, k_j_slice, mask_value, broadcasted_mask, m_i_j)
+        if fuse_logits:
+          p_i_j = must_fuse_call("1")(fuse_this)(q_slice, k_j_slice, mask_value, broadcasted_mask, m_i_j)
+        else:
+          p_i_j = fuse_this(q_slice, k_j_slice, mask_value, broadcasted_mask, m_i_j)
         l_i_j = p_i_j.sum(axis=-1)
         assert m_i_j.shape == m_i_slice.shape
         m_i_new = jnp.maximum(m_i_slice, m_i_j)
@@ -254,11 +281,11 @@ def flash_attention_block_masked(
 
       return output, l, m
 
-    output, l, m = jax.lax.fori_loop(0, num_q_blocks, inner_loop_body, (output, l, m), unroll=True)
+    output, l, m = jax.lax.fori_loop(0, num_q_blocks, inner_loop_body, (output, l, m), unroll=loop_unroll)
 
     return (output, l, m)
 
-  output, l, m = jax.lax.fori_loop(0, num_kv_blocks, outer_loop_body, (output, l, m), unroll=True)
+  output, l, m = jax.lax.fori_loop(0, num_kv_blocks, outer_loop_body, (output, l, m), unroll=loop_unroll)
 
   # Reshape the output to drop the size one dimension at index 2,
   # which corresponds to `num_q_heads // num_kv_heads` when

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -2115,6 +2115,59 @@ class AttentionOp(nnx.Module):
         decoder_segment_ids_tuple = None
 
       if self.config.use_tokamax_splash:
+        if indexer_mask is not None and cp_size > 1:
+          # Dynamic Tokamax Splash derives its Pallas grid from each shard-local
+          # mask, which is unsupported under sharding; the native block-sparse
+          # implementation consumes the runtime mask without a data-dependent
+          # device-local grid.
+          if sinks is not None:
+            # cp_size comes from the mesh axis named by context_sharding, which
+            # custom mesh rules can point at an axis the config validation does
+            # not cover.
+            raise ValueError(
+                "Sparse indexer with all-gather context parallelism for flash attention does not support"
+                " attention sinks."
+            )
+          indexer_mask = indexer_mask == 0.0
+          # sa_config blocks are clamped to the global sequence lengths; inside
+          # the shard map the query is a sequence shard, and the blocks must
+          # divide the sequence lengths the kernel sees exactly.
+          block_q = math.gcd(sa_config.block_q, query.shape[2])
+          block_kv = math.gcd(sa_config.block_kv, key.shape[2])
+          if record_max_logits:
+            attention_output, stats = jax_flash_attention.flash_attention_block_masked(
+                query,
+                key,
+                value,
+                decoder_segment_ids_tuple,
+                block_kv=block_kv,
+                block_q=block_q,
+                mask=indexer_mask,
+                mask_value=DEFAULT_MASK_VALUE,
+                cap=attn_logits_soft_cap,
+                save_residuals=True,
+                logits_dtype=query.dtype,
+                loop_unroll=False,
+                fuse_logits=False,
+            )
+            return attention_output, stats["max_logits"]
+
+          attention_output = jax_flash_attention.flash_attention_block_masked(
+              query,
+              key,
+              value,
+              decoder_segment_ids_tuple,
+              block_kv=block_kv,
+              block_q=block_q,
+              mask=indexer_mask,
+              mask_value=DEFAULT_MASK_VALUE,
+              cap=attn_logits_soft_cap,
+              logits_dtype=query.dtype,
+              loop_unroll=False,
+              fuse_logits=False,
+          )
+          return attention_output, None
+
         if indexer_mask is not None:
           # Convert additive float mask (0.0=attend, negative=masked) to boolean mask for Tokamax splash kernel
           indexer_mask = indexer_mask == 0.0

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -103,6 +103,100 @@ class JaxFlashAttentionTest(unittest.TestCase):
         atol=1e-2,
     )
 
+  def test_flash_attention_block_masked_per_example_mask(self):
+    batch, heads, q_len, kv_len, head_dim = 2, 2, 8, 16, 4
+    rng = np.random.default_rng(0)
+    query = jnp.asarray(rng.normal(size=(batch, heads, q_len, head_dim)), dtype=jnp.float32)
+    key = jnp.asarray(rng.normal(size=(batch, heads, kv_len, head_dim)), dtype=jnp.float32)
+    value = jnp.asarray(rng.normal(size=(batch, heads, kv_len, head_dim)), dtype=jnp.float32)
+    mask = np.tril(np.ones((batch, q_len, kv_len), dtype=bool), k=kv_len - q_len)
+    mask[1, :, ::3] = False  # each batch item gets a different sparsity pattern
+    mask = jnp.asarray(mask)
+
+    def block_masked_qkv(q, k, v):
+      return jax_flash_attention.flash_attention_block_masked(
+          q,
+          k,
+          v,
+          segment_ids=None,
+          block_kv=4,
+          block_q=4,
+          mask=mask,
+          mask_value=-1.0e9,
+          logits_dtype=jnp.float32,
+          loop_unroll=False,
+          fuse_logits=False,
+      )
+
+    def block_masked(q):
+      return block_masked_qkv(q, key, value)
+
+    def dense_qkv(q, k, v):
+      logits = jnp.einsum("bhqd,bhkd->bhqk", q, k)
+      logits = jnp.where(mask[:, None, :, :], logits, -1.0e9)
+      return jnp.einsum("bhqk,bhkd->bhqd", jax.nn.softmax(logits, axis=-1), v)
+
+    def dense(q):
+      return dense_qkv(q, key, value)
+
+    np.testing.assert_allclose(np.asarray(block_masked(query)), np.asarray(dense(query)), rtol=1e-4, atol=1e-4)
+
+    grads_block = jax.grad(lambda q, k, v: jnp.sum(block_masked_qkv(q, k, v) ** 2), argnums=(0, 1, 2))(query, key, value)
+    grads_dense = jax.grad(lambda q, k, v: jnp.sum(dense_qkv(q, k, v) ** 2), argnums=(0, 1, 2))(query, key, value)
+    for grad_block, grad_dense in zip(grads_block, grads_dense):
+      np.testing.assert_allclose(np.asarray(grad_block), np.asarray(grad_dense), rtol=1e-3, atol=1e-3)
+
+    output, stats = jax_flash_attention.flash_attention_block_masked(
+        query,
+        key,
+        value,
+        segment_ids=None,
+        block_kv=4,
+        block_q=4,
+        mask=mask,
+        mask_value=-1.0e9,
+        logits_dtype=jnp.float32,
+        loop_unroll=False,
+        fuse_logits=False,
+        save_residuals=True,
+    )
+    np.testing.assert_allclose(np.asarray(output), np.asarray(dense(query)), rtol=1e-4, atol=1e-4)
+    dense_logits = jnp.einsum("bhqd,bhkd->bhqk", query, key)
+    dense_max_logits = jnp.max(jnp.where(mask[:, None, :, :], dense_logits, -1.0e9), axis=-1)
+    np.testing.assert_allclose(np.asarray(stats["max_logits"]), np.asarray(dense_max_logits), rtol=1e-4, atol=1e-4)
+
+  def test_flash_attention_block_masked_non_divisible_blocks(self):
+    batch, heads, seq_len, head_dim = 1, 1, 192, 4
+    rng = np.random.default_rng(0)
+    query = jnp.asarray(rng.normal(size=(batch, heads, seq_len, head_dim)), dtype=jnp.float32)
+    key = jnp.asarray(rng.normal(size=(batch, heads, seq_len, head_dim)), dtype=jnp.float32)
+    value = jnp.asarray(rng.normal(size=(batch, heads, seq_len, head_dim)), dtype=jnp.float32)
+    mask = jnp.ones((seq_len, seq_len), dtype=bool)
+
+    with self.assertRaisesRegex(ValueError, "must be divisible by block_q"):
+      jax_flash_attention.flash_attention_block_masked(
+          query,
+          key,
+          value,
+          segment_ids=None,
+          block_kv=64,
+          block_q=128,
+          mask=mask,
+          mask_value=-1.0e9,
+      )
+
+    with self.assertRaisesRegex(ValueError, "must be divisible by block_kv"):
+      jax_flash_attention.flash_attention_block_masked(
+          query,
+          key,
+          value,
+          segment_ids=None,
+          block_kv=128,
+          block_q=64,
+          mask=mask,
+          mask_value=-1.0e9,
+      )
+
   def test_flash_attention_block_masked_causal_mask(self):
     cap = 1.0
     mask_value = -1.0e9
@@ -3544,18 +3638,24 @@ class MLATest(attention_test_util.MLATestBase):
           "ici_context_parallelism": 4,
           "indexer_topk": 32,
       },
+      {
+          "testcase_name": "no_lb_cp2_seq384",
+          "context_parallel_load_balance": False,
+          "ici_context_parallelism": 2,
+          "indexer_topk": 256,
+          "max_target_length": 384,
+      },
   )
-  @pytest.mark.skip_on_tpu7x  # TODO(b/552989368): Investigate MLA Indexer all-gather CP failure on TPU7x
   @pytest.mark.tpu_only
   def test_tpu_flash_attention_context_parallel_with_indexer(
-      self, context_parallel_load_balance, ici_context_parallelism=2, indexer_topk=256
+      self, context_parallel_load_balance, ici_context_parallelism=2, indexer_topk=256, max_target_length=512
   ):
     """Test equivalence between dot_product MLA + Indexer and all-gather flash attention + context parallelism + Indexer"""
     config_arguments = {
         "per_device_batch_size": 1.0,
         "run_name": "test",
         "enable_checkpointing": False,
-        "max_target_length": 512,
+        "max_target_length": max_target_length,
         "sa_block_q": 128,
         "sa_block_kv": 128,
         "sa_block_kv_compute": 128,

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -237,6 +237,30 @@ class ConfigTest(absltest.TestCase):
     self.assertTrue(config.use_indexer)
     self.assertEqual(config.attention_type, "mla")
 
+  def test_indexer_all_gather_context_parallelism_rejects_attention_sink(self):
+    argv = [
+        "",
+        _BASE_CONFIG_PATH,
+        "run_name=test",
+        "attention=flash",
+        "attention_type=mla",
+        "use_indexer=True",
+        "q_lora_rank=1",
+        "attention_sink=True",
+        "use_tokamax_splash=True",
+        "use_jax_splash=False",
+        "context_parallel_strategy=all_gather",
+        "ici_context_parallelism=2",
+        "hardware=tpu",
+        "packing=False",
+        "dataset_type=synthetic",
+        "skip_jax_distributed_system=True",
+    ]
+    mock_devices = [unittest.mock.MagicMock(slice_index=0) for _ in range(8)]
+    with unittest.mock.patch("jax.devices", return_value=mock_devices):
+      with self.assertRaisesRegex(ValueError, "does not support attention sinks"):
+        pyconfig.initialize(argv)
+
   def test_tpu_tokamax_ring_config_validation_rejects_unsupported_configs(self):
     base_args = [
         "",


### PR DESCRIPTION
# Description

The dynamic-mask Tokamax splash kernel derives its Pallas grid from the shard-local mask. This mode is not supported for sharded masks and gives wrong attention output on TPU7x, so the indexer + all-gather CP test fails. This PR routes the indexer mask under CP to the native block-sparse implementation, which handles a runtime mask without a data-dependent grid.

FIXES: b/552989368

# Tests

- CPU unit tests: attention and configs pass.
- TPU7x unit tests: `test_tpu_flash_attention_context_parallel_with_indexer_*` via CI on this PR.
- A/B on v7x (deepseek3-tiny fp32, flash + all-gather CP vs dot_product): lm_loss matches within 1e-3 per step at seq 512 CP4, seq 512 CP4 load-balanced, and seq 384 CP2. 

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).