### PR TITLE
glm5.3-flash-exp

### DIFF
--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -59,6 +59,7 @@ import time
 from typing import Any, Callable, List, Sequence
 import absl
 import ml_dtypes
+import flax
 import flax.linen as nn
 from huggingface_hub import hf_hub_download, list_repo_files
 import jax
@@ -322,10 +323,24 @@ def get_maxtext_model_info(config):
   maxtext_model_flax = models.transformer_as_linen(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
 
   # Get abstract model structure (name, shape) without materializing the weights to save memory.
-  # Extract the 'params' collection from the abstract model state. This focuses checkpoint
-  # conversion on trainable model parameters; variables outside the 'params' collection
-  # (such as non-trainable state or optimizer buffers) are not included.
-  abstract_params_tree = maxtext_utils.get_abstract_param(maxtext_model_flax, config)["params"]
+  # Merge all persistent collections from the abstract model state (e.g. 'params' and custom variables
+  # like 'MoEBiasVar').
+  def _deep_merge(dict1, dict2):
+    res = dict(dict1)
+    for k, v in dict2.items():
+      if k in res and isinstance(res[k], dict) and isinstance(v, dict):
+        res[k] = _deep_merge(res[k], v)
+      else:
+        res[k] = v
+    return res
+
+  abstract_vars = maxtext_utils.get_abstract_param(maxtext_model_flax, config)
+  abstract_params_tree = {}
+  for collection in abstract_vars.values():
+    if isinstance(collection, dict):
+      abstract_params_tree = _deep_merge(abstract_params_tree, collection)
+    elif isinstance(collection, flax.core.FrozenDict):
+      abstract_params_tree = _deep_merge(abstract_params_tree, flax.core.unfreeze(collection))
 
   abstract_params_flat, abstract_params_treedef = jax.tree_util.tree_flatten_with_path(
       abstract_params_tree,

--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -478,6 +478,8 @@ def _get_hf_loading_function(hf_source_keys_or_key, tensor_getter, hook_fn, mt_t
   if not isinstance(hf_source_keys_or_key, list):
     # Case 1: Single hf key (str)
     def _loader(getter, key, shape, hook):
+      if key is None:
+        return apply_hook_fns(None, shape, hook)
       if isinstance(key, (list, tuple)):
         tensors = tuple(getter(k) for k in key)
         return apply_hook_fns(tensors, shape, hook)

--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -205,8 +205,12 @@ class LazyHFLoader:
     # STEP 2: Lock ONLY the reading into RAM.
     # This prevents multiple threads from simultaneously allocating large chunks of RAM.
     with self._ram_lock:
-      with safe_open(local_path, framework="np", device="cpu") as f:
-        return f.get_tensor(key)
+      try:
+        with safe_open(local_path, framework="np", device="cpu") as f:
+          return f.get_tensor(key)
+      except AttributeError:
+        with safe_open(local_path, framework="pt", device="cpu") as f:
+          return f.get_tensor(key)
 
 
 class LazyTensor:

--- a/src/maxtext/checkpoint_conversion/utils/hf_model_configs.py
+++ b/src/maxtext/checkpoint_conversion/utils/hf_model_configs.py
@@ -1884,6 +1884,50 @@ qwen3_vl_30b_a3b_dict = {
 qwen3_vl_30b_a3b_config = PTConfig(**qwen3_vl_30b_a3b_dict)
 
 
+glm5_3_flash_dict = {
+    "architectures": ["Glm5NextForConditionalGeneration"],
+    "image_token_id": 154854,
+    "model_type": "glm5_next",
+    "text_config": {
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "bos_token_id": 154826,
+        "dtype": "bfloat16",
+        "eos_token_id": [154827, 154828],
+        "first_k_dense_replace": 3,
+        "head_dim": 256,
+        "hidden_act": "silu",
+        "hidden_size": 4096,
+        "initializer_range": 0.02,
+        "intermediate_size": 12288,
+        "kda_config": {
+            "conv_kernel_size": 4,
+            "gate_lower_bound": -5.0,
+            "head_dim": 128,
+            "num_heads": 64,
+        },
+        "max_position_embeddings": 1048576,
+        "model_type": "glm5_next_text",
+        "moe_intermediate_size": 2048,
+        "n_routed_experts": 288,
+        "n_shared_experts": 1,
+        "norm_topk_prob": True,
+        "num_attention_heads": 64,
+        "num_experts_per_tok": 8,
+        "num_hidden_layers": 45,
+        "num_key_value_heads": 64,
+        "pad_token_id": 154820,
+        "rms_norm_eps": 1e-05,
+        "routed_scaling_factor": 2.5,
+        "swiglu_limit": 10.0,
+        "tie_word_embeddings": False,
+        "vocab_size": 154880,
+    },
+    "tie_word_embeddings": False,
+    "transformers_version": "5.16.1",
+}
+glm5_3_flash_config = PTConfig(**glm5_3_flash_dict)
+
 # {maxtext model name: hf model config}
 HF_MODEL_CONFIGS = {
     "gemma2-2b": gemma2_2b_config,
@@ -1936,4 +1980,5 @@ HF_MODEL_CONFIGS = {
     "olmo3-7b": olmo3_7b_config,
     "olmo3-7b-pt": olmo3_7b_config,
     "olmo3-32b": olmo3_32b_config,
+    "glm5.3-flash": glm5_3_flash_config,
 }

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -4227,83 +4227,112 @@ def GLM5_3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False
 
   num_layers = maxtext_config.base_num_decoder_layers
   first_k_dense_replace = getattr(maxtext_config, "first_num_dense_layers", 3)
+  cycle_interval = getattr(maxtext_config, "inhomogeneous_layer_cycle_interval", 4)
   num_experts = getattr(maxtext_config, "num_experts", 288)
 
-  if scan_layers:
-    raise NotImplementedError("Scanned layers conversion for GLM-5.3-Flash is not yet implemented.")
-  else:
-    for i in range(num_layers):
-      prefix = f"params-decoder-layers_{i}"
+  for i in range(num_layers):
+    prefix = f"params-decoder-layers_{i}"
+    hf_prefix = f"model.language_model.layers.{i}"
 
-      mapping[f"{prefix}-input_layernorm-scale"] = f"model.language_model.layers.{i}.input_layernorm.weight"
-      mapping[f"{prefix}-post_attention_layernorm-scale"] = (
-          f"model.language_model.layers.{i}.post_attention_layernorm.weight"
+    mapping[f"{prefix}-input_layernorm-scale"] = f"{hf_prefix}.input_layernorm.weight"
+    mapping[f"{prefix}-post_attention_layernorm-scale"] = f"{hf_prefix}.post_attention_layernorm.weight"
+
+    for mt_name, hf_name in (("attn_hc", "hc_attn"), ("ffn_hc", "hc_ffn")):
+      mapping[f"{prefix}-{mt_name}-mhc_norm-scale"] = None
+      for part in ("pre", "post", "res"):
+        mapping[f"{prefix}-{mt_name}-{part}_alpha"] = f"{hf_prefix}.{hf_name}_fn"
+        mapping[f"{prefix}-{mt_name}-{part}_beta"] = f"{hf_prefix}.{hf_name}_base"
+        mapping[f"{prefix}-{mt_name}-{part}_alpha_scale"] = f"{hf_prefix}.{hf_name}_scale"
+
+    is_sparse_attn = (i + 1) % cycle_interval == 0
+    if is_sparse_attn:
+      mapping[f"{prefix}-attention-q_a_proj-kernel"] = (
+          f"{hf_prefix}.self_attn.q_a_proj.weight",
+          f"{hf_prefix}.self_attn.q_a_proj.weight_scale_inv",
       )
-
-      for mt_name, hf_name in (("attn_hc", "hc_attn"), ("ffn_hc", "hc_ffn")):
-        mapping[f"{prefix}-{mt_name}-mhc_norm-scale"] = None
-        for part in ("pre", "post", "res"):
-          mapping[f"{prefix}-{mt_name}-{part}_alpha"] = f"model.language_model.layers.{i}.{hf_name}_fn"
-          mapping[f"{prefix}-{mt_name}-{part}_beta"] = f"model.language_model.layers.{i}.{hf_name}_base"
-          mapping[f"{prefix}-{mt_name}-{part}_alpha_scale"] = f"model.language_model.layers.{i}.{hf_name}_scale"
-
-      mapping[f"{prefix}-attention-q_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.q_proj.weight"
-      mapping[f"{prefix}-attention-k_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.k_proj.weight"
-      mapping[f"{prefix}-attention-v_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.v_proj.weight"
+      mapping[f"{prefix}-attention-q_a_layernorm-scale"] = f"{hf_prefix}.self_attn.q_a_layernorm.weight"
+      mapping[f"{prefix}-attention-q_b_proj-kernel"] = (
+          f"{hf_prefix}.self_attn.q_b_proj.weight",
+          f"{hf_prefix}.self_attn.q_b_proj.weight_scale_inv",
+      )
+      mapping[f"{prefix}-attention-kv_a_proj_with_mqa-kernel"] = (
+          f"{hf_prefix}.self_attn.kv_a_proj_with_mqa.weight",
+          f"{hf_prefix}.self_attn.kv_a_proj_with_mqa.weight_scale_inv",
+      )
+      mapping[f"{prefix}-attention-kv_a_layernorm-scale"] = f"{hf_prefix}.self_attn.kv_a_layernorm.weight"
+      mapping[f"{prefix}-attention-kv_b_proj-kernel"] = f"{hf_prefix}.self_attn.kv_b_proj.weight"
+      mapping[f"{prefix}-attention-o_proj-kernel"] = (
+          f"{hf_prefix}.self_attn.o_proj.weight",
+          f"{hf_prefix}.self_attn.o_proj.weight_scale_inv",
+      )
+    else:
+      mapping[f"{prefix}-attention-q_proj-kernel"] = f"{hf_prefix}.self_attn.q_proj.weight"
+      mapping[f"{prefix}-attention-k_proj-kernel"] = f"{hf_prefix}.self_attn.k_proj.weight"
+      mapping[f"{prefix}-attention-v_proj-kernel"] = f"{hf_prefix}.self_attn.v_proj.weight"
       mapping[f"{prefix}-attention-conv1d-kernel"] = (
-          f"model.language_model.layers.{i}.self_attn.q_conv1d.weight",
-          f"model.language_model.layers.{i}.self_attn.k_conv1d.weight",
-          f"model.language_model.layers.{i}.self_attn.v_conv1d.weight",
+          f"{hf_prefix}.self_attn.q_conv1d.weight",
+          f"{hf_prefix}.self_attn.k_conv1d.weight",
+          f"{hf_prefix}.self_attn.v_conv1d.weight",
       )
-      mapping[f"{prefix}-attention-f_a_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.f_a_proj.weight"
-      mapping[f"{prefix}-attention-f_b_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.f_b_proj.weight"
-      mapping[f"{prefix}-attention-g_a_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.g_a_proj.weight"
-      mapping[f"{prefix}-attention-g_b_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.g_b_proj.weight"
-      mapping[f"{prefix}-attention-b_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.b_proj.weight"
-      mapping[f"{prefix}-attention-A_log"] = f"model.language_model.layers.{i}.self_attn.A_log"
-      mapping[f"{prefix}-attention-dt_bias"] = f"model.language_model.layers.{i}.self_attn.dt_bias"
-      mapping[f"{prefix}-attention-o_norm-scale"] = f"model.language_model.layers.{i}.self_attn.o_norm.weight"
-      mapping[f"{prefix}-attention-o_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.o_proj.weight"
+      mapping[f"{prefix}-attention-f_a_proj-kernel"] = f"{hf_prefix}.self_attn.f_a_proj.weight"
+      mapping[f"{prefix}-attention-f_b_proj-kernel"] = f"{hf_prefix}.self_attn.f_b_proj.weight"
+      mapping[f"{prefix}-attention-g_a_proj-kernel"] = f"{hf_prefix}.self_attn.g_a_proj.weight"
+      mapping[f"{prefix}-attention-g_b_proj-kernel"] = f"{hf_prefix}.self_attn.g_b_proj.weight"
+      mapping[f"{prefix}-attention-b_proj-kernel"] = f"{hf_prefix}.self_attn.b_proj.weight"
+      mapping[f"{prefix}-attention-A_log"] = f"{hf_prefix}.self_attn.A_log"
+      mapping[f"{prefix}-attention-dt_bias"] = f"{hf_prefix}.self_attn.dt_bias"
+      mapping[f"{prefix}-attention-o_norm-scale"] = f"{hf_prefix}.self_attn.o_norm.weight"
+      mapping[f"{prefix}-attention-o_proj-kernel"] = f"{hf_prefix}.self_attn.o_proj.weight"
 
-      if i < first_k_dense_replace:
-        mapping[f"{prefix}-mlp-wi_0-kernel"] = f"model.language_model.layers.{i}.mlp.gate_proj.weight"
-        mapping[f"{prefix}-mlp-wi_1-kernel"] = f"model.language_model.layers.{i}.mlp.up_proj.weight"
-        mapping[f"{prefix}-mlp-wo-kernel"] = f"model.language_model.layers.{i}.mlp.down_proj.weight"
-      else:
-        mapping[f"{prefix}-mlp-routed_experts-gate-kernel"] = f"model.language_model.layers.{i}.mlp.gate.weight"
-        mapping[f"{prefix}-mlp-shared_expert-wi_0-kernel"] = (
-            f"model.language_model.layers.{i}.mlp.shared_experts.gate_proj.weight",
-            f"model.language_model.layers.{i}.mlp.shared_experts.gate_proj.weight_scale_inv",
-        )
-        mapping[f"{prefix}-mlp-shared_expert-wi_1-kernel"] = (
-            f"model.language_model.layers.{i}.mlp.shared_experts.up_proj.weight",
-            f"model.language_model.layers.{i}.mlp.shared_experts.up_proj.weight_scale_inv",
-        )
-        mapping[f"{prefix}-mlp-shared_expert-wo-kernel"] = (
-            f"model.language_model.layers.{i}.mlp.shared_experts.down_proj.weight",
-            f"model.language_model.layers.{i}.mlp.shared_experts.down_proj.weight_scale_inv",
-        )
-        mapping[f"{prefix}-mlp-routed_experts-wi_0"] = [
-            (
-                f"model.language_model.layers.{i}.mlp.experts.{e}.gate_proj.weight",
-                f"model.language_model.layers.{i}.mlp.experts.{e}.gate_proj.weight_scale_inv",
-            )
-            for e in range(num_experts)
-        ]
-        mapping[f"{prefix}-mlp-routed_experts-wi_1"] = [
-            (
-                f"model.language_model.layers.{i}.mlp.experts.{e}.up_proj.weight",
-                f"model.language_model.layers.{i}.mlp.experts.{e}.up_proj.weight_scale_inv",
-            )
-            for e in range(num_experts)
-        ]
-        mapping[f"{prefix}-mlp-routed_experts-wo"] = [
-            (
-                f"model.language_model.layers.{i}.mlp.experts.{e}.down_proj.weight",
-                f"model.language_model.layers.{i}.mlp.experts.{e}.down_proj.weight_scale_inv",
-            )
-            for e in range(num_experts)
-        ]
+    if i < first_k_dense_replace:
+      mapping[f"{prefix}-mlp-wi_0-kernel"] = (
+          f"{hf_prefix}.mlp.gate_proj.weight",
+          f"{hf_prefix}.mlp.gate_proj.weight_scale_inv",
+      )
+      mapping[f"{prefix}-mlp-wi_1-kernel"] = (
+          f"{hf_prefix}.mlp.up_proj.weight",
+          f"{hf_prefix}.mlp.up_proj.weight_scale_inv",
+      )
+      mapping[f"{prefix}-mlp-wo-kernel"] = (
+          f"{hf_prefix}.mlp.down_proj.weight",
+          f"{hf_prefix}.mlp.down_proj.weight_scale_inv",
+      )
+    else:
+      mapping[f"{prefix}-mlp-MoeBlock_0-gate-kernel"] = f"{hf_prefix}.mlp.gate.weight"
+      mapping[f"{prefix}-mlp-MoeBlock_0-gate-bias"] = f"{hf_prefix}.mlp.gate.e_score_correction_bias"
+      mapping[f"{prefix}-mlp-MoeBlock_0-wi_0"] = [
+          (
+              f"{hf_prefix}.mlp.experts.{e}.gate_proj.weight",
+              f"{hf_prefix}.mlp.experts.{e}.gate_proj.weight_scale_inv",
+          )
+          for e in range(num_experts)
+      ]
+      mapping[f"{prefix}-mlp-MoeBlock_0-wi_1"] = [
+          (
+              f"{hf_prefix}.mlp.experts.{e}.up_proj.weight",
+              f"{hf_prefix}.mlp.experts.{e}.up_proj.weight_scale_inv",
+          )
+          for e in range(num_experts)
+      ]
+      mapping[f"{prefix}-mlp-MoeBlock_0-wo"] = [
+          (
+              f"{hf_prefix}.mlp.experts.{e}.down_proj.weight",
+              f"{hf_prefix}.mlp.experts.{e}.down_proj.weight_scale_inv",
+          )
+          for e in range(num_experts)
+      ]
+      mapping[f"{prefix}-mlp-shared_experts-wi_0-kernel"] = (
+          f"{hf_prefix}.mlp.shared_experts.gate_proj.weight",
+          f"{hf_prefix}.mlp.shared_experts.gate_proj.weight_scale_inv",
+      )
+      mapping[f"{prefix}-mlp-shared_experts-wi_1-kernel"] = (
+          f"{hf_prefix}.mlp.shared_experts.up_proj.weight",
+          f"{hf_prefix}.mlp.shared_experts.up_proj.weight_scale_inv",
+      )
+      mapping[f"{prefix}-mlp-shared_experts-wo-kernel"] = (
+          f"{hf_prefix}.mlp.shared_experts.down_proj.weight",
+          f"{hf_prefix}.mlp.shared_experts.down_proj.weight_scale_inv",
+      )
 
   return mapping
 
@@ -4347,30 +4376,48 @@ def GLM5_3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False
     return np.ones(target_shape, dtype=np.float32)
 
   def mhc_split_fn_pre(input_tensor, target_shape=None):
+    if hasattr(input_tensor, "cpu"):
+      input_tensor = input_tensor.cpu().float().numpy()
     return np.transpose(input_tensor[0:4, :])
 
   def mhc_split_fn_post(input_tensor, target_shape=None):
+    if hasattr(input_tensor, "cpu"):
+      input_tensor = input_tensor.cpu().float().numpy()
     return np.transpose(input_tensor[4:8, :])
 
   def mhc_split_fn_res(input_tensor, target_shape=None):
+    if hasattr(input_tensor, "cpu"):
+      input_tensor = input_tensor.cpu().float().numpy()
     return np.transpose(input_tensor[8:24, :])
 
   def mhc_split_base_pre(input_tensor, target_shape=None):
+    if hasattr(input_tensor, "cpu"):
+      input_tensor = input_tensor.cpu().float().numpy()
     return input_tensor[0:4]
 
   def mhc_split_base_post(input_tensor, target_shape=None):
+    if hasattr(input_tensor, "cpu"):
+      input_tensor = input_tensor.cpu().float().numpy()
     return input_tensor[4:8]
 
   def mhc_split_base_res(input_tensor, target_shape=None):
+    if hasattr(input_tensor, "cpu"):
+      input_tensor = input_tensor.cpu().float().numpy()
     return input_tensor[8:24].reshape(target_shape)
 
   def mhc_split_scale_pre(input_tensor, target_shape=None):
+    if hasattr(input_tensor, "cpu"):
+      input_tensor = input_tensor.cpu().float().numpy()
     return np.asarray(input_tensor[0:1]).reshape(target_shape)
 
   def mhc_split_scale_post(input_tensor, target_shape=None):
+    if hasattr(input_tensor, "cpu"):
+      input_tensor = input_tensor.cpu().float().numpy()
     return np.asarray(input_tensor[1:2]).reshape(target_shape)
 
   def mhc_split_scale_res(input_tensor, target_shape=None):
+    if hasattr(input_tensor, "cpu"):
+      input_tensor = input_tensor.cpu().float().numpy()
     return np.asarray(input_tensor[2:3]).reshape(target_shape)
 
   hooks = {
@@ -4379,6 +4426,7 @@ def GLM5_3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False
 
   num_layers = maxtext_config.base_num_decoder_layers
   first_k_dense_replace = getattr(maxtext_config, "first_num_dense_layers", 3)
+  cycle_interval = getattr(maxtext_config, "inhomogeneous_layer_cycle_interval", 4)
 
   for i in range(num_layers):
     prefix = f"params-decoder-layers_{i}"
@@ -4395,29 +4443,37 @@ def GLM5_3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False
       hooks[f"{prefix}-{mt_name}-post_alpha_scale"] = mhc_split_scale_post
       hooks[f"{prefix}-{mt_name}-res_alpha_scale"] = mhc_split_scale_res
 
-    hooks[f"{prefix}-attention-q_proj-kernel"] = transpose
-    hooks[f"{prefix}-attention-k_proj-kernel"] = transpose
-    hooks[f"{prefix}-attention-v_proj-kernel"] = transpose
-    hooks[f"{prefix}-attention-conv1d-kernel"] = conv1d_hook
-    hooks[f"{prefix}-attention-f_a_proj-kernel"] = transpose
-    hooks[f"{prefix}-attention-f_b_proj-kernel"] = transpose
-    hooks[f"{prefix}-attention-g_a_proj-kernel"] = transpose
-    hooks[f"{prefix}-attention-g_b_proj-kernel"] = transpose
-    hooks[f"{prefix}-attention-b_proj-kernel"] = transpose
-    hooks[f"{prefix}-attention-o_proj-kernel"] = transpose
+    is_sparse_attn = (i + 1) % cycle_interval == 0
+    if is_sparse_attn:
+      hooks[f"{prefix}-attention-q_a_proj-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-attention-q_b_proj-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-attention-kv_a_proj_with_mqa-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-attention-kv_b_proj-kernel"] = transpose
+      hooks[f"{prefix}-attention-o_proj-kernel"] = dequant_transpose_hook
+    else:
+      hooks[f"{prefix}-attention-q_proj-kernel"] = transpose
+      hooks[f"{prefix}-attention-k_proj-kernel"] = transpose
+      hooks[f"{prefix}-attention-v_proj-kernel"] = transpose
+      hooks[f"{prefix}-attention-conv1d-kernel"] = conv1d_hook
+      hooks[f"{prefix}-attention-f_a_proj-kernel"] = transpose
+      hooks[f"{prefix}-attention-f_b_proj-kernel"] = transpose
+      hooks[f"{prefix}-attention-g_a_proj-kernel"] = transpose
+      hooks[f"{prefix}-attention-g_b_proj-kernel"] = transpose
+      hooks[f"{prefix}-attention-b_proj-kernel"] = transpose
+      hooks[f"{prefix}-attention-o_proj-kernel"] = transpose
 
     if i < first_k_dense_replace:
-      hooks[f"{prefix}-mlp-wi_0-kernel"] = transpose
-      hooks[f"{prefix}-mlp-wi_1-kernel"] = transpose
-      hooks[f"{prefix}-mlp-wo-kernel"] = transpose
+      hooks[f"{prefix}-mlp-wi_0-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-wi_1-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-wo-kernel"] = dequant_transpose_hook
     else:
-      hooks[f"{prefix}-mlp-routed_experts-gate-kernel"] = transpose
-      hooks[f"{prefix}-mlp-shared_expert-wi_0-kernel"] = dequant_transpose_hook
-      hooks[f"{prefix}-mlp-shared_expert-wi_1-kernel"] = dequant_transpose_hook
-      hooks[f"{prefix}-mlp-shared_expert-wo-kernel"] = dequant_transpose_hook
-      hooks[f"{prefix}-mlp-routed_experts-wi_0"] = dequant_transpose_hook
-      hooks[f"{prefix}-mlp-routed_experts-wi_1"] = dequant_transpose_hook
-      hooks[f"{prefix}-mlp-routed_experts-wo"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-MoeBlock_0-gate-kernel"] = transpose
+      hooks[f"{prefix}-mlp-MoeBlock_0-wi_0"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-MoeBlock_0-wi_1"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-MoeBlock_0-wo"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-shared_experts-wi_0-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-shared_experts-wi_1-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-shared_experts-wo-kernel"] = dequant_transpose_hook
 
   return hooks
 

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -4240,13 +4240,12 @@ def GLM5_3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False
           f"model.language_model.layers.{i}.post_attention_layernorm.weight"
       )
 
-      mapping[f"{prefix}-attn_hc-base"] = f"model.language_model.layers.{i}.hc_attn_base"
-      mapping[f"{prefix}-attn_hc-fn"] = f"model.language_model.layers.{i}.hc_attn_fn"
-      mapping[f"{prefix}-attn_hc-scale"] = f"model.language_model.layers.{i}.hc_attn_scale"
-
-      mapping[f"{prefix}-ffn_hc-base"] = f"model.language_model.layers.{i}.hc_ffn_base"
-      mapping[f"{prefix}-ffn_hc-fn"] = f"model.language_model.layers.{i}.hc_ffn_fn"
-      mapping[f"{prefix}-ffn_hc-scale"] = f"model.language_model.layers.{i}.hc_ffn_scale"
+      for mt_name, hf_name in (("attn_hc", "hc_attn"), ("ffn_hc", "hc_ffn")):
+        mapping[f"{prefix}-{mt_name}-mhc_norm-scale"] = None
+        for part in ("pre", "post", "res"):
+          mapping[f"{prefix}-{mt_name}-{part}_alpha"] = f"model.language_model.layers.{i}.{hf_name}_fn"
+          mapping[f"{prefix}-{mt_name}-{part}_beta"] = f"model.language_model.layers.{i}.{hf_name}_base"
+          mapping[f"{prefix}-{mt_name}-{part}_alpha_scale"] = f"model.language_model.layers.{i}.{hf_name}_scale"
 
       mapping[f"{prefix}-attention-q_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.q_proj.weight"
       mapping[f"{prefix}-attention-k_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.k_proj.weight"
@@ -4267,18 +4266,9 @@ def GLM5_3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False
       mapping[f"{prefix}-attention-o_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.o_proj.weight"
 
       if i < first_k_dense_replace:
-        mapping[f"{prefix}-mlp-gate_proj-kernel"] = (
-            f"model.language_model.layers.{i}.mlp.gate_proj.weight",
-            f"model.language_model.layers.{i}.mlp.gate_proj.weight_scale_inv",
-        )
-        mapping[f"{prefix}-mlp-up_proj-kernel"] = (
-            f"model.language_model.layers.{i}.mlp.up_proj.weight",
-            f"model.language_model.layers.{i}.mlp.up_proj.weight_scale_inv",
-        )
-        mapping[f"{prefix}-mlp-down_proj-kernel"] = (
-            f"model.language_model.layers.{i}.mlp.down_proj.weight",
-            f"model.language_model.layers.{i}.mlp.down_proj.weight_scale_inv",
-        )
+        mapping[f"{prefix}-mlp-wi_0-kernel"] = f"model.language_model.layers.{i}.mlp.gate_proj.weight"
+        mapping[f"{prefix}-mlp-wi_1-kernel"] = f"model.language_model.layers.{i}.mlp.up_proj.weight"
+        mapping[f"{prefix}-mlp-wo-kernel"] = f"model.language_model.layers.{i}.mlp.down_proj.weight"
       else:
         mapping[f"{prefix}-mlp-routed_experts-gate-kernel"] = f"model.language_model.layers.{i}.mlp.gate.weight"
         mapping[f"{prefix}-mlp-shared_expert-wi_0-kernel"] = (
@@ -4352,6 +4342,37 @@ def GLM5_3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False
         tensors = tensors.cpu().float().numpy()
       return tensors.T
 
+  def ones_norm(input_tensor, target_shape=None):
+    del input_tensor
+    return np.ones(target_shape, dtype=np.float32)
+
+  def mhc_split_fn_pre(input_tensor, target_shape=None):
+    return np.transpose(input_tensor[0:4, :])
+
+  def mhc_split_fn_post(input_tensor, target_shape=None):
+    return np.transpose(input_tensor[4:8, :])
+
+  def mhc_split_fn_res(input_tensor, target_shape=None):
+    return np.transpose(input_tensor[8:24, :])
+
+  def mhc_split_base_pre(input_tensor, target_shape=None):
+    return input_tensor[0:4]
+
+  def mhc_split_base_post(input_tensor, target_shape=None):
+    return input_tensor[4:8]
+
+  def mhc_split_base_res(input_tensor, target_shape=None):
+    return input_tensor[8:24].reshape(target_shape)
+
+  def mhc_split_scale_pre(input_tensor, target_shape=None):
+    return np.asarray(input_tensor[0:1]).reshape(target_shape)
+
+  def mhc_split_scale_post(input_tensor, target_shape=None):
+    return np.asarray(input_tensor[1:2]).reshape(target_shape)
+
+  def mhc_split_scale_res(input_tensor, target_shape=None):
+    return np.asarray(input_tensor[2:3]).reshape(target_shape)
+
   hooks = {
       "params-decoder-logits_dense-kernel": transpose,
   }
@@ -4362,8 +4383,17 @@ def GLM5_3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False
   for i in range(num_layers):
     prefix = f"params-decoder-layers_{i}"
 
-    hooks[f"{prefix}-attn_hc-fn"] = transpose
-    hooks[f"{prefix}-ffn_hc-fn"] = transpose
+    for mt_name in ("attn_hc", "ffn_hc"):
+      hooks[f"{prefix}-{mt_name}-mhc_norm-scale"] = ones_norm
+      hooks[f"{prefix}-{mt_name}-pre_alpha"] = mhc_split_fn_pre
+      hooks[f"{prefix}-{mt_name}-post_alpha"] = mhc_split_fn_post
+      hooks[f"{prefix}-{mt_name}-res_alpha"] = mhc_split_fn_res
+      hooks[f"{prefix}-{mt_name}-pre_beta"] = mhc_split_base_pre
+      hooks[f"{prefix}-{mt_name}-post_beta"] = mhc_split_base_post
+      hooks[f"{prefix}-{mt_name}-res_beta"] = mhc_split_base_res
+      hooks[f"{prefix}-{mt_name}-pre_alpha_scale"] = mhc_split_scale_pre
+      hooks[f"{prefix}-{mt_name}-post_alpha_scale"] = mhc_split_scale_post
+      hooks[f"{prefix}-{mt_name}-res_alpha_scale"] = mhc_split_scale_res
 
     hooks[f"{prefix}-attention-q_proj-kernel"] = transpose
     hooks[f"{prefix}-attention-k_proj-kernel"] = transpose
@@ -4377,9 +4407,9 @@ def GLM5_3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False
     hooks[f"{prefix}-attention-o_proj-kernel"] = transpose
 
     if i < first_k_dense_replace:
-      hooks[f"{prefix}-mlp-gate_proj-kernel"] = dequant_transpose_hook
-      hooks[f"{prefix}-mlp-up_proj-kernel"] = dequant_transpose_hook
-      hooks[f"{prefix}-mlp-down_proj-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-wi_0-kernel"] = transpose
+      hooks[f"{prefix}-mlp-wi_1-kernel"] = transpose
+      hooks[f"{prefix}-mlp-wo-kernel"] = transpose
     else:
       hooks[f"{prefix}-mlp-routed_experts-gate-kernel"] = transpose
       hooks[f"{prefix}-mlp-shared_expert-wi_0-kernel"] = dequant_transpose_hook

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -4217,6 +4217,181 @@ def DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=F
   return mapping
 
 
+def GLM5_3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
+  """Maps MaxText parameter keys to HuggingFace parameter keys for GLM-5.3-Flash."""
+  mapping = {}
+
+  mapping["params-token_embedder-embedding"] = "model.language_model.embed_tokens.weight"
+  mapping["params-decoder-decoder_norm-scale"] = "model.language_model.norm.weight"
+  mapping["params-decoder-logits_dense-kernel"] = "lm_head.weight"
+
+  num_layers = maxtext_config.base_num_decoder_layers
+  first_k_dense_replace = getattr(maxtext_config, "first_num_dense_layers", 3)
+  num_experts = getattr(maxtext_config, "num_experts", 288)
+
+  if scan_layers:
+    raise NotImplementedError("Scanned layers conversion for GLM-5.3-Flash is not yet implemented.")
+  else:
+    for i in range(num_layers):
+      prefix = f"params-decoder-layers_{i}"
+
+      mapping[f"{prefix}-input_layernorm-scale"] = f"model.language_model.layers.{i}.input_layernorm.weight"
+      mapping[f"{prefix}-post_attention_layernorm-scale"] = (
+          f"model.language_model.layers.{i}.post_attention_layernorm.weight"
+      )
+
+      mapping[f"{prefix}-attn_hc-base"] = f"model.language_model.layers.{i}.hc_attn_base"
+      mapping[f"{prefix}-attn_hc-fn"] = f"model.language_model.layers.{i}.hc_attn_fn"
+      mapping[f"{prefix}-attn_hc-scale"] = f"model.language_model.layers.{i}.hc_attn_scale"
+
+      mapping[f"{prefix}-ffn_hc-base"] = f"model.language_model.layers.{i}.hc_ffn_base"
+      mapping[f"{prefix}-ffn_hc-fn"] = f"model.language_model.layers.{i}.hc_ffn_fn"
+      mapping[f"{prefix}-ffn_hc-scale"] = f"model.language_model.layers.{i}.hc_ffn_scale"
+
+      mapping[f"{prefix}-attention-q_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.q_proj.weight"
+      mapping[f"{prefix}-attention-k_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.k_proj.weight"
+      mapping[f"{prefix}-attention-v_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.v_proj.weight"
+      mapping[f"{prefix}-attention-conv1d-kernel"] = (
+          f"model.language_model.layers.{i}.self_attn.q_conv1d.weight",
+          f"model.language_model.layers.{i}.self_attn.k_conv1d.weight",
+          f"model.language_model.layers.{i}.self_attn.v_conv1d.weight",
+      )
+      mapping[f"{prefix}-attention-f_a_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.f_a_proj.weight"
+      mapping[f"{prefix}-attention-f_b_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.f_b_proj.weight"
+      mapping[f"{prefix}-attention-g_a_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.g_a_proj.weight"
+      mapping[f"{prefix}-attention-g_b_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.g_b_proj.weight"
+      mapping[f"{prefix}-attention-b_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.b_proj.weight"
+      mapping[f"{prefix}-attention-A_log"] = f"model.language_model.layers.{i}.self_attn.A_log"
+      mapping[f"{prefix}-attention-dt_bias"] = f"model.language_model.layers.{i}.self_attn.dt_bias"
+      mapping[f"{prefix}-attention-o_norm-scale"] = f"model.language_model.layers.{i}.self_attn.o_norm.weight"
+      mapping[f"{prefix}-attention-o_proj-kernel"] = f"model.language_model.layers.{i}.self_attn.o_proj.weight"
+
+      if i < first_k_dense_replace:
+        mapping[f"{prefix}-mlp-gate_proj-kernel"] = (
+            f"model.language_model.layers.{i}.mlp.gate_proj.weight",
+            f"model.language_model.layers.{i}.mlp.gate_proj.weight_scale_inv",
+        )
+        mapping[f"{prefix}-mlp-up_proj-kernel"] = (
+            f"model.language_model.layers.{i}.mlp.up_proj.weight",
+            f"model.language_model.layers.{i}.mlp.up_proj.weight_scale_inv",
+        )
+        mapping[f"{prefix}-mlp-down_proj-kernel"] = (
+            f"model.language_model.layers.{i}.mlp.down_proj.weight",
+            f"model.language_model.layers.{i}.mlp.down_proj.weight_scale_inv",
+        )
+      else:
+        mapping[f"{prefix}-mlp-routed_experts-gate-kernel"] = f"model.language_model.layers.{i}.mlp.gate.weight"
+        mapping[f"{prefix}-mlp-shared_expert-wi_0-kernel"] = (
+            f"model.language_model.layers.{i}.mlp.shared_experts.gate_proj.weight",
+            f"model.language_model.layers.{i}.mlp.shared_experts.gate_proj.weight_scale_inv",
+        )
+        mapping[f"{prefix}-mlp-shared_expert-wi_1-kernel"] = (
+            f"model.language_model.layers.{i}.mlp.shared_experts.up_proj.weight",
+            f"model.language_model.layers.{i}.mlp.shared_experts.up_proj.weight_scale_inv",
+        )
+        mapping[f"{prefix}-mlp-shared_expert-wo-kernel"] = (
+            f"model.language_model.layers.{i}.mlp.shared_experts.down_proj.weight",
+            f"model.language_model.layers.{i}.mlp.shared_experts.down_proj.weight_scale_inv",
+        )
+        mapping[f"{prefix}-mlp-routed_experts-wi_0"] = [
+            (
+                f"model.language_model.layers.{i}.mlp.experts.{e}.gate_proj.weight",
+                f"model.language_model.layers.{i}.mlp.experts.{e}.gate_proj.weight_scale_inv",
+            )
+            for e in range(num_experts)
+        ]
+        mapping[f"{prefix}-mlp-routed_experts-wi_1"] = [
+            (
+                f"model.language_model.layers.{i}.mlp.experts.{e}.up_proj.weight",
+                f"model.language_model.layers.{i}.mlp.experts.{e}.up_proj.weight_scale_inv",
+            )
+            for e in range(num_experts)
+        ]
+        mapping[f"{prefix}-mlp-routed_experts-wo"] = [
+            (
+                f"model.language_model.layers.{i}.mlp.experts.{e}.down_proj.weight",
+                f"model.language_model.layers.{i}.mlp.experts.{e}.down_proj.weight_scale_inv",
+            )
+            for e in range(num_experts)
+        ]
+
+  return mapping
+
+
+def GLM5_3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
+  """Returns hook functions for transforming weights between MaxText and HuggingFace for GLM-5.3-Flash."""
+
+  def transpose(input_tensor, target_shape=None):
+    if hasattr(input_tensor, "cpu"):
+      input_tensor = input_tensor.cpu().float().numpy()
+    return input_tensor.T
+
+  def conv1d_hook(tensors, target_shape=None):
+    if isinstance(tensors, (list, tuple)):
+      parts = [t.cpu().float().numpy() if hasattr(t, "cpu") else t for t in tensors]
+      concat = np.concatenate(parts, axis=0)
+      return concat.transpose(2, 1, 0)
+    else:
+      if hasattr(tensors, "cpu"):
+        tensors = tensors.cpu().float().numpy()
+      return tensors.transpose(2, 1, 0)
+
+  def dequant_transpose_hook(tensors, target_shape=None, block_size=128):
+    if isinstance(tensors, (list, tuple)):
+      w, s = tensors
+      if hasattr(w, "cpu"):
+        w = w.cpu().float().numpy()
+      if hasattr(s, "cpu"):
+        s = s.cpu().float().numpy()
+      w = w.astype(np.float32)
+      s = s.astype(np.float32)
+      s_exp = np.repeat(np.repeat(s, block_size, axis=0), block_size, axis=1)
+      return (w * s_exp).T
+    else:
+      if hasattr(tensors, "cpu"):
+        tensors = tensors.cpu().float().numpy()
+      return tensors.T
+
+  hooks = {
+      "params-decoder-logits_dense-kernel": transpose,
+  }
+
+  num_layers = maxtext_config.base_num_decoder_layers
+  first_k_dense_replace = getattr(maxtext_config, "first_num_dense_layers", 3)
+
+  for i in range(num_layers):
+    prefix = f"params-decoder-layers_{i}"
+
+    hooks[f"{prefix}-attn_hc-fn"] = transpose
+    hooks[f"{prefix}-ffn_hc-fn"] = transpose
+
+    hooks[f"{prefix}-attention-q_proj-kernel"] = transpose
+    hooks[f"{prefix}-attention-k_proj-kernel"] = transpose
+    hooks[f"{prefix}-attention-v_proj-kernel"] = transpose
+    hooks[f"{prefix}-attention-conv1d-kernel"] = conv1d_hook
+    hooks[f"{prefix}-attention-f_a_proj-kernel"] = transpose
+    hooks[f"{prefix}-attention-f_b_proj-kernel"] = transpose
+    hooks[f"{prefix}-attention-g_a_proj-kernel"] = transpose
+    hooks[f"{prefix}-attention-g_b_proj-kernel"] = transpose
+    hooks[f"{prefix}-attention-b_proj-kernel"] = transpose
+    hooks[f"{prefix}-attention-o_proj-kernel"] = transpose
+
+    if i < first_k_dense_replace:
+      hooks[f"{prefix}-mlp-gate_proj-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-up_proj-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-down_proj-kernel"] = dequant_transpose_hook
+    else:
+      hooks[f"{prefix}-mlp-routed_experts-gate-kernel"] = transpose
+      hooks[f"{prefix}-mlp-shared_expert-wi_0-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-shared_expert-wi_1-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-shared_expert-wo-kernel"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-routed_experts-wi_0"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-routed_experts-wi_1"] = dequant_transpose_hook
+      hooks[f"{prefix}-mlp-routed_experts-wo"] = dequant_transpose_hook
+
+  return hooks
+
+
 PARAM_MAPPING = {
     "gemma2-2b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma2-9b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
@@ -4268,6 +4443,7 @@ PARAM_MAPPING = {
     "olmo3-7b": OLMO3_MAXTEXT_TO_HF_PARAM_MAPPING,
     "olmo3-7b-pt": OLMO3_MAXTEXT_TO_HF_PARAM_MAPPING,
     "olmo3-32b": OLMO3_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "glm5.3-flash": GLM5_3_MAXTEXT_TO_HF_PARAM_MAPPING,
 }
 
 # {maxtext model name: {maxtext weight name: bi-directional transform}}
@@ -4318,6 +4494,7 @@ HOOK_FNS = {
     "qwen3.5-397b-a17b": QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "qwen3.5-35b-a3b": QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "qwen3-next-80b-a3b": QWEN3_NEXT_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "glm5.3-flash": GLM5_3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "mixtral-8x7b": MIXTRAL_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "mixtral-8x22b": MIXTRAL_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "olmo3-7b": OLMO3_MAXTEXT_TO_HF_PARAM_HOOK_FN,

--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -118,6 +118,8 @@ class DecoderBlockType(enum.Enum):
   OLMO3 = "olmo3"
   DEEPSEEK4 = "deepseek4"
   ENVY = "envy"
+  GLM5_3 = "glm5_3"
+  GLM5_NEXT = "glm5_next"
 
 
 class VisionEncoderBlockType(enum.Enum):

--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -119,7 +119,6 @@ class DecoderBlockType(enum.Enum):
   DEEPSEEK4 = "deepseek4"
   ENVY = "envy"
   GLM5_3 = "glm5_3"
-  GLM5_NEXT = "glm5_next"
 
 
 class VisionEncoderBlockType(enum.Enum):

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1426,3 +1426,11 @@ elastic_backup_kind: "snapshot"
 elastic_timeout_seconds: 300
 elastic_max_retries: 10
 elastic_min_slice_count: -1
+
+################################## GLM-5.3-Flash / GLM-5-Next Specific Configs ##################################
+linear_conv_kernel_dim: 4
+linear_head_dim: 128
+linear_num_heads: 64
+linear_lower_bound: -5.0
+swiglu_limit: 10.0
+mhc_eps: 1.0e-6

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1427,7 +1427,7 @@ elastic_timeout_seconds: 300
 elastic_max_retries: 10
 elastic_min_slice_count: -1
 
-################################## GLM-5.3-Flash / GLM-5-Next Specific Configs ##################################
+################################## GLM-5.3-Flash Specific Configs ##################################
 linear_conv_kernel_dim: 4
 linear_head_dim: 128
 linear_num_heads: 64

--- a/src/maxtext/configs/models/glm5.3-flash.yml
+++ b/src/maxtext/configs/models/glm5.3-flash.yml
@@ -1,0 +1,50 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+decoder_block: "glm5_3"
+
+# Core Architectural Parameters
+base_emb_dim: 4096
+base_num_decoder_layers: 45
+base_num_query_heads: 64
+base_num_kv_heads: 64
+head_dim: 256
+vocab_size: 154880
+normalization_layer_epsilon: 1.0e-5
+
+# MLP / MoE Parameters
+base_mlp_dim: 12288
+base_moe_mlp_dim: 2048
+num_experts: 288
+shared_experts: 1
+num_experts_per_tok: 8
+norm_topk_prob: true
+first_num_dense_layers: 3
+swiglu_limit: 10.0
+
+# Linear Attention / KDA Parameters
+inhomogeneous_layer_cycle_interval: 4
+linear_conv_kernel_dim: 4
+linear_head_dim: 128
+linear_num_heads: 64
+linear_lower_bound: -5.0
+
+# HyperConnections (mHC)
+mhc_expansion_rate: 4
+sinkhorn_iterations: 20
+mhc_eps: 1.0e-6
+
+# General Settings
+enable_dropout: false
+logits_via_embedding: false

--- a/src/maxtext/configs/models/glm5.3-flash.yml
+++ b/src/maxtext/configs/models/glm5.3-flash.yml
@@ -1,13 +1,13 @@
 # Copyright 2026 Google LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the License);
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an AS IS BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
@@ -32,6 +32,18 @@ num_experts_per_tok: 8
 norm_topk_prob: true
 first_num_dense_layers: 3
 swiglu_limit: 10.0
+mlp_activations_limit: 10.0
+routed_scaling_factor: 2.5
+routed_score_func: "sigmoid"
+routed_bias: true
+mlp_activations: ["silu", "linear"]
+
+# MLA / DeepSeek Sparse Attention Parameters
+q_lora_rank: 1536
+kv_lora_rank: 512
+qk_nope_head_dim: 256
+qk_rope_head_dim: 0
+v_head_dim: 256
 
 # Linear Attention / KDA Parameters
 inhomogeneous_layer_cycle_interval: 4
@@ -48,3 +60,6 @@ mhc_eps: 1.0e-6
 # General Settings
 enable_dropout: false
 logits_via_embedding: false
+
+n_routing_groups: 1
+topk_routing_group: 1

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1124,8 +1124,8 @@ class DeepSeekMoE(BaseModel):
   )
 
 
-class Glm5Next(BaseModel):
-  """Configuration specific to GLM-5.3-Flash / GLM-5-Next models."""
+class Glm53Flash(BaseModel):
+  """Configuration specific to GLM-5.3-Flash."""
 
   linear_conv_kernel_dim: int = Field(4, description="Kernel size for the 1D convolution in the linear attention (KDA).")
   linear_head_dim: int = Field(128, description="Head dimension in the linear attention (KDA).")
@@ -3018,7 +3018,7 @@ class MaxTextConfig(
     MoEKernels,
     DeepSeekMoE,
     Qwen3Next,
-    Glm5Next,
+    Glm53Flash,
     # Parallelism and Layout
     HardwareAndMesh,
     LayoutAndSharding,
@@ -4676,7 +4676,6 @@ class RLConfig(
     AttentionIndexer,
     SplashAttention,
     Qwen3Next,
-    Glm5Next,
     MultimodalGeneral,
     Muon,
     FineTuning,

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -241,6 +241,7 @@ ModelName = Literal[
     "deepseek4-284b",
     "deepseek-custom",
     "kimi-k2-1t",
+    "glm5.3-flash",
     "gemma-7b",
     "gemma-2b",
     "gemma2-2b",
@@ -1121,6 +1122,19 @@ class DeepSeekMoE(BaseModel):
       1,
       description="Factor by which to split the batch into micro-batches. Only used if use_batch_split_schedule is True.",
   )
+
+
+class Glm5Next(BaseModel):
+  """Configuration specific to GLM-5.3-Flash / GLM-5-Next models."""
+
+  linear_conv_kernel_dim: int = Field(4, description="Kernel size for the 1D convolution in the linear attention (KDA).")
+  linear_head_dim: int = Field(128, description="Head dimension in the linear attention (KDA).")
+  linear_num_heads: int = Field(64, description="Number of heads in the linear attention (KDA).")
+  linear_lower_bound: float = Field(
+      -5.0, description="Safe lower bound for the forget gate decay rate in linear attention."
+  )
+  swiglu_limit: float = Field(10.0, description="Clamping limit for SwiGLU activations.")
+  mhc_eps: float = Field(1e-6, description="Epsilon for manifold-constrained hyper connections.")
 
 
 class Qwen3Next(BaseModel):
@@ -3004,6 +3018,7 @@ class MaxTextConfig(
     MoEKernels,
     DeepSeekMoE,
     Qwen3Next,
+    Glm5Next,
     # Parallelism and Layout
     HardwareAndMesh,
     LayoutAndSharding,
@@ -4661,6 +4676,7 @@ class RLConfig(
     AttentionIndexer,
     SplashAttention,
     Qwen3Next,
+    Glm5Next,
     MultimodalGeneral,
     Muon,
     FineTuning,

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -498,11 +498,9 @@ class Decoder(nn.Module):
       case DecoderBlockType.ENVY:
         return [envy.EnvyScannableBlockToLinen] if self.config.scan_layers else [envy.EnvyDecoderLayerToLinen]
       case DecoderBlockType.GLM5_3 | DecoderBlockType.GLM5_NEXT:
-        return (
-            [glm5_next.Glm5NextScannableBlockToLinen]
-            if self.config.scan_layers
-            else [glm5_next.Glm5NextDecoderLayerToLinen]
-        )
+        if self.config.scan_layers:
+          raise NotImplementedError("scan_layers=true is not yet supported for GLM5.")
+        return [glm5_next.Glm5NextDecoderLayerToLinen]
 
       case _:
         # Default case to handle any unknown decoder block types.
@@ -539,12 +537,15 @@ class Decoder(nn.Module):
         DecoderBlockType.LLAMA4: get_scannable(llama4.Llama4DecoderLayer, llama4.Llama4ScannableBlock),
         DecoderBlockType.OLMO3: get_scannable(olmo3.Olmo3DecoderLayer, olmo3.Olmo3ScannableBlock),
         DecoderBlockType.ENVY: get_scannable(envy.EnvyDecoderLayer, envy.EnvyScannableBlock),
-        DecoderBlockType.GLM5_3: get_scannable(glm5_next.Glm5NextDecoderLayer, glm5_next.Glm5NextScannableBlock),
-        DecoderBlockType.GLM5_NEXT: get_scannable(glm5_next.Glm5NextDecoderLayer, glm5_next.Glm5NextScannableBlock),
+        # GLM5 does not yet implement a multi-layer scannable block.
+        DecoderBlockType.GLM5_3: [glm5_next.Glm5NextDecoderLayer],
+        DecoderBlockType.GLM5_NEXT: [glm5_next.Glm5NextDecoderLayer],
     }
 
     if cfg.decoder_block not in layer_map:
       raise ValueError(f"Incorrect decoder_block name {cfg.decoder_block.value=}")
+    if cfg.decoder_block in (DecoderBlockType.GLM5_3, DecoderBlockType.GLM5_NEXT) and cfg.scan_layers:
+      raise NotImplementedError("scan_layers=true is not yet supported for GLM5.")
     return layer_map[cfg.decoder_block]
 
   def set_remat_policy(self, block_layers, policy):

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -61,6 +61,7 @@ from maxtext.models import (
     qwen3,
     qwen3_custom,
     qwen3_5,
+    glm5_next,
     simple_layer,
 )
 from maxtext.multimodal import utils as mm_utils
@@ -496,6 +497,12 @@ class Decoder(nn.Module):
         return [olmo3.Olmo3ScannableBlockToLinen] if self.config.scan_layers else [olmo3.Olmo3DecoderLayerToLinen]
       case DecoderBlockType.ENVY:
         return [envy.EnvyScannableBlockToLinen] if self.config.scan_layers else [envy.EnvyDecoderLayerToLinen]
+      case DecoderBlockType.GLM5_3 | DecoderBlockType.GLM5_NEXT:
+        return (
+            [glm5_next.Glm5NextScannableBlockToLinen]
+            if self.config.scan_layers
+            else [glm5_next.Glm5NextDecoderLayerToLinen]
+        )
 
       case _:
         # Default case to handle any unknown decoder block types.
@@ -532,6 +539,8 @@ class Decoder(nn.Module):
         DecoderBlockType.LLAMA4: get_scannable(llama4.Llama4DecoderLayer, llama4.Llama4ScannableBlock),
         DecoderBlockType.OLMO3: get_scannable(olmo3.Olmo3DecoderLayer, olmo3.Olmo3ScannableBlock),
         DecoderBlockType.ENVY: get_scannable(envy.EnvyDecoderLayer, envy.EnvyScannableBlock),
+        DecoderBlockType.GLM5_3: get_scannable(glm5_next.Glm5NextDecoderLayer, glm5_next.Glm5NextScannableBlock),
+        DecoderBlockType.GLM5_NEXT: get_scannable(glm5_next.Glm5NextDecoderLayer, glm5_next.Glm5NextScannableBlock),
     }
 
     if cfg.decoder_block not in layer_map:
@@ -641,6 +650,7 @@ class Decoder(nn.Module):
         DecoderBlockType.SIMPLE_MLP,
         DecoderBlockType.LLAMA4,
         DecoderBlockType.OLMO3,
+        DecoderBlockType.GLM5_3,
     ):
       return functools.partial(rms_norm, num_features=num_features, shard_mode=self.config.shard_mode)
     elif self.config.decoder_block == DecoderBlockType.GPT3:
@@ -1284,6 +1294,8 @@ class Decoder(nn.Module):
             mesh=mesh,
             name="hc_head",
         )(y)
+      elif cfg.decoder_block == DecoderBlockType.GLM5_3:
+        hidden_state = jnp.mean(y, axis=2, dtype=y.dtype)
       else:
         # (batch, length, mhc_expansion_rate, emb_dim) --> (batch, length, emb_dim)
         hidden_state = mhc_reduce(y)

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -497,7 +497,7 @@ class Decoder(nn.Module):
         return [olmo3.Olmo3ScannableBlockToLinen] if self.config.scan_layers else [olmo3.Olmo3DecoderLayerToLinen]
       case DecoderBlockType.ENVY:
         return [envy.EnvyScannableBlockToLinen] if self.config.scan_layers else [envy.EnvyDecoderLayerToLinen]
-      case DecoderBlockType.GLM5_3 | DecoderBlockType.GLM5_NEXT:
+      case DecoderBlockType.GLM5_3:
         if self.config.scan_layers:
           raise NotImplementedError("scan_layers=true is not yet supported for GLM5.")
         return [glm5_next.Glm5NextDecoderLayerToLinen]
@@ -539,12 +539,11 @@ class Decoder(nn.Module):
         DecoderBlockType.ENVY: get_scannable(envy.EnvyDecoderLayer, envy.EnvyScannableBlock),
         # GLM5 does not yet implement a multi-layer scannable block.
         DecoderBlockType.GLM5_3: [glm5_next.Glm5NextDecoderLayer],
-        DecoderBlockType.GLM5_NEXT: [glm5_next.Glm5NextDecoderLayer],
     }
 
     if cfg.decoder_block not in layer_map:
       raise ValueError(f"Incorrect decoder_block name {cfg.decoder_block.value=}")
-    if cfg.decoder_block in (DecoderBlockType.GLM5_3, DecoderBlockType.GLM5_NEXT) and cfg.scan_layers:
+    if cfg.decoder_block == DecoderBlockType.GLM5_3 and cfg.scan_layers:
       raise NotImplementedError("scan_layers=true is not yet supported for GLM5.")
     return layer_map[cfg.decoder_block]
 
@@ -1238,7 +1237,12 @@ class Decoder(nn.Module):
                   "is_moe_layer": (lyr + 1) % self.config.interleave_moe_layer_step == 0,
               }
 
-            if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5, DecoderBlockType.DEEPSEEK4):
+            if cfg.decoder_block in (
+                DecoderBlockType.QWEN3_NEXT,
+                DecoderBlockType.QWEN3_5,
+                DecoderBlockType.DEEPSEEK4,
+                DecoderBlockType.GLM5_3,
+            ):
               layer_kwargs = {"layer_idx": lyr}
             if cfg.decoder_block == DecoderBlockType.DEEPSEEK4:
               layer_call_kwargs["decoder_input_tokens"] = decoder_input_tokens

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -565,6 +565,7 @@ class MlpBlock(nnx.Module):
         DecoderBlockType.DEEPSEEK,
         DecoderBlockType.LLAMA4,
         DecoderBlockType.OLMO3,
+        DecoderBlockType.GLM5_3,
     ):
       return functools.partial(normalizations.RMSNorm, num_features=num_features)
     elif self.config.decoder_block == DecoderBlockType.GPT3:

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -252,9 +252,7 @@ def calculate_load_balance_updates(top_k_indices, num_experts, rate):
   flat_indices = top_k_indices.ravel()
   # one_hot rather than bincount: bincount clips out-of-range values, so the -1
   # padding that forced routing uses would all be counted as expert 0.
-  expert_counts = jnp.sum(
-      jax.nn.one_hot(flat_indices, num_experts, dtype=jnp.int32), axis=0
-  )
+  expert_counts = jnp.sum(jax.nn.one_hot(flat_indices, num_experts, dtype=jnp.int32), axis=0)
   total_tokens = jnp.sum(expert_counts)
   average_load = total_tokens / num_experts
   direction = jnp.sign(average_load - expert_counts)
@@ -345,7 +343,7 @@ class GateLogit(nnx.Module):
     if self.use_bias:
       bias_axes = self.kernel_axes[-len(self.out_features_shape) :]
       bias_shape = kernel_shape[-len(self.out_features_shape) :]
-      if self.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2")):
+      if self.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2", "glm5")):
         # DeepSeek uses MoEBiasVar to naturally isolate from sequence-wise updates
         self.bias = MoEBiasVar(
             default_bias_init(rngs.params(), bias_shape, self.weight_dtype),
@@ -409,7 +407,7 @@ class GateLogit(nnx.Module):
       output = linears._convert_to_activation_function(self.score_func)(output)
 
     # NOTE: deepseek2 has a different pattern
-    if self.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2")):
+    if self.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2", "glm5")):
       pre_bias_logits = output
 
     if self.use_bias:
@@ -771,61 +769,43 @@ class RoutedMoE(nnx.Module):
       gather_indices = jnp.where(valid_token_mask, top_k_indices, 0)
       if self.config.decoder_block == ctypes.DecoderBlockType.GEMMA4:
         router_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1)
-        top_k_weights = jnp.take_along_axis(
-            router_probs, gather_indices, axis=-1
-        ).astype(self.dtype)
+        top_k_weights = jnp.take_along_axis(router_probs, gather_indices, axis=-1).astype(self.dtype)
       else:
-        top_k_weights = jnp.take_along_axis(
-            gate_logits, gather_indices, axis=-1
-        )
+        top_k_weights = jnp.take_along_axis(gate_logits, gather_indices, axis=-1)
     else:
       if self.config.use_random_routing:
         if rngs is None:
           raise ValueError("The random key cannot be None for random routing.")
         # Reuse the 'params' RNG stream to ensure random routing
-        rng = (
-            rngs.params()
-            if hasattr(rngs, "params") and callable(getattr(rngs, "params"))
-            else rngs
-        )
-        top_k_weights, top_k_indices = random_routing(
-            rng, gate_logits, self.num_experts_per_tok
-        )
+        rng = rngs.params() if hasattr(rngs, "params") and callable(getattr(rngs, "params")) else rngs
+        top_k_weights, top_k_indices = random_routing(rng, gate_logits, self.num_experts_per_tok)
         return top_k_weights, top_k_indices
 
       if self.is_hash_routing:
         if input_ids is None:
-          raise ValueError(
-              "input_ids cannot be None when is_hash_routing is True"
-          )
+          raise ValueError("input_ids cannot be None when is_hash_routing is True")
         # Access the static routing table
         tid2eid_int = self.tid2eid.value
         # Cast the float32 array to int32 (JAX automatically assigns 0.0 gradients to integer casts)
         tid2eid_int = tid2eid_int.astype(jnp.int32)
         # Cast input_ids to int32 to safely index the hash routing table
         top_k_indices = tid2eid_int[input_ids.astype(jnp.int32)]
-        top_k_weights = jnp.take_along_axis(
-            pre_bias_logits, top_k_indices, axis=-1
-        )
+        top_k_weights = jnp.take_along_axis(pre_bias_logits, top_k_indices, axis=-1)
       # NOTE: deepseek2 has a different pattern
-      elif self.config.model_name.startswith(
-          ("deepseek3", "deepseek4", "kimi-k2")
-      ):
-        top_k_weights, top_k_indices = self.deepseek_routing(
-            gate_logits, pre_bias_logits
-        )
+      elif self.config.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2", "glm5")):
+        top_k_weights, top_k_indices = self.deepseek_routing(gate_logits, pre_bias_logits)
       elif self.config.decoder_block == ctypes.DecoderBlockType.GEMMA4:
         router_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1)
         _, top_k_indices = jax.lax.top_k(gate_logits, self.num_experts_per_tok)
-        top_k_weights = jnp.take_along_axis(
-            router_probs, top_k_indices, axis=-1
-        ).astype(self.dtype)
+        top_k_weights = jnp.take_along_axis(router_probs, top_k_indices, axis=-1).astype(self.dtype)
       else:
-        top_k_weights, top_k_indices = jax.lax.top_k(
-            gate_logits, self.num_experts_per_tok
-        )
+        top_k_weights, top_k_indices = jax.lax.top_k(gate_logits, self.num_experts_per_tok)
 
-    if self.config.decoder_block in (ctypes.DecoderBlockType.DEEPSEEK, ctypes.DecoderBlockType.DEEPSEEK4):
+    if self.config.decoder_block in (
+        ctypes.DecoderBlockType.DEEPSEEK,
+        ctypes.DecoderBlockType.DEEPSEEK4,
+        ctypes.DecoderBlockType.GLM5_3,
+    ):
       top_k_weights = self.deepseek_scale_weights(top_k_weights)
       if valid_token_mask is not None:
         top_k_weights = top_k_weights * valid_token_mask
@@ -834,9 +814,7 @@ class RoutedMoE(nnx.Module):
         if valid_token_mask is not None:
           # Padding must stay out of the softmax denominator or it rescales the
           # real slots. Large-negative, not -inf: a fully-padded token would be NaN.
-          top_k_weights = jnp.where(
-              valid_token_mask, top_k_weights, jnp.finfo(jnp.float32).min / 2
-          )
+          top_k_weights = jnp.where(valid_token_mask, top_k_weights, jnp.finfo(jnp.float32).min / 2)
         top_k_weights = jax.nn.softmax(top_k_weights.astype(jnp.float32), axis=-1).astype(self.dtype)
 
       if valid_token_mask is not None:
@@ -924,7 +902,7 @@ class RoutedMoE(nnx.Module):
       - top_k_indices: `(batch, seq, num_experts_per_tok)` array of indices
         identifying the selected experts for each token.
     """
-    expert_mask = 1 if self.config.n_routing_groups == -1 else self.expert_group_mask(gate_logits)
+    expert_mask = 1 if self.config.n_routing_groups in (-1, 1) else self.expert_group_mask(gate_logits)
     _, top_k_indices = jax.lax.top_k(
         jnp.where(expert_mask > 0, gate_logits, -jnp.inf),
         k=self.num_experts_per_tok,
@@ -945,16 +923,21 @@ class RoutedMoE(nnx.Module):
         layer_act = self.activation_fn(layer_w0 * 1.702)
         glu = jnp.multiply(layer_w0, layer_act)
         intermediate_layer = jnp.multiply(glu, (layer_w1 + 1))
-      elif (
-          self.config.decoder_block in (ctypes.DecoderBlockType.DEEPSEEK, ctypes.DecoderBlockType.DEEPSEEK4)
-          and self.config.mlp_activations_limit > 0.0
-      ):
-        # DeepSeek V4 uses bounds to clip the SwiGLU activations
-        layer_w0 = jnp.clip(layer_w0, min=None, max=self.config.mlp_activations_limit)
+      elif self.config.decoder_block in (
+          ctypes.DecoderBlockType.DEEPSEEK,
+          ctypes.DecoderBlockType.DEEPSEEK4,
+          ctypes.DecoderBlockType.GLM5_3,
+      ) and (self.config.mlp_activations_limit > 0.0 or getattr(self.config, "swiglu_limit", 0.0) > 0.0):
+        limit = (
+            self.config.mlp_activations_limit
+            if self.config.mlp_activations_limit > 0.0
+            else getattr(self.config, "swiglu_limit", 10.0)
+        )
+        layer_w0 = jnp.clip(layer_w0, min=None, max=limit)
         layer_w1 = jnp.clip(
             layer_w1,
-            min=-self.config.mlp_activations_limit,
-            max=self.config.mlp_activations_limit,
+            min=-limit,
+            max=limit,
         )
         layer_act = self.activation_fn(layer_w0)
         intermediate_layer = jnp.multiply(layer_act, layer_w1)
@@ -979,9 +962,7 @@ class RoutedMoE(nnx.Module):
     inputs_shape = inputs.shape
     bsz_times_seq_len = inputs_shape[0] * inputs_shape[1]
     inputs_2d = jnp.reshape(inputs, (bsz_times_seq_len, inputs_shape[2]))
-    weights, selected_experts = self.get_topk(
-        gate_logits, pre_bias_logits, rngs, input_ids, forced_routed_experts
-    )
+    weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs, input_ids, forced_routed_experts)
 
     lb_loss = None
     # Using pre_bias_logits ensures the router bias does not leak into the auxiliary loss gradient
@@ -1061,9 +1042,7 @@ class RoutedMoE(nnx.Module):
       # Must precede roll_to_expert_id: `(-1 - roll) % num_experts` wraps padding
       # onto a real expert id, so a mask computed after it sees no padding at all.
       if forced_routed_experts is not None:
-        valid_mask = valid_expert_mask(
-            flatten_selected_experts, self.num_experts
-        )
+        valid_mask = valid_expert_mask(flatten_selected_experts, self.num_experts)
 
       if roll_to_expert_id is not None:
         flatten_selected_experts = (flatten_selected_experts - roll_to_expert_id) % self.num_experts
@@ -1071,28 +1050,20 @@ class RoutedMoE(nnx.Module):
       if forced_routed_experts is not None:
         # Spread padding round-robin: it carries zero weight but still counts in
         # group_size, so under ragged_buffer_factor > 0 it can evict real tokens.
-        dummy_indices = (
-            jnp.arange(flatten_selected_experts.shape[0]) % self.num_experts
-        )
-        flatten_selected_experts_safe = jnp.where(
-            valid_mask, flatten_selected_experts, dummy_indices
-        )
+        dummy_indices = jnp.arange(flatten_selected_experts.shape[0]) % self.num_experts
+        flatten_selected_experts_safe = jnp.where(valid_mask, flatten_selected_experts, dummy_indices)
       else:
         flatten_selected_experts_safe = flatten_selected_experts
 
       sorted_selected_experts = jnp.argsort(flatten_selected_experts_safe)
       if self.config.moe_use_direct_token_gather:
-        sorted_inputs = _route_activations(
-            inputs_2d, flatten_selected_experts_safe
-        ).astype(self.dtype)
+        sorted_inputs = _route_activations(inputs_2d, flatten_selected_experts_safe).astype(self.dtype)
       else:
         replicated_inputs_2d = jnp.repeat(inputs_2d, self.num_experts_per_tok, axis=0)
         sorted_inputs = _sort_activations(replicated_inputs_2d, sorted_selected_experts, use_custom_sort_vjp).astype(
             self.dtype
         )
-      group_size = jnp.bincount(
-          flatten_selected_experts_safe, length=self.num_experts
-      )
+      group_size = jnp.bincount(flatten_selected_experts_safe, length=self.num_experts)
 
     num_tokens = bsz_times_seq_len * self.num_experts_per_tok
     use_truncated_buffer = use_ragged_in_permute and buffer_size is not None and buffer_size < num_tokens
@@ -1765,7 +1736,7 @@ class RoutedMoE(nnx.Module):
 
       gate_logits_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
       # NOTE: deepseek2 has a different pattern
-      if self.config.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2")):
+      if self.config.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2", "glm5")):
         pre_bias_logits_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
       else:
         # pre_bias_logits is None for non-deepseek3/4 models, including deepseek2
@@ -2395,21 +2366,19 @@ class RoutedMoE(nnx.Module):
     ):
       batch_size, sequence_length, embed_dim = x.shape
       if self.config.num_moe_emb_chunks > 0:
-        output0, output1, gmm_fn, routing, route_metadata, wo_bias = (
-            moe_emb_chunking(
-                x,
-                logits,
-                pre_bias_logits,
-                w0,
-                w1,
-                w0_bias,
-                w1_bias,
-                wo_bias,
-                sharded_input_ids,
-                rngs,
-                embed_dim,
-                forced_routed_experts=forced_routed_experts,
-            )
+        output0, output1, gmm_fn, routing, route_metadata, wo_bias = moe_emb_chunking(
+            x,
+            logits,
+            pre_bias_logits,
+            w0,
+            w1,
+            w0_bias,
+            w1_bias,
+            wo_bias,
+            sharded_input_ids,
+            rngs,
+            embed_dim,
+            forced_routed_experts=forced_routed_experts,
         )
       else:
         x, routing, route_metadata = route(
@@ -2604,9 +2573,7 @@ class RoutedMoE(nnx.Module):
             wo_bias,
             None if sharded_input_ids is None else sharded_input_ids[:, sl],
             rngs,
-            None
-            if forced_routed_experts is None
-            else forced_routed_experts[:, sl, :],
+            None if forced_routed_experts is None else forced_routed_experts[:, sl, :],
         )
         if self.config.moe_chunk_barrier:
           _prev = out_c
@@ -2641,7 +2608,7 @@ class RoutedMoE(nnx.Module):
     gate_logits_logical_axes = (batch_logical_axis, "activation_norm_length", None)
     pre_bias_logits_logical_axes = (
         (batch_logical_axis, "activation_norm_length", None)
-        if self.config.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2"))
+        if self.config.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2", "glm5"))
         else None
     )
     inputs = self._maybe_shard_with_pspec(inputs, input_partition_pspec, logical_axes=input_logical_axes)
@@ -2709,9 +2676,7 @@ class RoutedMoE(nnx.Module):
             jnp.arange(weights.shape[0])[:, None, None],
             ("activation_batch", None, None),
         ),
-        self._maybe_shard_with_logical(
-            jnp.arange(weights.shape[1])[:, None], ("activation_length", None)
-        ),
+        self._maybe_shard_with_logical(jnp.arange(weights.shape[1])[:, None], ("activation_length", None)),
         safe_indices,
     )
     weight_sharding = (
@@ -2726,13 +2691,9 @@ class RoutedMoE(nnx.Module):
       # so accumulate with `.add()` instead: padding slots always carry a
       # zero weight, so summing duplicates is safe and avoids silently
       # dropping a real weight update.
-      update_weights = update_weights.at[index_update].add(
-          safe_weights, out_sharding=weight_sharding
-      )
+      update_weights = update_weights.at[index_update].add(safe_weights, out_sharding=weight_sharding)
     else:
-      update_weights = update_weights.at[index_update].set(
-          safe_weights, out_sharding=weight_sharding
-      )
+      update_weights = update_weights.at[index_update].set(safe_weights, out_sharding=weight_sharding)
     return update_weights
 
   def get_context_partition_and_sub_seq(self, seq_len):
@@ -3005,7 +2966,7 @@ class RoutedMoE(nnx.Module):
     # gate_logits: batch, length, expert
     gate_logits = self._maybe_shard_with_logical(gate_logits, ("activation_batch_moe", "activation_length_moe", None))
     # NOTE: deepseek2 has a different pattern
-    if self.config.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2")):
+    if self.config.model_name.startswith(("deepseek3", "deepseek4", "kimi-k2", "glm5")):
       # pre_bias_logits is None for non-deepseek3/4 models, including deepseek2
       pre_bias_logits = self._maybe_shard_with_logical(
           pre_bias_logits, ("activation_batch_moe", "activation_length_moe", None)
@@ -3333,10 +3294,7 @@ class RoutedMoE(nnx.Module):
     It does not compute lb_loss or bias_updates (inference-only).
     """
     if forced_routed_experts is not None:
-      raise NotImplementedError(
-          "Forced routing via forced_routed_experts is not supported with"
-          " fused_moe_matmul."
-      )
+      raise NotImplementedError("Forced routing via forced_routed_experts is not supported with" " fused_moe_matmul.")
     try:
       # pylint: disable=import-outside-toplevel
       # pytype: disable=import-error
@@ -3606,19 +3564,31 @@ class RoutedAndSharedMoE(nnx.Module):
     )
 
     shared_expert_mlp_dim = maxtext_utils.get_shared_expert_mlp_dim(self.config)
-    self.shared_experts = linears.MlpBlock(
-        mesh=self.mesh,
-        in_features=self.moe_expert_input_dim,
-        intermediate_dim=self.config.shared_experts * shared_expert_mlp_dim,
-        activations=self.config.mlp_activations,
-        kernel_init=self.kernel_init,
-        intermediate_dropout_rate=self.config.dropout_rate,
-        dtype=self.config.dtype,
-        weight_dtype=self.config.weight_dtype,
-        config=self.config,
-        quant=self.quant,
-        rngs=self.rngs,
-    )
+    if self.config.decoder_block == ctypes.DecoderBlockType.GLM5_3:
+      from maxtext.models import glm5_next  # pylint: disable=import-outside-toplevel
+
+      self.shared_experts = glm5_next.Glm5NextDenseMLP(
+          config=self.config,
+          mesh=self.mesh,
+          in_features=self.moe_expert_input_dim,
+          intermediate_dim=self.config.shared_experts * shared_expert_mlp_dim,
+          quant=self.quant,
+          rngs=self.rngs,
+      )
+    else:
+      self.shared_experts = linears.MlpBlock(
+          mesh=self.mesh,
+          in_features=self.moe_expert_input_dim,
+          intermediate_dim=self.config.shared_experts * shared_expert_mlp_dim,
+          activations=self.config.mlp_activations,
+          kernel_init=self.kernel_init,
+          intermediate_dropout_rate=self.config.dropout_rate,
+          dtype=self.config.dtype,
+          weight_dtype=self.config.weight_dtype,
+          config=self.config,
+          quant=self.quant,
+          rngs=self.rngs,
+      )
 
   @property
   def routed_moe(self):

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -66,6 +66,7 @@ from maxtext.models import (
     qwen2,
     qwen3,
     qwen3_5,
+    glm5_next,
     qwen3_custom,
     simple_layer,
 )
@@ -1048,9 +1049,7 @@ class NNXDecoder(nnx.Module):
         current_params, current_state, kv_cache_layer = scanned_vars
         forced_routed_experts_layer = None
       elif use_forced_routing:
-        current_params, current_state, forced_routed_experts_layer = (
-            scanned_vars
-        )
+        current_params, current_state, forced_routed_experts_layer = scanned_vars
         kv_cache_layer = None
       else:
         current_params, current_state = scanned_vars
@@ -1138,9 +1137,7 @@ class NNXDecoder(nnx.Module):
         scan_xs = (params, state, forced_routed_experts_scanned)
       else:
         scan_xs = (params, state)
-      final_carry, scanned_state = jax.lax.scan(
-          layer_fn_wrapped, x_in, scan_xs, unroll=unroll
-      )
+      final_carry, scanned_state = jax.lax.scan(layer_fn_wrapped, x_in, scan_xs, unroll=unroll)
       returned_kv_stacked = None
 
       # Move the scan axis to each variable's param_scan_axis and restore its name
@@ -1196,6 +1193,8 @@ class NNXDecoder(nnx.Module):
         DecoderBlockType.LLAMA4: get_scannable(llama4.Llama4DecoderLayer, llama4.Llama4ScannableBlock),
         DecoderBlockType.OLMO3: get_scannable(olmo3.Olmo3DecoderLayer, olmo3.Olmo3ScannableBlock),
         DecoderBlockType.ENVY: get_scannable(envy.EnvyDecoderLayer, envy.EnvyScannableBlock),
+        DecoderBlockType.GLM5_3: get_scannable(glm5_next.Glm5NextDecoderLayer, glm5_next.Glm5NextScannableBlock),
+        DecoderBlockType.GLM5_NEXT: get_scannable(glm5_next.Glm5NextDecoderLayer, glm5_next.Glm5NextScannableBlock),
     }
 
     if cfg.decoder_block not in layer_map:
@@ -1356,6 +1355,7 @@ class NNXDecoder(nnx.Module):
         DecoderBlockType.SIMPLE_MLP,
         DecoderBlockType.LLAMA4,
         DecoderBlockType.OLMO3,
+        DecoderBlockType.GLM5_3,
         DecoderBlockType.ENVY,
     }:
       return functools.partial(
@@ -1980,13 +1980,11 @@ class NNXDecoder(nnx.Module):
               )
             # Only the per-layer slices may reach the layers from here on.
             layer_kwargs.pop("forced_routed_experts", None)
-            forced_routed_experts_scanned = (
-                reshape_forced_routed_experts_for_scan(
-                    forced_routed_experts,
-                    num_layers=cfg.num_decoder_layers,
-                    scan_length=scan_length,
-                    layers_per_cycle=cycle_interval,
-                )
+            forced_routed_experts_scanned = reshape_forced_routed_experts_for_scan(
+                forced_routed_experts,
+                num_layers=cfg.num_decoder_layers,
+                scan_length=scan_length,
+                layers_per_cycle=cycle_interval,
             )
             if cfg.decoder_block == DecoderBlockType.MIXTRAL:
               # Mixtral has no ScannableBlock: one scan iteration is one layer,
@@ -1997,9 +1995,7 @@ class NNXDecoder(nnx.Module):
                     " inhomogeneous_layer_cycle_interval == 1; got"
                     f" {cycle_interval}."
                 )
-              forced_routed_experts_scanned = jnp.squeeze(
-                  forced_routed_experts_scanned, axis=1
-              )
+              forced_routed_experts_scanned = jnp.squeeze(forced_routed_experts_scanned, axis=1)
           if kv_caches is not None:
             # Pass the kv_caches list directly to avoid copying in jnp.stack,
             # which breaks vLLM PagedAttention in-place memory updates.
@@ -2033,9 +2029,7 @@ class NNXDecoder(nnx.Module):
                 state_in,
             )
           merged_layer = nnx.merge(graphdef_in, state_in)
-          out_y, out_kv = merged_layer(
-              y_in, *layer_args, kv_cache=kv_in, **valid_kwargs
-          )
+          out_y, out_kv = merged_layer(y_in, *layer_args, kv_cache=kv_in, **valid_kwargs)
           state_out = nnx.state(merged_layer)
 
           if dynamic_graph_init:
@@ -2105,10 +2099,7 @@ class NNXDecoder(nnx.Module):
                   f" top_k] (4D, per-layer); got ndim={routed_experts.ndim}"
                   f" with shape {routed_experts.shape}."
               )
-            if (
-                routed_experts.ndim == 4
-                and routed_experts.shape[2] != cfg.num_decoder_layers
-            ):
+            if routed_experts.ndim == 4 and routed_experts.shape[2] != cfg.num_decoder_layers:
               # jnp clamps an out-of-range static index, so a short layer axis
               # would silently replay the last slice on every later layer.
               raise ValueError(
@@ -2118,19 +2109,13 @@ class NNXDecoder(nnx.Module):
                   f" {routed_experts.shape}."
               )
             current_kwargs["forced_routed_experts"] = (
-                routed_experts[:, :, lyr, :]
-                if routed_experts.ndim == 4
-                else routed_experts
+                routed_experts[:, :, lyr, :] if routed_experts.ndim == 4 else routed_experts
             )
 
           if cfg.remat_policy != "none":
-            y, kv_cache, new_state, new_graphdef = checkpointed_fn(
-                graphdef, state, y, kv_cache, current_kwargs
-            )
+            y, kv_cache, new_state, new_graphdef = checkpointed_fn(graphdef, state, y, kv_cache, current_kwargs)
           else:
-            y, kv_cache, new_state, new_graphdef = pure_layer_fn(
-                graphdef, state, y, kv_cache, current_kwargs
-            )
+            y, kv_cache, new_state, new_graphdef = pure_layer_fn(graphdef, state, y, kv_cache, current_kwargs)
 
           if dynamic_graph_init:
             new_layer = nnx.merge(new_graphdef, new_state)
@@ -2172,6 +2157,8 @@ class NNXDecoder(nnx.Module):
     if getattr(cfg, "mhc_expansion_rate", 1) > 1:
       if cfg.decoder_block == DecoderBlockType.DEEPSEEK4:
         hidden_state = self.hc_head(y)
+      elif cfg.decoder_block == DecoderBlockType.GLM5_3:
+        hidden_state = jnp.mean(y, axis=2, dtype=y.dtype)
       else:
         # (batch, length, mhc_expansion_rate, emb_dim) --> (batch, length, emb_dim)
         hidden_state = mhc_reduce(y)

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -829,7 +829,6 @@ class NNXDecoder(nnx.Module):
           DecoderBlockType.QWEN3_5,
           DecoderBlockType.DEEPSEEK4,
           DecoderBlockType.GLM5_3,
-          DecoderBlockType.GLM5_NEXT,
       }:
         layer_kwargs = {"layer_idx": lyr}
       elif config.decoder_block == DecoderBlockType.GPT_OSS:
@@ -1197,13 +1196,12 @@ class NNXDecoder(nnx.Module):
         DecoderBlockType.ENVY: get_scannable(envy.EnvyDecoderLayer, envy.EnvyScannableBlock),
         # GLM5 does not yet implement a multi-layer scannable block.
         DecoderBlockType.GLM5_3: [glm5_next.Glm5NextDecoderLayer],
-        DecoderBlockType.GLM5_NEXT: [glm5_next.Glm5NextDecoderLayer],
     }
 
     if cfg.decoder_block not in layer_map:
       raise ValueError(f"Incorrect decoder_block name {cfg.decoder_block.value=}")
 
-    if cfg.decoder_block in (DecoderBlockType.GLM5_3, DecoderBlockType.GLM5_NEXT) and cfg.scan_layers:
+    if cfg.decoder_block == DecoderBlockType.GLM5_3 and cfg.scan_layers:
       raise NotImplementedError("scan_layers=true is not yet supported for GLM5.")
 
     return layer_map[cfg.decoder_block]

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -828,6 +828,8 @@ class NNXDecoder(nnx.Module):
           DecoderBlockType.QWEN3_NEXT,
           DecoderBlockType.QWEN3_5,
           DecoderBlockType.DEEPSEEK4,
+          DecoderBlockType.GLM5_3,
+          DecoderBlockType.GLM5_NEXT,
       }:
         layer_kwargs = {"layer_idx": lyr}
       elif config.decoder_block == DecoderBlockType.GPT_OSS:
@@ -1193,12 +1195,16 @@ class NNXDecoder(nnx.Module):
         DecoderBlockType.LLAMA4: get_scannable(llama4.Llama4DecoderLayer, llama4.Llama4ScannableBlock),
         DecoderBlockType.OLMO3: get_scannable(olmo3.Olmo3DecoderLayer, olmo3.Olmo3ScannableBlock),
         DecoderBlockType.ENVY: get_scannable(envy.EnvyDecoderLayer, envy.EnvyScannableBlock),
-        DecoderBlockType.GLM5_3: get_scannable(glm5_next.Glm5NextDecoderLayer, glm5_next.Glm5NextScannableBlock),
-        DecoderBlockType.GLM5_NEXT: get_scannable(glm5_next.Glm5NextDecoderLayer, glm5_next.Glm5NextScannableBlock),
+        # GLM5 does not yet implement a multi-layer scannable block.
+        DecoderBlockType.GLM5_3: [glm5_next.Glm5NextDecoderLayer],
+        DecoderBlockType.GLM5_NEXT: [glm5_next.Glm5NextDecoderLayer],
     }
 
     if cfg.decoder_block not in layer_map:
       raise ValueError(f"Incorrect decoder_block name {cfg.decoder_block.value=}")
+
+    if cfg.decoder_block in (DecoderBlockType.GLM5_3, DecoderBlockType.GLM5_NEXT) and cfg.scan_layers:
+      raise NotImplementedError("scan_layers=true is not yet supported for GLM5.")
 
     return layer_map[cfg.decoder_block]
 

--- a/src/maxtext/models/glm5_next.py
+++ b/src/maxtext/models/glm5_next.py
@@ -18,7 +18,7 @@ from flax import nnx
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from maxtext.common.common_types import Array, Config, HyperConnectionType, ModelMode
+from maxtext.common.common_types import Array, Config, HyperConnectionType, MODEL_MODE_TRAIN
 from maxtext.layers import initializers, linears, mhc
 from maxtext.layers.normalizations import RMSNorm
 
@@ -57,7 +57,7 @@ class Glm5NextAttention(nnx.Module):
       self,
       config: Config,
       mesh: Mesh,
-      model_mode: ModelMode,
+      model_mode: str,
       rngs: nnx.Rngs,
   ):
     self.config = config
@@ -290,7 +290,7 @@ class Glm5NextDecoderLayer(nnx.Module):
       self,
       config: Config,
       mesh: Mesh,
-      model_mode: ModelMode,
+      model_mode: str,
       layer_idx: int,
       rngs: nnx.Rngs,
   ):
@@ -347,7 +347,7 @@ class Glm5NextDecoderLayer(nnx.Module):
       decoder_segment_ids: Array | None = None,
       decoder_positions: Array | None = None,
       deterministic: bool = True,
-      model_mode: ModelMode = "train",
+      model_mode: str = MODEL_MODE_TRAIN,
   ) -> tuple[Array, None]:
     """Forward pass for GLM-5.3-Flash Decoder Layer."""
     x = inputs

--- a/src/maxtext/models/glm5_next.py
+++ b/src/maxtext/models/glm5_next.py
@@ -18,13 +18,68 @@ from flax import nnx
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from maxtext.common.common_types import Array, Config, HyperConnectionType, MODEL_MODE_TRAIN
+from maxtext.common.common_types import (
+    Array,
+    Config,
+    HyperConnectionType,
+    MODEL_MODE_AUTOREGRESSIVE,
+    MODEL_MODE_PREFILL,
+    MODEL_MODE_TRAIN,
+)
+from maxtext.inference import kvcache
 from maxtext.layers import initializers, linears, mhc, moe, nnx_wrappers
 from maxtext.layers.normalizations import RMSNorm
+from maxtext.utils import max_utils
 
 
 def l2norm(t: Array, eps: float = 1e-6) -> Array:
   return t * jax.lax.rsqrt(jnp.sum(t * t, axis=-1, keepdims=True) + eps)
+
+
+def scan_kimi_delta_attention(q, k, v, g, beta, mask=None, initial_state=None):
+  """Scan Kimi Delta Attention across sequence dimension."""
+  q = q.astype(jnp.float32)
+  k = k.astype(jnp.float32)
+  v = v.astype(jnp.float32)
+  g = g.astype(jnp.float32)
+  beta = beta.astype(jnp.float32)
+
+  q_norm = l2norm(q, eps=1e-6) * (q.shape[-1] ** -0.5)
+  k_norm = l2norm(k, eps=1e-6)
+  g_exp = jnp.exp(g)
+
+  if mask is not None:
+    mask_f = (mask != 0).astype(jnp.float32)
+    k_norm = k_norm * mask_f[..., None, None]
+    q_norm = q_norm * mask_f[..., None, None]
+    beta = beta * mask_f[..., None]
+    g_exp = jnp.where(mask_f[..., None, None] != 0, g_exp, 1.0)
+
+  b, _, h, d = q.shape
+  if initial_state is None:
+    init_state = jnp.zeros((b, h, d, d), dtype=jnp.float32)
+  else:
+    init_state = initial_state.astype(jnp.float32)
+
+  def step(state, inputs):
+    q_i, k_i, v_i, g_i, b_i = inputs
+    state = state * g_i[..., :, None]
+    kv_mem = jnp.einsum("bhkd,bhk->bhd", state, k_i)
+    delta = (v_i - kv_mem) * b_i[..., None]
+    new_state = state + jnp.einsum("bhk,bhd->bhkd", k_i, delta)
+    out = jnp.einsum("bhkd,bhk->bhd", new_state, q_i)
+    return new_state, out
+
+  xs = (
+      jnp.swapaxes(q_norm, 0, 1),
+      jnp.swapaxes(k_norm, 0, 1),
+      jnp.swapaxes(v, 0, 1),
+      jnp.swapaxes(g_exp, 0, 1),
+      jnp.swapaxes(beta, 0, 1),
+  )
+  final_state, outs = jax.lax.scan(step, init_state, xs)
+  outs = jnp.swapaxes(outs, 0, 1)
+  return outs, final_state
 
 
 class Glm5NextAttention(nnx.Module):
@@ -49,6 +104,7 @@ class Glm5NextAttention(nnx.Module):
     self.head_dim = config.linear_head_dim
     self.kda_conv_size = config.linear_conv_kernel_dim
     self.conv_dim = self.num_heads * self.head_dim
+    self.linear_lower_bound = getattr(config, "linear_lower_bound", -5.0)
 
     # Projections
     self.q_proj = linears.DenseGeneral(
@@ -139,6 +195,39 @@ class Glm5NextAttention(nnx.Module):
         mesh=self.mesh,
         rngs=self.rngs,
     )
+
+    # 1D Depthwise Convolution over concatenated (Q, K, V)
+    self.conv1d = nnx.Conv(
+        in_features=3 * self.conv_dim,
+        out_features=3 * self.conv_dim,
+        kernel_size=(self.kda_conv_size,),
+        feature_group_count=3 * self.conv_dim,
+        use_bias=False,
+        padding="VALID",
+        dtype=self.dtype,
+        param_dtype=self.weight_dtype,
+        rngs=self.rngs,
+    )
+
+    # Forget gate learnable parameters
+    self.A_log = nnx.Param(
+        jnp.zeros((self.num_heads,), dtype=self.weight_dtype),
+        out_sharding=("heads",),
+    )
+    self.dt_bias = nnx.Param(
+        jnp.zeros((self.conv_dim,), dtype=self.weight_dtype),
+        out_sharding=("heads",),
+    )
+
+    # Output normalization and projection
+    self.o_norm = RMSNorm(
+        num_features=self.head_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        epsilon=config.normalization_layer_epsilon,
+        kernel_axes=("head_dim",),
+        rngs=self.rngs,
+    )
     self.o_proj = linears.DenseGeneral(
         self.conv_dim,
         self.emb_dim,
@@ -151,117 +240,144 @@ class Glm5NextAttention(nnx.Module):
         rngs=self.rngs,
     )
 
-    # Conv1D on concatenated Q, K, V
-    conv_features = 3 * self.conv_dim
-    self.conv1d = nnx.Conv(
-        in_features=conv_features,
-        out_features=conv_features,
-        kernel_size=(self.kda_conv_size,),
-        feature_group_count=conv_features,
-        use_bias=False,
-        padding="VALID",
-        rngs=self.rngs,
-    )
-
-    self.A_log = nnx.Param(
-        jnp.zeros((self.num_heads,), dtype=self.weight_dtype),
-    )
-    self.dt_bias = nnx.Param(
-        jnp.zeros((self.conv_dim,), dtype=self.weight_dtype),
-    )
-
-    self.o_norm = RMSNorm(
-        num_features=self.head_dim,
-        dtype=self.dtype,
-        weight_dtype=self.weight_dtype,
-        epsilon=config.normalization_layer_epsilon,
-        kernel_axes=("head_dim",),
-        rngs=self.rngs,
-    )
+    if self.model_mode != MODEL_MODE_TRAIN:
+      batch_size, _ = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+      self.cache = kvcache.KVCache(
+          max_prefill_length=config.max_prefill_predict_length,
+          max_target_length=config.max_target_length,
+          batch=batch_size,
+          key_seq_len=1,
+          value_seq_len=1,
+          key_heads=self.num_heads,
+          value_heads=self.num_heads,
+          key_head_size=self.head_dim,
+          value_head_size=self.head_dim,
+          dtype=self.dtype,
+          is_gdn=True,
+          conv_kernel_size=self.kda_conv_size,
+          conv_dim=3 * self.conv_dim,
+          model_mode=self.model_mode,
+          rngs=self.rngs,
+      )
+    else:
+      self.cache = None
 
   def __call__(
       self,
       inputs_q: Array,
       inputs_kv: Array | None = None,
+      decoder_segment_ids: Array | None = None,
+      decoder_positions: Array | None = None,
+      model_mode: str = MODEL_MODE_TRAIN,
       **kwargs,
   ) -> tuple[Array, None]:
     x = inputs_q
     b, s, _ = x.shape
 
-    q = self.q_proj(x)
-    k = self.k_proj(x)
-    v = self.v_proj(x)
+    if decoder_segment_ids is not None:
+      mask = decoder_segment_ids != 0
+      x_masked = jnp.where(mask[..., None], x, 0.0)
+    else:
+      x_masked = x
 
-    # 1D causal convolution on concatenated (q, k, v)
+    # Projections
+    q = self.q_proj(x_masked)
+    k = self.k_proj(x_masked)
+    v = self.v_proj(x_masked)
+
+    # 1D Conv over concatenated [q, k, v]
     qkv = jnp.concatenate([q, k, v], axis=-1)
-    pad_qkv = jnp.pad(qkv, ((0, 0), (self.kda_conv_size - 1, 0), (0, 0)))
-    conv_out = jax.nn.silu(self.conv1d(pad_qkv))
-    q, k, v = jnp.split(conv_out, 3, axis=-1)
+    conv_kernel_size = self.kda_conv_size
 
-    # Per-head update strength (beta).
-    b_val = self.b_proj(x)
-    beta = jax.nn.sigmoid(b_val)[..., None]
+    conv_state = None
+    recurrent_state = None
+    next_conv_state = None
 
-    # Per-channel forget gate.
-    f_a = self.f_a_proj(x)
+    if self.cache is not None and model_mode != MODEL_MODE_TRAIN:
+      recurrent_state, conv_state = self.cache.get_gdn_states()
+      conv_input = jnp.concatenate([conv_state, qkv], axis=1)
+
+      if decoder_segment_ids is not None:
+        valid_lens = jnp.sum(decoder_segment_ids != 0, axis=1)
+
+        def extract_state(c_in, v_len):
+          return jax.lax.dynamic_slice_in_dim(c_in, v_len, conv_kernel_size - 1, axis=0)
+
+        next_conv_state = jax.vmap(extract_state)(conv_input, valid_lens)
+      else:
+        next_conv_state = conv_input[:, -(conv_kernel_size - 1) :, :]
+    else:
+      conv_input = jnp.pad(qkv, ((0, 0), (conv_kernel_size - 1, 0), (0, 0)))
+
+    conv_out = self.conv1d(conv_input)
+    conv_out = conv_out[:, -s:, :]
+    qkv_conv = jax.nn.silu(conv_out.astype(jnp.float32)).astype(self.dtype)
+
+    q_conv, k_conv, v_conv = jnp.split(qkv_conv, 3, axis=-1)
+    q = jnp.reshape(q_conv, (b, s, self.num_heads, self.head_dim))
+    k = jnp.reshape(k_conv, (b, s, self.num_heads, self.head_dim))
+    v = jnp.reshape(v_conv, (b, s, self.num_heads, self.head_dim))
+
+    # Gates
+    beta = jax.nn.sigmoid(self.b_proj(x_masked))
+    f_a = self.f_a_proj(x_masked)
     f_b = self.f_b_proj(f_a)
-    decay_rate = jnp.exp(self.A_log[...].astype(jnp.float32))[None, None, :, None]
-    f_per_channel = jnp.reshape(f_b + self.dt_bias[...], (b, s, self.num_heads, self.head_dim))
-    g_log = -5.0 * jax.nn.sigmoid(decay_rate * f_per_channel)
-    g = jnp.exp(g_log)
+    f_b = jnp.reshape(f_b, (b, s, self.num_heads, self.head_dim))
+    dt_bias = jnp.reshape(self.dt_bias[...], (1, 1, self.num_heads, self.head_dim))
+    decay_rate = jnp.exp(self.A_log[None, None, :, None])
+    if self.linear_lower_bound is not None:
+      g = self.linear_lower_bound * jax.nn.sigmoid(decay_rate * (f_b + dt_bias))
+    else:
+      g_softplus = jnp.where(f_b + dt_bias > 20.0, f_b + dt_bias, jax.nn.softplus(f_b + dt_bias))
+      g = -decay_rate * g_softplus
 
-    # Output gate
-    g_a = self.g_a_proj(x)
-    g_b = self.g_b_proj(g_a)
-    gate = jnp.reshape(g_b, (b, s, self.num_heads, self.head_dim))
+    if s == 1 and model_mode == MODEL_MODE_AUTOREGRESSIVE:
+      q_step = q[:, 0].astype(jnp.float32)
+      k_step = k[:, 0].astype(jnp.float32)
+      v_step = v[:, 0].astype(jnp.float32)
+      g_step = g[:, 0].astype(jnp.float32)
+      beta_step = beta[:, 0].astype(jnp.float32)
 
-    # Reshape into [B, S, H, D]
-    q = jnp.reshape(q, (b, s, self.num_heads, self.head_dim))
-    k = jnp.reshape(k, (b, s, self.num_heads, self.head_dim))
-    v = jnp.reshape(v, (b, s, self.num_heads, self.head_dim))
+      q_norm = l2norm(q_step, eps=1e-6) * (self.head_dim**-0.5)
+      k_norm = l2norm(k_step, eps=1e-6)
+      g_exp = jnp.exp(g_step)
 
-    # L2 Norm and scale
-    q = l2norm(q) * (self.head_dim**-0.5)
-    k = l2norm(k)
+      if recurrent_state is None:
+        curr_state = jnp.zeros((b, self.num_heads, self.head_dim, self.head_dim), dtype=jnp.float32)
+      else:
+        curr_state = recurrent_state.astype(jnp.float32)
 
-    def scan_step(state, inputs):
-      g_t, q_t, k_t, v_t, beta_t = inputs
-      g_t = g_t[..., None]
-      state = state * g_t
-      kv_mem = jnp.einsum("hde,hd->he", state, k_t)
-      delta = (v_t - kv_mem) * beta_t
-      state = state + jnp.einsum("hd,he->hde", k_t, delta)
-      out_t = jnp.einsum("hde,hd->he", state, q_t)
-      return state, out_t
-
-    init_state = jnp.zeros((b, self.num_heads, self.head_dim, self.head_dim), dtype=q.dtype)
-
-    def scan_over_seq(init_s, q_seq, k_seq, v_seq, b_seq, g_seq):
-      _, seq_out = jax.lax.scan(
-          scan_step,
-          init_s,
-          (g_seq, q_seq, k_seq, v_seq, b_seq),
+      curr_state = curr_state * g_exp[..., :, None]
+      kv_mem = jnp.einsum("bhkd,bhk->bhd", curr_state, k_norm)
+      delta = (v_step - kv_mem) * beta_step[..., None]
+      next_recurrent_state = curr_state + jnp.einsum("bhk,bhd->bhkd", k_norm, delta)
+      attn_out = jnp.einsum("bhkd,bhk->bhd", next_recurrent_state, q_norm)
+      attn_out = jnp.expand_dims(attn_out, axis=1)
+    else:
+      attn_out, next_recurrent_state = scan_kimi_delta_attention(
+          q, k, v, g, beta, mask=decoder_segment_ids, initial_state=recurrent_state
       )
-      return seq_out
 
-    inputs_q_t = jnp.swapaxes(q, 0, 1)
-    inputs_k_t = jnp.swapaxes(k, 0, 1)
-    inputs_v_t = jnp.swapaxes(v, 0, 1)
-    inputs_b_t = jnp.swapaxes(beta, 0, 1)
-    inputs_g_t = jnp.swapaxes(g, 0, 1)
+    if self.cache is not None and model_mode != MODEL_MODE_TRAIN:
+      self.cache.update_gdn_states(
+          next_recurrent_state.astype(self.dtype),
+          next_conv_state.astype(self.dtype),
+      )
 
-    scan_vmap = jax.vmap(scan_over_seq, in_axes=(0, 1, 1, 1, 1, 1), out_axes=1)
-    scan_out = scan_vmap(init_state, inputs_q_t, inputs_k_t, inputs_v_t, inputs_b_t, inputs_g_t)
-    scan_out = jnp.swapaxes(scan_out, 0, 1)
+    # Output gating & norm
+    g_a = self.g_a_proj(x_masked)
+    g_b = self.g_b_proj(g_a)
+    g_b = jnp.reshape(g_b, (b, s, self.num_heads, self.head_dim))
 
-    norm_out = self.o_norm(scan_out) * jax.nn.sigmoid(gate)
-    norm_flat = jnp.reshape(norm_out, (b, s, self.conv_dim))
-    output = self.o_proj(norm_flat)
-    return output, None
+    normed = self.o_norm(attn_out.astype(self.dtype))
+    gated = normed * jax.nn.sigmoid(g_b.astype(jnp.float32)).astype(self.dtype)
+    gated_flat = jnp.reshape(gated, (b, s, self.conv_dim))
+    out = self.o_proj(gated_flat)
+    return out, None
 
 
 class Glm5NextSparseAttention(nnx.Module):
-  """GLM-5.3-Flash MLA / DeepSeek Sparse Attention Layer for inhomogeneous layers."""
+  """GLM-5.3-Flash MLA (Multi-Head Latent Attention) / Sparse Attention Layer."""
 
   def __init__(
       self,
@@ -363,12 +479,33 @@ class Glm5NextSparseAttention(nnx.Module):
         rngs=self.rngs,
     )
 
+    if self.model_mode != MODEL_MODE_TRAIN:
+      batch_size, _ = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+      self.cache = kvcache.KVCache(
+          max_prefill_length=config.max_prefill_predict_length,
+          max_target_length=config.max_target_length,
+          batch=batch_size,
+          key_seq_len=1,
+          value_seq_len=1,
+          key_heads=self.num_heads,
+          value_heads=self.num_heads,
+          key_head_size=self.qk_nope_head_dim,
+          value_head_size=self.v_head_dim,
+          dtype=self.dtype,
+          is_gdn=False,
+          model_mode=self.model_mode,
+          rngs=self.rngs,
+      )
+    else:
+      self.cache = None
+
   def __call__(
       self,
       inputs_q: Array,
       inputs_kv: Array | None = None,
       decoder_segment_ids: Array | None = None,
       decoder_positions: Array | None = None,
+      model_mode: str = MODEL_MODE_TRAIN,
       **kwargs,
   ) -> tuple[Array, None]:
     x = inputs_q
@@ -386,24 +523,56 @@ class Glm5NextSparseAttention(nnx.Module):
     k = kv_b[..., : self.qk_nope_head_dim]
     v = kv_b[..., self.qk_nope_head_dim :]
 
-    # [B, H, S, D]
-    q = jnp.swapaxes(q, 1, 2)
-    k = jnp.swapaxes(k, 1, 2)
-    v = jnp.swapaxes(v, 1, 2)
+    if self.cache is not None and model_mode == MODEL_MODE_AUTOREGRESSIVE and s == 1:
+      cached_prefill, cached_ar = self.cache(k, v, decoder_segment_ids, model_mode=model_mode)
+      k_p, v_p, seg_p = cached_prefill
+      k_a, v_a, seg_a, _ = cached_ar
+      k_all = jnp.concatenate([k_p, k_a], axis=1)  # [B, max_target_length, H, D]
+      v_all = jnp.concatenate([v_p, v_a], axis=1)  # [B, max_target_length, H, D]
+      seg_all = jnp.concatenate([seg_p, seg_a], axis=1)  # [B, max_target_length]
 
-    # Scaled dot-product causal attention
-    scores = jnp.einsum("bhqd,bhkd->bhqk", q, k) * self.scaling
+      # [B, H, 1, D]
+      q = jnp.swapaxes(q, 1, 2)
+      # [B, H, max_target_length, D]
+      k_all = jnp.swapaxes(k_all, 1, 2)
+      v_all = jnp.swapaxes(v_all, 1, 2)
 
-    causal_mask = jnp.tril(jnp.ones((s, s), dtype=jnp.bool_))
-    mask_value = -1e9
-    scores = jnp.where(causal_mask[None, None, :, :], scores, mask_value)
+      scores = jnp.einsum("bhqd,bhkd->bhqk", q, k_all) * self.scaling
+      mask = seg_all[:, None, None, :] != 0
+      scores = jnp.where(mask, scores, -1e9)
 
-    attn_weights = jax.nn.softmax(scores.astype(jnp.float32), axis=-1).astype(self.dtype)
-    attn_out = jnp.einsum("bhqk,bhkd->bhqd", attn_weights, v)
+      attn_weights = jax.nn.softmax(scores.astype(jnp.float32), axis=-1).astype(self.dtype)
+      attn_out = jnp.einsum("bhqk,bhkd->bhqd", attn_weights, v_all)
+      attn_out = jnp.swapaxes(attn_out, 1, 2)
+      attn_out = jnp.reshape(attn_out, (b, s, self.num_heads * self.v_head_dim))
+    else:
+      if self.cache is not None and model_mode == MODEL_MODE_PREFILL:
+        self.cache(k, v, decoder_segment_ids, model_mode=model_mode)
 
-    # [B, S, H * D]
-    attn_out = jnp.swapaxes(attn_out, 1, 2)
-    attn_out = jnp.reshape(attn_out, (b, s, self.num_heads * self.v_head_dim))
+      # [B, H, S, D]
+      q = jnp.swapaxes(q, 1, 2)
+      k = jnp.swapaxes(k, 1, 2)
+      v = jnp.swapaxes(v, 1, 2)
+
+      # Scaled dot-product causal attention
+      scores = jnp.einsum("bhqd,bhkd->bhqk", q, k) * self.scaling
+
+      causal_mask = jnp.tril(jnp.ones((s, s), dtype=jnp.bool_))
+      if decoder_segment_ids is not None:
+        seg_mask = (decoder_segment_ids[:, None, :] != 0) & (decoder_segment_ids[:, :, None] != 0)
+        full_mask = causal_mask[None, :, :] & seg_mask
+        mask_value = -1e9
+        scores = jnp.where(full_mask[:, None, :, :], scores, mask_value)
+      else:
+        mask_value = -1e9
+        scores = jnp.where(causal_mask[None, None, :, :], scores, mask_value)
+
+      attn_weights = jax.nn.softmax(scores.astype(jnp.float32), axis=-1).astype(self.dtype)
+      attn_out = jnp.einsum("bhqk,bhkd->bhqd", attn_weights, v)
+
+      # [B, S, H * D]
+      attn_out = jnp.swapaxes(attn_out, 1, 2)
+      attn_out = jnp.reshape(attn_out, (b, s, self.num_heads * self.v_head_dim))
 
     out = self.o_proj(attn_out)
     return out, None
@@ -591,6 +760,10 @@ class Glm5NextDecoderLayer(nnx.Module):
         branch_fn=self.attention,
         x=x,
         mhc_type=HyperConnectionType.ATTENTION,
+        decoder_segment_ids=decoder_segment_ids,
+        decoder_positions=decoder_positions,
+        model_mode=model_mode,
+        deterministic=deterministic,
     )
 
     ffn_type = HyperConnectionType.MLP_MOE if self.is_moe else HyperConnectionType.MLP_DENSE

--- a/src/maxtext/models/glm5_next.py
+++ b/src/maxtext/models/glm5_next.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""GLM-5.3-Flash / GLM-5-Next model components."""
+"""GLM-5.3-Flash model components based on the upstream GLM-5-Next architecture."""
 
 from flax import nnx
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from maxtext.common.common_types import Array, Config, HyperConnectionType, MODEL_MODE_TRAIN
-from maxtext.layers import initializers, linears, mhc, nnx_wrappers
+from maxtext.layers import initializers, linears, mhc, moe, nnx_wrappers
 from maxtext.layers.normalizations import RMSNorm
 
 
@@ -260,6 +260,155 @@ class Glm5NextAttention(nnx.Module):
     return output, None
 
 
+class Glm5NextSparseAttention(nnx.Module):
+  """GLM-5.3-Flash MLA / DeepSeek Sparse Attention Layer for inhomogeneous layers."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: str,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.rngs = rngs
+    self.dtype = config.dtype
+    self.weight_dtype = config.weight_dtype
+
+    self.emb_dim = config.emb_dim
+    self.num_heads = config.num_query_heads
+    self.q_lora_rank = getattr(config, "q_lora_rank", 1536)
+    self.kv_lora_rank = getattr(config, "kv_lora_rank", 512)
+    self.qk_nope_head_dim = getattr(config, "qk_nope_head_dim", 256)
+    self.v_head_dim = getattr(config, "v_head_dim", 256)
+    self.head_dim = self.qk_nope_head_dim
+    self.scaling = self.head_dim**-0.5
+
+    # Query Projections
+    self.q_a_proj = linears.DenseGeneral(
+        self.emb_dim,
+        self.q_lora_rank,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("embed", "q_lora"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.q_a_layernorm = RMSNorm(
+        num_features=self.q_lora_rank,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        epsilon=config.normalization_layer_epsilon,
+        kernel_axes=("norm",),
+        rngs=self.rngs,
+    )
+    self.q_b_proj = linears.DenseGeneral(
+        self.q_lora_rank,
+        self.num_heads * self.qk_nope_head_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("q_lora", "heads"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+
+    # Key/Value Projections
+    self.kv_a_proj_with_mqa = linears.DenseGeneral(
+        self.emb_dim,
+        self.kv_lora_rank,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("embed", "kv_lora"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.kv_a_layernorm = RMSNorm(
+        num_features=self.kv_lora_rank,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        epsilon=config.normalization_layer_epsilon,
+        kernel_axes=("norm",),
+        rngs=self.rngs,
+    )
+    self.kv_b_proj = linears.DenseGeneral(
+        self.kv_lora_rank,
+        self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("kv_lora", "heads"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+
+    # Output projection
+    self.o_proj = linears.DenseGeneral(
+        self.num_heads * self.v_head_dim,
+        self.emb_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("heads", "embed"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+
+  def __call__(
+      self,
+      inputs_q: Array,
+      inputs_kv: Array | None = None,
+      decoder_segment_ids: Array | None = None,
+      decoder_positions: Array | None = None,
+      **kwargs,
+  ) -> tuple[Array, None]:
+    x = inputs_q
+    b, s, _ = x.shape
+
+    # Query: [B, S, Q_LORA] -> [B, S, Q_LORA] -> [B, S, H * D] -> [B, S, H, D]
+    q_resid = self.q_a_layernorm(self.q_a_proj(x))
+    q = self.q_b_proj(q_resid)
+    q = jnp.reshape(q, (b, s, self.num_heads, self.qk_nope_head_dim))
+
+    # Key / Value: [B, S, KV_LORA] -> [B, S, KV_LORA] -> [B, S, H * (D_K + D_V)]
+    compressed_kv = self.kv_a_layernorm(self.kv_a_proj_with_mqa(x))
+    kv_b = self.kv_b_proj(compressed_kv)
+    kv_b = jnp.reshape(kv_b, (b, s, self.num_heads, self.qk_nope_head_dim + self.v_head_dim))
+    k = kv_b[..., : self.qk_nope_head_dim]
+    v = kv_b[..., self.qk_nope_head_dim :]
+
+    # [B, H, S, D]
+    q = jnp.swapaxes(q, 1, 2)
+    k = jnp.swapaxes(k, 1, 2)
+    v = jnp.swapaxes(v, 1, 2)
+
+    # Scaled dot-product causal attention
+    scores = jnp.einsum("bhqd,bhkd->bhqk", q, k) * self.scaling
+
+    causal_mask = jnp.tril(jnp.ones((s, s), dtype=jnp.bool_))
+    mask_value = -1e9
+    scores = jnp.where(causal_mask[None, None, :, :], scores, mask_value)
+
+    attn_weights = jax.nn.softmax(scores.astype(jnp.float32), axis=-1).astype(self.dtype)
+    attn_out = jnp.einsum("bhqk,bhkd->bhqd", attn_weights, v)
+
+    # [B, S, H * D]
+    attn_out = jnp.swapaxes(attn_out, 1, 2)
+    attn_out = jnp.reshape(attn_out, (b, s, self.num_heads * self.v_head_dim))
+
+    out = self.o_proj(attn_out)
+    return out, None
+
+
 class Glm5NextDenseMLP(nnx.Module):
   """GLM-5.3-Flash Dense MLP with SwiGLU clamping."""
 
@@ -338,7 +487,7 @@ class Glm5NextDenseMLP(nnx.Module):
 
 
 class Glm5NextDecoderLayer(nnx.Module):
-  """GLM-5.3-Flash Decoder Layer wrapping Attention and MLP in mHC blocks."""
+  """GLM-5.3-Flash Decoder Layer wrapping Attention and MLP/MoE in mHC blocks."""
 
   def __init__(
       self,
@@ -373,21 +522,44 @@ class Glm5NextDecoderLayer(nnx.Module):
         rngs=self.rngs,
     )
 
-    self.attention = Glm5NextAttention(
-        config=config,
-        mesh=self.mesh,
-        model_mode=self.model_mode,
-        rngs=self.rngs,
-    )
-    self.mlp = Glm5NextDenseMLP(
-        config=config,
-        mesh=self.mesh,
-        in_features=config.emb_dim,
-        intermediate_dim=config.mlp_dim,
-        quant=self.quant,
-        model_mode=self.model_mode,
-        rngs=self.rngs,
-    )
+    is_sparse_attn = (layer_idx + 1) % config.inhomogeneous_layer_cycle_interval == 0
+    if is_sparse_attn:
+      self.attention = Glm5NextSparseAttention(
+          config=config,
+          mesh=self.mesh,
+          model_mode=self.model_mode,
+          rngs=self.rngs,
+      )
+    else:
+      self.attention = Glm5NextAttention(
+          config=config,
+          mesh=self.mesh,
+          model_mode=self.model_mode,
+          rngs=self.rngs,
+      )
+
+    self.is_moe = layer_idx >= getattr(config, "first_num_dense_layers", 3)
+    if self.is_moe:
+      self.mlp = moe.RoutedAndSharedMoE(
+          config=self.config,
+          mesh=self.mesh,
+          kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+          kernel_axes=("embed_moe", None),
+          dtype=self.config.dtype,
+          weight_dtype=self.config.weight_dtype,
+          quant=quant,
+          rngs=rngs,
+      )
+    else:
+      self.mlp = Glm5NextDenseMLP(
+          config=config,
+          mesh=self.mesh,
+          in_features=config.emb_dim,
+          intermediate_dim=config.mlp_dim,
+          quant=self.quant,
+          model_mode=self.model_mode,
+          rngs=self.rngs,
+      )
 
     self.attn_hc = mhc.ManifoldConstrainedHyperConnections(
         config=config,
@@ -421,11 +593,12 @@ class Glm5NextDecoderLayer(nnx.Module):
         mhc_type=HyperConnectionType.ATTENTION,
     )
 
+    ffn_type = HyperConnectionType.MLP_MOE if self.is_moe else HyperConnectionType.MLP_DENSE
     x, _ = self.ffn_hc(
         norm_fn=self.post_attention_layernorm,
         branch_fn=self.mlp,
         x=x,
-        mhc_type=HyperConnectionType.MLP_DENSE,
+        mhc_type=ffn_type,
     )
 
     return x, None

--- a/src/maxtext/models/glm5_next.py
+++ b/src/maxtext/models/glm5_next.py
@@ -19,35 +19,12 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from maxtext.common.common_types import Array, Config, HyperConnectionType, MODEL_MODE_TRAIN
-from maxtext.layers import initializers, linears, mhc
+from maxtext.layers import initializers, linears, mhc, nnx_wrappers
 from maxtext.layers.normalizations import RMSNorm
 
 
-def causal_conv1d(
-    inputs: Array,
-    weight: Array,
-    bias: Array | None = None,
-) -> Array:
-  """1D depthwise causal convolution for KDA attention.
-
-  inputs: [B, S, C]
-  weight: [K, C] (depthwise filter of kernel size K and channels C)
-  """
-  k, c = weight.shape
-  pad_inputs = jnp.pad(inputs, ((0, 0), (k - 1, 0), (0, 0)))
-  # Conv in JAX with dimension numbers (B, S, C), (K, 1, C)
-  w = weight[:, None, :]  # [K, 1, C]
-  out = jax.lax.conv_general_dilated(
-      lhs=pad_inputs,
-      rhs=w,
-      window_strides=(1,),
-      padding="VALID",
-      dimension_numbers=("NHC", "HIO", "NHC"),
-      feature_group_count=c,
-  )
-  if bias is not None:
-    out = out + bias
-  return out
+def l2norm(t: Array, eps: float = 1e-6) -> Array:
+  return t * jax.lax.rsqrt(jnp.sum(t * t, axis=-1, keepdims=True) + eps)
 
 
 class Glm5NextAttention(nnx.Module):
@@ -68,13 +45,13 @@ class Glm5NextAttention(nnx.Module):
     self.weight_dtype = config.weight_dtype
 
     self.emb_dim = config.emb_dim
-    self.num_heads = config.num_query_heads
-    self.head_dim = config.head_dim
-    self.kda_conv_size = getattr(config, "kda_conv_size", 4)
+    self.num_heads = config.linear_num_heads
+    self.head_dim = config.linear_head_dim
+    self.kda_conv_size = config.linear_conv_kernel_dim
     self.conv_dim = self.num_heads * self.head_dim
 
     # Projections
-    self.q_proj = linears.Dense(
+    self.q_proj = linears.DenseGeneral(
         self.emb_dim,
         self.conv_dim,
         dtype=self.dtype,
@@ -85,7 +62,7 @@ class Glm5NextAttention(nnx.Module):
         mesh=self.mesh,
         rngs=self.rngs,
     )
-    self.k_proj = linears.Dense(
+    self.k_proj = linears.DenseGeneral(
         self.emb_dim,
         self.conv_dim,
         dtype=self.dtype,
@@ -96,7 +73,7 @@ class Glm5NextAttention(nnx.Module):
         mesh=self.mesh,
         rngs=self.rngs,
     )
-    self.v_proj = linears.Dense(
+    self.v_proj = linears.DenseGeneral(
         self.emb_dim,
         self.conv_dim,
         dtype=self.dtype,
@@ -107,7 +84,7 @@ class Glm5NextAttention(nnx.Module):
         mesh=self.mesh,
         rngs=self.rngs,
     )
-    self.b_proj = linears.Dense(
+    self.b_proj = linears.DenseGeneral(
         self.emb_dim,
         self.num_heads,
         dtype=self.dtype,
@@ -118,51 +95,51 @@ class Glm5NextAttention(nnx.Module):
         mesh=self.mesh,
         rngs=self.rngs,
     )
-    self.f_a_proj = linears.Dense(
+    self.f_a_proj = linears.DenseGeneral(
         self.emb_dim,
-        self.num_heads,
+        self.head_dim,
         dtype=self.dtype,
         weight_dtype=self.weight_dtype,
         use_bias=False,
         kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
-        kernel_axes=("embed", "heads"),
+        kernel_axes=("embed", "head_dim"),
         mesh=self.mesh,
         rngs=self.rngs,
     )
-    self.f_b_proj = linears.Dense(
-        self.num_heads,
-        self.num_heads,
-        dtype=self.dtype,
-        weight_dtype=self.weight_dtype,
-        use_bias=False,
-        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
-        kernel_axes=("heads", "heads"),
-        mesh=self.mesh,
-        rngs=self.rngs,
-    )
-    self.g_a_proj = linears.Dense(
-        self.emb_dim,
-        self.num_heads,
-        dtype=self.dtype,
-        weight_dtype=self.weight_dtype,
-        use_bias=False,
-        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
-        kernel_axes=("embed", "heads"),
-        mesh=self.mesh,
-        rngs=self.rngs,
-    )
-    self.g_b_proj = linears.Dense(
-        self.num_heads,
+    self.f_b_proj = linears.DenseGeneral(
+        self.head_dim,
         self.conv_dim,
         dtype=self.dtype,
         weight_dtype=self.weight_dtype,
         use_bias=False,
         kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
-        kernel_axes=("heads", "heads"),
+        kernel_axes=("head_dim", "heads"),
         mesh=self.mesh,
         rngs=self.rngs,
     )
-    self.o_proj = linears.Dense(
+    self.g_a_proj = linears.DenseGeneral(
+        self.emb_dim,
+        self.head_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("embed", "head_dim"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.g_b_proj = linears.DenseGeneral(
+        self.head_dim,
+        self.conv_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("head_dim", "heads"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.o_proj = linears.DenseGeneral(
         self.conv_dim,
         self.emb_dim,
         dtype=self.dtype,
@@ -190,15 +167,15 @@ class Glm5NextAttention(nnx.Module):
         jnp.zeros((self.num_heads,), dtype=self.weight_dtype),
     )
     self.dt_bias = nnx.Param(
-        jnp.zeros((self.num_heads,), dtype=self.weight_dtype),
+        jnp.zeros((self.conv_dim,), dtype=self.weight_dtype),
     )
 
     self.o_norm = RMSNorm(
-        dim=self.head_dim,
+        num_features=self.head_dim,
         dtype=self.dtype,
         weight_dtype=self.weight_dtype,
         epsilon=config.normalization_layer_epsilon,
-        mesh=self.mesh,
+        kernel_axes=("head_dim",),
         rngs=self.rngs,
     )
 
@@ -221,66 +198,143 @@ class Glm5NextAttention(nnx.Module):
     conv_out = jax.nn.silu(self.conv1d(pad_qkv))
     q, k, v = jnp.split(conv_out, 3, axis=-1)
 
-    # Beta gating (dt)
+    # Per-head update strength (beta).
     b_val = self.b_proj(x)
-    dt = jax.nn.softplus(b_val + self.dt_bias[...])
+    beta = jax.nn.sigmoid(b_val)[..., None]
 
-    # Forget gate (g)
+    # Per-channel forget gate.
     f_a = self.f_a_proj(x)
     f_b = self.f_b_proj(f_a)
-    a_val = -jnp.exp(self.A_log[...].astype(jnp.float32))
-    g = jnp.exp(a_val * dt * jax.nn.sigmoid(f_b))
+    decay_rate = jnp.exp(self.A_log[...].astype(jnp.float32))[None, None, :, None]
+    f_per_channel = jnp.reshape(f_b + self.dt_bias[...], (b, s, self.num_heads, self.head_dim))
+    g_log = -5.0 * jax.nn.sigmoid(decay_rate * f_per_channel)
+    g = jnp.exp(g_log)
 
     # Output gate
     g_a = self.g_a_proj(x)
     g_b = self.g_b_proj(g_a)
-    out_gate = jax.nn.sigmoid(g_b)
+    gate = jnp.reshape(g_b, (b, s, self.num_heads, self.head_dim))
 
     # Reshape into [B, S, H, D]
     q = jnp.reshape(q, (b, s, self.num_heads, self.head_dim))
     k = jnp.reshape(k, (b, s, self.num_heads, self.head_dim))
     v = jnp.reshape(v, (b, s, self.num_heads, self.head_dim))
 
-    # Gated Delta recurrence / causal scan
-    q = q * (self.head_dim**-0.5)
-    beta = dt[..., None]
-    k_beta = k * beta
+    # L2 Norm and scale
+    q = l2norm(q) * (self.head_dim**-0.5)
+    k = l2norm(k)
 
     def scan_step(state, inputs):
-      g_t, q_t, k_t, v_t, k_beta_t = inputs
-      g_t = g_t[..., None, None]
+      g_t, q_t, k_t, v_t, beta_t = inputs
+      g_t = g_t[..., None]
       state = state * g_t
-      kv_mem = jnp.einsum("hd,he->hde", state, k_t)
-      delta = v_t - kv_mem
-      state = state + jnp.einsum("hd,he->hde", delta, k_beta_t)
+      kv_mem = jnp.einsum("hde,hd->he", state, k_t)
+      delta = (v_t - kv_mem) * beta_t
+      state = state + jnp.einsum("hd,he->hde", k_t, delta)
       out_t = jnp.einsum("hde,hd->he", state, q_t)
       return state, out_t
 
     init_state = jnp.zeros((b, self.num_heads, self.head_dim, self.head_dim), dtype=q.dtype)
 
-    def scan_over_seq(init_s, q_seq, k_seq, v_seq, k_b_seq, g_seq):
+    def scan_over_seq(init_s, q_seq, k_seq, v_seq, b_seq, g_seq):
       _, seq_out = jax.lax.scan(
           scan_step,
           init_s,
-          (g_seq, q_seq, k_seq, v_seq, k_b_seq),
+          (g_seq, q_seq, k_seq, v_seq, b_seq),
       )
       return seq_out
 
     inputs_q_t = jnp.swapaxes(q, 0, 1)
     inputs_k_t = jnp.swapaxes(k, 0, 1)
     inputs_v_t = jnp.swapaxes(v, 0, 1)
-    inputs_kb_t = jnp.swapaxes(k_beta, 0, 1)
+    inputs_b_t = jnp.swapaxes(beta, 0, 1)
     inputs_g_t = jnp.swapaxes(g, 0, 1)
 
     scan_vmap = jax.vmap(scan_over_seq, in_axes=(0, 1, 1, 1, 1, 1), out_axes=1)
-    scan_out = scan_vmap(init_state, inputs_q_t, inputs_k_t, inputs_v_t, inputs_kb_t, inputs_g_t)
+    scan_out = scan_vmap(init_state, inputs_q_t, inputs_k_t, inputs_v_t, inputs_b_t, inputs_g_t)
     scan_out = jnp.swapaxes(scan_out, 0, 1)
 
-    norm_out = self.o_norm(scan_out)
+    norm_out = self.o_norm(scan_out) * jax.nn.sigmoid(gate)
     norm_flat = jnp.reshape(norm_out, (b, s, self.conv_dim))
-    gated_out = norm_flat * out_gate
-    output = self.o_proj(gated_out)
+    output = self.o_proj(norm_flat)
     return output, None
+
+
+class Glm5NextDenseMLP(nnx.Module):
+  """GLM-5.3-Flash Dense MLP with SwiGLU clamping."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      in_features: int,
+      intermediate_dim: int,
+      rngs: nnx.Rngs,
+      quant=None,
+      model_mode: str = MODEL_MODE_TRAIN,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.in_features = in_features
+    self.intermediate_dim = intermediate_dim
+    self.dtype = config.dtype
+    self.weight_dtype = config.weight_dtype
+    self.swiglu_limit = getattr(config, "swiglu_limit", 10.0)
+
+    self.wi_0 = linears.DenseGeneral(
+        in_features_shape=in_features,
+        out_features_shape=self.intermediate_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed", "mlp"),
+        quant=quant,
+        use_bias=False,
+        shard_mode=config.shard_mode,
+        matmul_precision=config.matmul_precision,
+        mesh=self.mesh,
+        rngs=rngs,
+    )
+    self.wi_1 = linears.DenseGeneral(
+        in_features_shape=in_features,
+        out_features_shape=self.intermediate_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed", "mlp"),
+        quant=quant,
+        use_bias=False,
+        shard_mode=config.shard_mode,
+        matmul_precision=config.matmul_precision,
+        mesh=self.mesh,
+        rngs=rngs,
+    )
+    self.wo = linears.DenseGeneral(
+        in_features_shape=self.intermediate_dim,
+        out_features_shape=in_features,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("mlp", "embed"),
+        quant=quant,
+        use_bias=False,
+        shard_mode=config.shard_mode,
+        matmul_precision=config.matmul_precision,
+        mesh=self.mesh,
+        rngs=rngs,
+    )
+
+  def __call__(
+      self,
+      inputs: Array,
+      **kwargs,
+  ) -> Array:
+    gate = self.wi_0(inputs)
+    up = self.wi_1(inputs)
+    gate = jnp.minimum(gate, self.swiglu_limit)
+    up = jnp.clip(up, -self.swiglu_limit, self.swiglu_limit)
+    act = jax.nn.silu(gate) * up
+    return self.wo(act)
 
 
 class Glm5NextDecoderLayer(nnx.Module):
@@ -293,27 +347,29 @@ class Glm5NextDecoderLayer(nnx.Module):
       model_mode: str,
       layer_idx: int,
       rngs: nnx.Rngs,
+      quant=None,
   ):
     self.config = config
     self.mesh = mesh
     self.model_mode = model_mode
     self.layer_idx = layer_idx
+    self.quant = quant
     self.rngs = rngs
 
     self.input_layernorm = RMSNorm(
-        dim=config.emb_dim,
+        num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
         epsilon=config.normalization_layer_epsilon,
-        mesh=self.mesh,
+        kernel_axes=("norm",),
         rngs=self.rngs,
     )
     self.post_attention_layernorm = RMSNorm(
-        dim=config.emb_dim,
+        num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
         epsilon=config.normalization_layer_epsilon,
-        mesh=self.mesh,
+        kernel_axes=("norm",),
         rngs=self.rngs,
     )
 
@@ -323,20 +379,25 @@ class Glm5NextDecoderLayer(nnx.Module):
         model_mode=self.model_mode,
         rngs=self.rngs,
     )
-    self.mlp = linears.MlpBlock(
+    self.mlp = Glm5NextDenseMLP(
         config=config,
         mesh=self.mesh,
+        in_features=config.emb_dim,
+        intermediate_dim=config.mlp_dim,
+        quant=self.quant,
         model_mode=self.model_mode,
         rngs=self.rngs,
     )
 
     self.attn_hc = mhc.ManifoldConstrainedHyperConnections(
         config=config,
+        dim=config.emb_dim,
         mesh=self.mesh,
         rngs=self.rngs,
     )
     self.ffn_hc = mhc.ManifoldConstrainedHyperConnections(
         config=config,
+        dim=config.emb_dim,
         mesh=self.mesh,
         rngs=self.rngs,
     )
@@ -348,6 +409,7 @@ class Glm5NextDecoderLayer(nnx.Module):
       decoder_positions: Array | None = None,
       deterministic: bool = True,
       model_mode: str = MODEL_MODE_TRAIN,
+      **kwargs,
   ) -> tuple[Array, None]:
     """Forward pass for GLM-5.3-Flash Decoder Layer."""
     x = inputs
@@ -367,3 +429,9 @@ class Glm5NextDecoderLayer(nnx.Module):
     )
 
     return x, None
+
+
+Glm5NextDecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    Glm5NextDecoderLayer,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)

--- a/src/maxtext/models/glm5_next.py
+++ b/src/maxtext/models/glm5_next.py
@@ -1,0 +1,369 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GLM-5.3-Flash / GLM-5-Next model components."""
+
+from flax import nnx
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh
+from maxtext.common.common_types import Array, Config, HyperConnectionType, ModelMode
+from maxtext.layers import initializers, linears, mhc
+from maxtext.layers.normalizations import RMSNorm
+
+
+def causal_conv1d(
+    inputs: Array,
+    weight: Array,
+    bias: Array | None = None,
+) -> Array:
+  """1D depthwise causal convolution for KDA attention.
+
+  inputs: [B, S, C]
+  weight: [K, C] (depthwise filter of kernel size K and channels C)
+  """
+  k, c = weight.shape
+  pad_inputs = jnp.pad(inputs, ((0, 0), (k - 1, 0), (0, 0)))
+  # Conv in JAX with dimension numbers (B, S, C), (K, 1, C)
+  w = weight[:, None, :]  # [K, 1, C]
+  out = jax.lax.conv_general_dilated(
+      lhs=pad_inputs,
+      rhs=w,
+      window_strides=(1,),
+      padding="VALID",
+      dimension_numbers=("NHC", "HIO", "NHC"),
+      feature_group_count=c,
+  )
+  if bias is not None:
+    out = out + bias
+  return out
+
+
+class Glm5NextAttention(nnx.Module):
+  """GLM-5.3-Flash KDA (Knowledge-Driven Attention / Gated Delta Attention) Layer."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: ModelMode,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.rngs = rngs
+    self.dtype = config.dtype
+    self.weight_dtype = config.weight_dtype
+
+    self.emb_dim = config.emb_dim
+    self.num_heads = config.num_query_heads
+    self.head_dim = config.head_dim
+    self.kda_conv_size = getattr(config, "kda_conv_size", 4)
+    self.conv_dim = self.num_heads * self.head_dim
+
+    # Projections
+    self.q_proj = linears.Dense(
+        self.emb_dim,
+        self.conv_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("embed", "q_heads"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.k_proj = linears.Dense(
+        self.emb_dim,
+        self.conv_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("embed", "kv_heads"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.v_proj = linears.Dense(
+        self.emb_dim,
+        self.conv_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("embed", "kv_heads"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.b_proj = linears.Dense(
+        self.emb_dim,
+        self.num_heads,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("embed", "heads"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.f_a_proj = linears.Dense(
+        self.emb_dim,
+        self.num_heads,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("embed", "heads"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.f_b_proj = linears.Dense(
+        self.num_heads,
+        self.num_heads,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("heads", "heads"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.g_a_proj = linears.Dense(
+        self.emb_dim,
+        self.num_heads,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("embed", "heads"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.g_b_proj = linears.Dense(
+        self.num_heads,
+        self.conv_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("heads", "heads"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.o_proj = linears.Dense(
+        self.conv_dim,
+        self.emb_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        use_bias=False,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "normal"),
+        kernel_axes=("heads", "embed"),
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+
+    # Conv1D on concatenated Q, K, V
+    conv_features = 3 * self.conv_dim
+    self.conv1d = nnx.Conv(
+        in_features=conv_features,
+        out_features=conv_features,
+        kernel_size=(self.kda_conv_size,),
+        feature_group_count=conv_features,
+        use_bias=False,
+        padding="VALID",
+        rngs=self.rngs,
+    )
+
+    self.A_log = nnx.Param(
+        jnp.zeros((self.num_heads,), dtype=self.weight_dtype),
+    )
+    self.dt_bias = nnx.Param(
+        jnp.zeros((self.num_heads,), dtype=self.weight_dtype),
+    )
+
+    self.o_norm = RMSNorm(
+        dim=self.head_dim,
+        dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
+        epsilon=config.normalization_layer_epsilon,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+
+  def __call__(
+      self,
+      inputs_q: Array,
+      inputs_kv: Array | None = None,
+      **kwargs,
+  ) -> tuple[Array, None]:
+    x = inputs_q
+    b, s, _ = x.shape
+
+    q = self.q_proj(x)
+    k = self.k_proj(x)
+    v = self.v_proj(x)
+
+    # 1D causal convolution on concatenated (q, k, v)
+    qkv = jnp.concatenate([q, k, v], axis=-1)
+    pad_qkv = jnp.pad(qkv, ((0, 0), (self.kda_conv_size - 1, 0), (0, 0)))
+    conv_out = jax.nn.silu(self.conv1d(pad_qkv))
+    q, k, v = jnp.split(conv_out, 3, axis=-1)
+
+    # Beta gating (dt)
+    b_val = self.b_proj(x)
+    dt = jax.nn.softplus(b_val + self.dt_bias[...])
+
+    # Forget gate (g)
+    f_a = self.f_a_proj(x)
+    f_b = self.f_b_proj(f_a)
+    a_val = -jnp.exp(self.A_log[...].astype(jnp.float32))
+    g = jnp.exp(a_val * dt * jax.nn.sigmoid(f_b))
+
+    # Output gate
+    g_a = self.g_a_proj(x)
+    g_b = self.g_b_proj(g_a)
+    out_gate = jax.nn.sigmoid(g_b)
+
+    # Reshape into [B, S, H, D]
+    q = jnp.reshape(q, (b, s, self.num_heads, self.head_dim))
+    k = jnp.reshape(k, (b, s, self.num_heads, self.head_dim))
+    v = jnp.reshape(v, (b, s, self.num_heads, self.head_dim))
+
+    # Gated Delta recurrence / causal scan
+    q = q * (self.head_dim**-0.5)
+    beta = dt[..., None]
+    k_beta = k * beta
+
+    def scan_step(state, inputs):
+      g_t, q_t, k_t, v_t, k_beta_t = inputs
+      g_t = g_t[..., None, None]
+      state = state * g_t
+      kv_mem = jnp.einsum("hd,he->hde", state, k_t)
+      delta = v_t - kv_mem
+      state = state + jnp.einsum("hd,he->hde", delta, k_beta_t)
+      out_t = jnp.einsum("hde,hd->he", state, q_t)
+      return state, out_t
+
+    init_state = jnp.zeros((b, self.num_heads, self.head_dim, self.head_dim), dtype=q.dtype)
+
+    def scan_over_seq(init_s, q_seq, k_seq, v_seq, k_b_seq, g_seq):
+      _, seq_out = jax.lax.scan(
+          scan_step,
+          init_s,
+          (g_seq, q_seq, k_seq, v_seq, k_b_seq),
+      )
+      return seq_out
+
+    inputs_q_t = jnp.swapaxes(q, 0, 1)
+    inputs_k_t = jnp.swapaxes(k, 0, 1)
+    inputs_v_t = jnp.swapaxes(v, 0, 1)
+    inputs_kb_t = jnp.swapaxes(k_beta, 0, 1)
+    inputs_g_t = jnp.swapaxes(g, 0, 1)
+
+    scan_vmap = jax.vmap(scan_over_seq, in_axes=(0, 1, 1, 1, 1, 1), out_axes=1)
+    scan_out = scan_vmap(init_state, inputs_q_t, inputs_k_t, inputs_v_t, inputs_kb_t, inputs_g_t)
+    scan_out = jnp.swapaxes(scan_out, 0, 1)
+
+    norm_out = self.o_norm(scan_out)
+    norm_flat = jnp.reshape(norm_out, (b, s, self.conv_dim))
+    gated_out = norm_flat * out_gate
+    output = self.o_proj(gated_out)
+    return output, None
+
+
+class Glm5NextDecoderLayer(nnx.Module):
+  """GLM-5.3-Flash Decoder Layer wrapping Attention and MLP in mHC blocks."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: ModelMode,
+      layer_idx: int,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.layer_idx = layer_idx
+    self.rngs = rngs
+
+    self.input_layernorm = RMSNorm(
+        dim=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        epsilon=config.normalization_layer_epsilon,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.post_attention_layernorm = RMSNorm(
+        dim=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        epsilon=config.normalization_layer_epsilon,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+
+    self.attention = Glm5NextAttention(
+        config=config,
+        mesh=self.mesh,
+        model_mode=self.model_mode,
+        rngs=self.rngs,
+    )
+    self.mlp = linears.MlpBlock(
+        config=config,
+        mesh=self.mesh,
+        model_mode=self.model_mode,
+        rngs=self.rngs,
+    )
+
+    self.attn_hc = mhc.ManifoldConstrainedHyperConnections(
+        config=config,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.ffn_hc = mhc.ManifoldConstrainedHyperConnections(
+        config=config,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+
+  def __call__(
+      self,
+      inputs: Array,
+      decoder_segment_ids: Array | None = None,
+      decoder_positions: Array | None = None,
+      deterministic: bool = True,
+      model_mode: ModelMode = "train",
+  ) -> tuple[Array, None]:
+    """Forward pass for GLM-5.3-Flash Decoder Layer."""
+    x = inputs
+
+    x, _ = self.attn_hc(
+        norm_fn=self.input_layernorm,
+        branch_fn=self.attention,
+        x=x,
+        mhc_type=HyperConnectionType.ATTENTION,
+    )
+
+    x, _ = self.ffn_hc(
+        norm_fn=self.post_attention_layernorm,
+        branch_fn=self.mlp,
+        x=x,
+        mhc_type=HyperConnectionType.MLP_DENSE,
+    )
+
+    return x, None

--- a/src/maxtext/utils/globals.py
+++ b/src/maxtext/utils/globals.py
@@ -79,6 +79,7 @@ HF_IDS = {
     "deepseek3-671b": "deepseek-ai/DeepSeek-V3",
     "deepseek3.2-671b": "deepseek-ai/DeepSeek-V3.2",
     "deepseek4-284b": "deepseek-ai/DeepSeek-V4-Flash",
+    "glm5.3-flash": "zai-org/GLM-5.3-Flash",
     "gpt-oss-20b": "unsloth/gpt-oss-20b-BF16",
     "gpt-oss-120b": "unsloth/gpt-oss-120b-BF16",
     "qwen3-omni-30b-a3b": "Qwen/Qwen3-Omni-30B-A3B-Instruct",

--- a/tests/unit/glm5_3_components_test.py
+++ b/tests/unit/glm5_3_components_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit test verifying MaxText GLM-5.3-Flash / GLM-5-Next layer components against PyTorch reference."""
+"""Shape and smoke tests for the MaxText GLM-5.3-Flash layer components."""
 
 import unittest
 from flax import nnx
@@ -23,11 +23,10 @@ from maxtext.configs import pyconfig
 from maxtext.layers import mhc
 from maxtext.models.glm5_next import Glm5NextAttention, Glm5NextDecoderLayer, Glm5NextDenseMLP
 import numpy as np
-import torch
 
 
-class Glm5NextVsReferenceTest(unittest.TestCase):
-  """Tests comparing individual MaxText GLM-5.3-Flash components against reference PyTorch implementation."""
+class Glm53FlashComponentsTest(unittest.TestCase):
+  """Tests individual MaxText GLM-5.3-Flash components."""
 
   def setUp(self):
     super().setUp()
@@ -36,6 +35,15 @@ class Glm5NextVsReferenceTest(unittest.TestCase):
             "src/maxtext/configs/base.yml",
             "model_name=glm5.3-flash",
             "base_num_decoder_layers=1",
+            "base_emb_dim=16",
+            "base_mlp_dim=32",
+            "base_num_query_heads=2",
+            "base_num_kv_heads=2",
+            "head_dim=4",
+            "linear_num_heads=2",
+            "linear_head_dim=4",
+            "vocab_size=32",
+            "mhc_expansion_rate=2",
             "scan_layers=false",
             "override_model_config=true",
             "dtype=float32",
@@ -46,11 +54,10 @@ class Glm5NextVsReferenceTest(unittest.TestCase):
     )
     self.mesh = jax.sharding.Mesh(jax.devices()[:1], ("data",))
     self.rngs = nnx.Rngs(0)
-    torch.manual_seed(42)
     np.random.seed(42)
 
   def test_mhc_layer(self):
-    """Tests MaxText ManifoldConstrainedHyperConnections against reference implementation."""
+    """Tests the mHC output shape and numerical sanity."""
     mhc_jax = mhc.ManifoldConstrainedHyperConnections(
         config=self.config,
         dim=self.config.emb_dim,
@@ -92,7 +99,7 @@ class Glm5NextVsReferenceTest(unittest.TestCase):
     self.assertFalse(np.isnan(np.asarray(out_jax)).any())
 
   def test_kda_attention_layer(self):
-    """Tests MaxText Glm5NextAttention against PyTorch reference delta attention logic."""
+    """Tests the KDA attention output shape and numerical sanity."""
     attn_jax = Glm5NextAttention(
         config=self.config,
         mesh=self.mesh,

--- a/tests/unit/glm5_next_vs_reference_test.py
+++ b/tests/unit/glm5_next_vs_reference_test.py
@@ -21,19 +21,9 @@ import jax.numpy as jnp
 from maxtext.common.common_types import HyperConnectionType
 from maxtext.configs import pyconfig
 from maxtext.layers import mhc
-from maxtext.models.glm5_next import Glm5NextAttention, Glm5NextDecoderLayer
+from maxtext.models.glm5_next import Glm5NextAttention, Glm5NextDecoderLayer, Glm5NextDenseMLP
 import numpy as np
 import torch
-from torch import nn as torch_nn
-import torch.nn.functional as F
-
-
-def np_to_torch(x):
-  return torch.from_numpy(np.array(x, dtype=np.float32))
-
-
-def torch_to_jnp(x):
-  return jnp.array(x.detach().cpu().numpy(), dtype=jnp.float32)
 
 
 class Glm5NextVsReferenceTest(unittest.TestCase):
@@ -41,17 +31,19 @@ class Glm5NextVsReferenceTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.config = pyconfig.initialize_pydantic([
-        "src/maxtext/configs/base.yml",
-        "model_name=glm5.3-flash",
-        "base_num_decoder_layers=1",
-        "scan_layers=false",
-        "override_model_config=true",
-        "dtype=float32",
-        "weight_dtype=float32",
-        "per_device_batch_size=1",
-        "max_target_length=64",
-    ])
+    self.config = pyconfig.initialize_pydantic(
+        [
+            "src/maxtext/configs/base.yml",
+            "model_name=glm5.3-flash",
+            "base_num_decoder_layers=1",
+            "scan_layers=false",
+            "override_model_config=true",
+            "dtype=float32",
+            "weight_dtype=float32",
+            "per_device_batch_size=1",
+            "max_target_length=64",
+        ]
+    )
     self.mesh = jax.sharding.Mesh(jax.devices()[:1], ("data",))
     self.rngs = nnx.Rngs(0)
     torch.manual_seed(42)
@@ -61,6 +53,7 @@ class Glm5NextVsReferenceTest(unittest.TestCase):
     """Tests MaxText ManifoldConstrainedHyperConnections against reference implementation."""
     mhc_jax = mhc.ManifoldConstrainedHyperConnections(
         config=self.config,
+        dim=self.config.emb_dim,
         mesh=self.mesh,
         rngs=self.rngs,
     )
@@ -70,7 +63,7 @@ class Glm5NextVsReferenceTest(unittest.TestCase):
     def dummy_norm(inp):
       return inp
 
-    def dummy_branch(inputs_q, inputs_kv, **kwargs):
+    def dummy_branch(inputs_q, inputs_kv=None, **kwargs):
       return inputs_q * 0.5, None
 
     out_jax, _ = mhc_jax(
@@ -83,12 +76,12 @@ class Glm5NextVsReferenceTest(unittest.TestCase):
     self.assertFalse(np.isnan(np.asarray(out_jax)).any())
 
   def test_dense_mlp_layer(self):
-    """Tests MaxText MlpBlock with SwiGLU against PyTorch reference."""
-    from maxtext.layers import linears
-
-    mlp_jax = linears.MlpBlock(
+    """Tests MaxText Glm5NextDenseMLP with SwiGLU clamping."""
+    mlp_jax = Glm5NextDenseMLP(
         config=self.config,
         mesh=self.mesh,
+        in_features=self.config.emb_dim,
+        intermediate_dim=self.config.mlp_dim,
         model_mode="train",
         rngs=self.rngs,
     )
@@ -96,6 +89,7 @@ class Glm5NextVsReferenceTest(unittest.TestCase):
     x_np = np.random.randn(b, s, d).astype(np.float32)
     out_jax = mlp_jax(jnp.array(x_np))
     self.assertEqual(out_jax.shape, (b, s, d))
+    self.assertFalse(np.isnan(np.asarray(out_jax)).any())
 
   def test_kda_attention_layer(self):
     """Tests MaxText Glm5NextAttention against PyTorch reference delta attention logic."""

--- a/tests/unit/glm5_next_vs_reference_test.py
+++ b/tests/unit/glm5_next_vs_reference_test.py
@@ -1,0 +1,131 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit test verifying MaxText GLM-5.3-Flash / GLM-5-Next layer components against PyTorch reference."""
+
+import unittest
+from flax import nnx
+import jax
+import jax.numpy as jnp
+from maxtext.common.common_types import HyperConnectionType
+from maxtext.configs import pyconfig
+from maxtext.layers import mhc
+from maxtext.models.glm5_next import Glm5NextAttention, Glm5NextDecoderLayer
+import numpy as np
+import torch
+from torch import nn as torch_nn
+import torch.nn.functional as F
+
+
+def np_to_torch(x):
+  return torch.from_numpy(np.array(x, dtype=np.float32))
+
+
+def torch_to_jnp(x):
+  return jnp.array(x.detach().cpu().numpy(), dtype=jnp.float32)
+
+
+class Glm5NextVsReferenceTest(unittest.TestCase):
+  """Tests comparing individual MaxText GLM-5.3-Flash components against reference PyTorch implementation."""
+
+  def setUp(self):
+    super().setUp()
+    self.config = pyconfig.initialize_pydantic([
+        "src/maxtext/configs/base.yml",
+        "model_name=glm5.3-flash",
+        "base_num_decoder_layers=1",
+        "scan_layers=false",
+        "override_model_config=true",
+        "dtype=float32",
+        "weight_dtype=float32",
+        "per_device_batch_size=1",
+        "max_target_length=64",
+    ])
+    self.mesh = jax.sharding.Mesh(jax.devices()[:1], ("data",))
+    self.rngs = nnx.Rngs(0)
+    torch.manual_seed(42)
+    np.random.seed(42)
+
+  def test_mhc_layer(self):
+    """Tests MaxText ManifoldConstrainedHyperConnections against reference implementation."""
+    mhc_jax = mhc.ManifoldConstrainedHyperConnections(
+        config=self.config,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    b, s, k, d = 2, 4, self.config.mhc_expansion_rate, self.config.emb_dim
+    x_np = np.random.randn(b, s, k, d).astype(np.float32)
+
+    def dummy_norm(inp):
+      return inp
+
+    def dummy_branch(inputs_q, inputs_kv, **kwargs):
+      return inputs_q * 0.5, None
+
+    out_jax, _ = mhc_jax(
+        norm_fn=dummy_norm,
+        branch_fn=dummy_branch,
+        x=jnp.array(x_np),
+        mhc_type=HyperConnectionType.ATTENTION,
+    )
+    self.assertEqual(out_jax.shape, (b, s, k, d))
+    self.assertFalse(np.isnan(np.asarray(out_jax)).any())
+
+  def test_dense_mlp_layer(self):
+    """Tests MaxText MlpBlock with SwiGLU against PyTorch reference."""
+    from maxtext.layers import linears
+
+    mlp_jax = linears.MlpBlock(
+        config=self.config,
+        mesh=self.mesh,
+        model_mode="train",
+        rngs=self.rngs,
+    )
+    b, s, d = 2, 4, self.config.emb_dim
+    x_np = np.random.randn(b, s, d).astype(np.float32)
+    out_jax = mlp_jax(jnp.array(x_np))
+    self.assertEqual(out_jax.shape, (b, s, d))
+
+  def test_kda_attention_layer(self):
+    """Tests MaxText Glm5NextAttention against PyTorch reference delta attention logic."""
+    attn_jax = Glm5NextAttention(
+        config=self.config,
+        mesh=self.mesh,
+        model_mode="train",
+        rngs=self.rngs,
+    )
+    b, s, d = 2, 4, self.config.emb_dim
+    x_np = np.random.randn(b, s, d).astype(np.float32)
+    out_jax, _ = attn_jax(inputs_q=jnp.array(x_np))
+    self.assertEqual(out_jax.shape, (b, s, d))
+    self.assertFalse(np.isnan(np.asarray(out_jax)).any())
+
+  def test_decoder_layer(self):
+    """Tests full Glm5NextDecoderLayer forward pass."""
+    layer_jax = Glm5NextDecoderLayer(
+        config=self.config,
+        mesh=self.mesh,
+        model_mode="train",
+        layer_idx=0,
+        rngs=self.rngs,
+    )
+    b, s, k, d = 2, 4, self.config.mhc_expansion_rate, self.config.emb_dim
+    x_np = np.random.randn(b, s, k, d).astype(np.float32)
+    out_jax, _ = layer_jax(jnp.array(x_np))
+    self.assertEqual(out_jax.shape, (b, s, k, d))
+    self.assertFalse(np.isnan(np.asarray(out_jax)).any())
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/utils/forward_pass_logit_checker.py
+++ b/tests/utils/forward_pass_logit_checker.py
@@ -604,8 +604,9 @@ def main(config, test_args):  # pylint: disable=W0621
 
   else:
     """Comparing maxtext model with HF model on-the-fly"""
-    if test_args.hf_model_path == "":
-      raise ValueError("run_hf_model requires hf_model_path")
+    if test_args.hf_model_path == "" and not HF_IDS.get(config.model_name):
+      raise ValueError("run_hf_model requires hf_model_path or a model_name registered in HF_IDS")
+    hf_model_path = test_args.hf_model_path or HF_IDS.get(config.model_name)
 
     hf_token = config.hf_access_token
     # Map MaxText config.dtype to PyTorch dtype
@@ -629,9 +630,40 @@ def main(config, test_args):  # pylint: disable=W0621
     else:
       model_class = AutoModelForCausalLM
 
-    hf_model = model_class.from_pretrained(
-        test_args.hf_model_path, torch_dtype=torch_dtype, token=hf_token, trust_remote_code=test_args.trust_remote_code
-    )
+    hf_config = None
+    if test_args.hf_overrides:
+      import ast  # pylint: disable=import-outside-toplevel
+      import json  # pylint: disable=import-outside-toplevel
+      from transformers import AutoConfig  # pylint: disable=import-outside-toplevel
+
+      if isinstance(test_args.hf_overrides, str):
+        try:
+          overrides = json.loads(test_args.hf_overrides)
+        except json.JSONDecodeError:
+          overrides = ast.literal_eval(test_args.hf_overrides)
+      else:
+        overrides = test_args.hf_overrides
+
+      hf_config = AutoConfig.from_pretrained(hf_model_path, token=hf_token, trust_remote_code=test_args.trust_remote_code)
+      for k, v in overrides.items():
+        setattr(hf_config, k, v)
+        max_logging.log(f"Overriding HF config {k} = {v}")
+
+    if hf_config is not None:
+      hf_model = model_class.from_pretrained(
+          hf_model_path,
+          config=hf_config,
+          torch_dtype=torch_dtype,
+          token=hf_token,
+          trust_remote_code=test_args.trust_remote_code,
+      )
+    else:
+      hf_model = model_class.from_pretrained(
+          hf_model_path,
+          torch_dtype=torch_dtype,
+          token=hf_token,
+          trust_remote_code=test_args.trust_remote_code,
+      )
     hf_lora_path = config.hf_lora_adapter_path
     if hf_lora_path:
       max_logging.log(f"Loading HF PEFT LoRA adapter from {hf_lora_path}")
@@ -781,6 +813,13 @@ if __name__ == "__main__":
       default="linen",
       choices=["linen", "nnx"],
       help="Checkpoint format to load: 'linen' (default) or 'nnx'.",
+  )
+  parser.add_argument(
+      "--hf_overrides",
+      type=str,
+      required=False,
+      default="",
+      help="HuggingFace config overrides formatted as a JSON/dict string, e.g. '{\"num_hidden_layers\": 1}'.",
   )
   parser.add_argument(
       "--trust_remote_code", type=bool, required=False, default=True, help="from_pretrained: trust_remote_code"

--- a/tests/utils/forward_pass_logit_checker.py
+++ b/tests/utils/forward_pass_logit_checker.py
@@ -604,9 +604,8 @@ def main(config, test_args):  # pylint: disable=W0621
 
   else:
     """Comparing maxtext model with HF model on-the-fly"""
-    if test_args.hf_model_path == "" and not HF_IDS.get(config.model_name):
-      raise ValueError("run_hf_model requires hf_model_path or a model_name registered in HF_IDS")
-    hf_model_path = test_args.hf_model_path or HF_IDS.get(config.model_name)
+    if test_args.hf_model_path == "":
+      raise ValueError("run_hf_model requires hf_model_path")
 
     hf_token = config.hf_access_token
     # Map MaxText config.dtype to PyTorch dtype
@@ -634,42 +633,12 @@ def main(config, test_args):  # pylint: disable=W0621
     else:
       model_class = AutoModelForCausalLM
 
-    hf_config = None
-    if test_args.hf_overrides:
-      import ast  # pylint: disable=import-outside-toplevel
-      import json  # pylint: disable=import-outside-toplevel
-      from transformers import AutoConfig  # pylint: disable=import-outside-toplevel
-
-      if isinstance(test_args.hf_overrides, str):
-        try:
-          overrides = json.loads(test_args.hf_overrides)
-        except json.JSONDecodeError:
-          overrides = ast.literal_eval(test_args.hf_overrides)
-      else:
-        overrides = test_args.hf_overrides
-
-      hf_config = AutoConfig.from_pretrained(hf_model_path, token=hf_token, trust_remote_code=test_args.trust_remote_code)
-      for k, v in overrides.items():
-        if hasattr(hf_config, "text_config") and hasattr(hf_config.text_config, k):
-          setattr(hf_config.text_config, k, v)
-        setattr(hf_config, k, v)
-        max_logging.log(f"Overriding HF config {k} = {v}")
-
-    if hf_config is not None:
-      hf_model = model_class.from_pretrained(
-          hf_model_path,
-          config=hf_config,
-          torch_dtype=torch_dtype,
-          token=hf_token,
-          trust_remote_code=test_args.trust_remote_code,
-      )
-    else:
-      hf_model = model_class.from_pretrained(
-          hf_model_path,
-          torch_dtype=torch_dtype,
-          token=hf_token,
-          trust_remote_code=test_args.trust_remote_code,
-      )
+    hf_model = model_class.from_pretrained(
+        test_args.hf_model_path,
+        torch_dtype=torch_dtype,
+        token=hf_token,
+        trust_remote_code=test_args.trust_remote_code,
+    )
     hf_model = hf_model.to(torch_dtype)
     hf_lora_path = config.hf_lora_adapter_path
     if hf_lora_path:
@@ -820,13 +789,6 @@ if __name__ == "__main__":
       default="linen",
       choices=["linen", "nnx"],
       help="Checkpoint format to load: 'linen' (default) or 'nnx'.",
-  )
-  parser.add_argument(
-      "--hf_overrides",
-      type=str,
-      required=False,
-      default="",
-      help="HuggingFace config overrides formatted as a JSON/dict string, e.g. '{\"num_hidden_layers\": 1}'.",
   )
   parser.add_argument(
       "--trust_remote_code", type=bool, required=False, default=True, help="from_pretrained: trust_remote_code"

--- a/tests/utils/forward_pass_logit_checker.py
+++ b/tests/utils/forward_pass_logit_checker.py
@@ -627,6 +627,10 @@ def main(config, test_args):  # pylint: disable=W0621
       from transformers import Qwen3VLForConditionalGeneration  # pylint: disable=import-outside-toplevel
 
       model_class = Qwen3VLForConditionalGeneration
+    elif "glm5" in config.model_name.lower():
+      from transformers import AutoModelForImageTextToText  # pylint: disable=import-outside-toplevel
+
+      model_class = AutoModelForImageTextToText
     else:
       model_class = AutoModelForCausalLM
 
@@ -646,6 +650,8 @@ def main(config, test_args):  # pylint: disable=W0621
 
       hf_config = AutoConfig.from_pretrained(hf_model_path, token=hf_token, trust_remote_code=test_args.trust_remote_code)
       for k, v in overrides.items():
+        if hasattr(hf_config, "text_config") and hasattr(hf_config.text_config, k):
+          setattr(hf_config.text_config, k, v)
         setattr(hf_config, k, v)
         max_logging.log(f"Overriding HF config {k} = {v}")
 
@@ -664,6 +670,7 @@ def main(config, test_args):  # pylint: disable=W0621
           token=hf_token,
           trust_remote_code=test_args.trust_remote_code,
       )
+    hf_model = hf_model.to(torch_dtype)
     hf_lora_path = config.hf_lora_adapter_path
     if hf_lora_path:
       max_logging.log(f"Loading HF PEFT LoRA adapter from {hf_lora_path}")


### PR DESCRIPTION
# Description

Support for **GLM-5.3-Flash** (`zai-org/GLM-5.3-Flash`), including Kimi Delta Attention (KDA), Manifold-Constrained HyperConnections (mHC), DeepSeek-V3 MLA sparse attention, Routed & Shared MoE with SwiGLU clamping, and Hugging Face checkpoint conversion.

- **GLM-5.3 Architecture (`src/maxtext/models/glm5_next.py`)**:
  - Implemented inhomogeneous decoder layer scheduling: KDA Linear Attention for standard layers and MLA Sparse Attention for periodic layers (`inhomogeneous_layer_cycle_interval=4`).
  - Implemented KDA linear attention with 1D causal depthwise convolution, decay rates ($A_{\log}$), forget gate ($g$), and recurrent state updates.
  - Implemented mHC multi-stream residual blocks with Sinkhorn-Knopp doubly-stochastic normalization and unweighted mean stream collapse.
  - Implemented initial Dense SwiGLU layers (`first_num_dense_layers=3`) and subsequent Routed + Shared MoE blocks (288 routed experts + 1 shared expert).

- **MoE Routing & Activation Alignment (`src/maxtext/layers/moe.py`)**:
  - Integrated `glm5_3` / `glm5.3-flash` into `GateLogit` and `RoutedMoE` for Sigmoid scoring, e-score correction bias, top-k selection, and routed scaling factor ($2.5$).
  - Added SwiGLU activation clamping (`swiglu_limit = 10.0`) across routed and shared experts.
  - Handled single routing group (`n_routing_groups: 1`, `topk_routing_group: 1`).

- **Checkpoint Conversion & Dynamic Loading (`src/maxtext/checkpoint_conversion/`)**:
  - Added `GLM5_3_MAXTEXT_TO_HF_PARAM_MAPPING` and `GLM5_3_MAXTEXT_TO_HF_PARAM_HOOK_FN` in `param_mapping.py`.
  - Added support for dequantizing FP8 expert & attention weights (`weight_scale_inv`), parameter transpositions, and mHC parameter decomposition.
  - Registered `glm5.3-flash` in `hf_model_configs.py` and `globals.py`.

- **Configuration (`src/maxtext/configs/models/glm5.3-flash.yml`)**:
  - Added model YAML with full architectural parameters for GLM-5.3-Flash.

---

# Test

End-to-end decode test: [Logs](https://pantheon.corp.google.com/logs/query;cursorTimestamp=2026-09-01T03:56:33.610277326Z;duration=P1D;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22v5p-128-bodaborg-europe-west4-b%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22glm53-flash-decode-slice-job-0-0-%22%0Aseverity%3E%3DDEFAULT%0Atimestamp%3D%222026-09-01T03:56:33.610277326Z%22%0AinsertId%3D%22lwul14iw20jynw97%22;storageScope=project?project=cloud-tpu-multipod-dev).

1. **Unit Tests**:
   - `python -m unittest tests/unit/glm5_3_components_test.py` (all component tests pass).
2. **Logit Validation (`forward_pass_logit_checker.py`)**:
   - Verified 4-layer mini checkpoint (Dense layers 0, 1, 2 + MoE layer 3) against Hugging Face reference:
     - **Top-10 Token Overlap**: 10/10 (100%) across all test prompts.
     - **Jaccard Similarity**: 1.0.
     - **Max Token KL Divergence**: $0.0118 \le 0.10$ threshold (**PASS**).

<details>
<summary><b>Text-only input (USE_MULTIMODAL=false)</b></summary>

```
--- Prompt: I love to ---
INFO:absl:
--- MaxText model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 387        | be                   | 13.1250    |
| 90346      | /from                | 11.1875    |
| 11751      | asts                 | 11.0000    |
| 88070      | plevel               | 10.4375    |
| 1477       | find                 | 9.8750     |
| 6723       | hear                 | 9.8750     |
| 7664       | ads                  | 9.5625     |
| 14715      | asting               | 9.3750     |
| 14968      | asty                 | 9.3125     |
| 7024       | ying                 | 9.2500     |

INFO:absl:
--- HF model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 387        | be                   | 13.0000    |
| 90346      | /from                | 11.2500    |
| 11751      | asts                 | 11.0000    |
| 88070      | plevel               | 10.4375    |
| 1477       | find                 | 9.8750     |
| 6723       | hear                 | 9.8750     |
| 7664       | ads                  | 9.5000     |
| 14715      | asting               | 9.2500     |
| 14968      | asty                 | 9.1875     |
| 7024       | ying                 | 9.1250     |

INFO:absl:
--- Similarity Metrics of Top Tokens ---
INFO:absl:| Metric                         | Value                |
|--------------------------------|----------------------|
| overlap_count                  | 10/10                |
| jaccard_similarity             | 1.0                  |
| rank_agreement_percentage      | 100.0                |

INFO:absl:
Average KL divergence per token (D_KL(P_golden || Q_model)): -2.80e-05
INFO:absl:Per-token KL Divergences: 
['-3.40e-04', '-1.14e-03', '1.39e-03']
INFO:absl:
Max KL divergence for a single token in the set: 1.39e-03
INFO:absl:
--- Prompt: Today is a ---
INFO:absl:
--- MaxText model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 2421       | few                  | 12.7500    |
| 1602       | very                 | 10.7500    |
| 1632       | well                 | 10.7500    |
| 2696       | lot                  | 10.0000    |
| 4583       | complete             | 9.7500     |
| 4013       | series               | 9.5000     |
| 1661       | good                 | 9.4375     |
| 5625       | couple               | 9.3750     |
| 8650       | separate             | 9.3750     |
| 4586       | general              | 9.2500     |

INFO:absl:
--- HF model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 2421       | few                  | 12.6875    |
| 1632       | well                 | 10.7500    |
| 1602       | very                 | 10.6875    |
| 2696       | lot                  | 9.9375     |
| 4583       | complete             | 9.6875     |
| 4013       | series               | 9.4375     |
| 5625       | couple               | 9.3750     |
| 1661       | good                 | 9.3750     |
| 8650       | separate             | 9.3125     |
| 4586       | general              | 9.2500     |

INFO:absl:
--- Similarity Metrics of Top Tokens ---
INFO:absl:| Metric                         | Value                |
|--------------------------------|----------------------|
| overlap_count                  | 10/10                |
| jaccard_similarity             | 1.0                  |
| rank_agreement_percentage      | 60.0                 |

INFO:absl:
Average KL divergence per token (D_KL(P_golden || Q_model)): -4.12e-04
INFO:absl:Per-token KL Divergences: 
['-1.26e-03', '2.27e-03', '-2.24e-03']
INFO:absl:
Max KL divergence for a single token in the set: 2.27e-03
INFO:absl:
--- Prompt: What is the ---
INFO:absl:
--- MaxText model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 2701       | following            | 15.1250    |
| 9272       | ses                  | 14.1250    |
| 1852       | same                 | 13.2500    |
| 1850       | best                 | 11.6250    |
| 29477      | easiest              | 10.4375    |
| 7772       | largest              | 10.4375    |
| 15259      | latter               | 10.2500    |
| 1429       | most                 | 10.2500    |
| 18145      | oret                 | 10.0625    |
| 8425       | highest              | 10.0625    |

INFO:absl:
--- HF model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 2701       | following            | 15.1250    |
| 9272       | ses                  | 14.0625    |
| 1852       | same                 | 13.2500    |
| 1850       | best                 | 11.6875    |
| 15259      | latter               | 10.3750    |
| 29477      | easiest              | 10.3750    |
| 7772       | largest              | 10.3750    |
| 1429       | most                 | 10.2500    |
| 8425       | highest              | 10.0000    |
| 18145      | oret                 | 10.0000    |

INFO:absl:
--- Similarity Metrics of Top Tokens ---
INFO:absl:| Metric                         | Value                |
|--------------------------------|----------------------|
| overlap_count                  | 10/10                |
| jaccard_similarity             | 1.0                  |
| rank_agreement_percentage      | 50.0                 |

INFO:absl:
Average KL divergence per token (D_KL(P_golden || Q_model)): 6.25e-04
INFO:absl:Per-token KL Divergences: 
['-2.20e-03', '2.96e-03', '1.11e-03']
INFO:absl:
Max KL divergence for a single token in the set: 2.96e-03
INFO:absl:
--- Prompt: The city of Lyon sits at the confluence of the Rhone and Saone rivers in eastern... ---
INFO:absl:
--- MaxText model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 1449       | every                | 8.6250     |
| 97789      | chers                | 8.0625     |
| 9031       | cher                 | 7.5938     |
| 81478      | midway               | 7.4375     |
| 566        | he                   | 7.1250     |
| 5019       | everyone             | 7.0938     |
| 1817       | each                 | 7.0625     |
| 17287      | hex                  | 7.0000     |
| 2397       | ched                 | 6.9375     |
| 1340       | she                  | 6.9375     |

INFO:absl:
--- HF model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 1449       | every                | 8.6250     |
| 97789      | chers                | 8.0000     |
| 9031       | cher                 | 7.5312     |
| 81478      | midway               | 7.4375     |
| 566        | he                   | 7.1250     |
| 5019       | everyone             | 7.0938     |
| 1817       | each                 | 7.0938     |
| 17287      | hex                  | 6.9688     |
| 1340       | she                  | 6.9688     |
| 2397       | ched                 | 6.9062     |

INFO:absl:
--- Similarity Metrics of Top Tokens ---
INFO:absl:| Metric                         | Value                |
|--------------------------------|----------------------|
| overlap_count                  | 10/10                |
| jaccard_similarity             | 1.0                  |
| rank_agreement_percentage      | 80.0                 |

INFO:absl:
Average KL divergence per token (D_KL(P_golden || Q_model)): 1.60e-03
INFO:absl:Per-token KL Divergences: 
['-1.66e-04', '4.36e-04', '3.63e-03', '2.15e-03', '4.51e-03', '4.40e-04', '-1.73e-03', '2.46e-03', '-1.01e-03', '-4.70e-04', '2.80e-04', '2.46e-03', '-2.19e-03', '3.12e-05', '-2.48e-03', '1.62e-03', '1.89e-03', '-1.64e-04', '-2.46e-03', '3.97e-03', '2.26e-03', '4.39e-03', '-5.85e-04', '-7.00e-04', '6.03e-03', '-2.91e-03', '-3.89e-03', '2.15e-03', '2.23e-03', '1.27e-03', '4.23e-03', '5.12e-04', '2.40e-03', '-1.09e-03', '2.56e-03', '-5.49e-04', '-5.47e-05', '1.85e-03', '-1.88e-03', '1.07e-03', '5.94e-03', '1.77e-03', '-3.29e-05', '-8.88e-04', '3.80e-03', '3.94e-03', '2.36e-03', '-1.99e-03', '-1.63e-04', '-6.68e-04', '-3.58e-04', '2.11e-03', '3.56e-04', '-2.30e-03', '-3.53e-04', '5.15e-03', '5.24e-03', '4.28e-04', '-2.91e-03', '-6.57e-04', '2.33e-04', '-1.85e-04', '9.95e-04', '7.31e-04', '3.49e-03', '5.08e-03', '-5.20e-04', '1.23e-03', '3.47e-03', '5.28e-03', '2.34e-03', '1.18e-03', '4.19e-03', '3.01e-03', '2.03e-03', '-2.04e-03', '-1.87e-03', '1.68e-04', '-7.07e-04', '3.21e-03', '1.22e-03', '2.29e-03', '3.35e-03', '5.35e-03', '-2.41e-03', '2.55e-03', '-3.13e-05', '1.02e-02', '1.10e-03', '2.07e-03', '3.85e-03', '1.10e-03', '4.38e-03', '3.31e-04', '-2.87e-04', '-4.13e-03', '2.51e-03', '1.36e-03', '-1.15e-03', '-7.74e-04', '1.86e-03', '2.52e-03', '-8.61e-04', '1.69e-03', '-2.24e-03', '4.59e-03', '5.01e-03', '6.64e-05', '3.11e-03', '3.90e-03', '3.92e-03', '2.04e-04', '1.46e-03', '-1.17e-03', '9.81e-04', '1.65e-03', '-9.52e-05', '4.71e-03', '-1.02e-03', '3.98e-03', '4.81e-03', '-8.94e-05', '-7.19e-04', '4.55e-03', '4.13e-03', '2.27e-03', '5.29e-03', '1.46e-03', '-2.26e-03', '-4.38e-05', '3.07e-03', '-3.07e-03', '-5.51e-04', '-2.94e-04', '3.55e-03', '4.24e-03', '1.47e-03', '1.08e-03', '3.98e-03', '2.46e-03', '3.19e-03', '6.35e-04', '9.13e-04', '8.86e-04', '3.85e-04', '6.82e-03', '-8.39e-04', '3.98e-03', '4.54e-03', '-8.77e-04', '-1.40e-03', '9.63e-04', '2.00e-03', '6.01e-03', '1.07e-03', '-2.10e-04', '1.94e-03', '3.46e-03', '4.43e-03', '3.15e-03', '9.97e-04', '2.28e-03', '2.58e-03', '-1.12e-03', '-1.34e-03', '-1.69e-03', '5.01e-03', '-2.83e-03', '-5.31e-04', '4.53e-03', '-2.27e-03', '3.74e-03', '2.52e-03', '2.07e-03', '2.86e-03', '3.44e-03', '6.18e-04', '5.92e-03', '-1.17e-03', '1.05e-03', '-2.14e-04', '2.24e-03', '3.14e-03', '-2.28e-03', '-1.07e-04', '1.22e-03', '1.17e-02', '3.08e-03', '1.73e-03', '-1.93e-03', '4.92e-03', '2.59e-03', '1.91e-03', '-6.20e-04', '-8.81e-05', '6.15e-03', '5.25e-04', '1.26e-03', '-6.99e-04', '-3.63e-04', '-2.13e-03', '8.41e-05', '2.31e-03', '1.15e-03', '4.17e-03', '1.87e-03', '1.83e-03', '-1.53e-04', '3.63e-03', '2.31e-03', '1.93e-04', '1.09e-03', '4.35e-03', '5.12e-03', '-2.68e-04', '1.47e-03', '-1.33e-03', '2.82e-03', '1.60e-03', '3.53e-04', '5.03e-04', '1.63e-03', '5.83e-03', '5.73e-04', '-5.14e-04', '5.68e-04', '4.55e-04', '-4.34e-04', '1.75e-03', '1.15e-03', '3.54e-04', '1.15e-03', '4.61e-03', '-9.20e-04', '3.56e-03', '1.52e-03', '1.13e-03', '1.99e-03', '-1.59e-03', '2.03e-03', '-7.85e-04', '3.34e-03', '2.54e-03', '-3.33e-04', '1.77e-03', '1.16e-03', '-1.09e-03', '2.27e-04', '3.26e-03', '4.25e-03', '-1.83e-04', '1.15e-03', '2.83e-03', '-5.16e-04', '4.67e-03', '3.71e-03', '7.76e-03', '4.97e-03', '1.62e-03', '3.09e-04', '4.75e-03', '2.28e-03', '7.51e-03', '1.94e-03', '1.30e-03', '-4.08e-03', '2.67e-03', '8.23e-04', '6.49e-03', '2.53e-03', '3.15e-04', '2.27e-04', '7.68e-04', '6.64e-03', '5.82e-04', '4.87e-03', '-1.08e-03', '1.65e-03', '1.76e-03', '-6.33e-04', '1.08e-02', '5.19e-03', '-1.81e-03', '1.96e-03', '1.21e-03', '-3.98e-04', '4.70e-03', '-7.85e-04', '-9.31e-04', '3.19e-03', '-2.71e-03', '9.58e-04', '2.21e-03', '1.37e-03', '-4.07e-04', '7.83e-05', '-8.18e-04', '2.40e-03', '-1.03e-03', '-6.23e-04', '-1.12e-03', '-1.48e-03', '4.16e-03', '3.91e-04', '1.29e-04', '4.91e-04', '3.89e-03', '2.63e-03', '6.41e-05', '2.13e-03', '2.04e-03', '3.11e-03', '2.53e-03', '-2.81e-04', '-2.54e-03', '1.32e-03', '3.24e-03', '-1.34e-03', '4.65e-04', '3.56e-03', '3.07e-03', '-2.21e-03', '1.55e-03', '-2.24e-03', '1.40e-03', '1.38e-03', '2.41e-03', '1.29e-03', '1.79e-03', '4.25e-03', '6.35e-04', '1.71e-03', '4.85e-04', '4.58e-03', '1.26e-03', '-4.45e-04', '3.72e-03', '3.57e-03', '1.31e-04', '6.93e-04', '2.14e-03', '3.85e-03', '-1.17e-03', '6.17e-03', '-8.61e-04', '4.00e-03', '2.96e-03', '8.55e-05', '2.25e-03', '2.04e-03', '5.13e-03', '1.91e-03', '3.20e-03', '1.40e-03', '6.75e-03', '4.65e-03', '1.36e-03', '-3.15e-03', '4.15e-03', '-9.06e-04', '1.46e-03', '-7.69e-04', '5.22e-03', '2.17e-03', '5.04e-03', '-3.95e-03', '6.78e-04', '2.74e-03', '1.36e-04', '-5.41e-04', '2.51e-03', '-2.56e-03', '3.26e-03', '6.38e-04', '1.03e-02', '1.10e-02', '-1.80e-03', '2.26e-03', '-2.46e-03', '3.70e-04', '3.41e-03', '-8.61e-04', '4.87e-03', '-2.06e-03', '1.95e-03', '1.42e-04', '-1.74e-03', '1.78e-03', '2.24e-03', '9.88e-05', '-2.26e-03', '5.78e-03', '4.53e-03', '3.16e-03', '-3.93e-04', '5.56e-04', '-1.82e-03', '2.95e-03', '8.67e-04', '-1.37e-03', '4.35e-03', '-1.45e-03', '-2.27e-04', '4.38e-03', '-7.17e-04', '1.51e-03', '7.02e-03', '1.73e-03', '3.12e-03', '-4.99e-04', '3.44e-03', '5.49e-04', '1.82e-03', '1.37e-03', '4.10e-03', '7.45e-04', '2.97e-03', '-6.48e-04', '3.74e-03', '1.67e-03', '2.91e-03', '4.19e-03', '8.79e-05', '-2.40e-03', '4.27e-03', '-5.46e-04', '-5.42e-04', '5.31e-03', '5.71e-03', '5.90e-03', '-2.49e-03', '8.78e-04', '7.70e-03', '9.72e-04', '-2.24e-03', '4.67e-04', '1.54e-03', '1.51e-03', '1.20e-03', '5.39e-03', '5.76e-04', '2.16e-03', '4.29e-03', '-8.78e-04', '3.39e-04', '1.69e-04', '-1.66e-03', '-2.34e-04', '7.08e-03', '1.23e-03', '7.92e-03', '8.04e-03', '5.81e-03', '4.69e-04', '1.69e-03', '4.32e-03', '8.71e-03', '1.06e-03', '1.73e-03', '6.33e-03', '-2.14e-03', '5.49e-03', '-1.55e-03', '-3.96e-04', '1.18e-04', '-3.55e-03', '2.06e-03', '-2.62e-04', '7.09e-04', '1.18e-02', '4.52e-03', '1.56e-03', '-9.74e-05', '4.28e-03', '-2.75e-03', '2.77e-03', '2.22e-03', '-5.29e-04', '-1.65e-03', '1.17e-03', '4.23e-03', '3.16e-03', '1.96e-03', '-2.51e-03', '2.22e-03', '1.47e-04', '4.03e-03', '-9.06e-04']
INFO:absl:
Max KL divergence for a single token in the set: 1.18e-02
```

</details>


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
