### PR TITLE
Fix dropped routing-weight gradient in ring_ragged_unsort

### DIFF
--- a/src/maxtext/kernels/ragged/ragged_sort.py
+++ b/src/maxtext/kernels/ragged/ragged_sort.py
@@ -253,7 +253,8 @@ def ring_ragged_unsort(
     during the reduction.
 
   Backward:
-    ``g_sorted_tokens[j] = w[i] * g_out[i // topk]`` where
+    ``g_sorted_tokens[j] = w[i] * g_out[i // topk]`` and
+    ``g_w[i] = <g_out[i // topk], sorted_tokens_local[j]>`` where
     ``j = topk_argsort_revert_indices[i]`` and ``j`` is in
     ``[shard_output_start, shard_output_end)``.
 
@@ -265,6 +266,7 @@ def ring_ragged_unsort(
     local_num_experts: scalar ``int`` representing the count of experts hosted on this shard.
     ep_name: ``str`` identifying the expert parallel axis name.
     topk_weights: ``[num_tokens_local * topk]`` tensor of per-slot routing weights.
+      Differentiated: its gradient is what trains the router.
 
   Returns:
     A 2D ``[num_tokens_local, hidden]`` tensor with expert outputs scattered back
@@ -351,6 +353,7 @@ def ring_ragged_unsort(
       )
 
     res = (
+        sorted_tokens_local,
         topk_argsort_revert_indices,
         topk_weights_flat,
         shard_output_start,
@@ -371,8 +374,13 @@ def ring_ragged_unsort(
     Gradient w.r.t. sorted_tokens:
       g_sorted_tokens[j] = w[i] * g_out[i // topk]
     where j = revert[i] and j in [start, end).
+
+    Gradient w.r.t. the routing weights:
+      g_w[i] = <g_out[i // topk], sorted_tokens[revert[i]]>
+    for valid i, zero otherwise.
     """
     (
+        sorted_tokens_local,
         topk_argsort_revert_indices,
         topk_weights_flat,
         shard_output_start,
@@ -387,22 +395,16 @@ def ring_ragged_unsort(
     idx_inv = jnp.argsort(topk_argsort_revert_indices)
 
     # Handle the same two buffering modes for backward pass.
-    # We let ragged_gather do both the fan-out (by indexing into the
-    # un-expanded g_hidden_states_local via idx_inv // topk) and the
-    # per-slot weight application (via the fused weights parameter),
-    # avoiding an extra HBM read-write pass.
+    # ragged_gather does the fan-out, by indexing into the un-expanded
+    # g_hidden_states_local via idx_inv // topk. It gathers unweighted so the same rows
+    # feed both gradients: the activation one after scaling, the weight one after a dot.
     if buffer_size >= n:
-      # ragged_gather fans out g_hidden_states_local by reading the same row
-      # multiple times when idx_inv // topk maps multiple positions to it.
-      # Per-slot routing weights are applied inside the kernel.
       weight_for_sorted = topk_weights_flat[idx_inv]
-      grad_sorted_tokens = ragged_gather(
+      gathered = ragged_gather(
           g_hidden_states_local,
           idx_inv // topk,
           shard_output_start[None],
           shard_output_end[None],
-          weights=weight_for_sorted,
-          has_weights=True,
           enforce_fallback=enforce_gather_fallback,
           flops_override=gather_flops_override,
           bytes_accessed_override=gather_bytes_accessed_override,
@@ -411,7 +413,11 @@ def ring_ragged_unsort(
       # Mask out gradients that correspond to elements outside the valid shard
       # output range.
       mask = (jnp.arange(n) >= shard_output_start) & (jnp.arange(n) < shard_output_end)
-      grad_sorted_tokens = jnp.where(mask[:, None], grad_sorted_tokens, 0.0)
+      gathered = jnp.where(mask[:, None], gathered, 0.0)
+      grad_sorted_tokens = (gathered * weight_for_sorted[:, None]).astype(gathered.dtype)
+      # Row-wise dot in sorted order, then permuted back to flat slot order.
+      dot_sorted = jnp.sum(gathered.astype(jnp.float32) * sorted_tokens_local[:n].astype(jnp.float32), axis=-1)
+      grad_topk_weights = dot_sorted[topk_argsort_revert_indices]
     else:
       # Slice the inverse permutation to match the packed local buffer.
       padded_idx_inv = jnp.pad(idx_inv, (0, buffer_size))
@@ -420,13 +426,11 @@ def ring_ragged_unsort(
       # Slice the per-slot routing weights to match the packed local buffer.
       padded_weights = jnp.pad(topk_weights_flat[idx_inv], (0, buffer_size))
       sliced_weights = jax.lax.dynamic_slice_in_dim(padded_weights, shard_output_start, buffer_size, axis=0)
-      grad_sorted_tokens = ragged_gather(
+      gathered = ragged_gather(
           g_hidden_states_local,
           sliced_idx_inv // topk,
           jnp.int32(0)[None],
           gather_end[None],
-          weights=sliced_weights,
-          has_weights=True,
           enforce_fallback=enforce_gather_fallback,
           flops_override=gather_flops_override,
           bytes_accessed_override=gather_bytes_accessed_override,
@@ -435,8 +439,13 @@ def ring_ragged_unsort(
       # Mask out gradients for elements beyond the valid limit of the local buffer.
       limit = jnp.minimum(shard_output_end - shard_output_start, buffer_size)
       mask = jnp.arange(buffer_size) < limit
-      grad_sorted_tokens = jnp.where(mask[:, None], grad_sorted_tokens, 0.0)
-    return grad_sorted_tokens, None, None, None
+      gathered = jnp.where(mask[:, None], gathered, 0.0)
+      grad_sorted_tokens = (gathered * sliced_weights[:, None]).astype(gathered.dtype)
+      # Scatter the per-slot dot back to flat slot order; dropped slots stay zero.
+      dot_local = jnp.sum(gathered.astype(jnp.float32) * sorted_tokens_local.astype(jnp.float32), axis=-1)
+      slots = jnp.where(mask, sliced_idx_inv, n)
+      grad_topk_weights = jnp.zeros((n,), jnp.float32).at[slots].set(dot_local, mode="drop")
+    return grad_sorted_tokens, None, None, grad_topk_weights
 
   _ring_ragged_unsort.defvjp(_ring_ragged_unsort_fwd, _ring_ragged_unsort_bwd)
 

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -1003,8 +1003,9 @@ class RoutedMoeTest(parameterized.TestCase):
     # through `ring_ragged_sort`'s custom_vjp backward (the kernel under
     # test). Without checking this, DCE removes the bwd entirely.
     self.assertEqual(x_grad_ref.shape, x_grad_rs.shape, "Hidden-state grad shape mismatch")
+    x_atol = 8e-2 * jnp.max(jnp.abs(x_grad_ref.astype(jnp.float32)))
     self.assertTrue(
-        jnp.allclose(x_grad_rs.astype(jnp.float32), x_grad_ref.astype(jnp.float32), rtol=1e-2, atol=8e-2),
+        jnp.allclose(x_grad_rs.astype(jnp.float32), x_grad_ref.astype(jnp.float32), rtol=1e-2, atol=x_atol),
         msg=(
             "Hidden-state gradient mismatch: max abs diff="
             f"{jnp.max(jnp.abs(x_grad_rs.astype(jnp.float32) - x_grad_ref.astype(jnp.float32)))}"
@@ -1017,11 +1018,13 @@ class RoutedMoeTest(parameterized.TestCase):
     self.assertEqual(treedef_ref, treedef_rs, "Gradient pytree structures differ")
     for i, (g_ref, g_rs) in enumerate(zip(leaves_ref, leaves_rs)):
       self.assertEqual(g_ref.shape, g_rs.shape, f"Grad shape mismatch at leaf {i}")
+      # Scaled to the leaf: a fixed atol passes a leaf whose whole gradient is below it.
+      atol = 8e-2 * jnp.max(jnp.abs(g_ref.astype(jnp.float32)))
       self.assertTrue(
-          jnp.allclose(g_rs.astype(jnp.float32), g_ref.astype(jnp.float32), rtol=1e-2, atol=8e-2),
+          jnp.allclose(g_rs.astype(jnp.float32), g_ref.astype(jnp.float32), rtol=1e-2, atol=atol),
           msg=(
               f"Gradient mismatch at leaf {i} (shape={g_ref.shape}): "
-              f"max abs diff={jnp.max(jnp.abs(g_rs.astype(jnp.float32) - g_ref.astype(jnp.float32)))}"
+              f"max abs diff={jnp.max(jnp.abs(g_rs.astype(jnp.float32) - g_ref.astype(jnp.float32)))}, {atol=}"
           ),
       )
 


### PR DESCRIPTION
# Description

`_ring_ragged_unsort_bwd` returned `None` for `topk_weights_flat`:

```python
return grad_sorted_tokens, None, None, None
```

Of the four primals `(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices, topk_weights_flat)` the first three are correctly `None` — two are int32 index arrays — but the fourth is the router's top-k combine weight, which is differentiable. `jax.custom_vjp` accepts `None` there and silently substitutes a zero cotangent, so with `use_ragged_sort` + `use_ring_of_experts` the router received no gradient from the main loss and trained only on the auxiliary load-balance loss. The forward was unaffected.

This computes the missing term, `g_w[i] = <g_out[i // topk], sorted_tokens[revert[i]]>` for valid `i`, in both buffering branches. The backward's `ragged_gather` drops its fused per-slot weights so one gather feeds both gradients — the activation gradient after scaling, the weight gradient after a row-wise dot — and the forward residual gains `sorted_tokens_local`, which the `use_ragged_sort=False` path already retains for its `weight_sum` einsum.

The no-ring path combines with `jnp.einsum` and is unaffected.

FIXES: b/553024870

# Tests

`_run_ragged_sort_loss_and_grad` already compared the full gradient pytree across the flag, but under a fixed `atol=8e-2` while the loss is `jnp.mean(out**2)`, so every leaf is O(1e-5). On its own config (mixtral-8x7b, emb 7168, EP=2, bf16, v7x):

```
['gate']['kernel'] (7168, 8) | max|g_ref| 4.4373e-05  max|g_rs| 0.0000e+00 | allclose: PASS
```

An identically zero gradient passes because the tolerance is ~1800x the whole gradient; the hidden-state assertion above it is vacuous the same way (that gradient peaks at 2.85e-08). Scaling both tolerances to the magnitude being compared makes the existing test fix-sensitive without adding a new one.

| `tests/unit/moe_test.py` (TPU v7x) | result |
| --- | --- |
| `-k ragged_sort`, tolerances only, production file at upstream | 4 failed (all ring-of-experts variants), 4 passed |
| `-k ragged_sort`, this branch | 8 passed |
| `-k no_ring_of_experts`, without the fix | 4 passed — unaffected path, so the bound is not indiscriminate |
| full file, this branch | 18 passed, 57 skipped (cpu_only / AOT / 4-device), 0 failed |

Post-fix `max|diff| / max|g_ref|`: gate 9.2e-04 (was 1.000), `wi_0` 1.03e-2, `wi_1` 8.7e-3, `wo` 4.5e-3, hidden state 8.2e-3 — all inside the 8e-2 bound. Forward loss unchanged to 6 decimal places.

Also checked off-TPU, where both kernels take their JAX fallback: over 6 configurations covering both buffering branches, `<g_w, d>` is 0.0 before and matches a central-difference directional derivative to ≤3.7e-3 after. The `use_ragged_sort=False` arm agrees analytic-vs-finite-difference to ~1e-6, so the probe itself is sound.

`pre-commit` (codespell, pylint, pyink) passes on both changed files.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload links above if applicable. Unit and gradient tests only — the convergence job in b/553024870 (43 vs 49 steps) should be rerun with this patch to confirm how much of the gap it accounts for.
- [x] I have made or will make corresponding changes to the doc if needed.