### PR TITLE
Add a remat checkpoint after the MoE expert-parallel combine

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -375,6 +375,7 @@ mlpwo: 'remat'
 moe_mlpwi_0: 'remat'
 moe_mlpwi_1: 'remat'
 moe_mlpwo: 'remat'
+moe_combine: 'remat' # Output of the expert-parallel combine (reduce-scatter / ragged all-to-all)
 query_proj: 'remat'
 key_proj: 'remat'
 value_proj: 'remat'

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1353,6 +1353,13 @@ class RematAndOffload(BaseModel):
       RematLocation.REMAT,
       description="Remat policy for the second MoE layer's output.",
   )
+  moe_combine: RematLocation = Field(
+      RematLocation.REMAT,
+      description=(
+          "Remat policy for the output of the expert-parallel combine collective"
+          " (reduce-scatter or ragged all-to-all)."
+      ),
+  )
   query_proj: RematLocation = Field(RematLocation.REMAT, description="Remat policy for the query projection.")
   key_proj: RematLocation = Field(RematLocation.REMAT, description="Remat policy for the key projection.")
   value_proj: RematLocation = Field(RematLocation.REMAT, description="Remat policy for the value projection.")
@@ -3580,6 +3587,7 @@ class MaxTextConfig(
           "moe_mlpwi_0",
           "moe_mlpwi_1",
           "moe_mlpwo",
+          "moe_combine",
           "mlpwi_0",
           "mlpwi_1",
           "mlpwo",
@@ -4745,6 +4753,7 @@ class RLConfig(
           "moe_mlpwi_0",
           "moe_mlpwi_1",
           "moe_mlpwo",
+          "moe_combine",
           "mlpwi_0",
           "mlpwi_1",
           "mlpwo",

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -2315,6 +2315,7 @@ class RoutedMoE(nnx.Module):
             scatter_dimension=0,
             tiled=True,
         )
+        output = adc.checkpoint_name(output, "moe_combine")
         return output, routing.lb_loss, routing.bias_updates
 
       if self.get_expert_parallelism_size() > 1:
@@ -2336,6 +2337,7 @@ class RoutedMoE(nnx.Module):
             output_shape,
             is_batch_sharded_by_expert,
         )
+        intermediate_output = adc.checkpoint_name(intermediate_output, "moe_combine")
 
       output = self.unpermute(
           intermediate_output,


### PR DESCRIPTION
# Description

In the sparse-matmul MoE path (`_moe_body` in `src/maxtext/layers/moe.py`), the expert-parallel combine collective sits inside the remat region, so the backward pass recomputes it:

- `unsort_output_and_ra2a(...)` — the ragged all-to-all that returns tokens to their original shards, and
- the `psum_scatter` over the expert axis on the `use_ring_of_experts` path.

Both are pure communication, so recomputing them buys nothing but latency. This PR names their outputs `moe_combine` via `adc.checkpoint_name`, so a custom remat policy can save the combine output on device (or offload it) and skip re-running the RS / A2A in the backward pass:

```
remat_policy=custom moe_combine=device
```

The new knob is registered alongside the existing `moe_mlpwo`-style tensors (`base.yml`, `configs/types.py`) and defaults to `'remat'`, so behavior is unchanged unless it is set.

# Tests

**Unit:** `python -m pytest tests/unit/moe_test.py -q` → 11 passed, 8 skipped, 1 failed (`test_gmm_grad_equivalence_tokamax_v2_fp8_static_ep1`, which fails identically on the base commit without this change).

**Small-scale e2e on a v5p-8, EP=4** (DeepSeek-v3 shape, `base_emb_dim=2048`, `base_moe_mlp_dim=1408`, 4 layers / 1 dense, 16 experts, top-8, `per_device_batch_size=2`, `max_target_length=2048`, synthetic data, `remat_policy=custom`):

```
python -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
  model_name=deepseek3-tiny override_model_config=true \
  base_emb_dim=2048 base_moe_mlp_dim=1408 base_num_decoder_layers=4 first_num_dense_layers=1 \
  num_experts=16 num_experts_per_tok=8 per_device_batch_size=2 max_target_length=2048 \
  steps=12 enable_checkpointing=false dataset_type=synthetic \
  ici_expert_parallelism=4 ici_fsdp_parallelism=1 \
  remat_policy=custom moe_combine=<remat|device> run_name=...
```

| | `moe_combine=remat` (today) | `moe_combine=device` |
|---|---|---|
| steady-state step time | 0.128 s | 0.120 s (**-6%**) |
| TFLOP/s/device | 98.1 | 104.6 |
| compiler HBM estimate | 6.2 GB (3.5 GB temp) | 6.9 GB (4.2 GB temp) |
| AOT `temp_size_in_bytes` (`train_compile.py compile_topology=v5p-8`) | 3.72 GB | 4.53 GB |

Loss is bit-identical between the two runs at every step (e.g. step 11: `11.486` both), as expected for a remat-policy-only change.

The optimized HLO confirms the intended effect — counting `ragged-all-to-all` in `jit_train_step`, the combine A2A recompute in the backward pass disappears:

- `moe_combine=remat`: 6 (fwd dispatch + fwd combine, plus recomputed dispatch and recomputed combine in bwd)
- `moe_combine=device`: 5 (the recomputed combine is gone)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
