### PR TITLE
Remove duplicate mesh axis parallelism maps from create_device_mesh

### DIFF
--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -2197,58 +2197,15 @@ def create_device_mesh(config, devices=None):
   num_slices = 1 if getattr(config, "inference_benchmark_test", False) else num_slices
   num_devices_per_slice = num_devices // num_slices
 
-  # Find possible unspecified parallelisms
-  ici_parallelism = getattr(config, "ici_parallelism", None)
-  if ici_parallelism is None:
-    ici_map = {
-        "diloco": getattr(config, "ici_diloco_parallelism", 1),
-        "data": getattr(config, "ici_data_parallelism", 1),
-        "stage": getattr(config, "ici_pipeline_parallelism", 1),
-        "fsdp": getattr(config, "ici_fsdp_parallelism", -1),
-        "fsdp_transpose": getattr(config, "ici_fsdp_transpose_parallelism", 1),
-        "sequence": getattr(config, "ici_sequence_parallelism", 1),
-        "context": getattr(config, "ici_context_parallelism", 1),
-        "context_usp_ulysses": getattr(config, "ici_context_usp_ulysses_parallelism", 1),
-        "context_autoregressive": getattr(config, "ici_context_autoregressive_parallelism", 1),
-        "tensor": getattr(config, "ici_tensor_parallelism", 1),
-        "tensor_sequence": getattr(config, "ici_tensor_sequence_parallelism", 1),
-        "model": getattr(config, "ici_tensor_parallelism", 1),
-        "expert": getattr(config, "ici_expert_parallelism", 1),
-        "autoregressive": getattr(config, "ici_autoregressive_parallelism", 1),
-        "attn_dp": 1,
-        "attn_dp_expert": 1,
-    }
-    ici_parallelism = [ici_map[axis] for axis in config.mesh_axes]
-  else:
-    ici_parallelism = ici_parallelism.copy()
+  # Find possible unspecified parallelisms. The config derives these per-axis lists from
+  # its `mesh_axes`, so they are the single source of truth for the mesh shape.
+  ici_parallelism = config.ici_parallelism.copy()
   ici_parallelism = max_utils.fill_unspecified_mesh_axes(ici_parallelism, num_devices_per_slice, "ICI")
 
   allow_split_physical_axes = config.allow_split_physical_axes if config.allow_split_physical_axes else False
 
   if num_slices > 1:
-    dcn_parallelism = getattr(config, "dcn_parallelism", None)
-    if dcn_parallelism is None:
-      dcn_map = {
-          "diloco": getattr(config, "dcn_diloco_parallelism", 1),
-          "data": getattr(config, "dcn_data_parallelism", 1),
-          "stage": getattr(config, "dcn_pipeline_parallelism", 1),
-          "fsdp": getattr(config, "dcn_fsdp_parallelism", 1),
-          "fsdp_transpose": getattr(config, "dcn_fsdp_transpose_parallelism", 1),
-          "sequence": getattr(config, "dcn_sequence_parallelism", 1),
-          "context": getattr(config, "dcn_context_parallelism", 1),
-          "context_usp_ulysses": getattr(config, "dcn_context_usp_ulysses_parallelism", 1),
-          "context_autoregressive": getattr(config, "dcn_context_autoregressive_parallelism", 1),
-          "tensor": getattr(config, "dcn_tensor_parallelism", 1),
-          "tensor_sequence": getattr(config, "dcn_tensor_sequence_parallelism", 1),
-          "model": getattr(config, "dcn_tensor_parallelism", 1),
-          "expert": getattr(config, "dcn_expert_parallelism", 1),
-          "autoregressive": getattr(config, "dcn_autoregressive_parallelism", 1),
-          "attn_dp": 1,
-          "attn_dp_expert": 1,
-      }
-      dcn_parallelism = [dcn_map[axis] for axis in config.mesh_axes]
-    else:
-      dcn_parallelism = dcn_parallelism.copy()
+    dcn_parallelism = config.dcn_parallelism.copy()
     dcn_parallelism = max_utils.fill_unspecified_mesh_axes(dcn_parallelism, num_slices, "DCN")
 
     if max_utils.is_valid_custom_mesh(ici_parallelism, config.custom_mesh):

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -1024,6 +1024,17 @@ class TestMeshUtils(unittest.TestCase):
     # Verify the second argument to create_device_mesh was our device list
     mock_create_device_mesh.assert_called_once_with(config, specific_devices)
 
+  def test_create_device_mesh_honors_non_default_mesh_axes(self):
+    """Tests mesh creation for the vLLM inference axes, which include dcp and pcp."""
+    mesh_axes = ["data", "attn_dp", "model", "expert", "attn_dp_expert", "dcp", "pcp"]
+    config = pyconfig.initialize([None, get_test_config_path()], enable_checkpointing=False, mesh_axes=mesh_axes)
+
+    self.assertEqual(len(config.ici_parallelism), len(mesh_axes))
+    self.assertEqual(len(config.dcn_parallelism), len(mesh_axes))
+
+    devices_array = maxtext_utils.create_device_mesh(config, devices=jax.devices()[:1])
+    self.assertEqual(devices_array.shape, (1,) * len(mesh_axes))
+
 
 class TestGetFunctionalTrainWithSignature(unittest.TestCase):
   """Tests for get_functional_train_with_signature."""


### PR DESCRIPTION
# Description



You can also provide a comma-separated list. If you don't want to close a bug but
simply to reference it, use BUGS, e.g.: 
BUGS: b/123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
