### PR TITLE
Onboard Mistral and Mixtral to explicit sharding and efficient ZeRO-1 + GA

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4145,6 +4145,8 @@ class MaxTextConfig(
           "simple_mlp",
           "llama2",
           "deepseek",
+          "mistral",
+          "mixtral",
           "qwen3",
           "qwen3_moe",
           "qwen3_custom_moe",

--- a/src/maxtext/models/mistral.py
+++ b/src/maxtext/models/mistral.py
@@ -16,7 +16,8 @@
 # pylint: disable=arguments-differ
 # pylint: disable=no-name-in-module
 
-from flax import linen as nn
+import functools
+
 from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
 import jax
@@ -30,6 +31,7 @@ from maxtext.layers.linears import Dropout, MlpBlock
 from maxtext.layers.normalizations import RMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.utils import max_utils
+from maxtext.utils.sharding import create_sharding, get_logical_axis_rules, maybe_shard_with_logical
 
 # -----------------------------------------
 # The Decoder Layer for Mistral
@@ -56,10 +58,26 @@ class MistralDecoderLayer(nnx.Module):
     batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
+    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    self.mlp_activation_axis_names = ("activation_batch", "activation_norm_length", "activation_mlp")
+
+    # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore these and let GSPMD infer the layout.
+    self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
+    self.mlp_intermediate_sharding = create_sharding(mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules())
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
+
     self.pre_self_attention_layer_norm = RMSNorm(
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=self.rngs,
@@ -97,6 +115,7 @@ class MistralDecoderLayer(nnx.Module):
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=self.rngs,
@@ -117,8 +136,6 @@ class MistralDecoderLayer(nnx.Module):
     )
 
     self.dropout = Dropout(rate=config.dropout_rate, broadcast_dims=(-2,), rngs=self.rngs)
-
-    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
 
   def __call__(
       self,
@@ -143,10 +160,10 @@ class MistralDecoderLayer(nnx.Module):
       is_scan_carry = True
     elif isinstance(inputs, tuple):
       inputs = inputs[0]
-    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
-    lnx = self.pre_self_attention_layer_norm(inputs)
-    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+    lnx = self.pre_self_attention_layer_norm(inputs, out_sharding=self.out_sharding)
+    lnx = self._maybe_shard_with_logical(lnx, self.activation_axis_names)
 
     attention_lnx, kv_cache = self.self_attention(
         lnx,
@@ -157,24 +174,30 @@ class MistralDecoderLayer(nnx.Module):
         model_mode=model_mode,
         slot=slot,
         previous_chunk=previous_chunk,
+        out_sharding=self.out_sharding,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
     )
 
-    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
+    attention_lnx = self._maybe_shard_with_logical(attention_lnx, self.activation_axis_names)
     intermediate_inputs = inputs + attention_lnx
 
     # Fully Connected
-    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # MLP block.
-    mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+    mlp_lnx = self.mlp(
+        hidden_states,
+        deterministic=deterministic,
+        intermediate_sharding=self.mlp_intermediate_sharding,
+        out_sharding=self.out_sharding,
+    )
+    mlp_lnx = self._maybe_shard_with_logical(mlp_lnx, self.activation_axis_names)
 
     layer_output = mlp_lnx + intermediate_inputs
     layer_output = self.dropout(layer_output, deterministic=deterministic)
-    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+    layer_output = self._maybe_shard_with_logical(layer_output, self.activation_axis_names)
 
     if getattr(cfg, "record_internal_nn_metrics", False):
       self.sow(nnx.Intermediate, "activation_mean", jnp.mean(layer_output))

--- a/src/maxtext/models/mixtral.py
+++ b/src/maxtext/models/mixtral.py
@@ -17,6 +17,8 @@
 # pylint: disable=no-name-in-module
 
 
+import functools
+
 from flax import linen as nn
 from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
@@ -31,6 +33,7 @@ from maxtext.layers.linears import Dropout
 from maxtext.layers.normalizations import RMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.utils import max_utils
+from maxtext.utils.sharding import create_sharding, get_logical_axis_rules, maybe_shard_with_logical
 
 # -----------------------------------------
 # The Decoder Layer for Mixtral
@@ -59,10 +62,24 @@ class MixtralDecoderLayer(nnx.Module):
     batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
+    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
+    # Physical sharding used to pin sublayer outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore it and let GSPMD infer the layout.
+    self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
+
     self.pre_self_attention_layer_norm = RMSNorm(
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=self.rngs,
@@ -100,6 +117,7 @@ class MixtralDecoderLayer(nnx.Module):
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=self.rngs,
@@ -121,8 +139,6 @@ class MixtralDecoderLayer(nnx.Module):
 
     self.dropout = Dropout(rate=config.dropout_rate, broadcast_dims=(-2,), rngs=rngs)
 
-    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
-
   def __call__(
       self,
       inputs,
@@ -140,11 +156,11 @@ class MixtralDecoderLayer(nnx.Module):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):
       inputs = inputs[0]
-    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 
-    lnx = self.pre_self_attention_layer_norm(inputs)
-    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+    lnx = self.pre_self_attention_layer_norm(inputs, out_sharding=self.out_sharding)
+    lnx = self._maybe_shard_with_logical(lnx, self.activation_axis_names)
 
     attention_lnx, kv_cache = self.self_attention(
         lnx,
@@ -154,29 +170,30 @@ class MixtralDecoderLayer(nnx.Module):
         deterministic=deterministic,
         model_mode=model_mode,
         previous_chunk=previous_chunk,
+        out_sharding=self.out_sharding,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
     )
 
-    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
+    attention_lnx = self._maybe_shard_with_logical(attention_lnx, self.activation_axis_names)
     intermediate_inputs = inputs + attention_lnx
 
     # Fully Connected
-    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     load_balance_loss = None
     # NOTE: the naming mismatch here is to ensure reverse compatibility with existing checkpoints.
     # The `name` represents the weight name in JAX/checkpoints and so the class name
     # is just for readability.
     mlp_lnx, load_balance_loss, _ = self.MoeBlock_0(
-        hidden_states, forced_routed_experts=forced_routed_experts
+        hidden_states, out_sharding=self.out_sharding, forced_routed_experts=forced_routed_experts
     )
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+    mlp_lnx = self._maybe_shard_with_logical(mlp_lnx, self.activation_axis_names)
 
     layer_output = mlp_lnx + intermediate_inputs
     layer_output = self.dropout(layer_output, deterministic=deterministic)
-    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+    layer_output = self._maybe_shard_with_logical(layer_output, self.activation_axis_names)
 
     if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
       self.sow(nnx.Intermediate, "moe_lb_loss", load_balance_loss)

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -54,6 +54,19 @@ _QWEN3_MODELS = {
     + _MOE_OVERRIDES,
 }
 
+# One tiny model per Mistral-family decoder block that supports explicit sharding.
+_MISTRAL_MODELS = {
+    "mistral": ["model_name=mistral-7b"],
+    "mixtral": [
+        "model_name=mixtral-8x7b",
+        # RoutedMoE.dense_matmul is not onboarded to explicit sharding yet (a gap it
+        # shares with qwen3_moe), so exercise the sparse_matmul path.
+        "sparse_matmul=True",
+        "megablox=True",
+    ]
+    + _MOE_OVERRIDES,
+}
+
 
 class TrainTests(unittest.TestCase):
   """Tests train.py with various configs"""
@@ -121,6 +134,19 @@ class TrainTests(unittest.TestCase):
       # vendored in the repo; use the checked-in tiktoken asset instead.
       "tokenizer_type=tiktoken",
       rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+  ]
+
+  _mistral_overrides = [
+      "override_model_config=True",
+      "base_num_decoder_layers=2",
+      "base_emb_dim=256",
+      "base_mlp_dim=512",
+      "base_num_query_heads=8",
+      "base_num_kv_heads=8",
+      "head_dim=128",
+      "vocab_size=2048",
+      "max_target_length=256",
+      rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.mistral-v1')}",
   ]
 
   CONFIGS = {
@@ -751,6 +777,95 @@ class TrainTests(unittest.TestCase):
             args + ["shard_mode=auto", "shard_optimizer_over_data=False"],
         )
         sharded = self._qwen3_losses(
+            f"{decoder_block}_ga_zero1",
+            args + ["shard_mode=explicit", "shard_optimizer_over_data=True"],
+        )
+        print(f"[{decoder_block}] auto + GA losses: {baseline}", flush=True)
+        print(f"[{decoder_block}] explicit + ZeRO-1 + GA losses: {sharded}", flush=True)
+        self.assertTrue(baseline, "baseline run produced no metrics")
+        # ZeRO-1 reassociates the gradient all-reduce, so allow a little float slack.
+        np.testing.assert_allclose(sharded, baseline, rtol=1e-4, atol=0.0)
+
+  def _mistral_losses(self, run_name, extra_args):
+    """Trains a tiny Mistral/Mixtral model for a few steps and returns its per-step losses."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      metrics_file = os.path.join(tmp_dir, "metrics.txt")
+      train_main(
+          [
+              None,
+              get_test_config_path(),
+              f"base_output_directory={self._base_output_directory}",
+              f"dataset_path={self.dataset_path}",
+              f"run_name={run_name}",
+              f"metrics_file={metrics_file}",
+              "dataset_type=synthetic",
+              "steps=3",
+              "enable_checkpointing=False",
+              "enable_goodput_recording=False",
+          ]
+          + self._mistral_overrides
+          + list(extra_args)
+      )
+      with open(metrics_file, "rt", encoding="utf8") as f:
+        return [json.loads(line)["learning/loss"] for line in f if line.strip()]
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  def test_tpu_mistral_explicit_sharding_matches_auto(self):
+    """Explicit sharding only changes how layouts are expressed, so the losses must not move.
+
+    Each decoder block is paired with the parallelism that stresses it most:
+    tensor parallelism shards the dense MLP intermediate, and expert parallelism
+    shards the MoE dispatch.
+    """
+    parallelism = {
+        "mistral": ["ici_fsdp_parallelism=1", "ici_tensor_parallelism=-1"],
+        "mixtral": ["ici_fsdp_parallelism=1", "ici_expert_parallelism=-1"],
+    }
+    # Under expert parallelism the two modes are bit-for-bit. Under tensor parallelism
+    # pinning the MLP intermediate reassociates the backward reduction over the tensor
+    # axis, which drifts by a few ULPs by the third step; the runs stay bit-for-bit if
+    # the same model is run under FSDP instead.
+    rtol = {"mistral": 1e-5, "mixtral": 1e-6}
+    for decoder_block, model_args in _MISTRAL_MODELS.items():
+      with self.subTest(decoder_block=decoder_block):
+        args = model_args + parallelism[decoder_block]
+        auto_losses = self._mistral_losses(f"{decoder_block}_auto", args + ["shard_mode=auto"])
+        explicit_losses = self._mistral_losses(f"{decoder_block}_explicit", args + ["shard_mode=explicit"])
+        print(f"[{decoder_block}] auto losses: {auto_losses}", flush=True)
+        print(f"[{decoder_block}] explicit losses: {explicit_losses}", flush=True)
+        self.assertTrue(auto_losses, "auto run produced no metrics")
+        np.testing.assert_allclose(explicit_losses, auto_losses, rtol=rtol[decoder_block], atol=0.0)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  # TODO(b/517509898): Skip ZeRo-1 compiler Segfault on TPU7x SparseCore platforms
+  @pytest.mark.skip_on_tpu7x
+  def test_tpu_mistral_zero1_gradient_accumulation(self):
+    """ZeRO-1 only shards the optimizer state, so it must not change the loss trajectory.
+
+    Under explicit sharding this routes the accumulated gradients through the
+    `reduced`/`unreduced` PartitionSpec labels applied in
+    `maxtext.utils.gradient_accumulation`, and casts the parameters to bf16 before
+    the accumulation scan so the all-gather happens once in low precision.
+    """
+    zero1_ga = [
+        "remat_policy=minimal",
+        "per_device_batch_size=2",
+        "ici_data_parallelism=-1",
+        "dcn_data_parallelism=1",
+        "ici_fsdp_parallelism=1",
+        "dcn_fsdp_parallelism=1",
+        "gradient_accumulation_steps=8",
+    ]
+    for decoder_block, model_args in _MISTRAL_MODELS.items():
+      with self.subTest(decoder_block=decoder_block):
+        args = model_args + zero1_ga
+        baseline = self._mistral_losses(
+            f"{decoder_block}_ga",
+            args + ["shard_mode=auto", "shard_optimizer_over_data=False"],
+        )
+        sharded = self._mistral_losses(
             f"{decoder_block}_ga_zero1",
             args + ["shard_mode=explicit", "shard_optimizer_over_data=True"],
         )

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -245,6 +245,18 @@ class PyconfigTest(unittest.TestCase):
           scan_layers=False,  # Required by the Qwen3-VL deepstack path; unrelated to sharding.
       )
 
+  def test_explicit_sharding_mistral_decoder_support(self):
+    """The Mistral-family decoders that have been onboarded to explicit sharding are accepted."""
+    for decoder_block in ("mistral", "mixtral"):
+      with self.subTest(decoder_block=decoder_block):
+        config = pyconfig.initialize(
+            [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+            skip_jax_distributed_system=True,
+            shard_mode="explicit",
+            decoder_block=decoder_block,
+        )
+        self.assertEqual(config.decoder_block.value, decoder_block)
+
   def test_resolve_config_path(self):
     self.assertEqual(resolve_config_path("foo"), os.path.join("src", "foo"))
     self.assertEqual(resolve_config_path(__file__), __file__)


### PR DESCRIPTION
## What

Onboards the **Mistral** and **Mixtral** decoder layers to `shard_mode=explicit`, which in turn unlocks the efficient **ZeRO-1 + gradient accumulation** path for these models.

## Why

`shard_mode=explicit` was already supported for `simple`, `simple_mlp`, `llama2`, `deepseek` and the Qwen3 family, but `decoder_block=mistral` / `mixtral` were rejected by config validation. Explicit sharding is also the gate for the efficient ZeRO-1 + GA path: `maxtext.utils.gradient_accumulation` only applies the `reduced` / `unreduced` `PartitionSpec` labels when `shard_mode == ShardMode.EXPLICIT` and the resolved `data` axis is larger than 1. Without it, Mistral/Mixtral runs with `shard_optimizer_over_data=True` fall back to the generic path and lose the bf16 pre-scan all-gather plus the single post-scan gradient all-reduce.

## Changes

**`src/maxtext/models/mistral.py`, `src/maxtext/models/mixtral.py`** — the same transformation llama2/deepseek/qwen3 already use:

- `nn.with_logical_constraint(x, names)` → `self._maybe_shard_with_logical(x, names)`, a `functools.partial` of `maybe_shard_with_logical` bound to the mesh and `config.shard_mode`. It is a no-op under `ShardMode.AUTO` and emits a reshard under `ShardMode.EXPLICIT`.
- Activation `NamedSharding`s are built once in `__init__` via `create_sharding(..., rules=get_logical_axis_rules())` and threaded into the sublayers as `out_sharding=` (both `RMSNorm`s, `Attention`, `MlpBlock`, `RoutedMoE`) and `intermediate_sharding=` (Mistral's `MlpBlock`), so the sublayers pin their output layout instead of leaving it to GSPMD.
- `shard_mode=config.shard_mode` is passed to both `RMSNorm`s.
- `activation_axis_names` moves to the top of `__init__` (it is now needed to build the shardings); no behavioural change.

**`src/maxtext/configs/types.py`** — add `mistral` and `mixtral` to `supported_decoders` for `shard_mode=explicit`.

## Efficient ZeRO-1 + GA

No model-side work was required beyond making these decoders explicit-sharding clean — `gradient_accumulation_loss_and_grad` is already generic. With `shard_mode=explicit`, `shard_optimizer_over_data=True` and `gradient_accumulation_steps > 1`, these models now get:

- parameters cast to bf16 and resharded **before** the accumulation `scan`, so the FSDP/ZeRO all-gather happens once in low precision;
- gradients marked `unreduced={"data"}` **after** the scan (the annotation cannot live in the scan carry, since `scan` traces its body against an `AbstractMesh` whose axis types are all `Auto`), so the data-parallel reduction happens once per step rather than per microbatch.

## Tests

**`tests/integration/train_tests.py`**

- `test_tpu_mistral_explicit_sharding_matches_auto` — trains a tiny `mistral-7b` and `mixtral-8x7b` for 3 steps under both `shard_mode=auto` and `shard_mode=explicit` and asserts the loss trajectories match. Each decoder is paired with the parallelism that stresses it most: tensor parallelism for Mistral, expert parallelism for Mixtral.
- `test_tpu_mistral_zero1_gradient_accumulation` — same two models with `gradient_accumulation_steps=8`, comparing `auto` + plain GA against `explicit` + ZeRO-1 + GA. ZeRO-1 only shards optimizer state, so the loss trajectory must not move.

**`tests/unit/pyconfig_test.py`**

- `test_explicit_sharding_mistral_decoder_support` — `mistral` and `mixtral` are accepted under `shard_mode=explicit`.

### Local results (v7-8, 8 devices)

```
[mistral] auto     losses: [8.121367454528809, 8.108650207519531, 8.101734161376953]
[mistral] explicit losses: [8.121367454528809, 8.108650207519531, 8.101778984069824]
[mixtral] auto     losses: [8.121824264526367, 8.112176895141602, 8.106920242309570]
[mixtral] explicit losses: [8.121824264526367, 8.112176895141602, 8.106920242309570]

[mistral] auto + GA            losses: [8.120077133178711, 8.109002113342285, 8.102952957153320]
[mistral] explicit + ZeRO1 + GA losses: [8.120077133178711, 8.109018325805664, 8.102913856506348]
[mixtral] auto + GA            losses: [8.120052337646484, 8.111700057983398, 8.107090950012207]
[mixtral] explicit + ZeRO1 + GA losses: [8.120052337646484, 8.111715316772461, 8.107082366943360]
```

Mixtral is bit-for-bit between `auto` and `explicit`. Mistral is bit-for-bit under FSDP; under tensor parallelism pinning the MLP intermediate reassociates the backward reduction over the tensor axis, which drifts by a few ULPs by the third step (5.5e-6 relative), so that subtest uses `rtol=1e-5`. The tolerance choice is documented in the test.

`tests/unit/moe_test.py`, `tests/unit/decoder_layer_model_mode_test.py`, `tests/unit/configs_test.py` and `tests/unit/pyconfig_test.py` all pass locally.

## Known gap

`RoutedMoE.dense_matmul` (`sparse_matmul=False`) is not onboarded to explicit sharding — its `wi`/`wo` einsums leave both operands sharded on `fsdp` along non-contracting dims and JAX rejects the result. This is a pre-existing gap in `moe.py` shared with the already-supported `qwen3_moe` (reproducible on `main` with `decoder_block=qwen3_moe shard_mode=explicit sparse_matmul=False`), so it is left for a follow-up. The Mixtral tests here use the `sparse_matmul` path.


## Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files). No doc change is needed: the set of decoders supported under `shard_mode=explicit` is not enumerated in the docs, only in the `supported_decoders` validation error message, which this PR updates.
