### PR TITLE
DSv3 improvement by keeping the unreduced gradient tag under ZeRO-1 + explicit sharding, including through the MoE shard_map

### DIFF
--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -44,6 +44,7 @@ from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
 from maxtext.utils.sharding import (
+    carry_reduced_axes,
     create_sharding,
     get_logical_axis_rules,
     logical_to_mesh_axes,
@@ -1837,6 +1838,18 @@ class RoutedMoE(nnx.Module):
         decoder_tokens_pspec,
     ) = get_routed_moe_shardings(is_batch_sharded_by_expert, input_ids is not None)
     w0_pspec, w1_pspec, wo_pspec = maybe_aqt_partition(w0_kernel, w0_pspec, w1_kernel, w1_pspec, wo_kernel, wo_pspec)
+    # `shard_map` makes every mesh axis manual, so an expert weight that enters on an
+    # untagged spec has its cotangent reduced over the data axis inside the body — once
+    # per microbatch under gradient accumulation, and again when the accumulated gradient
+    # leaves the scan. Carrying the `reduced` tag the accumulator put on the parameters
+    # keeps the cotangent partial, so the expert weights reduce once per step like every
+    # other parameter. Outside gradient accumulation the tag is absent and this is a no-op.
+    w0_pspec = carry_reduced_axes(w0_pspec, w0_kernel)
+    w1_pspec = carry_reduced_axes(w1_pspec, w1_kernel)
+    wo_pspec = carry_reduced_axes(wo_pspec, wo_kernel)
+    w0_bias_pspec = carry_reduced_axes(w0_bias_pspec, w0_bias)
+    w1_bias_pspec = carry_reduced_axes(w1_bias_pspec, w1_bias)
+    wo_bias_pspec = carry_reduced_axes(wo_bias_pspec, wo_bias)
     output_pspec = self._logical_to_mesh_axes(
         (
             batch_logical_axis,
@@ -2075,15 +2088,17 @@ class RoutedMoE(nnx.Module):
     def get_wi_gmm_params():
       wi_gather_axes = []
       if weight_gather:
+        # Read `.partitions`: a kernel spec carrying a reduced axis refuses direct indexing.
+        wi_partitions = w0_pspec.partitions
         # weight_gather implies either exp or embed_moe is sharded.
         if self.config.shard_exp_on_fsdp:
           # wi [Experts, In, Hidden] -> Gather Exp(0)
-          wi_gather_axes.extend(get_active_sharding_axes(w0_pspec[0], 0))
+          wi_gather_axes.extend(get_active_sharding_axes(wi_partitions[0], 0))
         else:
           # Gather In(1) where embed_moe is sharded.
-          wi_gather_axes.extend(get_active_sharding_axes(w0_pspec[1], 1))
+          wi_gather_axes.extend(get_active_sharding_axes(wi_partitions[1], 1))
         # Gather Hidden(2)
-        wi_gather_axes.extend(get_active_sharding_axes(w0_pspec[2], 2))
+        wi_gather_axes.extend(get_active_sharding_axes(wi_partitions[2], 2))
       wi_tile_size = (
           self.config.wi_tile_fwd_batch_seq,  # m (LHS batch)
           self.config.wi_tile_fwd_embed_dim,  # k  (contracting)
@@ -2100,15 +2115,17 @@ class RoutedMoE(nnx.Module):
     def get_wo_gmm_params():
       wo_gather_axes = []
       if weight_gather:
+        # Read `.partitions`: a kernel spec carrying a reduced axis refuses direct indexing.
+        wo_partitions = wo_pspec.partitions
         # weight_gather implies either exp or embed_moe is sharded.
         if self.config.shard_exp_on_fsdp:
           # wo [Experts, Hidden, Out] -> Gather Exp(0)
-          wo_gather_axes.extend(get_active_sharding_axes(wo_pspec[0], 0))
+          wo_gather_axes.extend(get_active_sharding_axes(wo_partitions[0], 0))
         else:
           # Gather Out(2) where embed_moe is sharded.
-          wo_gather_axes.extend(get_active_sharding_axes(wo_pspec[2], 2))
+          wo_gather_axes.extend(get_active_sharding_axes(wo_partitions[2], 2))
         # Gather Hidden(1)
-        wo_gather_axes.extend(get_active_sharding_axes(wo_pspec[1], 1))
+        wo_gather_axes.extend(get_active_sharding_axes(wo_partitions[1], 1))
       wo_tile_size = (
           self.config.wo_tile_fwd_batch_seq,  # m (LHS batch)
           self.config.wo_tile_fwd_mlp_dim,  # k (contracting)

--- a/src/maxtext/layers/normalizations.py
+++ b/src/maxtext/layers/normalizations.py
@@ -44,11 +44,17 @@ def _align_scale_with_normalized_axis(scale: jnp.ndarray, y: jnp.ndarray) -> jnp
   This is a no-op whenever the two already agree, which includes every
   auto-sharding-equivalent layout for the ordinary layer norms.
   """
-  activation_spec = jax.typeof(y).sharding.spec
+  # Read through `.partitions`: a scale carrying a reduced/unreduced tag (ZeRO-1 +
+  # gradient accumulation) rejects direct indexing. The tags are carried over to the
+  # new spec so the scale keeps its place in the deferred all-reduce.
+  activation_axis = jax.typeof(y).sharding.spec.partitions[-1]
   scale_spec = jax.typeof(scale).sharding.spec
-  if scale_spec[-1] == activation_spec[-1]:
+  if scale_spec.partitions[-1] == activation_axis:
     return scale
-  return jax.sharding.reshard(scale, jax.sharding.PartitionSpec(activation_spec[-1]))
+  return jax.sharding.reshard(
+      scale,
+      jax.sharding.PartitionSpec(activation_axis, unreduced=scale_spec.unreduced, reduced=scale_spec.reduced),
+  )
 
 
 class RMSNorm(nnx.Module):

--- a/src/maxtext/utils/gradient_accumulation.py
+++ b/src/maxtext/utils/gradient_accumulation.py
@@ -21,7 +21,7 @@ from jax.sharding import NamedSharding
 from flax import nnx
 
 from maxtext.common.common_types import ShardMode
-from maxtext.utils.sharding import maybe_shard_with_name
+from maxtext.utils.sharding import batch_mesh_axes, get_mesh_axes_used_by_tensor_spec, maybe_shard_with_name
 
 
 def gradient_accumulation_loss_and_grad(
@@ -70,18 +70,15 @@ def gradient_accumulation_loss_and_grad(
 
   is_nnx = isinstance(model, nnx.Module)
 
-  # For ZeRO-1 + GA, read the resolved "data" axis size from the mesh rather than
-  # config.ici_data_parallelism, which may be -1 (auto-fill) and resolves to 1 when
-  # FSDP already consumes every device — in which case data parallelism is not active.
-  param_mesh = jax.tree.leaves(params_shardings)[0].mesh
-  data_parallel_active = config.shard_mode == ShardMode.EXPLICIT and param_mesh.shape.get("data", 1) > 1
-  if data_parallel_active:
-    # reduced/unreduced PartitionSpecs are rejected inside a jax.lax.scan carry: scan
-    # traces its body against an AbstractMesh whose axis types are all Auto, and the
-    # annotations require Explicit axes. Keep plain params_shardings in the carry and
-    # apply the data-parallel all-reduce to the gradients after the scan instead.
-    ga_params_shardings = params_shardings
-    grad_shardings = params_shardings
+  if data_is_only_batch_axis(config, params_shardings):
+    # Params entering the loop are replicated over "data" and the accumulator holds a
+    # per-replica partial sum, so tagging them reduced/unreduced keeps the accumulation
+    # local and the cross-replica all-reduce runs once after the scan instead of once per
+    # microbatch. JAX requires the unreduced set to equal the axes actually contracted
+    # over — the activation batch axes — which is why the pair is only applied when "data"
+    # is the sole batch axis of size > 1.
+    ga_params_shardings = jax.tree.map(update_sharding_for_reduced, params_shardings)
+    grad_shardings = jax.tree.map(update_sharding_for_unreduced, params_shardings)
   else:
     ga_params_shardings = grad_shardings = params_shardings
 
@@ -172,12 +169,7 @@ def gradient_accumulation_loss_and_grad(
   )
   loss = jnp.where(has_weights, loss, 0.0)
   raw_grads = grad_and_loss["grad"]
-  if data_parallel_active:
-    # Mark the gradients unreduced over the "data" axis now that we're outside the
-    # scan; this triggers the cross-replica all-reduce. The annotation can't live in
-    # the scan carry (see above), so it's applied here instead.
-    unreduced_shardings = jax.tree.map(update_sharding_for_unreduced, params_shardings)
-    raw_grads = jax.tree.map(_maybe_shard_with_name, raw_grads, unreduced_shardings)
+  # Resharding away from the unreduced spec is what emits the cross-replica all-reduce.
   raw_grads = jax.tree.map(_maybe_shard_with_name, raw_grads, params_shardings)
   divisor = (
       config.gradient_accumulation_steps if getattr(config, "use_tunix_gradient_accumulation", False) else denominator
@@ -195,10 +187,41 @@ def gradient_accumulation_loss_and_grad(
 
 
 # GA helper functions
+def data_is_only_batch_axis(config, params_shardings) -> bool:
+  """True when "data" is the single batch mesh axis of size > 1 under explicit sharding.
+
+  This is the condition under which the gradient accumulator can carry an `unreduced`
+  tag: JAX requires the unreduced axes to equal the axes actually contracted over, which
+  for a gradient are the mesh axes the activation batch dimension is sharded on.
+
+  The batch axes are read from the resolved mesh rather than `config.ici_data_parallelism`,
+  which may be -1 (auto-fill) and resolves to 1 when FSDP already consumes every device.
+  """
+  if config.shard_mode != ShardMode.EXPLICIT:
+    return False
+  param_shardings = jax.tree.leaves(params_shardings)
+  if not param_shardings:
+    return False
+  try:
+    batch_axes = batch_mesh_axes(param_shardings[0].mesh, rules=config.logical_axis_rules)
+  except (KeyError, ValueError):
+    # No "activation_batch" rule for this mesh: leave the gradients untagged.
+    return False
+  return batch_axes == frozenset({"data"})
+
+
+def _shards_over_data(sharding: NamedSharding) -> bool:
+  """True if the tensor is itself sharded over the data axis."""
+  return "data" in get_mesh_axes_used_by_tensor_spec(sharding.spec)
+
+
 def update_sharding_for_reduced(sharding: NamedSharding) -> NamedSharding:
   """
   Add reduced on data axis of given NamedSharding
   """
+  # A tensor cannot be reduced over an axis it is sharded on; leave those alone.
+  if _shards_over_data(sharding):
+    return sharding
   return sharding.update(spec=sharding.spec.update(reduced={"data"}))
 
 
@@ -206,4 +229,6 @@ def update_sharding_for_unreduced(sharding: NamedSharding) -> NamedSharding:
   """
   Add unreduced on data axis of given NamedSharding
   """
+  if _shards_over_data(sharding):
+    return sharding
   return sharding.update(spec=sharding.spec.update(unreduced={"data"}))

--- a/src/maxtext/utils/sharding.py
+++ b/src/maxtext/utils/sharding.py
@@ -218,6 +218,29 @@ def batch_mesh_axes(mesh, rules=None):
   return frozenset(axis for axis in mesh_axes_for_dim(spec.partitions[0]) if mesh.shape.get(axis, 1) > 1)
 
 
+def carry_reduced_axes(spec, value):
+  """Copies the `reduced` mesh axes of `value`'s own spec onto `spec`.
+
+  Gradient accumulation marks the parameters it carries through the scan `reduced` over
+  the data axis so their cotangents come out `unreduced` and reduce once after the loop.
+  A spec rebuilt from the logical axis rules has no such tag, so resharding a parameter
+  onto it drops the parameter off the deferred path and its gradient reduces eagerly
+  instead. Copying the tag across keeps it on.
+
+  The tag is left off when it would overlap the partitions, which a PartitionSpec rejects,
+  and when `value` has no spec to read, which is the case outside explicit sharding.
+  """
+  if spec is None or value is None:
+    return spec
+  try:
+    reduced = jax.typeof(value).sharding.spec.reduced
+  except (AttributeError, TypeError):
+    return spec
+  if not reduced or reduced & set(get_mesh_axes_used_by_tensor_spec(spec)):
+    return spec
+  return spec.update(reduced=reduced)
+
+
 def mesh_axes_size(mesh, axes, *, label):
   """Returns the product of mesh sizes for a set of axes."""
   size = 1

--- a/src/maxtext/utils/sharding.py
+++ b/src/maxtext/utils/sharding.py
@@ -190,7 +190,8 @@ def remove_size_one_mesh_axis(spec, mesh):
   if spec is None:
     return None
   new_spec = []  # type: ignore
-  for s in spec:
+  # Iterate `.partitions`: a spec carrying reduced/unreduced axes refuses plain iteration.
+  for s in spec.partitions:
     if s is None or s == P.UNCONSTRAINED:
       new_spec.append(s)  # type: ignore
     elif isinstance(s, tuple):
@@ -207,6 +208,14 @@ def mesh_axes_for_dim(axis_names):
   if isinstance(axis_names, str):
     return (axis_names,)
   return tuple(axis for axis in axis_names if axis is not None)
+
+
+def batch_mesh_axes(mesh, rules=None):
+  """Returns the mesh axes of size > 1 that the activation batch dimension is sharded over."""
+  spec = logical_to_mesh_axes(("activation_batch",), mesh, rules=rules)
+  if spec is None:
+    return frozenset()
+  return frozenset(axis for axis in mesh_axes_for_dim(spec.partitions[0]) if mesh.shape.get(axis, 1) > 1)
 
 
 def mesh_axes_size(mesh, axes, *, label):
@@ -239,7 +248,8 @@ def adjust_pspec_for_indivisible_shapes(spec: P, shape: tuple[int, ...], mesh) -
   if spec is None or mesh is None or not shape:
     return spec
   new_spec = []
-  for i, s in enumerate(spec):
+  # Iterate `.partitions`: a spec carrying reduced/unreduced axes refuses plain iteration.
+  for i, s in enumerate(spec.partitions):
     if i >= len(shape) or s is None or s == P.UNCONSTRAINED:
       new_spec.append(s)
     else:
@@ -442,6 +452,9 @@ def get_mesh_axes_used_by_tensor_spec(tensor_sharding_spec):
     A set of strings, where each string is a mesh axis name used by the
     tensor's sharding spec. Returns an empty set for unsharded tensors.
   """
+  # Read through `.partitions`: a spec carrying reduced/unreduced axes refuses plain iteration.
+  if isinstance(tensor_sharding_spec, P):
+    tensor_sharding_spec = tensor_sharding_spec.partitions
   # Flatten the sharding spec, as it can contain nested iterables (e.g., ('data', 'mdl')).
   tensor_sharding_spec = sum(
       [

--- a/tests/integration/gradient_accumulation_test.py
+++ b/tests/integration/gradient_accumulation_test.py
@@ -17,13 +17,18 @@
 import tempfile
 
 import numpy as np
+import gc
 import json
+import statistics
 import unittest
+from unittest import mock
 import pytest
 import string
 import random
 import os
 import os.path
+
+import jax
 
 from flax.linen import partitioning as nn_partitioning
 
@@ -31,7 +36,7 @@ from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.configs import pyconfig
 from maxtext.trainers.pre_train import train, train_compile
 from maxtext.trainers.pre_train.train import main as train_main
-from maxtext.utils import maxtext_utils, sharding
+from maxtext.utils import gradient_accumulation, maxtext_utils, sharding
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.trainers.post_train.sft.train_sft_native import main as sft_main
 
@@ -42,6 +47,47 @@ from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path
 # the token count — are scalars. The smallest DeepSeek parameter gradient is thousands of
 # elements, so this bound separates "a per-microbatch scalar" from "a parameter gradient".
 _MAX_PER_MICROBATCH_REDUCTION_ELEMENTS = 8
+
+# A ~1.3B-parameter DeepSeek MoE, the smallest size at which the per-microbatch expert
+# gradient reductions cost enough wall clock to measure over run-to-run noise. Sized to
+# fit a single host of four large-HBM chips at roughly a third of the memory limit, so
+# the peak comparison is not clamped by rematerialization kicking in on one variant only.
+_SCALE_OVERRIDES = [
+    "model_name=deepseek3-tiny",
+    "override_model_config=True",
+    "base_emb_dim=1024",
+    "base_mlp_dim=2048",
+    "base_moe_mlp_dim=1024",
+    "base_num_decoder_layers=24",
+    "first_num_dense_layers=1",
+    "num_experts=16",
+    "num_experts_per_tok=2",
+    "max_target_length=1024",
+    "per_device_batch_size=2",
+    "steps=12",
+    "enable_checkpointing=False",
+    "enable_goodput_recording=False",
+    "dataset_type=synthetic",
+    "ici_data_parallelism=-1",
+    "ici_fsdp_parallelism=1",
+    "shard_optimizer_over_data=true",
+    "shard_mode=explicit",
+    "gradient_accumulation_steps=4",
+]
+
+# Compilation, the first donated-buffer step and the input pipeline reaching steady state
+# all land in the opening steps; from the fifth on, step times repeat to a few tenths of
+# a percent on a dedicated host.
+_SCALE_WARMUP_STEPS = 4
+# Measured on a 2x2 v6e host: 0.316 s per step tagged against 0.383 s untagged, and peak
+# HBM within 0.01%. The thresholds keep a wide margin on both so the test fails on the
+# tag being lost rather than on jitter.
+_SCALE_MIN_SPEEDUP = 1.05
+_SCALE_MAX_MEMORY_RATIO = 1.02
+# Below this the config has been shrunk past the point where the assertions mean anything.
+_SCALE_MIN_PEAK_HBM_BYTES = 4 * 2**30
+_SCALE_MIN_DEVICES = 4
+_SCALE_MIN_HBM_BYTES = 24 * 2**30
 
 
 def generate_random_string(length=10):
@@ -235,6 +281,90 @@ class GradientAccumulationTest(unittest.TestCase):
         per_microbatch,
         [],
         f"gradient all-reduce is still inside the accumulation loop: {per_microbatch} elements per buffer",
+    )
+
+  def _train_scale_variant(self, variant):
+    """Trains the scale config once; returns its median steady-state step time and peak HBM."""
+    metrics_file = os.path.join(tempfile.gettempdir(), f"scale_{variant}_{generate_random_string()}.jsonl")
+    train_main(
+        [
+            None,
+            get_test_config_path(),
+            f"base_output_directory={self.base_output_directory}",
+            f"run_name=deepseek_zero1_ga_scale_{variant}",
+            f"metrics_file={metrics_file}",
+        ]
+        + _SCALE_OVERRIDES
+    )
+    # Drop the train state before reading the peak, so the next variant starts from the
+    # same live-memory baseline rather than on top of this one's parameters.
+    gc.collect()
+
+    step_times = []
+    with open(metrics_file, "rt", encoding="utf8") as metrics:
+      for line in metrics:
+        record = json.loads(line)
+        if "perf/step_time_seconds" in record:
+          step_times.append(record["perf/step_time_seconds"])
+    steady = step_times[_SCALE_WARMUP_STEPS:]
+    self.assertTrue(steady, f"{variant} run logged only {len(step_times)} steps")
+
+    peak_hbm_bytes = max(device.memory_stats()["peak_bytes_in_use"] for device in jax.local_devices())
+    step_time = statistics.median(steady)
+    print(
+        f"[Gradient Accumulation Scale Test] {variant}: {step_time:.6f} s/step over {len(steady)} steps, "
+        f"peak HBM so far {peak_hbm_bytes / 2**30:.4f} GiB",
+        flush=True,
+    )
+    return step_time, peak_hbm_bytes
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  def test_deepseek_zero1_ga_scale_memory_and_step_time(self):
+    """A ~1.3B DeepSeek MoE trains faster, and no heavier, once the accumulator is tagged.
+
+    `test_deepseek_zero1_reduces_gradients_once_per_step` reads the collective's position
+    out of the HLO, which says nothing about what the deferred reduction is worth. This
+    one trains the model twice on real chips — once as shipped, once with the tagging
+    suppressed — and compares step time and peak HBM, so a change that keeps the tag but
+    reduces gradients per microbatch somewhere downstream still shows up.
+    """
+    devices = jax.local_devices()
+    if len(devices) < _SCALE_MIN_DEVICES:
+      self.skipTest(f"needs at least {_SCALE_MIN_DEVICES} local devices, found {len(devices)}")
+    hbm_bytes = devices[0].memory_stats()["bytes_limit"]
+    if hbm_bytes < _SCALE_MIN_HBM_BYTES:
+      self.skipTest(f"needs at least {_SCALE_MIN_HBM_BYTES / 2**30:.0f} GiB per device, found {hbm_bytes / 2**30:.2f}")
+
+    # `peak_bytes_in_use` is a high-water mark the allocator never resets, so order the
+    # runs to make that work in the assertion's favour: the untagged variant goes first,
+    # its reading is its own peak, and the reading after the tagged run is the larger of
+    # the two. "The second reading is no higher than the first" is then exactly "tagging
+    # did not raise the peak", with no way for a regression to hide behind the mark.
+    # Suppressing the tag reproduces the behaviour before the accumulator carried one.
+    with mock.patch.object(gradient_accumulation, "data_is_only_batch_axis", return_value=False):
+      untagged_step_time, peak_after_untagged = self._train_scale_variant("untagged")
+    tagged_step_time, peak_after_tagged = self._train_scale_variant("tagged")
+
+    # Guards against the config being shrunk to where the reductions stop mattering.
+    self.assertGreater(
+        peak_after_untagged,
+        _SCALE_MIN_PEAK_HBM_BYTES,
+        "the scale config no longer reaches the memory footprint these thresholds were calibrated at",
+    )
+    memory_ratio = peak_after_tagged / peak_after_untagged
+    self.assertLess(
+        memory_ratio,
+        _SCALE_MAX_MEMORY_RATIO,
+        f"deferring the reduction cost {memory_ratio:.4f}x peak HBM; accumulating in the parameters' own layout "
+        "should not need more live memory than reducing every microbatch",
+    )
+    speedup = untagged_step_time / tagged_step_time
+    self.assertGreater(
+        speedup,
+        _SCALE_MIN_SPEEDUP,
+        f"reducing gradients once per step was only {speedup:.4f}x faster than once per microbatch; the accumulator's "
+        "`reduced` tag is being dropped somewhere between gradient accumulation and the layers",
     )
 
   @pytest.mark.integration_test

--- a/tests/integration/gradient_accumulation_test.py
+++ b/tests/integration/gradient_accumulation_test.py
@@ -25,17 +25,64 @@ import random
 import os
 import os.path
 
+from flax.linen import partitioning as nn_partitioning
+
 from maxtext.common.gcloud_stub import is_decoupled
+from maxtext.configs import pyconfig
+from maxtext.trainers.pre_train import train, train_compile
 from maxtext.trainers.pre_train.train import main as train_main
+from maxtext.utils import maxtext_utils, sharding
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.trainers.post_train.sft.train_sft_native import main as sft_main
 
+from tests.utils.hlo_test_utils import cross_replica_all_reduce_sizes, split_by_entry_loop
 from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
+
+# Cross-replica reductions that legitimately run once per microbatch — the summed loss and
+# the token count — are scalars. The smallest DeepSeek parameter gradient is thousands of
+# elements, so this bound separates "a per-microbatch scalar" from "a parameter gradient".
+_MAX_PER_MICROBATCH_REDUCTION_ELEMENTS = 8
 
 
 def generate_random_string(length=10):
   characters = string.ascii_letters  # Include letters, digits, and punctuation
   return "".join(random.choice(characters) for _ in range(length))
+
+
+def compile_train_step(overrides):
+  """AOT-compiles `train.train_step` for a config and returns the compiled executable.
+
+  Mirrors `train_compile.main`, which builds the same executable but does not hand it
+  back. Compiling ahead of time against `compile_topology` means the mesh can be larger
+  than the host's device count, which is what makes a data-parallel training step
+  inspectable from a single-device test runner.
+  """
+  config = pyconfig.initialize([None, get_test_config_path()] + overrides)
+  train_compile.validate_config(config)
+  topology_mesh = train_compile.get_topology_mesh(config)
+  shaped_args, shaped_kwargs, state_mesh_shardings, _, model = train_compile.get_shaped_inputs(topology_mesh, config)
+  # ZeRO-1 moves the params onto the optimizer's layout; gradient accumulation still sees
+  # the pre-ZeRO-1 layout through params_shardings.
+  params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
+  input_state_mesh_shardings = sharding.build_zero1_input_state_mesh_shardings(
+      config, state_mesh_shardings, params_shardings
+  )
+  data_sharding = sharding.get_input_data_sharding(config, topology_mesh)
+  func, in_shardings, out_shardings, static_argnums, donate_argnums = maxtext_utils.get_functional_train_with_signature(
+      train.train_step, data_sharding, input_state_mesh_shardings, model, config, params_shardings
+  )
+  return train_compile.jit_and_compile(
+      func,
+      shaped_args,
+      shaped_kwargs,
+      topology_mesh,
+      in_shardings,
+      out_shardings,
+      static_argnums,
+      donate_argnums,
+      config,
+      nn_partitioning.axis_rules(config.logical_axis_rules),
+  )
 
 
 class GradientAccumulationTest(unittest.TestCase):
@@ -146,6 +193,49 @@ class GradientAccumulationTest(unittest.TestCase):
           flush=True,
       )
       np.testing.assert_equal(accum_device_tflops, regular_device_tflops)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  def test_deepseek_zero1_reduces_gradients_once_per_step(self):
+    """DeepSeek + ZeRO-1 + gradient accumulation must all-reduce gradients once per step.
+
+    Under explicit sharding the accumulator carries an `unreduced` PartitionSpec tag over
+    the data axis, so each microbatch's gradient is summed locally and the cross-replica
+    reduction happens once, when the accumulated gradient is resharded back after the
+    scan. Losing that tag is silent — the gradients stay numerically identical — and only
+    shows up as the reduction being emitted inside the accumulation loop, once per
+    microbatch. So assert on where the collective sits rather than on the loss.
+    """
+    compiled = compile_train_step(
+        [
+            "run_name=deepseek_zero1_ga_all_reduce",
+            f"base_output_directory={self.base_output_directory}",
+            "enable_checkpointing=False",
+            "enable_goodput_recording=False",
+            "dataset_type=synthetic",
+            "model_name=deepseek3-tiny",
+            "compile_topology=v5e-8",
+            "compile_topology_num_slices=1",
+            "ici_data_parallelism=-1",
+            "ici_fsdp_parallelism=1",
+            "shard_optimizer_over_data=true",
+            "shard_mode=explicit",
+            "gradient_accumulation_steps=4",
+            "per_device_batch_size=1",
+        ]
+    )
+    inside, outside = split_by_entry_loop(compiled.as_text(), "all-reduce")
+    inside_sizes = cross_replica_all_reduce_sizes(inside)
+    # Guards the assertion below against passing vacuously: if SPMD partitioning stopped
+    # spelling its replica groups over mesh axes, `inside_sizes` would be empty for the
+    # wrong reason.
+    self.assertTrue(cross_replica_all_reduce_sizes(outside), "no cross-replica all-reduce outside the loop")
+    per_microbatch = [size for size in inside_sizes if size > _MAX_PER_MICROBATCH_REDUCTION_ELEMENTS]
+    self.assertEqual(
+        per_microbatch,
+        [],
+        f"gradient all-reduce is still inside the accumulation loop: {per_microbatch} elements per buffer",
+    )
 
   @pytest.mark.integration_test
   @pytest.mark.tpu_only

--- a/tests/unit/gradient_accumulation_nnx_test.py
+++ b/tests/unit/gradient_accumulation_nnx_test.py
@@ -39,6 +39,7 @@ class _Cfg:
   debug_sharding: bool = False
   training_objective: str = "causal_lm"
   use_tunix_gradient_accumulation: bool = False
+  logical_axis_rules: tuple = (("activation_batch", ("data", "fsdp", "fsdp_transpose", "expert")),)
 
 
 class _TinyNNX(nnx.Module):
@@ -248,6 +249,68 @@ class TestGradientAccumulationNNX(unittest.TestCase):
           for gradient in jax.tree.leaves(raw_grads):
             self.assertTrue(jnp.all(jnp.isfinite(gradient)))
             self.assertTrue(jnp.all(gradient == 0))
+
+
+class TestUnreducedGradientTagging(unittest.TestCase):
+  """Cover when gradient accumulation tags its accumulator `unreduced` over "data".
+
+  The tag is what defers the cross-replica gradient reduction until after the scan. JAX
+  requires the unreduced axes to equal the axes the gradient was contracted over, which
+  are the mesh axes the activation batch dimension is sharded on, so the tag is only
+  valid when "data" is the one batch axis with more than one shard.
+  """
+
+  # Only the mesh shape and the logical rules decide this, so an abstract mesh keeps the
+  # axis sizes independent of how many devices the test runner has.
+  def _shardings(self, axis_sizes, spec=PartitionSpec()):
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes,
+        ("data", "fsdp", "expert"),
+        axis_types=(jax.sharding.AxisType.Explicit,) * 3,
+    )
+    return {"kernel": NamedSharding(mesh, spec)}
+
+  def test_data_only_batch_axis_is_tagged(self):
+    cfg = _Cfg(shard_mode=ShardMode.EXPLICIT)
+    self.assertTrue(gradient_accumulation.data_is_only_batch_axis(cfg, self._shardings((8, 1, 1))))
+
+  def test_batch_split_across_data_and_fsdp_is_not_tagged(self):
+    """With FSDP on too, "data" alone no longer matches the contracted axes.
+
+    Tagging anyway raises a ShardingTypeError from the backward pass, and the alternative
+    of tagging both axes is illegal because the parameters are sharded over "fsdp".
+    """
+    cfg = _Cfg(shard_mode=ShardMode.EXPLICIT)
+    self.assertFalse(gradient_accumulation.data_is_only_batch_axis(cfg, self._shardings((2, 4, 1))))
+
+  def test_data_parallelism_of_one_is_not_tagged(self):
+    cfg = _Cfg(shard_mode=ShardMode.EXPLICIT)
+    self.assertFalse(gradient_accumulation.data_is_only_batch_axis(cfg, self._shardings((1, 8, 1))))
+
+  def test_auto_shard_mode_is_not_tagged(self):
+    """Auto sharding has no `unreduced` spec to express the deferred reduction with."""
+    cfg = _Cfg(shard_mode=ShardMode.AUTO)
+    self.assertFalse(gradient_accumulation.data_is_only_batch_axis(cfg, self._shardings((8, 1, 1))))
+
+  def test_missing_activation_batch_rule_is_not_tagged(self):
+    cfg = _Cfg(shard_mode=ShardMode.EXPLICIT, logical_axis_rules=())
+    self.assertFalse(gradient_accumulation.data_is_only_batch_axis(cfg, self._shardings((8, 1, 1))))
+
+  def test_tags_are_added_for_a_replicated_parameter(self):
+    sharding = self._shardings((8, 1, 1), PartitionSpec(None))["kernel"]
+    self.assertEqual(gradient_accumulation.update_sharding_for_reduced(sharding).spec.reduced, frozenset({"data"}))
+    self.assertEqual(gradient_accumulation.update_sharding_for_unreduced(sharding).spec.unreduced, frozenset({"data"}))
+
+  def test_parameter_sharded_over_data_is_left_alone(self):
+    """A tensor cannot be reduced over an axis it is already split along.
+
+    ZeRO-1 puts "data" into some parameter specs, and PartitionSpec rejects a tag that
+    overlaps its own partitions, so those parameters keep the untagged spec and their
+    reduction stays where it was.
+    """
+    sharding = self._shardings((8, 1, 1), PartitionSpec("data", None))["kernel"]
+    self.assertIs(gradient_accumulation.update_sharding_for_reduced(sharding), sharding)
+    self.assertIs(gradient_accumulation.update_sharding_for_unreduced(sharding), sharding)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sharding_nnx_test.py
+++ b/tests/unit/sharding_nnx_test.py
@@ -504,5 +504,37 @@ class TruncateOutShardingTest(unittest.TestCase):
     self.assertEqual(truncated.reduced, frozenset({"data"}))
 
 
+class TaggedPartitionSpecTest(unittest.TestCase):
+  """A spec carrying reduced/unreduced axes must survive the sharding helpers.
+
+  JAX rejects indexing, slicing, unpacking and iterating such a spec — only `.partitions`
+  reads through it — so every helper that rebuilds a spec has to go through that path.
+  A tagged axis can never also appear in the partitions, so these specs tag "data" while
+  sharding over the other axes.
+  """
+
+  # Only mesh.shape is read by the helpers below, so an abstract mesh keeps the axis
+  # sizes fixed regardless of how many devices the test runner has.
+  mesh = jax.sharding.AbstractMesh((2, 1, 4), ("data", "fsdp", "model"))
+
+  def test_mesh_axes_used_by_tagged_spec(self):
+    spec = PartitionSpec(("fsdp", "model"), None, unreduced={"data"})
+    self.assertEqual(sharding.get_mesh_axes_used_by_tensor_spec(spec), ["fsdp", "model"])
+
+  def test_remove_size_one_mesh_axis_keeps_tags(self):
+    # "fsdp" has size 1, so it is dropped from the partitions while "model" stays.
+    spec = PartitionSpec("fsdp", "model", reduced={"data"})
+    trimmed = sharding.remove_size_one_mesh_axis(spec, self.mesh)
+    self.assertEqual(trimmed.partitions, (None, "model"))
+    self.assertEqual(trimmed.reduced, frozenset({"data"}))
+
+  def test_adjust_pspec_for_indivisible_shapes_keeps_tags(self):
+    # A dimension of 6 does not divide evenly over the 4-way "model" axis, so it is unsharded.
+    spec = PartitionSpec("model", "fsdp", unreduced={"data"})
+    adjusted = sharding.adjust_pspec_for_indivisible_shapes(spec, (6, 8), self.mesh)
+    self.assertEqual(adjusted.partitions, (None, "fsdp"))
+    self.assertEqual(adjusted.unreduced, frozenset({"data"}))
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/tests/utils/hlo_test_utils.py
+++ b/tests/utils/hlo_test_utils.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Helpers for asserting on the collectives in attention HLO text.
+"""Helpers for asserting on the collectives in HLO text.
 
 The helpers work on HLO text lines such as:
 
@@ -26,6 +26,13 @@ each collective is counted once.
 import re
 
 _FLOAT_TYPES = ("bf16", "f16", "f32", "f64")
+
+# `%name (p: f32[8]) -> f32[8] {`, optionally prefixed with ENTRY, at column 0.
+_COMPUTATION_HEADER = re.compile(r"^(ENTRY )?%?([\w.\-]+)\s*\(.*\)\s*->\s*.*\{\s*$")
+# Computation operands named by a single attribute, e.g. `body=%loop_body`.
+_CALLEE = re.compile(r"(?:body|condition|to_apply|true_computation|false_computation|select|scatter)=%?([\w.\-]+)")
+# Computation operands named by a braced list, e.g. `called_computations={%a, %b}`.
+_CALLEE_LIST = re.compile(r"(?:called_computations|branch_computations)=\{([^}]*)\}")
 
 
 def collective_lines(hlo_text, collective):
@@ -56,6 +63,84 @@ def _collective_dimensions(line):
   if not match:
     return ()
   return tuple(int(dim) for dim in match.group(1).split(",") if dim)
+
+
+def _computations(hlo_text):
+  """Splits HLO text into {computation name: instruction lines} and the entry name."""
+  computations, entry, current = {}, None, None
+  for line in hlo_text.splitlines():
+    header = _COMPUTATION_HEADER.match(line)
+    if header and not line.startswith(" "):
+      current = header.group(2)
+      computations[current] = []
+      if header.group(1):
+        entry = current
+    elif line == "}":
+      current = None
+    elif current is not None:
+      computations[current].append(line)
+  return computations, entry
+
+
+def _callees(line):
+  """Names the computations an HLO instruction line invokes."""
+  names = set(_CALLEE.findall(line))
+  for group in _CALLEE_LIST.findall(line):
+    names.update(name.strip().lstrip("%") for name in group.split(",") if name.strip())
+  return names
+
+
+def _reachable(computations, roots):
+  """Names of `roots` plus every computation they transitively invoke."""
+  seen, pending = set(), list(roots)
+  while pending:
+    name = pending.pop()
+    if name in seen or name not in computations:
+      continue
+    seen.add(name)
+    pending.extend(_callees(" ".join(computations[name])))
+  return seen
+
+
+def split_by_entry_loop(hlo_text, collective):
+  """Splits a collective's instruction lines by whether they run inside an entry-level loop.
+
+  Returns `(inside, outside)`. `inside` holds the lines belonging to computations
+  reachable from the body of a `while` that the entry computation calls directly, so
+  those instructions run once per loop iteration; `outside` holds the rest, which run
+  once per call. A `jax.lax.scan` lowers to exactly such a `while`, which makes this the
+  discriminator for "is this collective hoisted out of the scan or not".
+  """
+  computations, entry = _computations(hlo_text)
+  if entry is None:
+    raise ValueError("HLO text has no ENTRY computation")
+  loop_bodies = [match.group(1) for line in computations[entry] for match in re.finditer(r"body=%?([\w.\-]+)", line)]
+  in_loop = _reachable(computations, loop_bodies)
+  lines = collective_lines(hlo_text, collective)
+  in_loop_lines = {line for name in in_loop for line in computations[name]}
+  inside = [line for line in lines if line in in_loop_lines]
+  outside = [line for line in lines if line not in in_loop_lines]
+  return inside, outside
+
+
+def cross_replica_all_reduce_sizes(lines):
+  """Element counts of the buffers reduced by each SPMD-generated all-reduce line.
+
+  Only lines whose `replica_groups` name a mesh axis are counted. Those are the
+  collectives SPMD partitioning inserts to reduce over a mesh axis; a `jax.shard_map`
+  body instead emits manual-mode collectives, which spell their replica groups out as
+  literal device ids and are not partitioning decisions the caller controls.
+  """
+  sizes = []
+  for line in lines:
+    if not re.search(r"replica_groups=mesh\[", line):
+      continue
+    for _, dims in _result_shapes(line, "all-reduce"):
+      size = 1
+      for dim in dims:
+        size *= dim
+      sizes.append(size)
+  return sizes
 
 
 def attention_sequence_all_gather_lines(hlo_text, sequence_lengths, dtypes=_FLOAT_TYPES):


### PR DESCRIPTION
# Description

Running DeepSeek + ZeRO-1 + gradient accumulation under `shard_mode=explicit` drops the `unreduced` tag on some parameter gradients, so those gradients get all-reduced **once per microbatch inside the accumulation loop** instead of once per step after it.

```
smoke_train ici_data_parallelism=-1 ici_fsdp_parallelism=1 \
  shard_optimizer_over_data=true model_name=deepseek3-tiny \
  shard_mode=explicit gradient_accumulation_steps=4
```

The failure is silent — gradients stay numerically identical, because JAX happily converts a fully-reduced value back to a partial one. The only symptom is wasted collective traffic.

## Background: how the tag works

Under explicit sharding, gradient accumulation marks the parameters it carries through the scan as `reduced` over the `data` axis. A `reduced` input means "already summed over that axis", so its cotangent comes out `unreduced`, and the all-reduce is deferred until something reshards away from `unreduced` — which happens once, after the loop. Any code path that rebuilds a `PartitionSpec` from the logical axis rules produces an untagged spec, and resharding a parameter onto it silently drops that parameter off the deferred path.

## Fix 1 — restore the tag under ZeRO-1 + explicit sharding

A tagged `PartitionSpec` rejects indexing, slicing, unpacking and iteration; only `.partitions` reads through it. Several sharding helpers were doing exactly that and so were either raising or quietly dropping the tag.

`src/maxtext/utils/sharding.py`:
- `remove_size_one_mesh_axis` and `adjust_pspec_for_indivisible_shapes` now read `.partitions` instead of indexing the spec directly.
- `get_mesh_axes_used_by_tensor_spec` reads through `.partitions`.
- New `batch_mesh_axes` helper.
- `truncate_out_sharding` needed the same treatment; `main` has since landed an equivalent `_truncate_pspec` helper independently, so this PR now takes upstream's version and only keeps the accompanying tests.

`src/maxtext/utils/gradient_accumulation.py`:
- Gating via `data_is_only_batch_axis(config, params_shardings)`, plus `update_sharding_for_reduced` / `update_sharding_for_unreduced` and a post-scan `jax.tree.map(_maybe_shard_with_name, raw_grads, params_shardings)`.

No changes to `train.py`.

## Fix 2 — keep the tag through the MoE `shard_map`

Fix 1 alone turned out to be a **wall-clock regression on MoE models** — 2–4% slower. Root cause: `moe.py:sparse_matmul` reshards the expert kernels onto a pspec rebuilt from the logical axis rules, which carries no tag. `jax.shard_map` makes every mesh axis manual, so the kernel cotangent was psum'd over `data` *inside* the body — once per microbatch, per layer — and the accumulated gradient was reduced *again* on the way out of the scan. Double work, correct numerics.

- New `carry_reduced_axes(spec, value)` in `sharding.py`, which copies the `reduced` mesh axes of a value's own spec onto a rebuilt spec. It declines when the tag would overlap the partitions (which `PartitionSpec` rejects) and when there is no spec to read, so it is a no-op outside explicit sharding.
- `sparse_matmul` applies it to `w0/w1/wo` and their biases right after `maybe_aqt_partition`.
- `get_wi_gmm_params` / `get_wo_gmm_params` read `.partitions`, since a tagged spec refuses indexing.

Verified in isolation that `jax.shard_map` accepts a `reduced`-tagged `in_spec` and then emits **zero** in-body all-reduce.

## Rebase note

Rebased onto `main` at `d2d73155b` (30 commits). Two conflicts, both from upstream converging on the same ideas:

- `truncate_out_sharding` — `main` landed `_truncate_pspec`, which carries `reduced`/`unreduced` across truncation exactly as this branch did. Resolved in favour of upstream's factoring; only the tests from this branch remain.
- `sharding_nnx_test.py` — `main` added equivalent coverage for tag-preserving truncation. Kept upstream's two tests, dropped the redundant one from this branch, kept the new `TaggedPartitionSpecTest` class (which covers `get_mesh_axes_used_by_tensor_spec`, `remove_size_one_mesh_axis` and `adjust_pspec_for_indivisible_shapes`).

`moe.py` was heavily refactored upstream (~350 lines, including the new `get_routed_moe_shardings`) but merged cleanly: the `carry_reduced_axes` calls still sit between `maybe_aqt_partition` and the `shard_map`, whose `in_specs` still consume those pspecs. All measurements below were re-run after the rebase and are unchanged.

One thing did change upstream: the `ds_dp2fsdp4_z1_ga4` sweep case previously died with a `ShardingTypeError` deep in sharding. `main` now rejects it up front at config validation with a clear message — `` `shard_optimizer_over_data` (Zero-1) cannot be combined with FSDP `` — so that gap is closed and is no longer an open item for this PR.

# Tests

## New coverage

`tests/integration/gradient_accumulation_test.py` gains two tests.

**`test_deepseek_zero1_reduces_gradients_once_per_step`** (AOT, v5e-8 topology) asserts no cross-replica all-reduce larger than 8 elements sits inside the accumulation loop — the loss and token count are legitimately reduced per microbatch and are scalars, so the bound separates those from parameter gradients. A vacuity guard checks that one does exist outside the loop. Supporting helpers live in `tests/utils/hlo_test_utils.py` (`split_by_entry_loop`, `cross_replica_all_reduce_sizes`).

**`test_deepseek_zero1_ga_scale_memory_and_step_time`** actually *trains* a ~1.29B DeepSeek MoE on real chips, twice — once as shipped, once with `data_is_only_batch_axis` patched to `False` to reproduce pre-fix behaviour — and asserts on both step time and peak HBM. HLO placement says nothing about what the deferred reduction is worth; this catches a change that keeps the tag but reduces gradients per microbatch somewhere downstream.

```
untagged: 0.382786 s/step over 8 steps, peak HBM so far 9.9513 GiB
tagged:   0.316346 s/step over 8 steps, peak HBM so far 9.9518 GiB
```

Asserts speedup > 1.05x (measured 1.21x), memory ratio < 1.02 (measured 1.00005), and a >4 GiB peak floor so the config cannot be silently shrunk past the point where the thresholds mean anything. Skips below 4 devices or 24 GiB/chip.

One design note: the runs are ordered **untagged first, on purpose**. `peak_bytes_in_use` is a high-water mark the TPU allocator never resets, so the second reading is `max(both)`; asserting "second <= first" is then exactly "tagging did not raise the peak", with no way for a regression to hide behind the mark. An earlier subprocess-per-variant design was abandoned because the parent pytest process initialises the TPU when it checks the device count, which then locks the children out.

## How to reproduce

```bash
# Integration tests (needs >=4 chips with >=24 GiB HBM each)
python -m pytest tests/integration/gradient_accumulation_test.py -q -s

# Unit tests (CPU)
JAX_PLATFORMS=cpu python -m pytest \
  tests/unit/gradient_accumulation_nnx_test.py tests/unit/sharding_compare_test.py \
  tests/unit/sharding_desc_test.py tests/unit/sharding_nnx_test.py tests/unit/sharding_test.py -q

# MoE unit tests
python -m pytest tests/unit/moe_test.py -q
```

## Results

- Full `tests/integration/gradient_accumulation_test.py`: **4 passed** (67 s) on a 2x2 v6e host. Scale numbers reproduce identically when sharing a process with the other tests, confirming no peak-HBM carryover between runs.
- Sharding + gradient-accumulation unit tests (5 files, CPU): **102 passed, 1 skipped, 4 subtests**.
- `tests/unit/moe_test.py`: 32 passed, 42 skipped, 1 failed. The failure is `test_gmm_grad_equivalence_tokamax_v2_fp8_dynamic_ep4` (NaN relative-norm) and is **pre-existing** — it fails identically with `moe.py` stashed back to `main`.
- AOT sharding sweep, 7 configs: 6 pass. `ds_dp2fsdp4_z1_ga4` is now rejected by `main`'s own config validation as an unsupported combination (see the rebase note above).
- Numerics: losses match to ~1e-5 relative over 6 steps between tagged and untagged.
- `pyink --pyink-indentation=2 --line-length=122` clean on every file this PR touches except `moe.py`, which is already not pyink-clean on `main` in regions this PR does not touch; reformatting them would bury the diff. `pylint --rcfile=pylintrc` scores 10.00/10 on the test file, and the two `E1128` in `moe.py` are pre-existing on `main`.

## Measurements

All on a single 2x2 v6e host (4 chips, 31.24 GiB/chip), `bf16`, synthetic data, median of 8 steady-state steps after 4 warmup steps.

### The MoE fix flips the sign of Fix 1

| config | after Fix 1 only | after Fix 2 | |
|---|---|---|---|
| 8L / 8E, emb 1024 | 0.1084 s vs 0.1062 s untagged | 0.0958 s vs 0.1062 s | 2.0% slower -> **9.8% faster** |
| 24L / 16E, ~1.29B | 0.3994 s vs 0.3827 s untagged | 0.3164 s vs 0.3827 s | 4.3% slower -> **17.3% faster** |

Collective placement at 24L/16E: tagged has 2 in-loop all-reduce ops totalling 0.0 MiB plus 2809 MiB once outside; untagged has 34 MiB in-loop (x23 layers x4 microbatches ~ 9 GiB) plus 509 MiB outside.

### Explicit vs auto sharding

The tags only exist on an all-Explicit mesh, so this fix is a no-op under `shard_mode=auto`. What changes is where explicit mode lands relative to auto:

| shard_mode | median step | peak HBM | vs auto |
|---|---|---|---|
| `explicit` (with fix) | **0.3163 s** | 9.9518 GiB | **1.15x faster** |
| `auto` | 0.3650 s | 9.9481 GiB | — |
| `explicit` (pre-fix) | 0.3827 s | 9.9513 GiB | 0.95x (slower) |

Explicit went from 4.9% slower than auto to 13.3% faster. Peak HBM is flat across all three (spread 0.04%), so this is pure traffic, not a memory/compute tradeoff.

On stock `deepseek3-tiny` (pdbs 1, 0.35 GiB) explicit and auto are indistinguishable — 0.5871 s vs 0.5864 s. The model is far too small for collective traffic to register against fixed per-step overhead, which is why the original bug was invisible as a perf problem on the config it was reported against.

### When the fix pays off

One factor at a time from the 24L/16E/pdbs2/GA4 base:

| axis | value | untagged | tagged | speedup |
|---|---|---|---|---|
| **GA steps** | 2 | 0.2117 | 0.1911 | **1.108x** |
| | 4 | 0.3827 | 0.3164 | **1.210x** |
| | 8 | 0.7253 | 0.5670 | **1.279x** |
| **tokens/microbatch** | pdbs 1 | 0.3268 | 0.2589 | **1.262x** |
| | pdbs 2 | 0.3828 | 0.3163 | **1.210x** |
| | pdbs 4 | 0.4995 | 0.4373 | **1.142x** |
| **experts** (12L) | 8 | 0.1489 | 0.1323 | **1.125x** |
| | 16 | 0.1993 | 0.1669 | **1.194x** |
| | 32 | 0.2958 | 0.2367 | **1.250x** |
| **depth** (16E) | 12L | 0.1995 | 0.1671 | **1.194x** |
| | 24L | 0.3827 | 0.3163 | **1.210x** |
| | 36L | 0.5608 | 0.4518 | **1.241x** |

The eliminated work is exactly `(N-1)` redundant all-reduces, so time is `N*(c+a)` before and `N*c + a` after, giving a speedup of `(c+a)/(c+a/N)`.

- **Microbatch count is the strongest lever, but saturates.** Absolute time saved scales linearly in N — 0.021 / 0.066 / 0.158 s at N = 2/4/8, i.e. 1 : 3.2 : 7.7 against a predicted 1 : 3 : 7. Total step time scales with N too, so the ratio approaches a ceiling. Fitting `T = o + N*c + {N*a or a}` to the three points gives `a ~ 22 ms`, `c ~ 63 ms`, `o ~ 41 ms` fixed overhead, so the ceiling is **~1.35x** for this shape. GA=8 is already at 1.28.
- **Bigger model is roughly neutral.** Depth adds gradient bytes and FLOPs together, so `a/c` barely moves across 3x the layers. The mild 1.19 -> 1.24 drift is fixed per-step overhead being diluted, not a scaling effect.
- **Sparsity is the model-shape lever that matters.** 8 -> 32 experts moves 1.13x -> 1.25x, because expert weights add gradient bytes ~linearly while FLOPs only grow with routing overhead (top-k fixed at 2). Absolute saved time scaled 1 : 1.95 : 3.56 with expert count while total step time only scaled 1 : 1.34 : 1.99. A real DeepSeek-V3 shape (256 experts, top-8) sits much further right on this curve than anything that fits on four chips.
- **Smaller microbatches help**, same bytes-per-FLOP reason: fewer tokens per microbatch means the same all-reduce amortizes over less compute.

Summary: the gain is `(1 - 1/N) * a/c` where `a/c` is gradient-bytes-per-microbatch-FLOP. Largest with many microbatches, few tokens each, and a sparse MoE — precisely the regime GA exists to serve.

**Not measured:** this is 4-way DP on one host. More replicas make each all-reduce costlier, which should push `a/c` and therefore the win higher, but there is no data on it here. Treat multi-host gains as an expectation, not a number.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas. (The `reduced`/`unreduced` tag semantics are subtle and fail silently, so `carry_reduced_axes`, every `.partitions` read, and the untagged-first ordering in the scale test each carry a comment explaining why.)
- [x] I have run end-to-end tests tests and provided workload links above if applicable. (Run on a local 2x2 v6e host rather than an xpk workload, so there is no workload link; full commands and results are in the Tests section above.)
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files). (No doc changes needed — this is an internal sharding correctness fix with no user-facing config or API surface.)
