### PR TITLE
Expose enable_continuous_profiling CLI flag in MaxText RL

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -913,6 +913,7 @@ skip_first_n_steps_for_profiler: 1
 # Profile for a small number of steps to avoid a large profile file size.
 profiler_steps: 5
 hide_profiler_step_metric: false
+enable_continuous_profiling: false # Enables continuous profiling (Allows saving >2GB traces). Requires JAX >= 0.11.1.
 profile_cleanly: true # If set to true, adds a block_until_ready on train state which aligns the profile for each step.
 profile_periodically_period: -1 # If set to a positive integer, profile every profile_periodically_period steps.
 # This is useful to debug scenarios where performance is changing.

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -913,7 +913,7 @@ skip_first_n_steps_for_profiler: 1
 # Profile for a small number of steps to avoid a large profile file size.
 profiler_steps: 5
 hide_profiler_step_metric: false
-enable_continuous_profiling: false # Enables continuous profiling (Allows saving >2GB traces). Requires JAX >= 0.11.1.
+enable_continuous_profiling: false # Enables continuous profiling (Allows saving >2GB traces) in RL/Tunix profiler. Requires JAX >= 0.11.1.
 profile_cleanly: true # If set to true, adds a block_until_ready on train state which aligns the profile for each step.
 profile_periodically_period: -1 # If set to a positive integer, profile every profile_periodically_period steps.
 # This is useful to debug scenarios where performance is changing.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2203,6 +2203,7 @@ class Profiling(BaseModel):
   profile_cleanly: bool = Field(True, description="Add block_until_ready to align profile for each step.")
   profile_periodically_period: int = Field(-1, description="If positive, profile every N steps.")
   hide_profiler_step_metric: bool = Field(False, description="Whether to enable profiler step metric.")
+  enable_continuous_profiling: bool = Field(False, description="Enable continuous profiling in tunix profiler. If true, it will support saving profile > 2GB.")
   enable_jax_profiler: bool = Field(False, description="Enable the JAX live profiler.")
   jax_profiler_port: int = Field(9999, description="Port for the JAX profiler.")
   enable_tpu_profiling_options: bool = Field(False, description="Enable TPU advanced profiling options.")

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -474,7 +474,9 @@ def create_rl_components(  # pylint: disable=too-many-positional-arguments
         log_dir=trainer_config.tensorboard_dir,
         skip_first_n_steps=trainer_config.skip_first_n_steps_for_profiler,
         profiler_steps=trainer_config.profiler_steps,
+        # Skip setting tracer levels.
         set_profile_options=False,
+        enable_continuous_profiling=trainer_config.enable_continuous_profiling,
     )
 
   # Parse vllm_additional_config


### PR DESCRIPTION
# Description

Expose the `enable_continuous_profiling` CLI configuration flag in MaxText RL workflow to support saving trace profiles larger than 2GB as `.xplane.riegeli`.

### Context & Solution:
When profiling large model workloads or multi-step training runs, monolithic `.xplane.pb` trace files can exceed Protocol Buffer's 2GB wire format limit, leading to failed file upload.

Setting `enable_continuous_profiling=True` configures the profiler stream smaller trace chunks into Riegeli record containers (`.xplane.riegeli`), bypassing the 2GB single-protobuf size limitation.

**Note:** Direct streaming of `.xplane.riegeli` files to GCS paths (`gs://`) is currently not supported. Profiles should be saved locally on the host path and uploaded to GCS.

### Specific Changes:
- Added `enable_continuous_profiling` (boolean, default `False`) to `src/maxtext/configs/base.yml` and `src/maxtext/configs/types.py`.
- Updated `src/maxtext/trainers/post_train/rl/train_rl.py` to forward `enable_continuous_profiling` to the profiler configuration. Related Tunix PR: https://github.com/google/tunix/pull/2036

- Added documentation notes in `base.yml` clarifying that continuous profiling requires JAX >= 0.11.1.

# Tests

- Verified on Cloud TPU v6e-1 that setting `enable_continuous_profiling=True` enables continuous trace collection and produces `.xplane.riegeli` container files on local path when the profile is >2GB. See screenshot:
<img width="589" height="76" alt="Screenshot 2026-08-28 at 11 51 34 AM" src="https://github.com/user-attachments/assets/c779aeef-88f1-4d46-a61a-c8200bb700e2" />

- Verified that default `enable_continuous_profiling=False` retains existing JAX profiling behavior.

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).