### PR TITLE
[CI Fix] Disable pylint unbalanced-tuple-unpacking in nnx_decoders_test

### DIFF
--- a/tests/unit/nnx_decoders_test.py
+++ b/tests/unit/nnx_decoders_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=unbalanced-tuple-unpacking
 """Unit tests for nnx_decoders module.
 
 Tests cover:


### PR DESCRIPTION
## Description
Disables `unbalanced-tuple-unpacking` (`W0632`) in `tests/unit/nnx_decoders_test.py` to unblock scheduled CI pipeline runs on `main`.

### Context
PR #4813 added dynamic return tuple lengths to `NNXDecoder.__call__`, which caused Pylint to flag unpacking in `tests/unit/nnx_decoders_test.py` during full-repo pre-commit checks (`pre-commit run --all-files`).

BUG: b/553995493

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload links above if applicable.
- [x] I have added or updated tests accordingly.
- [x] I have updated documentation accordingly.
- [x] I have included unit tests for new features or bug fixes.
- [x] I have added unit test and integration test coverage for all modified code paths.