### PR TITLE
Onboard gpt3 and gpt-oss to explicit sharding

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4345,6 +4345,8 @@ class MaxTextConfig(
           "gemma",
           "gemma2",
           "gemma3",
+          "gpt3",
+          "gpt_oss",
       }
       if self.decoder_block.value not in supported_decoders:
         raise ValueError(

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -861,8 +861,7 @@ class YarnRotaryEmbedding(nnx.Module):
     if self.pairwise and not self.interleave:
       raise ValueError("rope_pairwise=True requires rope_interleave=True.")
 
-    # The gathered frequencies are [batch, length, half_dim]; the trailing axis is a slice of
-    # the head dimension, which is never sharded.
+    # freqs are [batch, length, half_dim]; the trailing head-dim slice is never sharded.
     self.freqs_sharding = (
         create_sharding(mesh, ("activation_batch", "activation_length", None))
         if shard_mode == ShardMode.EXPLICIT
@@ -983,10 +982,6 @@ class YarnRotaryEmbedding(nnx.Module):
         pairs = pairs.astype(jnp.float32)
         cos = jnp.real(freqs)[..., jnp.newaxis]
         sin = jnp.imag(freqs)[..., jnp.newaxis]
-        if self.shard_mode == ShardMode.EXPLICIT:
-          rotated_sharding = NamedSharding(self.mesh, jax.typeof(pairs).sharding.spec)
-          cos = jnp.broadcast_to(cos, pairs.shape, out_sharding=rotated_sharding)
-          sin = jnp.broadcast_to(sin, pairs.shape, out_sharding=rotated_sharding)
         swapped = jnp.flip(pairs, axis=-1)
         sign = jnp.asarray([-1.0, 1.0], dtype=jnp.float32)
         rotated_pairs = pairs * cos + swapped * sin * sign
@@ -1006,14 +1001,6 @@ class YarnRotaryEmbedding(nnx.Module):
 
       inputs_complex = first_half + 1j * second_half  # shape: [b, s, n, half_dim]
       # Apply the rotary transformation via complex multiplication.
-      # Broadcast the [b, s, 1, half_dim] frequencies onto the layout of the activations they
-      # multiply, so that a sharded heads axis (e.g. tensor parallelism) is preserved.
-      rotated_sharding = (
-          NamedSharding(self.mesh, jax.typeof(inputs_complex).sharding.spec)
-          if self.shard_mode == ShardMode.EXPLICIT
-          else None
-      )
-      freqs = jnp.broadcast_to(freqs, inputs_complex.shape, out_sharding=rotated_sharding)
       rotated = jnp.multiply(inputs_complex, freqs)  # shape: [b, s, n, half_dim]
 
       # Convert the complex result back to a real tensor.

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -861,8 +861,10 @@ class YarnRotaryEmbedding(nnx.Module):
     if self.pairwise and not self.interleave:
       raise ValueError("rope_pairwise=True requires rope_interleave=True.")
 
+    # The gathered frequencies are [batch, length, half_dim]; the trailing axis is a slice of
+    # the head dimension, which is never sharded.
     self.freqs_sharding = (
-        create_sharding(mesh, ("activation_batch", "activation_length", "q_heads"))
+        create_sharding(mesh, ("activation_batch", "activation_length", None))
         if shard_mode == ShardMode.EXPLICIT
         else None
     )
@@ -982,7 +984,7 @@ class YarnRotaryEmbedding(nnx.Module):
         cos = jnp.real(freqs)[..., jnp.newaxis]
         sin = jnp.imag(freqs)[..., jnp.newaxis]
         if self.shard_mode == ShardMode.EXPLICIT:
-          rotated_sharding = create_sharding(self.mesh, ("activation_batch", "activation_length", None, None, None))
+          rotated_sharding = NamedSharding(self.mesh, jax.typeof(pairs).sharding.spec)
           cos = jnp.broadcast_to(cos, pairs.shape, out_sharding=rotated_sharding)
           sin = jnp.broadcast_to(sin, pairs.shape, out_sharding=rotated_sharding)
         swapped = jnp.flip(pairs, axis=-1)
@@ -1004,8 +1006,10 @@ class YarnRotaryEmbedding(nnx.Module):
 
       inputs_complex = first_half + 1j * second_half  # shape: [b, s, n, half_dim]
       # Apply the rotary transformation via complex multiplication.
+      # Broadcast the [b, s, 1, half_dim] frequencies onto the layout of the activations they
+      # multiply, so that a sharded heads axis (e.g. tensor parallelism) is preserved.
       rotated_sharding = (
-          create_sharding(self.mesh, ("activation_batch", "activation_length", None, None))
+          NamedSharding(self.mesh, jax.typeof(inputs_complex).sharding.spec)
           if self.shard_mode == ShardMode.EXPLICIT
           else None
       )

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -105,11 +105,13 @@ def _align_bias_with_output(bias: Array, output: Array) -> Array:
   Returns:
     The bias, resharded if needed.
   """
-  out_spec = jax.typeof(output).sharding.spec
-  wanted = PartitionSpec(*out_spec.partitions[output.ndim - bias.ndim :])
+  out_sharding = jax.typeof(output).sharding
+  wanted = PartitionSpec(*out_sharding.spec.partitions[output.ndim - bias.ndim :])
   if jax.typeof(bias).sharding.spec == wanted:
     return bias
-  return jax.sharding.reshard(bias, wanted)
+  # Take the mesh from the output rather than passing a bare PartitionSpec, which would
+  # resolve against an ambient mesh context that is not guaranteed to be entered here.
+  return jax.sharding.reshard(bias, NamedSharding(out_sharding.mesh, wanted))
 
 
 def _compute_dot_general_nnx(

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -85,6 +85,33 @@ def _compute_dot_general(inputs, kernel, kernel_axes, axis, contract_ind, matmul
   return dot_general(inputs, kernel, ((axis, contract_ind), ((), ())), precision=matmul_precision)
 
 
+def _align_bias_with_output(bias: Array, output: Array) -> Array:
+  """Reshards a bias onto the sharding of the output axes it is added to.
+
+  A bias is stored with the trailing `kernel_axes` layout, which is a parameter
+  layout: an out-projection carries `embed_attn` -> `fsdp`, while the activation it
+  is added to carries `activation_embed` -> `tensor` on that same axis. Adding them
+  directly under `ShardMode.EXPLICIT` would place `fsdp` on two axes of the result,
+  which JAX rejects, so align the bias with the activation instead. Under
+  `ShardMode.AUTO` GSPMD inserts the same all-gather on its own.
+
+  This is a no-op whenever the two already agree, which is every layout in which the
+  bias axes are unsharded or sharded exactly as the output is.
+
+  Args:
+    bias: The bias, broadcast against the trailing axes of `output`.
+    output: The result of the contraction the bias is added to.
+
+  Returns:
+    The bias, resharded if needed.
+  """
+  out_spec = jax.typeof(output).sharding.spec
+  wanted = PartitionSpec(*out_spec.partitions[output.ndim - bias.ndim :])
+  if jax.typeof(bias).sharding.spec == wanted:
+    return bias
+  return jax.sharding.reshard(bias, wanted)
+
+
 def _compute_dot_general_nnx(
     inputs,
     kernel,
@@ -330,6 +357,8 @@ class DenseGeneral(nnx.Module):
       if slice_bounds is not None:
         begin, end = slice_bounds
         bias = bias[..., begin:end]
+      if self.shard_mode == ShardMode.EXPLICIT:
+        bias = _align_bias_with_output(bias, output)
       output += bias
     return output
 

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -39,6 +39,7 @@ from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 from maxtext.utils.sharding import maybe_shard_with_logical
 from maxtext.utils.sharding import maybe_shard_with_name
+from maxtext.utils.sharding import maybe_shard_with_pspec
 from maxtext.utils.sharding import get_physical_spec_without_axes
 from maxtext.utils.sharding import FSDP_MESH_AXES
 from maxtext.utils.sharding import truncate_out_sharding
@@ -85,33 +86,23 @@ def _compute_dot_general(inputs, kernel, kernel_axes, axis, contract_ind, matmul
   return dot_general(inputs, kernel, ((axis, contract_ind), ((), ())), precision=matmul_precision)
 
 
-def _align_bias_with_output(bias: Array, output: Array) -> Array:
-  """Reshards a bias onto the sharding of the output axes it is added to.
+def _align_bias_with_output(bias: Array, output: Array, shard_mode: ShardMode, debug_sharding: bool = False) -> Array:
+  """Reshards a bias onto the sharding of the trailing output axes it is added to.
 
-  A bias is stored with the trailing `kernel_axes` layout, which is a parameter
-  layout: an out-projection carries `embed_attn` -> `fsdp`, while the activation it
-  is added to carries `activation_embed` -> `tensor` on that same axis. Adding them
-  directly under `ShardMode.EXPLICIT` would place `fsdp` on two axes of the result,
-  which JAX rejects, so align the bias with the activation instead. Under
-  `ShardMode.AUTO` GSPMD inserts the same all-gather on its own.
-
-  This is a no-op whenever the two already agree, which is every layout in which the
-  bias axes are unsharded or sharded exactly as the output is.
-
-  Args:
-    bias: The bias, broadcast against the trailing axes of `output`.
-    output: The result of the contraction the bias is added to.
-
-  Returns:
-    The bias, resharded if needed.
+  Under explicit sharding the bias keeps its `kernel_axes` parameter layout
+  (`embed_attn` -> `fsdp`) while `output` carries the activation layout
+  (`activation_embed` -> `tensor`) on that axis, so adding them directly would map one
+  mesh axis onto two axes of the result. A no-op when the two already agree.
   """
-  out_sharding = jax.typeof(output).sharding
-  wanted = PartitionSpec(*out_sharding.spec.partitions[output.ndim - bias.ndim :])
-  if jax.typeof(bias).sharding.spec == wanted:
+  if shard_mode != ShardMode.EXPLICIT:
     return bias
-  # Take the mesh from the output rather than passing a bare PartitionSpec, which would
-  # resolve against an ambient mesh context that is not guaranteed to be entered here.
-  return jax.sharding.reshard(bias, NamedSharding(out_sharding.mesh, wanted))
+  out_sharding = jax.typeof(output).sharding
+  bias_spec = PartitionSpec(*out_sharding.spec.partitions[output.ndim - bias.ndim :])
+  if jax.typeof(bias).sharding.spec == bias_spec:
+    return bias
+  return maybe_shard_with_pspec(
+      bias, bias_spec, out_sharding.mesh, shard_mode, debug_sharding=debug_sharding, extra_stack_level=1
+  )
 
 
 def _compute_dot_general_nnx(
@@ -359,8 +350,7 @@ class DenseGeneral(nnx.Module):
       if slice_bounds is not None:
         begin, end = slice_bounds
         bias = bias[..., begin:end]
-      if self.shard_mode == ShardMode.EXPLICIT:
-        bias = _align_bias_with_output(bias, output)
+      bias = _align_bias_with_output(bias, output, self.shard_mode, self.debug_sharding)
       output += bias
     return output
 

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1409,6 +1409,7 @@ class NNXDecoder(nnx.Module):
       return functools.partial(
           gpt3.Gpt3LayerNorm,
           num_features=num_features,
+          shard_mode=self.config.shard_mode,
           reductions_in_fp32=False,
           use_bias=True,
           rngs=rngs,

--- a/src/maxtext/models/gpt3.py
+++ b/src/maxtext/models/gpt3.py
@@ -16,6 +16,7 @@
 # pylint: disable=arguments-differ
 # pylint: disable=no-name-in-module
 
+import functools
 from typing import Any, Optional
 
 import jax
@@ -27,7 +28,19 @@ from jax.sharding import Mesh, NamedSharding
 from flax import linen as nn
 from flax import nnx
 
-from maxtext.common.common_types import Config, DType, AxisNames, BATCH, LENGTH, EMBED, HEAD, D_KV, Array, MODEL_MODE_TRAIN
+from maxtext.common.common_types import (
+    Config,
+    DType,
+    AxisNames,
+    BATCH,
+    LENGTH,
+    EMBED,
+    HEAD,
+    D_KV,
+    Array,
+    MODEL_MODE_TRAIN,
+    ShardMode,
+)
 from maxtext.inference import kvcache
 from maxtext.layers import initializers, nnx_wrappers
 from maxtext.layers.linears import DenseGeneral, MlpBlock, canonicalize_tuple, normalize_axes
@@ -38,6 +51,7 @@ from maxtext.layers.initializers import Initializer, NdInitializer, nd_dense_ini
 from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
+from maxtext.utils.sharding import create_sharding, get_logical_axis_rules, maybe_shard_with_logical, truncate_out_sharding
 
 # -----------------------------------------
 # The Normalization Layer specific for GPT3
@@ -53,6 +67,7 @@ class Gpt3LayerNorm(nnx.Module):
       epsilon: float = 1e-6,
       dtype: Any = jnp.float32,
       weight_dtype: Any = jnp.float32,
+      shard_mode: ShardMode = ShardMode.AUTO,
       kernel_axes: tuple[None | str, ...] = (),
       scale_init: Initializer = nn.initializers.zeros,
       use_bias: bool = True,
@@ -64,6 +79,7 @@ class Gpt3LayerNorm(nnx.Module):
     self.epsilon = epsilon
     self.dtype = dtype
     self.weight_dtype = weight_dtype
+    self.shard_mode = shard_mode
     self.kernel_axes = kernel_axes
     self.scale_init = scale_init
     self.use_bias = use_bias
@@ -98,6 +114,13 @@ class Gpt3LayerNorm(nnx.Module):
       scale = jax.device_put(scale, max_utils.device_space())
 
     scale = jnp.asarray(scale, self.dtype)
+
+    # out_sharding must be None in auto shard mode
+    if self.shard_mode != ShardMode.EXPLICIT:
+      out_sharding = None
+    if out_sharding is not None:
+      out_sharding = truncate_out_sharding(out_sharding, normed_inputs.ndim)
+
     # broadcast second inputs and element-wise mul
     output = jnp.einsum(
         "i...k,...k->i...k",
@@ -241,6 +264,21 @@ class Gpt3MultiHeadAttention(nnx.Module):
     self.prefill_cache_axis_order = (1, 2, 0, 3)
     self.ar_cache_axis_order = (1, 2, 0, 3)
     self.use_ragged_attention = False
+
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+    )
+    # Physical shardings used to pin projection outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore them and let GSPMD infer the layout.
+    rules = get_logical_axis_rules()
+    self.qkv_sharding = create_sharding(mesh, self.query_axis_names, rules=rules)
+    # The fused projection emits (batch, length, 3, heads, head_dim); the size-3 axis
+    # holding q/k/v is never sharded, so it maps to None.
+    fused_qkv_axis_names = self.query_axis_names[:2] + (None,) + self.query_axis_names[2:]
+    self.fused_qkv_sharding = create_sharding(mesh, fused_qkv_axis_names, rules=rules)
     self.KVCache_0 = self.init_kv_caches(inputs_kv_shape=feature_dim) if self.model_mode != MODEL_MODE_TRAIN else None
     if self.fused_qkv:
       self.qkv_proj = self.create_projection_layer(
@@ -293,21 +331,25 @@ class Gpt3MultiHeadAttention(nnx.Module):
         weight_dtype=self.weight_dtype,
         quant=self.quant,
         use_bias=self.use_bias,
+        shard_mode=self.config.shard_mode,
         matmul_precision=self.config.matmul_precision,
         rngs=self.rngs,
     )
 
-  def qkv_projection(self, projection_layer: Any, inputs: Array):
+  def qkv_projection(self, projection_layer: Any, inputs: Array, out_sharding: NamedSharding | None = None):
     """Fused QKV projection"""
-    qkv_proj = projection_layer(inputs)
+    qkv_proj = projection_layer(inputs, out_sharding=out_sharding)
 
     qkv_proj = checkpoint_name(qkv_proj, "qkv_proj")
+    # Unlike the fused projection in layers/attentions.py, gpt3 keeps q, k and v on
+    # their own (never sharded) axis, so a plain slice splits them evenly under any
+    # tensor parallelism and no shard_map is needed.
     query, key, value = qkv_proj[:, :, 0, ...], qkv_proj[:, :, 1, ...], qkv_proj[:, :, 2, ...]
     return query, key, value
 
-  def projection(self, projection_layer: Any, inputs: Array) -> Array:
+  def projection(self, projection_layer: Any, inputs: Array, out_sharding: NamedSharding | None = None) -> Array:
     """individual projection for one of q, k and v."""
-    proj = projection_layer(inputs)
+    proj = projection_layer(inputs, out_sharding=out_sharding)
     return proj
 
   def init_kv_caches(self, inputs_kv_shape: tuple[int, ...]):
@@ -354,24 +396,25 @@ class Gpt3MultiHeadAttention(nnx.Module):
       previous_chunk: Any = None,
       kv_cache: Array | None = None,
       attention_metadata: dict[str, Any] | None = None,
+      out_sharding: NamedSharding | None = None,
   ):
-    inputs_q = nn.with_logical_constraint(inputs_q, self.input_axis_names)
+    inputs_q = self._maybe_shard_with_logical(inputs_q, self.input_axis_names)
     if self.fused_qkv:
-      query, key, value = self.qkv_projection(self.qkv_proj, inputs_q)
+      query, key, value = self.qkv_projection(self.qkv_proj, inputs_q, out_sharding=self.fused_qkv_sharding)
     else:
-      query = self.projection(self.query, inputs_q)
-      key = self.projection(self.key, inputs_q)
-      value = self.projection(self.value, inputs_q)
+      query = self.projection(self.query, inputs_q, out_sharding=self.qkv_sharding)
+      key = self.projection(self.key, inputs_q, out_sharding=self.qkv_sharding)
+      value = self.projection(self.value, inputs_q, out_sharding=self.qkv_sharding)
 
     depth_scaling = jnp.sqrt(self.head_dim).astype(self.dtype)
     query /= depth_scaling
 
     # annotate with sharding constraint.
-    query = nn.with_logical_constraint(query, self.query_axis_names)
+    query = self._maybe_shard_with_logical(query, self.query_axis_names)
     query = checkpoint_name(query, "query_proj")
-    key = nn.with_logical_constraint(key, self.key_axis_names)
+    key = self._maybe_shard_with_logical(key, self.key_axis_names)
     key = checkpoint_name(key, "key_proj")
-    value = nn.with_logical_constraint(value, self.value_axis_names)
+    value = self._maybe_shard_with_logical(value, self.value_axis_names)
     value = checkpoint_name(value, "value_proj")
 
     cached_values = [None, None]
@@ -380,10 +423,10 @@ class Gpt3MultiHeadAttention(nnx.Module):
 
     out = self.attention_op(query, key, value, decoder_segment_ids, None, model_mode, cached_values)
 
-    out = nn.with_logical_constraint(out, self.out_axis_names)
+    out = self._maybe_shard_with_logical(out, self.out_axis_names)
 
     # apply output projection,  output dim is set to the input dim.
-    out = self.projection(self.out, out)
+    out = self.projection(self.out, out, out_sharding=out_sharding)
     out = checkpoint_name(out, "out_proj")
     return out, kv_cache
 
@@ -412,9 +455,26 @@ class Gpt3DecoderLayer(nnx.Module):
     batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
+    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    self.mlp_activation_axis_names = ("activation_batch", "activation_length", "activation_mlp")
+
+    # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore them and let GSPMD infer the layout.
+    rules = get_logical_axis_rules()
+    self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=rules)
+    self.mlp_intermediate_sharding = create_sharding(mesh, self.mlp_activation_axis_names, rules=rules)
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
+
     self.pre_self_attention_norm = Gpt3LayerNorm(
         num_features=dummy_inputs_shape[-1],
         dtype=config.dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         reductions_in_fp32=False,
@@ -463,8 +523,6 @@ class Gpt3DecoderLayer(nnx.Module):
 
     self.dropout = linears.Dropout(rate=config.dropout_rate, broadcast_dims=(-2,), rngs=self.rngs)
 
-    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
-
   def __call__(
       self,
       inputs,
@@ -482,11 +540,11 @@ class Gpt3DecoderLayer(nnx.Module):
     if isinstance(inputs, tuple):
       inputs = inputs[0]
 
-    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
-    lnx = self.pre_self_attention_norm(inputs)
+    lnx = self.pre_self_attention_norm(inputs, out_sharding=self.out_sharding)
 
-    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+    lnx = self._maybe_shard_with_logical(lnx, self.activation_axis_names)
 
     # Self-attention block
     assert (
@@ -501,17 +559,23 @@ class Gpt3DecoderLayer(nnx.Module):
         previous_chunk=previous_chunk,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
+        out_sharding=self.out_sharding,
     )
 
-    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
+    attention_lnx = self._maybe_shard_with_logical(attention_lnx, self.activation_axis_names)
     attention_lnx += inputs
     # MLP block.
-    mlp_lnx = self.mlp(attention_lnx, deterministic=deterministic)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+    mlp_lnx = self.mlp(
+        attention_lnx,
+        deterministic=deterministic,
+        intermediate_sharding=self.mlp_intermediate_sharding,
+        out_sharding=self.out_sharding,
+    )
+    mlp_lnx = self._maybe_shard_with_logical(mlp_lnx, self.activation_axis_names)
 
     layer_output = attention_lnx + mlp_lnx
     layer_output = self.dropout(layer_output, deterministic=deterministic)
-    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+    layer_output = self._maybe_shard_with_logical(layer_output, self.activation_axis_names)
 
     if getattr(self.config, "record_internal_nn_metrics", False):
       self.sow(nnx.Intermediate, "activation_mean", jnp.mean(layer_output))

--- a/src/maxtext/models/gpt3.py
+++ b/src/maxtext/models/gpt3.py
@@ -271,12 +271,9 @@ class Gpt3MultiHeadAttention(nnx.Module):
         shard_mode=config.shard_mode,
         debug_sharding=config.debug_sharding,
     )
-    # Physical shardings used to pin projection outputs under ShardMode.EXPLICIT. In
-    # ShardMode.AUTO the callees ignore them and let GSPMD infer the layout.
     rules = get_logical_axis_rules()
     self.qkv_sharding = create_sharding(mesh, self.query_axis_names, rules=rules)
-    # The fused projection emits (batch, length, 3, heads, head_dim); the size-3 axis
-    # holding q/k/v is never sharded, so it maps to None.
+    # The size-3 q/k/v axis of the fused projection is never sharded.
     fused_qkv_axis_names = self.query_axis_names[:2] + (None,) + self.query_axis_names[2:]
     self.fused_qkv_sharding = create_sharding(mesh, fused_qkv_axis_names, rules=rules)
     self.KVCache_0 = self.init_kv_caches(inputs_kv_shape=feature_dim) if self.model_mode != MODEL_MODE_TRAIN else None
@@ -341,9 +338,6 @@ class Gpt3MultiHeadAttention(nnx.Module):
     qkv_proj = projection_layer(inputs, out_sharding=out_sharding)
 
     qkv_proj = checkpoint_name(qkv_proj, "qkv_proj")
-    # Unlike the fused projection in layers/attentions.py, gpt3 keeps q, k and v on
-    # their own (never sharded) axis, so a plain slice splits them evenly under any
-    # tensor parallelism and no shard_map is needed.
     query, key, value = qkv_proj[:, :, 0, ...], qkv_proj[:, :, 1, ...], qkv_proj[:, :, 2, ...]
     return query, key, value
 
@@ -458,8 +452,6 @@ class Gpt3DecoderLayer(nnx.Module):
     self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
     self.mlp_activation_axis_names = ("activation_batch", "activation_length", "activation_mlp")
 
-    # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
-    # ShardMode.AUTO the callees ignore them and let GSPMD infer the layout.
     rules = get_logical_axis_rules()
     self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=rules)
     self.mlp_intermediate_sharding = create_sharding(mesh, self.mlp_activation_axis_names, rules=rules)

--- a/src/maxtext/models/gpt_oss.py
+++ b/src/maxtext/models/gpt_oss.py
@@ -18,9 +18,9 @@ limitations under the License.
 # pylint: disable=no-name-in-module
 
 
+import functools
 from typing import Optional
 
-from flax import linen as nn
 from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
 import jax
@@ -37,6 +37,7 @@ from maxtext.layers.attentions import Attention
 from maxtext.layers.normalizations import RMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.utils import max_utils
+from maxtext.utils.sharding import create_sharding, get_logical_axis_rules, maybe_shard_with_logical
 
 # -----------------------------------------
 # The Decoder Layer for GPT OSS models
@@ -75,10 +76,24 @@ class GptOssDecoderLayer(nnx.Module):
     batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
+    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
+    # Physical sharding used to pin sublayer outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore it and let GSPMD infer the layout.
+    self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
+
     self.pre_self_attention_layer_norm = RMSNorm(
         num_features=dummy_inputs_shape[-1],
         dtype=config.dtype,
         weight_dtype=jnp.float32,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=rngs,
@@ -88,6 +103,7 @@ class GptOssDecoderLayer(nnx.Module):
         num_features=dummy_inputs_shape[-1],
         dtype=config.dtype,
         weight_dtype=jnp.float32,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=rngs,
@@ -157,11 +173,11 @@ class GptOssDecoderLayer(nnx.Module):
     elif isinstance(inputs, tuple):
       inputs = inputs[0]
 
-    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 
-    lnx = self.pre_self_attention_layer_norm(inputs)
-    lnx = nn.with_logical_constraint(lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
+    lnx = self.pre_self_attention_layer_norm(inputs, out_sharding=self.out_sharding)
+    lnx = self._maybe_shard_with_logical(lnx, self.activation_axis_names)
 
     attention_lnx, kv_cache = self.GptOssAttention(
         lnx,
@@ -170,32 +186,26 @@ class GptOssDecoderLayer(nnx.Module):
         decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
         model_mode=model_mode,
+        out_sharding=self.out_sharding,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
     )
 
-    attention_lnx = nn.with_logical_constraint(
-        attention_lnx, ("activation_batch", "activation_norm_length", "activation_embed")
-    )
+    attention_lnx = self._maybe_shard_with_logical(attention_lnx, self.activation_axis_names)
     intermediate_inputs = inputs + attention_lnx
 
     # Fully Connected
-    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(
-        hidden_states, ("activation_batch", "activation_norm_length", "activation_embed")
-    )
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     load_balance_loss = None
-    mlp_lnx, load_balance_loss, _ = self.GptOssMlp(hidden_states)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
+    mlp_lnx, load_balance_loss, _ = self.GptOssMlp(hidden_states, out_sharding=self.out_sharding)
+    mlp_lnx = self._maybe_shard_with_logical(mlp_lnx, self.activation_axis_names)
 
     layer_output = mlp_lnx + intermediate_inputs
     layer_output = self.dropout(layer_output, deterministic=deterministic)
 
-    layer_output = nn.with_logical_constraint(
-        layer_output,
-        ("activation_batch", "activation_norm_length", "activation_embed"),
-    )
+    layer_output = self._maybe_shard_with_logical(layer_output, self.activation_axis_names)
 
     if cfg.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
       self.sow(nnx.Intermediate, "moe_lb_loss", load_balance_loss)
@@ -256,6 +266,14 @@ class GptOssScannableBlock(nnx.Module):
     self.mesh = mesh
     self.model_mode = model_mode
     self.quant = quant
+    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
     for layer_id in range(config.inhomogeneous_layer_cycle_interval):
       attention_type = get_attention_type(layer_id)
       layer_name = f"layers_{layer_id}"
@@ -283,7 +301,7 @@ class GptOssScannableBlock(nnx.Module):
   ):
     cfg = self.config
 
-    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     y = inputs
     for layer_id in range(cfg.inhomogeneous_layer_cycle_interval):

--- a/src/maxtext/models/gpt_oss.py
+++ b/src/maxtext/models/gpt_oss.py
@@ -78,8 +78,6 @@ class GptOssDecoderLayer(nnx.Module):
 
     self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
 
-    # Physical sharding used to pin sublayer outputs under ShardMode.EXPLICIT. In
-    # ShardMode.AUTO the callees ignore it and let GSPMD infer the layout.
     self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
     self._maybe_shard_with_logical = functools.partial(
         maybe_shard_with_logical,

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -54,6 +54,25 @@ _QWEN3_MODELS = {
     + _MOE_OVERRIDES,
 }
 
+_GPT_OSS = [
+    "model_name=gpt-oss-20b",
+    # RoutedMoE.dense_matmul is not onboarded to explicit sharding yet (a gap it
+    # shares with mixtral and qwen3_moe), so exercise the sparse_matmul path.
+    "sparse_matmul=True",
+    "megablox=True",
+] + _MOE_OVERRIDES
+
+# One tiny model per GPT-family decoder block that supports explicit sharding. gpt3 is
+# listed twice because only the fused projection has to keep the q/k/v axis of its 5-D
+# output off the mesh before slicing q, k and v apart, and gpt-oss is listed twice
+# because only tensor parallelism shards the heads axis its YaRN rope broadcasts over.
+_GPT_MODELS = {
+    "gpt3_fused_qkv": ["model_name=gpt3-6b", "fused_qkv=True"],
+    "gpt3": ["model_name=gpt3-6b", "fused_qkv=False"],
+    "gpt_oss": _GPT_OSS,
+    "gpt_oss_tensor": _GPT_OSS,
+}
+
 # One tiny model per Mistral-family decoder block that supports explicit sharding.
 _MISTRAL_MODELS = {
     "mistral": ["model_name=mistral-7b"],
@@ -133,6 +152,21 @@ class TrainTests(unittest.TestCase):
       # The Qwen3 model configs default to a HuggingFace tokenizer that is not
       # vendored in the repo; use the checked-in tiktoken asset instead.
       "tokenizer_type=tiktoken",
+      rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+  ]
+
+  # gpt3 and gpt-oss both come with num_query_heads == num_kv_heads here: gpt3 asserts
+  # on it, and it keeps the two families on one shared override list.
+  _gpt_overrides = [
+      "override_model_config=True",
+      "base_num_decoder_layers=2",
+      "base_emb_dim=256",
+      "base_mlp_dim=512",
+      "base_num_query_heads=8",
+      "base_num_kv_heads=8",
+      "head_dim=128",
+      "vocab_size=2048",
+      "max_target_length=256",
       rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
   ]
 
@@ -831,6 +865,63 @@ class TrainTests(unittest.TestCase):
         self.assertTrue(baseline, "baseline run produced no metrics")
         # ZeRO-1 reassociates the gradient all-reduce, so allow a little float slack.
         np.testing.assert_allclose(sharded, baseline, rtol=1e-4, atol=0.0)
+
+  def _gpt_losses(self, run_name, extra_args):
+    """Trains a tiny gpt3/gpt-oss model for a few steps and returns its per-step losses."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      metrics_file = os.path.join(tmp_dir, "metrics.txt")
+      train_main(
+          [
+              None,
+              get_test_config_path(),
+              f"base_output_directory={self._base_output_directory}",
+              f"dataset_path={self.dataset_path}",
+              f"run_name={run_name}",
+              f"metrics_file={metrics_file}",
+              "dataset_type=synthetic",
+              "steps=3",
+              "enable_checkpointing=False",
+              "enable_goodput_recording=False",
+          ]
+          + self._gpt_overrides
+          + list(extra_args)
+      )
+      with open(metrics_file, "rt", encoding="utf8") as f:
+        return [json.loads(line)["learning/loss"] for line in f if line.strip()]
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  def test_tpu_gpt_explicit_sharding_matches_auto(self):
+    """Explicit sharding only changes how layouts are expressed, so the losses must not move.
+
+    Each decoder block is paired with the parallelism that stresses it most: tensor
+    parallelism shards the attention heads and the dense MLP intermediate, which is
+    what the gpt3 fused QKV projection has to split around and what the gpt-oss YaRN
+    rope has to broadcast its frequencies over, and expert parallelism shards the
+    gpt-oss MoE dispatch.
+    """
+    parallelism = {
+        "gpt3_fused_qkv": ["ici_fsdp_parallelism=1", "ici_tensor_parallelism=-1"],
+        "gpt3": ["ici_fsdp_parallelism=1", "ici_tensor_parallelism=-1"],
+        "gpt_oss": ["ici_fsdp_parallelism=1", "ici_expert_parallelism=-1"],
+        "gpt_oss_tensor": ["ici_fsdp_parallelism=1", "ici_tensor_parallelism=-1"],
+    }
+    # gpt3 is the only decoder block here with biased projections, so explicit sharding
+    # has to reshard every bias onto the layout of the activation it is added to. That
+    # reassociates the bias-gradient reductions, which leaves step 0 bit-for-bit and
+    # drifts by a few ULPs per step afterwards (~5e-5 by step 2 on v5p). gpt-oss under
+    # tensor parallelism is bit-for-bit; under expert parallelism the grouped matmul
+    # reassociates its own reductions and drifts by a few ULPs.
+    rtol = {"gpt3_fused_qkv": 1e-4, "gpt3": 1e-4, "gpt_oss": 1e-5, "gpt_oss_tensor": 1e-6}
+    for case, model_args in _GPT_MODELS.items():
+      with self.subTest(case=case):
+        args = model_args + parallelism[case]
+        auto_losses = self._gpt_losses(f"{case}_auto", args + ["shard_mode=auto"])
+        explicit_losses = self._gpt_losses(f"{case}_explicit", args + ["shard_mode=explicit"])
+        print(f"[{case}] auto losses: {auto_losses}", flush=True)
+        print(f"[{case}] explicit losses: {explicit_losses}", flush=True)
+        self.assertTrue(auto_losses, "auto run produced no metrics")
+        np.testing.assert_allclose(explicit_losses, auto_losses, rtol=rtol[case], atol=0.0)
 
   def _mistral_losses(self, run_name, extra_args):
     """Trains a tiny Mistral/Mixtral model for a few steps and returns its per-step losses."""

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -56,16 +56,12 @@ _QWEN3_MODELS = {
 
 _GPT_OSS = [
     "model_name=gpt-oss-20b",
-    # RoutedMoE.dense_matmul is not onboarded to explicit sharding yet (a gap it
-    # shares with mixtral and qwen3_moe), so exercise the sparse_matmul path.
+    # RoutedMoE.dense_matmul is not onboarded to explicit sharding yet.
     "sparse_matmul=True",
     "megablox=True",
 ] + _MOE_OVERRIDES
 
-# One tiny model per GPT-family decoder block that supports explicit sharding. gpt3 is
-# listed twice because only the fused projection has to keep the q/k/v axis of its 5-D
-# output off the mesh before slicing q, k and v apart, and gpt-oss is listed twice
-# because only tensor parallelism shards the heads axis its YaRN rope broadcasts over.
+# One tiny model per GPT-family decoder block that supports explicit sharding.
 _GPT_MODELS = {
     "gpt3_fused_qkv": ["model_name=gpt3-6b", "fused_qkv=True"],
     "gpt3": ["model_name=gpt3-6b", "fused_qkv=False"],
@@ -155,8 +151,6 @@ class TrainTests(unittest.TestCase):
       rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
   ]
 
-  # gpt3 and gpt-oss both come with num_query_heads == num_kv_heads here: gpt3 asserts
-  # on it, and it keeps the two families on one shared override list.
   _gpt_overrides = [
       "override_model_config=True",
       "base_num_decoder_layers=2",
@@ -894,11 +888,9 @@ class TrainTests(unittest.TestCase):
   def test_tpu_gpt_explicit_sharding_matches_auto(self):
     """Explicit sharding only changes how layouts are expressed, so the losses must not move.
 
-    Each decoder block is paired with the parallelism that stresses it most: tensor
-    parallelism shards the attention heads and the dense MLP intermediate, which is
-    what the gpt3 fused QKV projection has to split around and what the gpt-oss YaRN
-    rope has to broadcast its frequencies over, and expert parallelism shards the
-    gpt-oss MoE dispatch.
+    Each case is paired with the parallelism that stresses it most: tensor parallelism
+    shards the attention heads and the dense MLP intermediate, and expert parallelism
+    shards the gpt-oss MoE dispatch.
     """
     parallelism = {
         "gpt3_fused_qkv": ["ici_fsdp_parallelism=1", "ici_tensor_parallelism=-1"],
@@ -906,12 +898,8 @@ class TrainTests(unittest.TestCase):
         "gpt_oss": ["ici_fsdp_parallelism=1", "ici_expert_parallelism=-1"],
         "gpt_oss_tensor": ["ici_fsdp_parallelism=1", "ici_tensor_parallelism=-1"],
     }
-    # gpt3 is the only decoder block here with biased projections, so explicit sharding
-    # has to reshard every bias onto the layout of the activation it is added to. That
-    # reassociates the bias-gradient reductions, which leaves step 0 bit-for-bit and
-    # drifts by a few ULPs per step afterwards (~5e-5 by step 2 on v5p). gpt-oss under
-    # tensor parallelism is bit-for-bit; under expert parallelism the grouped matmul
-    # reassociates its own reductions and drifts by a few ULPs.
+    # gpt3's bias reshard reassociates the bias-gradient reductions (~5e-5 by step 2 on
+    # v5p); gpt-oss drifts a few ULPs through the grouped matmul under expert parallelism.
     rtol = {"gpt3_fused_qkv": 1e-4, "gpt3": 1e-4, "gpt_oss": 1e-5, "gpt_oss_tensor": 1e-6}
     for case, model_args in _GPT_MODELS.items():
       with self.subTest(case=case):

--- a/tests/unit/decoder_layer_model_mode_test.py
+++ b/tests/unit/decoder_layer_model_mode_test.py
@@ -56,7 +56,7 @@ from flax.linen import partitioning as nn_partitioning
 from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN, ShardMode
 from maxtext.configs import pyconfig
 from maxtext.layers import attention_mla, attentions
-from maxtext.models import deepseek, gemma, gemma2, gemma3, llama2, mistral, qwen2, qwen3
+from maxtext.models import deepseek, gemma, gemma2, gemma3, gpt3, gpt_oss, llama2, mistral, qwen2, qwen3
 from maxtext.utils import maxtext_utils
 from tests.utils.test_helpers import get_test_config_path
 
@@ -115,12 +115,32 @@ _GEMMA3 = {
     "head_dim": 16,
 }
 
-# Layers onboarded to explicit sharding, as (case name, layer class, extra config).
+# GPT-OSS routes every token through a RoutedMoE. `dense_matmul` has not been onboarded
+# to explicit sharding, so the sparse path is the one to exercise; with the TPU kernels
+# switched off it lowers to jax.lax.ragged_dot, which runs on the host devices here.
+_GPT_OSS = {
+    "decoder_block": "gpt_oss",
+    "num_experts": 4,
+    "num_experts_per_tok": 2,
+    "base_moe_mlp_dim": 64,
+    "sparse_matmul": True,
+    "megablox": False,
+    "use_tokamax_gmm": False,
+}
+
+# Layers onboarded to explicit sharding, as (case name, layer class, extra config,
+# extra constructor kwargs).
 _SHARD_MODE_LAYERS = [
-    ("gemma", gemma.GemmaDecoderLayer, {"decoder_block": "gemma"}),
-    ("gemma2", gemma2.Gemma2DecoderLayer, {"decoder_block": "gemma2"}),
-    ("gemma3", gemma3.Gemma3DecoderLayer, _GEMMA3),
-    ("gemma3_scannable_block", gemma3.Gemma3ScannableBlock, _GEMMA3),
+    ("gemma", gemma.GemmaDecoderLayer, {"decoder_block": "gemma"}, {}),
+    ("gemma2", gemma2.Gemma2DecoderLayer, {"decoder_block": "gemma2"}, {}),
+    ("gemma3", gemma3.Gemma3DecoderLayer, _GEMMA3, {}),
+    ("gemma3_scannable_block", gemma3.Gemma3ScannableBlock, _GEMMA3, {}),
+    # Both QKV layouts, because only the fused one has to keep the q/k/v axis of its
+    # 5-D projection off the mesh before slicing it apart.
+    ("gpt3", gpt3.Gpt3DecoderLayer, {"decoder_block": "gpt3", "fused_qkv": False}, {}),
+    ("gpt3_fused_qkv", gpt3.Gpt3DecoderLayer, {"decoder_block": "gpt3", "fused_qkv": True}, {}),
+    ("gpt_oss", gpt_oss.GptOssDecoderLayer, _GPT_OSS, {"attention_type": attentions.AttentionType.GLOBAL}),
+    ("gpt_oss_scannable_block", gpt_oss.GptOssScannableBlock, _GPT_OSS, {}),
 ]
 
 
@@ -238,7 +258,7 @@ class DecoderLayerShardModeTest(parameterized.TestCase):
           "set XLA_FLAGS=--xla_force_host_platform_device_count=8"
       )
 
-  def _forward(self, layer_cls, extra_config, shard_mode):
+  def _forward(self, layer_cls, extra_config, ctor_kwargs, shard_mode):
     """Builds one decoder layer in the given shard mode and runs a single forward pass.
 
     The rng seeds are fixed so both modes initialize identical weights; any difference
@@ -247,6 +267,7 @@ class DecoderLayerShardModeTest(parameterized.TestCase):
     Args:
       layer_cls: Decoder layer class to instantiate.
       extra_config: Config overrides this family needs, on top of _COMMON.
+      ctor_kwargs: Extra constructor arguments this family requires.
       shard_mode: Either "auto" or "explicit".
 
     Returns:
@@ -266,6 +287,7 @@ class DecoderLayerShardModeTest(parameterized.TestCase):
           mesh=mesh,
           model_mode=MODEL_MODE_TRAIN,
           rngs=nnx.Rngs(params=0, dropout=0),
+          **ctor_kwargs,
       )
       batch = cfg.micro_batch_size_to_train_on
       length = cfg.max_target_length
@@ -284,10 +306,10 @@ class DecoderLayerShardModeTest(parameterized.TestCase):
     return np.asarray(jax.device_get(output))
 
   @parameterized.named_parameters(*_SHARD_MODE_LAYERS)
-  def test_explicit_matches_auto(self, layer_cls, extra_config):
+  def test_explicit_matches_auto(self, layer_cls, extra_config, ctor_kwargs):
     """The explicit run must both succeed and reproduce the auto-mode activations."""
-    auto_out = self._forward(layer_cls, extra_config, "auto")
-    explicit_out = self._forward(layer_cls, extra_config, "explicit")
+    auto_out = self._forward(layer_cls, extra_config, ctor_kwargs, "auto")
+    explicit_out = self._forward(layer_cls, extra_config, ctor_kwargs, "explicit")
 
     self.assertEqual(auto_out.shape, explicit_out.shape)
     np.testing.assert_allclose(
@@ -299,9 +321,9 @@ class DecoderLayerShardModeTest(parameterized.TestCase):
     )
 
   @parameterized.named_parameters(*_SHARD_MODE_LAYERS)
-  def test_explicit_shard_mode_is_accepted_by_config(self, layer_cls, extra_config):
+  def test_explicit_shard_mode_is_accepted_by_config(self, layer_cls, extra_config, ctor_kwargs):
     """Every onboarded decoder must be on the explicit-sharding allowlist in configs/types.py."""
-    del layer_cls
+    del layer_cls, ctor_kwargs
     cfg = pyconfig.initialize(
         [sys.argv[0], get_test_config_path()],
         **(_COMMON | extra_config | {"shard_mode": "explicit"}),

--- a/tests/unit/decoder_layer_model_mode_test.py
+++ b/tests/unit/decoder_layer_model_mode_test.py
@@ -115,9 +115,7 @@ _GEMMA3 = {
     "head_dim": 16,
 }
 
-# GPT-OSS routes every token through a RoutedMoE. `dense_matmul` has not been onboarded
-# to explicit sharding, so the sparse path is the one to exercise; with the TPU kernels
-# switched off it lowers to jax.lax.ragged_dot, which runs on the host devices here.
+# With the TPU kernels off the sparse path lowers to ragged_dot, which runs on CPU.
 _GPT_OSS = {
     "decoder_block": "gpt_oss",
     "num_experts": 4,
@@ -128,15 +126,12 @@ _GPT_OSS = {
     "use_tokamax_gmm": False,
 }
 
-# Layers onboarded to explicit sharding, as (case name, layer class, extra config,
-# extra constructor kwargs).
+# Layers onboarded to explicit sharding, as (name, layer class, config, ctor kwargs).
 _SHARD_MODE_LAYERS = [
     ("gemma", gemma.GemmaDecoderLayer, {"decoder_block": "gemma"}, {}),
     ("gemma2", gemma2.Gemma2DecoderLayer, {"decoder_block": "gemma2"}, {}),
     ("gemma3", gemma3.Gemma3DecoderLayer, _GEMMA3, {}),
     ("gemma3_scannable_block", gemma3.Gemma3ScannableBlock, _GEMMA3, {}),
-    # Both QKV layouts, because only the fused one has to keep the q/k/v axis of its
-    # 5-D projection off the mesh before slicing it apart.
     ("gpt3", gpt3.Gpt3DecoderLayer, {"decoder_block": "gpt3", "fused_qkv": False}, {}),
     ("gpt3_fused_qkv", gpt3.Gpt3DecoderLayer, {"decoder_block": "gpt3", "fused_qkv": True}, {}),
     ("gpt_oss", gpt_oss.GptOssDecoderLayer, _GPT_OSS, {"attention_type": attentions.AttentionType.GLOBAL}),

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -305,6 +305,18 @@ class PyconfigTest(unittest.TestCase):
     )
     self.assertEqual(config.decoder_block.value, "deepseek")
 
+  def test_explicit_sharding_gpt_decoder_support(self):
+    """The GPT-family decoders that have been onboarded to explicit sharding are accepted."""
+    for decoder_block in ("gpt3", "gpt_oss"):
+      with self.subTest(decoder_block=decoder_block):
+        config = pyconfig.initialize(
+            [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+            skip_jax_distributed_system=True,
+            shard_mode="explicit",
+            decoder_block=decoder_block,
+        )
+        self.assertEqual(config.decoder_block.value, decoder_block)
+
   def test_resolve_config_path(self):
     self.assertEqual(resolve_config_path("foo"), os.path.join("src", "foo"))
     self.assertEqual(resolve_config_path(__file__), __file__)

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -758,6 +758,39 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
+  @parameterized.named_parameters(
+      ("expert_parallelism", "ici_expert_parallelism=8"),
+      ("tensor_parallelism", "ici_tensor_parallelism=8"),
+  )
+  def test_moe_gpt_oss_20b_explicit_sharding(self, parallelism):
+    """AOT test for gpt-oss under explicit sharding.
+
+    RoutedMoE.dense_matmul is not onboarded to explicit sharding yet, so only the
+    sparse_matmul path is compiled here.
+    """
+    compiled_trainstep_file = f"/tmp/test_moe_gpt_oss_20b_explicit_sharding_{parallelism}.pickle"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-16",
+            "compile_topology_num_slices=1",
+            "model_name=gpt-oss-20b",
+            "per_device_batch_size=1",
+            "max_target_length=1024",
+            "dtype=bfloat16",
+            "weight_dtype=bfloat16",
+            "scan_layers=True",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "shard_mode=explicit",
+            "ici_fsdp_parallelism=1",
+            parallelism,
+        )
+    )
+
   def test_gpt3_6b(self):
     compiled_trainstep_file = "/tmp/test_gpt3_6b"
     train_compile_main(
@@ -769,6 +802,28 @@ class TrainCompile(parameterized.TestCase):
             "compile_topology_num_slices=1",
             "model_name=gpt3-6b",
             "per_device_batch_size=1",
+        )
+    )
+
+  @parameterized.named_parameters(("fused_qkv", True), ("unfused_qkv", False))
+  def test_gpt3_6b_explicit_sharding(self, fused_qkv):
+    """AOT test for gpt3 under explicit sharding, with tensor parallelism on the heads axis."""
+    compiled_trainstep_file = f"/tmp/test_gpt3_6b_explicit_sharding_{fused_qkv}"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "compile_topology_num_slices=1",
+            "model_name=gpt3-6b",
+            "per_device_batch_size=1",
+            "shard_mode=explicit",
+            # gpt3-6b.yml sets fused_qkv, so flipping it needs the override.
+            "override_model_config=true",
+            f"fused_qkv={fused_qkv}",
+            "ici_fsdp_parallelism=1",
+            "ici_tensor_parallelism=4",
         )
     )
 

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -763,11 +763,7 @@ class TrainCompile(parameterized.TestCase):
       ("tensor_parallelism", "ici_tensor_parallelism=8"),
   )
   def test_moe_gpt_oss_20b_explicit_sharding(self, parallelism):
-    """AOT test for gpt-oss under explicit sharding.
-
-    RoutedMoE.dense_matmul is not onboarded to explicit sharding yet, so only the
-    sparse_matmul path is compiled here.
-    """
+    """AOT test for gpt-oss under explicit sharding, on the sparse_matmul path."""
     compiled_trainstep_file = f"/tmp/test_moe_gpt_oss_20b_explicit_sharding_{parallelism}.pickle"
     train_compile_main(
         (
@@ -819,7 +815,6 @@ class TrainCompile(parameterized.TestCase):
             "model_name=gpt3-6b",
             "per_device_batch_size=1",
             "shard_mode=explicit",
-            # gpt3-6b.yml sets fused_qkv, so flipping it needs the override.
             "override_model_config=true",
             f"fused_qkv={fused_qkv}",
             "ici_fsdp_parallelism=1",

--- a/tests/utils/reference_hlo_deepseek3.txt
+++ b/tests/utils/reference_hlo_deepseek3.txt
@@ -9,224 +9,224 @@ FileLocations
 StackFrames
 
 
-%fused_computation.1369 (param_0.3893: s32[1,128]) -> s32[1,1,128] {
-  %param_0.3893 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %constant.1684.clone.151 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %broadcast.4449 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1684.clone.151), dimensions={}, metadata={op_name="broadcast.360"}
-  %lt.832 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.3893, %broadcast.4449), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
-  %constant.1696.clone.1 = s32[]{:T(128)} constant(129280)
-  %add.3619 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1696.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %add.3557 = s32[1,128]{1,0:T(1,128)} add(%param_0.3893, %add.3619), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %select_n.2263 = s32[1,128]{1,0:T(1,128)} select(%lt.832, %add.3557, %param_0.3893), metadata={op_name="jit(train_step)/jvp()/select_n" stack_frame_id=0}
-  ROOT %bitcast.1748 = s32[1,1,128]{2,1,0:T(1,128)S(1)} bitcast(%select_n.2263)
+%fused_computation.1367 (param_0.3891: s32[1,128]) -> s32[1,1,128] {
+  %param_0.3891 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
+  %constant.1666.clone.151 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %broadcast.4395 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1666.clone.151), dimensions={}, metadata={op_name="broadcast.360"}
+  %lt.831 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.3891, %broadcast.4395), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
+  %constant.1678.clone.1 = s32[]{:T(128)} constant(129280)
+  %add.3574 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1678.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %add.3512 = s32[1,128]{1,0:T(1,128)} add(%param_0.3891, %add.3574), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %select_n.2263 = s32[1,128]{1,0:T(1,128)} select(%lt.831, %add.3512, %param_0.3891), metadata={op_name="jit(train_step)/jvp()/select_n" stack_frame_id=0}
+  ROOT %bitcast.1750 = s32[1,1,128]{2,1,0:T(1,128)S(1)} bitcast(%select_n.2263)
 }
 
-%fused_computation.1151 (param_0.3386: s32[512]) -> s32[1024] {
-  %constant.4100 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.4298 = s32[1024]{0:T(1024)} broadcast(%constant.4100), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %param_0.3386 = s32[512]{0:T(512)S(1)} parameter(0)
-  %constant.4106 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %pad.332 = s32[1024]{0:T(1024)} pad(%param_0.3386, %constant.4106), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %constant.4089 = s32[] constant(129279), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.4287 = s32[1024]{0:T(1024)} broadcast(%constant.4089), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  ROOT %clamp.60 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4298, %pad.332, %broadcast.4287), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+%fused_computation.1149 (param_0.3384: s32[512]) -> s32[1024] {
+  %constant.4082 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.4244 = s32[1024]{0:T(1024)} broadcast(%constant.4082), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %param_0.3384 = s32[512]{0:T(512)S(1)} parameter(0)
+  %constant.4088 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %pad.332 = s32[1024]{0:T(1024)} pad(%param_0.3384, %constant.4088), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.4071 = s32[] constant(129279), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.4233 = s32[1024]{0:T(1024)} broadcast(%constant.4071), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  ROOT %clamp.60 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4244, %pad.332, %broadcast.4233), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
 %fused_computation.6 (param_0.20: bf16[129280,128], param_1.121: s32[1024]) -> bf16[512,128] {
   %param_0.20 = bf16[129280,128]{1,0:T(8,128)(2,1)S(1)} parameter(0)
   %param_1.121 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.18 = s32[1024]{0:T(1024)} custom-call(%param_1.121), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %slice.1067 = s32[512]{0:T(512)} slice(%custom-call.18), slice={[0:512]}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %reshape.4259 = s32[4,128]{1,0:T(4,128)} reshape(%slice.1067), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/broadcast_in_dim" stack_frame_id=0}
-  %transpose.869 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.4259), dimensions={0,1}, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/broadcast_in_dim" stack_frame_id=0}
-  %gather.226 = bf16[4,128,128]{2,1,0:T(8,128)(2,1)} gather(%param_0.20, %transpose.869), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %transpose.868 = bf16[4,128,128]{2,1,0:T(8,128)(2,1)} transpose(%gather.226), dimensions={0,1,2}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  ROOT %reshape.4258 = bf16[512,128]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.868), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %slice.1059 = s32[512]{0:T(512)} slice(%custom-call.18), slice={[0:512]}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %reshape.4252 = s32[4,128]{1,0:T(4,128)} reshape(%slice.1059), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/broadcast_in_dim" stack_frame_id=0}
+  %transpose.871 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.4252), dimensions={0,1}, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/broadcast_in_dim" stack_frame_id=0}
+  %gather.226 = bf16[4,128,128]{2,1,0:T(8,128)(2,1)} gather(%param_0.20, %transpose.871), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %transpose.870 = bf16[4,128,128]{2,1,0:T(8,128)(2,1)} transpose(%gather.226), dimensions={0,1,2}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  ROOT %reshape.4251 = bf16[512,128]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.870), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
-%fused_computation.1445 (param_0.4471: f32[512,3]) -> bf16[3,512] {
-  %param_0.4471 = f32[512,3]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.1977 = f32[3,512]{1,0:T(4,128)} bitcast(%param_0.4471), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.1163 = bf16[3,512]{1,0:T(4,128)(2,1)} convert(%bitcast.1977)
+%fused_computation.1443 (param_0.4469: f32[512,3]) -> bf16[3,512] {
+  %param_0.4469 = f32[512,3]{0,1:T(4,128)S(1)} parameter(0)
+  %bitcast.1979 = f32[3,512]{1,0:T(4,128)} bitcast(%param_0.4469), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.1141 = bf16[3,512]{1,0:T(4,128)(2,1)} convert(%bitcast.1979)
 }
 
-%fused_computation.1140 (param_0.3274: f32[1536,3], param_1.3675: s32[]) -> bf16[3,384] {
-  %param_0.3274 = f32[1536,3]{0,1:T(4,128)S(1)} parameter(0)
-  %param_1.3675 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1684.clone.47 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %dynamic-slice.424 = bf16[384,3]{0,1:T(4,128)(2,1)} dynamic-slice(%param_0.3274, %param_1.3675, %constant.1684.clone.47), dynamic_slice_sizes={384,3}, metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294965375","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  ROOT %bitcast.1702 = bf16[3,384]{1,0:T(4,128)(2,1)} bitcast(%dynamic-slice.424), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+%fused_computation.1138 (param_0.3272: f32[1536,3], param_1.3677: s32[]) -> bf16[3,384] {
+  %param_0.3272 = f32[1536,3]{0,1:T(4,128)S(1)} parameter(0)
+  %param_1.3677 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1666.clone.47 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %dynamic-slice.424 = bf16[384,3]{0,1:T(4,128)(2,1)} dynamic-slice(%param_0.3272, %param_1.3677, %constant.1666.clone.47), dynamic_slice_sizes={384,3}, metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294965375","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %bitcast.1704 = bf16[3,384]{1,0:T(4,128)(2,1)} bitcast(%dynamic-slice.424), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
-%fused_computation.1444 (param_0.4470: f32[512,3]) -> bf16[3,512] {
-  %param_0.4470 = f32[512,3]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.1976 = f32[3,512]{1,0:T(4,128)} bitcast(%param_0.4470), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.1161 = bf16[3,512]{1,0:T(4,128)(2,1)} convert(%bitcast.1976)
+%fused_computation.1442 (param_0.4468: f32[512,3]) -> bf16[3,512] {
+  %param_0.4468 = f32[512,3]{0,1:T(4,128)S(1)} parameter(0)
+  %bitcast.1978 = f32[3,512]{1,0:T(4,128)} bitcast(%param_0.4468), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.1139 = bf16[3,512]{1,0:T(4,128)(2,1)} convert(%bitcast.1978)
 }
 
-%fused_computation.1439 (param_0.4452: f32[128,3,1536]) -> bf16[3,128,1536] {
-  %param_0.4452 = f32[128,3,1536]{2,0,1:T(8,128)S(1)} parameter(0)
-  %bitcast.1975 = f32[3,128,1536]{2,1,0:T(8,128)} bitcast(%param_0.4452), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.1159 = bf16[3,128,1536]{2,1,0:T(8,128)(2,1)} convert(%bitcast.1975)
+%fused_computation.1437 (param_0.4450: f32[128,3,1536]) -> bf16[3,128,1536] {
+  %param_0.4450 = f32[128,3,1536]{2,0,1:T(8,128)S(1)} parameter(0)
+  %bitcast.1977 = f32[3,128,1536]{2,1,0:T(8,128)} bitcast(%param_0.4450), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.1137 = bf16[3,128,1536]{2,1,0:T(8,128)(2,1)} convert(%bitcast.1977)
 }
 
-%fused_computation.1274 (param_0.3572: f32[512,3], param_1.4043: s32[]) -> bf16[3,128] {
-  %param_0.3572 = f32[512,3]{0,1:T(4,128)S(1)} parameter(0)
-  %param_1.4043 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1684.clone.59 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %dynamic-slice.442 = bf16[128,3]{0,1:T(4,128)(2,1)} dynamic-slice(%param_0.3572, %param_1.4043, %constant.1684.clone.59), dynamic_slice_sizes={128,3}, metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294966911","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  ROOT %bitcast.1727 = bf16[3,128]{1,0:T(4,128)(2,1)} bitcast(%dynamic-slice.442), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-}
-
-%fused_computation.1408 () -> f32[32] {
-  %constant.1700.clone.1 = f32[]{:T(128)} constant(10000)
-  %broadcast.4441 = f32[32]{0:T(128)} broadcast(%constant.1700.clone.1), dimensions={}, metadata={op_name="broadcast.1645"}
+%fused_computation.1406 () -> f32[32] {
+  %constant.1682.clone.1 = f32[]{:T(128)} constant(10000)
+  %broadcast.4387 = f32[32]{0:T(128)} broadcast(%constant.1682.clone.1), dimensions={}, metadata={op_name="broadcast.1640"}
   %iota.360 = f32[32]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/iota" stack_frame_id=0}
-  %constant.1701.clone.1 = f32[]{:T(128)} constant(0.03125)
-  %div.2468 = f32[32]{0:T(128)} broadcast(%constant.1701.clone.1), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2441 = f32[32]{0:T(128)} multiply(%iota.360, %div.2468), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %pow.47 = f32[32]{0:T(128)} negate(%div.2441), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
-  %pow.46 = f32[32]{0:T(128)} power(%broadcast.4441, %pow.47), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
-  %constant.1702.clone.1 = f32[]{:T(128)} constant(0.025)
-  %broadcast.4440 = f32[32]{0:T(128)} broadcast(%constant.1702.clone.1), dimensions={}, metadata={op_name="broadcast.1647"}
-  %div.2440 = f32[32]{0:T(128)} multiply(%pow.46, %broadcast.4440), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %constant.1683.clone.11 = f32[]{:T(128)} constant(1)
-  %broadcast.4439 = f32[32]{0:T(128)} broadcast(%constant.1683.clone.11), dimensions={}, metadata={op_name="broadcast.1648"}
-  %constant.1695.clone.95 = f32[]{:T(128)} constant(0)
-  %max.96 = f32[32]{0:T(128)} broadcast(%constant.1695.clone.95), dimensions={}, metadata={op_name="jit(train_step)/jit(clip)/max" stack_frame_id=0}
+  %constant.1683.clone.1 = f32[]{:T(128)} constant(0.03125)
+  %div.2467 = f32[32]{0:T(128)} broadcast(%constant.1683.clone.1), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2440 = f32[32]{0:T(128)} multiply(%iota.360, %div.2467), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %pow.47 = f32[32]{0:T(128)} negate(%div.2440), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
+  %pow.46 = f32[32]{0:T(128)} power(%broadcast.4387, %pow.47), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
+  %constant.1684.clone.1 = f32[]{:T(128)} constant(0.025)
+  %broadcast.4386 = f32[32]{0:T(128)} broadcast(%constant.1684.clone.1), dimensions={}, metadata={op_name="broadcast.1642"}
+  %div.2439 = f32[32]{0:T(128)} multiply(%pow.46, %broadcast.4386), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %constant.1665.clone.11 = f32[]{:T(128)} constant(1)
+  %broadcast.4385 = f32[32]{0:T(128)} broadcast(%constant.1665.clone.11), dimensions={}, metadata={op_name="broadcast.1643"}
+  %constant.1677.clone.95 = f32[]{:T(128)} constant(0)
+  %max.96 = f32[32]{0:T(128)} broadcast(%constant.1677.clone.95), dimensions={}, metadata={op_name="jit(train_step)/jit(clip)/max" stack_frame_id=0}
   %iota.359 = f32[32]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/iota" stack_frame_id=0}
-  %constant.1703.clone.1 = f32[]{:T(128)} constant(-10)
-  %broadcast.4438 = f32[32]{0:T(128)} broadcast(%constant.1703.clone.1), dimensions={}, metadata={op_name="broadcast.1651"}
-  %sub.875 = f32[32]{0:T(128)} add(%iota.359, %broadcast.4438), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
-  %constant.1704.clone.1 = f32[]{:T(128)} constant(0.0769230798)
-  %broadcast.4437 = f32[32]{0:T(128)} broadcast(%constant.1704.clone.1), dimensions={}, metadata={op_name="broadcast.1652"}
-  %div.2439 = f32[32]{0:T(128)} multiply(%sub.875, %broadcast.4437), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %min.42 = f32[32]{0:T(128)} clamp(%max.96, %div.2439, %broadcast.4439), metadata={op_name="jit(train_step)/jit(clip)/min" stack_frame_id=0}
-  %sub.874 = f32[32]{0:T(128)} subtract(%broadcast.4439, %min.42), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
-  %sub.873 = f32[32]{0:T(128)} subtract(%broadcast.4439, %sub.874), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
-  %mul.4518 = f32[32]{0:T(128)} multiply(%div.2440, %sub.873), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4517 = f32[32]{0:T(128)} multiply(%pow.46, %sub.874), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  ROOT %add.3598 = f32[32]{0:T(128)S(1)} add(%mul.4518, %mul.4517), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %constant.1685.clone.1 = f32[]{:T(128)} constant(-10)
+  %broadcast.4384 = f32[32]{0:T(128)} broadcast(%constant.1685.clone.1), dimensions={}, metadata={op_name="broadcast.1646"}
+  %sub.875 = f32[32]{0:T(128)} add(%iota.359, %broadcast.4384), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
+  %constant.1686.clone.1 = f32[]{:T(128)} constant(0.0769230798)
+  %broadcast.4383 = f32[32]{0:T(128)} broadcast(%constant.1686.clone.1), dimensions={}, metadata={op_name="broadcast.1647"}
+  %div.2438 = f32[32]{0:T(128)} multiply(%sub.875, %broadcast.4383), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %min.42 = f32[32]{0:T(128)} clamp(%max.96, %div.2438, %broadcast.4385), metadata={op_name="jit(train_step)/jit(clip)/min" stack_frame_id=0}
+  %sub.874 = f32[32]{0:T(128)} subtract(%broadcast.4385, %min.42), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
+  %sub.873 = f32[32]{0:T(128)} subtract(%broadcast.4385, %sub.874), metadata={op_name="jit(train_step)/sub" stack_frame_id=0}
+  %mul.4630 = f32[32]{0:T(128)} multiply(%div.2439, %sub.873), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4629 = f32[32]{0:T(128)} multiply(%pow.46, %sub.874), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  ROOT %add.3553 = f32[32]{0:T(128)S(1)} add(%mul.4630, %mul.4629), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
 }
 
-%fused_computation.502 (param_0.4560: f32[32]) -> (f32[163840,32], f32[163840,32]) {
-  %mul.3581 = f32[163840,32]{1,0:T(8,128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %param_0.4560 = f32[32]{0:T(128)S(1)} parameter(0)
-  %mul.3674 = f32[163840,32]{1,0:T(8,128)} broadcast(%param_0.4560), dimensions={1}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.3580 = f32[163840,32]{1,0:T(8,128)} multiply(%mul.3581, %mul.3674), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %constant.1695.clone.94 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2449 = f32[163840,32]{1,0:T(8,128)} broadcast(%constant.1695.clone.94), dimensions={}, metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  %exp.480 = pred[163840,32]{1,0:T(8,128)(4,1)} compare(%mul.3580, %convert_element_type.2449), direction=EQ, metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %mul.3561 = f32[163840,32]{1,0:T(8,128)} multiply(%mul.3580, %convert_element_type.2449), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %exp.473 = f32[163840,32]{1,0:T(8,128)} exponential(%mul.3561), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %constant.1705.clone.1 = f32[]{:T(128)} constant(inf)
-  %broadcast.4111 = f32[163840,32]{1,0:T(8,128)} broadcast(%constant.1705.clone.1), dimensions={}, metadata={op_name="broadcast.363"}
-  %exp.472 = pred[163840,32]{1,0:T(8,128)(4,1)} compare(%exp.473, %broadcast.4111), direction=EQ, metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %exp.460 = f32[163840,32]{1,0:T(8,128)} sine(%mul.3580), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %exp.459 = f32[163840,32]{1,0:T(8,128)} multiply(%exp.473, %exp.460), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %exp.458 = f32[163840,32]{1,0:T(8,128)} multiply(%exp.459, %exp.473), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %exp.457 = f32[163840,32]{1,0:T(8,128)} select(%exp.472, %exp.458, %exp.459), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %exp.453 = f32[163840,32]{1,0:T(8,128)} select(%exp.480, %convert_element_type.2449, %exp.457), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %exp.461.clone.1 = f32[163840,32]{1,0:T(8,128)} cosine(%mul.3580), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %exp.452.clone.1 = f32[163840,32]{1,0:T(8,128)} multiply(%exp.473, %exp.461.clone.1), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %exp.451.clone.1 = f32[163840,32]{1,0:T(8,128)} multiply(%exp.452.clone.1, %exp.473), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  %exp.450.clone.1 = f32[163840,32]{1,0:T(8,128)} select(%exp.472, %exp.451.clone.1, %exp.452.clone.1), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
-  ROOT %tuple.718 = (f32[163840,32]{1,0:T(8,128)}, f32[163840,32]{1,0:T(8,128)}) tuple(%exp.453, %exp.450.clone.1)
+%fused_computation.500 (param_0.4558: f32[32]) -> (f32[163840,32], f32[163840,32]) {
+  %mul.3681 = f32[163840,32]{1,0:T(8,128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %param_0.4558 = f32[32]{0:T(128)S(1)} parameter(0)
+  %mul.3774 = f32[163840,32]{1,0:T(8,128)} broadcast(%param_0.4558), dimensions={1}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.3680 = f32[163840,32]{1,0:T(8,128)} multiply(%mul.3681, %mul.3774), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %constant.1677.clone.94 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2409 = f32[163840,32]{1,0:T(8,128)} broadcast(%constant.1677.clone.94), dimensions={}, metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
+  %exp.479 = pred[163840,32]{1,0:T(8,128)(4,1)} compare(%mul.3680, %convert_element_type.2409), direction=EQ, metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %mul.3661 = f32[163840,32]{1,0:T(8,128)} multiply(%mul.3680, %convert_element_type.2409), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %exp.472 = f32[163840,32]{1,0:T(8,128)} exponential(%mul.3661), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %constant.1687.clone.1 = f32[]{:T(128)} constant(inf)
+  %broadcast.4057 = f32[163840,32]{1,0:T(8,128)} broadcast(%constant.1687.clone.1), dimensions={}, metadata={op_name="broadcast.363"}
+  %exp.471 = pred[163840,32]{1,0:T(8,128)(4,1)} compare(%exp.472, %broadcast.4057), direction=EQ, metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %exp.459 = f32[163840,32]{1,0:T(8,128)} sine(%mul.3680), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %exp.458 = f32[163840,32]{1,0:T(8,128)} multiply(%exp.472, %exp.459), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %exp.457 = f32[163840,32]{1,0:T(8,128)} multiply(%exp.458, %exp.472), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %exp.456 = f32[163840,32]{1,0:T(8,128)} select(%exp.471, %exp.457, %exp.458), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %exp.452 = f32[163840,32]{1,0:T(8,128)} select(%exp.479, %convert_element_type.2409, %exp.456), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %exp.460.clone.1 = f32[163840,32]{1,0:T(8,128)} cosine(%mul.3680), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %exp.451.clone.1 = f32[163840,32]{1,0:T(8,128)} multiply(%exp.472, %exp.460.clone.1), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %exp.450.clone.1 = f32[163840,32]{1,0:T(8,128)} multiply(%exp.451.clone.1, %exp.472), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  %exp.449.clone.1 = f32[163840,32]{1,0:T(8,128)} select(%exp.471, %exp.450.clone.1, %exp.451.clone.1), metadata={op_name="jit(train_step)/exp" stack_frame_id=0}
+  ROOT %tuple.719 = (f32[163840,32]{1,0:T(8,128)}, f32[163840,32]{1,0:T(8,128)}) tuple(%exp.452, %exp.449.clone.1)
 }
 
-%fused_computation.1370 (param_0.3897: s32[1,128]) -> s32[128] {
-  %param_0.3897 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %constant.1684.clone.89 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %broadcast.4448 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1684.clone.89), dimensions={}, metadata={op_name="broadcast.360"}
-  %lt.834 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.3897, %broadcast.4448), direction=LT, metadata={op_name="jit(train_step)/lt" stack_frame_id=0}
-  %constant.1706.clone.2 = s32[]{:T(128)} constant(163840)
-  %broadcast.4436 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1706.clone.2), dimensions={}, metadata={op_name="broadcast.351"}
-  %add.3559 = s32[1,128]{1,0:T(1,128)} add(%param_0.3897, %broadcast.4436), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %select_n.2265 = s32[1,128]{1,0:T(1,128)} select(%lt.834, %add.3559, %param_0.3897), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
-  ROOT %bitcast.1749 = s32[128]{0:T(128)S(1)} bitcast(%select_n.2265), metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+%fused_computation.1368 (param_0.3895: s32[1,128]) -> s32[128] {
+  %param_0.3895 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
+  %constant.1666.clone.89 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %broadcast.4394 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1666.clone.89), dimensions={}, metadata={op_name="broadcast.360"}
+  %lt.833 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.3895, %broadcast.4394), direction=LT, metadata={op_name="jit(train_step)/lt" stack_frame_id=0}
+  %constant.1688.clone.2 = s32[]{:T(128)} constant(163840)
+  %broadcast.4382 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.1688.clone.2), dimensions={}, metadata={op_name="broadcast.351"}
+  %add.3514 = s32[1,128]{1,0:T(1,128)} add(%param_0.3895, %broadcast.4382), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %select_n.2265 = s32[1,128]{1,0:T(1,128)} select(%lt.833, %add.3514, %param_0.3895), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
+  ROOT %bitcast.1751 = s32[128]{0:T(128)S(1)} bitcast(%select_n.2265), metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
 }
 
-%fused_computation.1150 (param_0.3385: s32[128]) -> s32[1024] {
-  %constant.4090 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.4297 = s32[1024]{0:T(1024)} broadcast(%constant.4090), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %param_0.3385 = s32[128]{0:T(128)S(1)} parameter(0)
-  %constant.4105 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %pad.331 = s32[1024]{0:T(1024)} pad(%param_0.3385, %constant.4105), padding=0_896, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %constant.4088 = s32[] constant(163839), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %broadcast.4286 = s32[1024]{0:T(1024)} broadcast(%constant.4088), dimensions={}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  ROOT %clamp.59 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4297, %pad.331, %broadcast.4286), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+%fused_computation.1148 (param_0.3383: s32[128]) -> s32[1024] {
+  %constant.4072 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.4243 = s32[1024]{0:T(1024)} broadcast(%constant.4072), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %param_0.3383 = s32[128]{0:T(128)S(1)} parameter(0)
+  %constant.4087 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %pad.331 = s32[1024]{0:T(1024)} pad(%param_0.3383, %constant.4087), padding=0_896, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %constant.4070 = s32[] constant(163839), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %broadcast.4232 = s32[1024]{0:T(1024)} broadcast(%constant.4070), dimensions={}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  ROOT %clamp.59 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4243, %pad.331, %broadcast.4232), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
 }
 
 %fused_computation.7 (param_0.23: f32[163840,32], param_1.123: s32[1024]) -> f32[128,32] {
   %param_0.23 = f32[163840,32]{1,0:T(8,128)} parameter(0)
   %param_1.123 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.20 = s32[1024]{0:T(1024)} custom-call(%param_1.123), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %slice.1069 = s32[128]{0:T(128)} slice(%custom-call.20), slice={[0:128]}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %reshape.4267 = s32[128]{0:T(128)} reshape(%slice.1069), metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.875 = s32[128]{0:T(128)} transpose(%reshape.4267), dimensions={0}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %gather.228 = f32[128,32]{1,0:T(8,128)} gather(%param_0.23, %transpose.875), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %transpose.874 = f32[128,32]{1,0:T(8,128)} transpose(%gather.228), dimensions={0,1}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  ROOT %reshape.4266 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.874), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %slice.1061 = s32[128]{0:T(128)} slice(%custom-call.20), slice={[0:128]}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %reshape.4260 = s32[128]{0:T(128)} reshape(%slice.1061), metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.877 = s32[128]{0:T(128)} transpose(%reshape.4260), dimensions={0}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %gather.228 = f32[128,32]{1,0:T(8,128)} gather(%param_0.23, %transpose.877), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %transpose.876 = f32[128,32]{1,0:T(8,128)} transpose(%gather.228), dimensions={0,1}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  ROOT %reshape.4259 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.876), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
 }
 
 %fused_computation.8 (param_0.26: f32[163840,32], param_1.125: s32[1024]) -> f32[128,32] {
   %param_0.26 = f32[163840,32]{1,0:T(8,128)} parameter(0)
   %param_1.125 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.22 = s32[1024]{0:T(1024)} custom-call(%param_1.125), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %slice.1071 = s32[128]{0:T(128)} slice(%custom-call.22), slice={[0:128]}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %reshape.4275 = s32[128]{0:T(128)} reshape(%slice.1071), metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.881 = s32[128]{0:T(128)} transpose(%reshape.4275), dimensions={0}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %gather.230 = f32[128,32]{1,0:T(8,128)} gather(%param_0.26, %transpose.881), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %transpose.880 = f32[128,32]{1,0:T(8,128)} transpose(%gather.230), dimensions={0,1}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  ROOT %reshape.4274 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.880), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %slice.1063 = s32[128]{0:T(128)} slice(%custom-call.22), slice={[0:128]}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %reshape.4268 = s32[128]{0:T(128)} reshape(%slice.1063), metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.883 = s32[128]{0:T(128)} transpose(%reshape.4268), dimensions={0}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
+  %gather.230 = f32[128,32]{1,0:T(8,128)} gather(%param_0.26, %transpose.883), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %transpose.882 = f32[128,32]{1,0:T(8,128)} transpose(%gather.230), dimensions={0,1}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  ROOT %reshape.4267 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.882), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
 }
 
-%fused_computation.1437 (param_0.4451: f32[128,3,18432]) -> bf16[3,128,18432] {
-  %param_0.4451 = f32[128,3,18432]{2,0,1:T(8,128)S(1)} parameter(0)
-  %bitcast.1974 = f32[3,128,18432]{2,1,0:T(8,128)} bitcast(%param_0.4451), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.1157 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} convert(%bitcast.1974)
+%fused_computation.1272 (param_0.3570: f32[512,3], param_1.4045: s32[]) -> bf16[3,128] {
+  %param_0.3570 = f32[512,3]{0,1:T(4,128)S(1)} parameter(0)
+  %param_1.4045 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1666.clone.59 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %dynamic-slice.442 = bf16[128,3]{0,1:T(4,128)(2,1)} dynamic-slice(%param_0.3570, %param_1.4045, %constant.1666.clone.59), dynamic_slice_sizes={128,3}, metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294966911","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %bitcast.1729 = bf16[3,128]{1,0:T(4,128)(2,1)} bitcast(%dynamic-slice.442), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
 }
 
-%fused_computation.1435 (param_0.4450: f32[128,3,18432]) -> bf16[3,128,18432] {
-  %param_0.4450 = f32[128,3,18432]{2,0,1:T(8,128)S(1)} parameter(0)
-  %bitcast.1973 = f32[3,128,18432]{2,1,0:T(8,128)} bitcast(%param_0.4450), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.1153 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} convert(%bitcast.1973)
+%fused_computation.1435 (param_0.4449: f32[128,3,18432]) -> bf16[3,128,18432] {
+  %param_0.4449 = f32[128,3,18432]{2,0,1:T(8,128)} parameter(0)
+  %bitcast.1976 = f32[3,128,18432]{2,1,0:T(8,128)} bitcast(%param_0.4449), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.1135 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} convert(%bitcast.1976)
 }
 
-%fused_computation.1436 (param_0.4449: f32[18432,3,128]) -> bf16[3,18432,128] {
-  %param_0.4449 = f32[18432,3,128]{2,0,1:T(8,128)} parameter(0)
-  %bitcast.1972 = f32[3,18432,128]{2,1,0:T(8,128)} bitcast(%param_0.4449), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.1155 = bf16[3,18432,128]{2,1,0:T(8,128)(2,1)} convert(%bitcast.1972)
+%fused_computation.1433 (param_0.4448: f32[128,3,18432]) -> bf16[3,128,18432] {
+  %param_0.4448 = f32[128,3,18432]{2,0,1:T(8,128)S(1)} parameter(0)
+  %bitcast.1975 = f32[3,128,18432]{2,1,0:T(8,128)} bitcast(%param_0.4448), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.1131 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} convert(%bitcast.1975)
 }
 
-%fused_computation.171.clone.1 (param_0.4899: bf16[3,1,128,512], param_1.5551: s32[], param_2.4328: bf16[1,128,512]) -> bf16[3,1,128,512] {
-  %param_0.4899 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_2.4328 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %bitcast.2360 = bf16[1,1,128,512]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.4328), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/broadcast_in_dim" stack_frame_id=0}
-  %param_1.5551 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.42 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-update-slice.65 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.4899, %bitcast.2360, %param_1.5551, %constant.1455.clone.42, %constant.1455.clone.42, /*index=5*/%constant.1455.clone.42), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.1434 (param_0.4447: f32[18432,3,128]) -> bf16[3,18432,128] {
+  %param_0.4447 = f32[18432,3,128]{2,0,1:T(8,128)S(1)} parameter(0)
+  %bitcast.1974 = f32[3,18432,128]{2,1,0:T(8,128)} bitcast(%param_0.4447), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.1133 = bf16[3,18432,128]{2,1,0:T(8,128)(2,1)} convert(%bitcast.1974)
 }
 
-%fused_computation.129.clone.1 (param_0.4931: bf16[3,128,128,128], param_1.5572: s32[]) -> bf16[1,128,128,128] {
-  %param_0.4931 = bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.5572 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.50 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.532 = bf16[1,128,128,128]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4931, %param_1.5572, %constant.1455.clone.50, %constant.1455.clone.50, %constant.1455.clone.50), dynamic_slice_sizes={1,128,128,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.169.clone.1 (param_0.4897: bf16[3,1,128,512], param_1.5553: s32[], param_2.4327: bf16[1,128,512]) -> bf16[3,1,128,512] {
+  %param_0.4897 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_2.4327 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %bitcast.2364 = bf16[1,1,128,512]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.4327), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/broadcast_in_dim" stack_frame_id=0}
+  %param_1.5553 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.42 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-update-slice.65 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.4897, %bitcast.2364, %param_1.5553, %constant.1437.clone.42, %constant.1437.clone.42, /*index=5*/%constant.1437.clone.42), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.99.clone.1 (param_0.4925: bf16[3,384,128,192], param_1.5567: s32[]) -> bf16[1,384,128,192] {
-  %param_0.4925 = bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)} parameter(0)
-  %param_1.5567 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.49 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.531 = bf16[1,384,128,192]{2,1,3,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4925, %param_1.5567, %constant.1455.clone.49, %constant.1455.clone.49, %constant.1455.clone.49), dynamic_slice_sizes={1,384,128,192}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.127.clone.1 (param_0.4929: bf16[3,128,128,128], param_1.5574: s32[]) -> bf16[1,128,128,128] {
+  %param_0.4929 = bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.5574 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.50 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.532 = bf16[1,128,128,128]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4929, %param_1.5574, %constant.1437.clone.50, %constant.1437.clone.50, %constant.1437.clone.50), dynamic_slice_sizes={1,128,128,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.140.clone.1 (param_0.4920: bf16[3,128,1536], param_1.5564: s32[]) -> bf16[1,128,1536] {
-  %param_0.4920 = bf16[3,128,1536]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.5564 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.48 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.530 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4920, %param_1.5564, %constant.1455.clone.48, %constant.1455.clone.48), dynamic_slice_sizes={1,128,1536}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.97.clone.1 (param_0.4923: bf16[3,384,128,192], param_1.5569: s32[]) -> bf16[1,384,128,192] {
+  %param_0.4923 = bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)} parameter(0)
+  %param_1.5569 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.49 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.531 = bf16[1,384,128,192]{2,1,3,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4923, %param_1.5569, %constant.1437.clone.49, %constant.1437.clone.49, %constant.1437.clone.49), dynamic_slice_sizes={1,384,128,192}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+}
+
+%fused_computation.138.clone.1 (param_0.4918: bf16[3,128,1536], param_1.5566: s32[]) -> bf16[1,128,1536] {
+  %param_0.4918 = bf16[3,128,1536]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.5566 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.48 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.530 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4918, %param_1.5566, %constant.1437.clone.48, %constant.1437.clone.48), dynamic_slice_sizes={1,128,1536}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %region_2.3 (reduce_sum.9: f32[], reduce_sum.13: f32[]) -> f32[] {
@@ -235,69 +235,69 @@ StackFrames
   ROOT %reduce_sum.14 = f32[]{:T(128)} add(%reduce_sum.9, %reduce_sum.13), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.158.clone.1 (param_0.4902: bf16[1,128,512]) -> f32[128] {
-  %param_0.4902 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.2806 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4902), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.700 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2806, %convert_element_type.2806), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
-  %constant.1456.clone.19 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.874 = f32[128]{0:T(128)S(1)} reduce(%square.700, %constant.1456.clone.19), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+%fused_computation.156.clone.1 (param_0.4900: bf16[1,128,512]) -> f32[128] {
+  %param_0.4900 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.2766 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4900), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.692 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2766, %convert_element_type.2766), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+  %constant.1438.clone.19 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.866 = f32[128]{0:T(128)S(1)} reduce(%square.692, %constant.1438.clone.19), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.205.clone.1 (param_0.4903: f32[128]) -> f32[128] {
-  %param_0.4903 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1457.clone.11 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4746 = f32[128]{0:T(128)} broadcast(%constant.1457.clone.11), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.2864 = f32[128]{0:T(128)} multiply(%param_0.4903, %broadcast.4746), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %constant.1458.clone.13 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4745 = f32[128]{0:T(128)} broadcast(%constant.1458.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3922 = f32[128]{0:T(128)} add(%div.2864, %broadcast.4745), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  ROOT %rsqrt.366 = f32[128]{0:T(128)S(1)} rsqrt(%add.3922), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
+%fused_computation.203.clone.1 (param_0.4901: f32[128]) -> f32[128] {
+  %param_0.4901 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1439.clone.11 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4692 = f32[128]{0:T(128)} broadcast(%constant.1439.clone.11), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.2863 = f32[128]{0:T(128)} multiply(%param_0.4901, %broadcast.4692), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %constant.1440.clone.13 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4691 = f32[128]{0:T(128)} broadcast(%constant.1440.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3877 = f32[128]{0:T(128)} add(%div.2863, %broadcast.4691), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  ROOT %rsqrt.358 = f32[128]{0:T(128)S(1)} rsqrt(%add.3877), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%convert_element_type.2193.reduce_sub_computation (lhs.15: bf16[], rhs.15: bf16[]) -> bf16[] {
+%convert_element_type.2153.reduce_sub_computation (lhs.15: bf16[], rhs.15: bf16[]) -> bf16[] {
   %lhs.15 = bf16[] parameter(0)
   %rhs.15 = bf16[] parameter(1)
-  ROOT %add.3016 = bf16[] add(%lhs.15, %rhs.15), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.2971 = bf16[] add(%lhs.15, %rhs.15), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%convert_element_type.2196.reduce_sub_computation (lhs.17: bf16[], rhs.17: bf16[]) -> bf16[] {
+%convert_element_type.2156.reduce_sub_computation (lhs.17: bf16[], rhs.17: bf16[]) -> bf16[] {
   %lhs.17 = bf16[] parameter(0)
   %rhs.17 = bf16[] parameter(1)
-  ROOT %add.3018 = bf16[] add(%lhs.17, %rhs.17), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.2973 = bf16[] add(%lhs.17, %rhs.17), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.197.clone.1 (param_0.4900: bf16[3,512], param_1.5552: s32[], param_2.4329: bf16[3,512]) -> (bf16[512], bf16[512]) {
-  %param_0.4900 = bf16[3,512]{1,0:T(4,128)(2,1)} parameter(0)
-  %param_1.5552 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.43 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.376 = bf16[1,512]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.4900, %param_1.5552, %constant.1455.clone.43), dynamic_slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %constant.4239 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %reduce.873 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%dynamic_slice.376, %constant.4239), dimensions={0}, to_apply=%convert_element_type.2193.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_2.4329 = bf16[3,512]{1,0:T(4,128)(2,1)} parameter(2)
-  %dynamic_slice.362.clone.3 = bf16[1,512]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.4329, %param_1.5552, %constant.1455.clone.43), dynamic_slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %reduce.677.clone.3 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%dynamic_slice.362.clone.3, %constant.4239), dimensions={0}, to_apply=%convert_element_type.2196.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.858 = (bf16[512]{0:T(512)(128)(2,1)S(1)}, bf16[512]{0:T(512)(128)(2,1)S(1)}) tuple(%reduce.873, %reduce.677.clone.3)
+%fused_computation.195.clone.1 (param_0.4898: bf16[3,512], param_1.5554: s32[], param_2.4328: bf16[3,512]) -> (bf16[512], bf16[512]) {
+  %param_0.4898 = bf16[3,512]{1,0:T(4,128)(2,1)} parameter(0)
+  %param_1.5554 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.43 = s32[]{:T(128)} constant(0)
+  %dynamic_slice.340 = bf16[1,512]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.4898, %param_1.5554, %constant.1437.clone.43), dynamic_slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.4221 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %reduce.865 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%dynamic_slice.340, %constant.4221), dimensions={0}, to_apply=%convert_element_type.2153.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_2.4328 = bf16[3,512]{1,0:T(4,128)(2,1)} parameter(2)
+  %dynamic_slice.326.clone.3 = bf16[1,512]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.4328, %param_1.5554, %constant.1437.clone.43), dynamic_slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %reduce.669.clone.3 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%dynamic_slice.326.clone.3, %constant.4221), dimensions={0}, to_apply=%convert_element_type.2156.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.859 = (bf16[512]{0:T(512)(128)(2,1)S(1)}, bf16[512]{0:T(512)(128)(2,1)S(1)}) tuple(%reduce.865, %reduce.669.clone.3)
 }
 
-%fused_computation.170.clone.1.clone.clone.clone.1 (param_0.4922: bf16[1,128,512], param_1.5565: f32[128], param_2.4335: bf16[512]) -> bf16[128,512] {
-  %param_2.4335 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.918 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4335), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1604 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.918)
-  %param_0.4922 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.2814 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4922), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.5565 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.5112 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.5565), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.5111 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2814, %mul.5112), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2813 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.5111), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1605 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2813)
-  %dot_general.917 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1604, %convert.1605), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1606 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.917)
-  ROOT %bitcast.2375 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1606)
+%fused_computation.168.clone.1.clone.clone.clone.1 (param_0.4920: bf16[1,128,512], param_1.5567: f32[128], param_2.4334: bf16[512]) -> bf16[128,512] {
+  %param_2.4334 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
+  %dot_general.903 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4334), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1580 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.903)
+  %param_0.4920 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.2774 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4920), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.5567 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.5234 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.5567), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5233 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2774, %mul.5234), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2773 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.5233), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1581 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2773)
+  %dot_general.902 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1580, %convert.1581), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1582 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.902)
+  ROOT %bitcast.2379 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1582)
 }
 
-%fused_computation.135.clone.clone.clone.clone.clone.clone.clone.1 (param_0.4921: bf16[1,512,1536]) -> bf16[512,1536] {
-  %param_0.4921 = bf16[1,512,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.2374 = bf16[512,1536]{1,0:T(8,128)(2,1)} bitcast(%param_0.4921), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.133.clone.clone.clone.clone.clone.clone.clone.1 (param_0.4919: bf16[1,512,1536]) -> bf16[512,1536] {
+  %param_0.4919 = bf16[1,512,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.2378 = bf16[512,1536]{1,0:T(8,128)(2,1)} bitcast(%param_0.4919), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
 %region_3.4 (reduce_sum.15: f32[], reduce_sum.16: f32[]) -> f32[] {
@@ -306,221 +306,221 @@ StackFrames
   ROOT %reduce_sum.20 = f32[]{:T(128)} add(%reduce_sum.15, %reduce_sum.16), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.139.clone.1 (param_0.4923: bf16[1,512,1536], param_1.5566: bf16[1,128,512], param_2.4336: f32[128], param_3.2930: bf16[512]) -> (f32[128], f32[1,128,1536]) {
-  %param_1.5566 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.4336 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.2930 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
-  %fusion.140.clone.3 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5566, %param_2.4336, %param_3.2930), kind=kLoop, calls=%fused_computation.170.clone.1.clone.clone.clone.1
-  %param_0.4923 = bf16[1,512,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.85.clone.3 = bf16[512,1536]{1,0:T(8,128)(2,1)} fusion(%param_0.4923), kind=kLoop, calls=%fused_computation.135.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.91.clone.3 = bf16[128,1536]{1,0:T(8,128)(2,1)} convolution(%fusion.140.clone.3, %fusion.85.clone.3), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %bitcast.734.clone.3 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.91.clone.3)
-  %convert.597.clone.3 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} convert(%bitcast.734.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.702 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.597.clone.3, %convert.597.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
-  %constant.1456.clone.22 = f32[]{:T(128)} constant(0)
-  %reduce.876 = f32[128]{0:T(128)S(1)} reduce(%square.702, %constant.1456.clone.22), dimensions={0,2}, to_apply=%region_3.4, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.862 = (f32[128]{0:T(128)S(1)}, f32[1,128,1536]{2,1,0:T(8,128)S(1)}) tuple(%reduce.876, %convert.597.clone.3)
+%fused_computation.137.clone.1 (param_0.4921: bf16[1,512,1536], param_1.5568: bf16[1,128,512], param_2.4335: f32[128], param_3.2929: bf16[512]) -> (f32[128], f32[1,128,1536]) {
+  %param_1.5568 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.4335 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.2929 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
+  %fusion.136.clone.3 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5568, %param_2.4335, %param_3.2929), kind=kLoop, calls=%fused_computation.168.clone.1.clone.clone.clone.1
+  %param_0.4921 = bf16[1,512,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.81.clone.3 = bf16[512,1536]{1,0:T(8,128)(2,1)} fusion(%param_0.4921), kind=kLoop, calls=%fused_computation.133.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.91.clone.3 = bf16[128,1536]{1,0:T(8,128)(2,1)} convolution(%fusion.136.clone.3, %fusion.81.clone.3), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %bitcast.736.clone.3 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.91.clone.3)
+  %convert.579.clone.3 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} convert(%bitcast.736.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.694 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.579.clone.3, %convert.579.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+  %constant.1438.clone.22 = f32[]{:T(128)} constant(0)
+  %reduce.868 = f32[128]{0:T(128)S(1)} reduce(%square.694, %constant.1438.clone.22), dimensions={0,2}, to_apply=%region_3.4, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.863 = (f32[128]{0:T(128)S(1)}, f32[1,128,1536]{2,1,0:T(8,128)S(1)}) tuple(%reduce.868, %convert.579.clone.3)
 }
 
-%fused_computation.204.clone.1 (param_0.4924: f32[128]) -> f32[128] {
-  %param_0.4924 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1459.clone.7 = f32[]{:T(128)} constant(0.000651041686)
-  %broadcast.4750 = f32[128]{0:T(128)} broadcast(%constant.1459.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %div.2866 = f32[128]{0:T(128)} multiply(%param_0.4924, %broadcast.4750), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %constant.1458.clone.15 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4749 = f32[128]{0:T(128)} broadcast(%constant.1458.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3925 = f32[128]{0:T(128)} add(%div.2866, %broadcast.4749), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  ROOT %rsqrt.368 = f32[128]{0:T(128)S(1)} rsqrt(%add.3925), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
+%fused_computation.202.clone.1 (param_0.4922: f32[128]) -> f32[128] {
+  %param_0.4922 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1441.clone.7 = f32[]{:T(128)} constant(0.000651041686)
+  %broadcast.4696 = f32[128]{0:T(128)} broadcast(%constant.1441.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %div.2865 = f32[128]{0:T(128)} multiply(%param_0.4922, %broadcast.4696), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %constant.1440.clone.15 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4695 = f32[128]{0:T(128)} broadcast(%constant.1440.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3880 = f32[128]{0:T(128)} add(%div.2865, %broadcast.4695), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  ROOT %rsqrt.360 = f32[128]{0:T(128)S(1)} rsqrt(%add.3880), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.200.clone.1 (param_0.4919: bf16[3,384], param_1.5563: s32[]) -> bf16[1,384] {
-  %param_0.4919 = bf16[3,384]{1,0:T(4,128)(2,1)} parameter(0)
-  %param_1.5563 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.47 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.529 = bf16[1,384]{1,0:T(2,128)(2,1)S(1)} dynamic-slice(%param_0.4919, %param_1.5563, %constant.1455.clone.47), dynamic_slice_sizes={1,384}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.198.clone.1 (param_0.4917: bf16[3,384], param_1.5565: s32[]) -> bf16[1,384] {
+  %param_0.4917 = bf16[3,384]{1,0:T(4,128)(2,1)} parameter(0)
+  %param_1.5565 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.47 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.529 = bf16[1,384]{1,0:T(2,128)(2,1)S(1)} dynamic-slice(%param_0.4917, %param_1.5565, %constant.1437.clone.47), dynamic_slice_sizes={1,384}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %all-gather.290.reduce_sub_computation (lhs.16: bf16[], rhs.16: bf16[]) -> bf16[] {
   %lhs.16 = bf16[] parameter(0)
   %rhs.16 = bf16[] parameter(1)
-  ROOT %add.3017 = bf16[] add(%lhs.16, %rhs.16), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.2972 = bf16[] add(%lhs.16, %rhs.16), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.149.clone.clone.1 (param_0.4926: f32[1,128,1536], param_1.5568: f32[128], param_2.4337: bf16[1536]) -> bf16[128,1536,1] {
-  %param_2.4337 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.920 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4337), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1607 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%dot_general.920)
-  %param_0.4926 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} parameter(0)
-  %param_1.5568 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.5114 = f32[1,128,1536]{2,1,0:T(8,128)} broadcast(%param_1.5568), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.5113 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%param_0.4926, %mul.5114), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2815 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} convert(%mul.5113), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1608 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%convert_element_type.2815)
-  %dot_general.919 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.1607, %convert.1608), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1536"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1609 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} convert(%dot_general.919)
-  ROOT %bitcast.2377 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.1609)
+%fused_computation.147.clone.clone.1 (param_0.4924: f32[1,128,1536], param_1.5570: f32[128], param_2.4336: bf16[1536]) -> bf16[128,1536,1] {
+  %param_2.4336 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.905 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4336), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1583 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%dot_general.905)
+  %param_0.4924 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} parameter(0)
+  %param_1.5570 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.5236 = f32[1,128,1536]{2,1,0:T(8,128)} broadcast(%param_1.5570), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5235 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%param_0.4924, %mul.5236), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2775 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} convert(%mul.5235), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1584 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%convert_element_type.2775)
+  %dot_general.904 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.1583, %convert.1584), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1536"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1585 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} convert(%dot_general.904)
+  ROOT %bitcast.2381 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.1585)
 }
 
 %bitcast_fusion.17.clone.1 (bitcast_input.27: bf16[1536,128,192]) -> bf16[1536,128,192] {
   %bitcast_input.27 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.2376 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} bitcast(%bitcast_input.27)
+  ROOT %bitcast.2380 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} bitcast(%bitcast_input.27)
 }
 
-%fused_computation.131.clone.1 (param_0.4927: bf16[1536,128,192], param_1.5569: f32[1,128,1536], param_2.4338: f32[128], param_3.2931: bf16[1536]) -> bf16[1,128,128,192] {
-  %param_1.5569 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} parameter(1)
-  %param_2.4338 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.2931 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(3)
-  %fusion.1123 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.5569, %param_2.4338, %param_3.2931), kind=kLoop, calls=%fused_computation.149.clone.clone.1
-  %param_0.4927 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} parameter(0)
-  %fusion.1124 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} fusion(%param_0.4927), kind=kLoop, calls=%bitcast_fusion.17.clone.1
-  %convolution.324 = bf16[128,128,192]{2,0,1:T(8,128)(2,1)} convolution(%fusion.1123, %fusion.1124), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  ROOT %bitcast.2378 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.324), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+%fused_computation.129.clone.1 (param_0.4925: bf16[1536,128,192], param_1.5571: f32[1,128,1536], param_2.4337: f32[128], param_3.2930: bf16[1536]) -> bf16[1,128,128,192] {
+  %param_1.5571 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} parameter(1)
+  %param_2.4337 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.2930 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(3)
+  %fusion.1119 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.5571, %param_2.4337, %param_3.2930), kind=kLoop, calls=%fused_computation.147.clone.clone.1
+  %param_0.4925 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} parameter(0)
+  %fusion.1120 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} fusion(%param_0.4925), kind=kLoop, calls=%bitcast_fusion.17.clone.1
+  %convolution.324 = bf16[128,128,192]{2,0,1:T(8,128)(2,1)} convolution(%fusion.1119, %fusion.1120), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  ROOT %bitcast.2382 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.324), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.1429.clone.1 (param_0.4928: bf16[1,128,128,32,2]) -> (bf16[1,128,128,32,1], bf16[1,128,128,32,1]) {
-  %param_0.4928 = bf16[1,128,128,32,2]{2,1,4,3,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.1454 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} slice(%param_0.4928), slice={[0:1], [0:128], [0:128], [0:32], [1:2]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
-  %slice.1455 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} slice(%param_0.4928), slice={[0:1], [0:128], [0:128], [0:32], [0:1]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
-  ROOT %tuple.863 = (bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}) tuple(%slice.1454, %slice.1455)
+%fused_computation.1427.clone.1 (param_0.4926: bf16[1,128,128,32,2]) -> (bf16[1,128,128,32,1], bf16[1,128,128,32,1]) {
+  %param_0.4926 = bf16[1,128,128,32,2]{2,1,4,3,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.1446 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} slice(%param_0.4926), slice={[0:1], [0:128], [0:128], [0:32], [1:2]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
+  %slice.1447 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} slice(%param_0.4926), slice={[0:1], [0:128], [0:128], [0:32], [0:1]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
+  ROOT %tuple.864 = (bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}) tuple(%slice.1446, %slice.1447)
 }
 
-%fused_computation.123.clone.1 (param_0.4929: bf16[1,128,128,32,1], param_1.5570: bf16[1,128,128,32,1], param_2.4339: f32[128,32], param_3.2932: f32[128,32]) -> (bf16[1,128,128,32], bf16[1,128,128,32]) {
-  %param_0.4929 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.2379 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_0.4929)
-  %convert.1244 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.2379), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.5570 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(1)
-  %bitcast.2380 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_1.5570)
-  %convert.1243 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.2380), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %constant.1456.clone.23 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2816 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1456.clone.23), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %mul.5118 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.1243, %convert_element_type.2816), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %add.3926 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%convert.1244, %mul.5118), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  %param_3.2932 = f32[128,32]{1,0:T(8,128)S(1)} parameter(3)
-  %broadcast_in_dim.1387 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.2932), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %mul.5117 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3926, %broadcast_in_dim.1387), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %param_2.4339 = f32[128,32]{1,0:T(8,128)S(1)} parameter(2)
-  %broadcast_in_dim.1386 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.4339), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %mul.5116 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.1243, %broadcast_in_dim.1386), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.5115 = f32[1,128,128,32]{3,1,2,0:T(8,128)} subtract(%mul.5117, %mul.5116), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.1242 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.5115), metadata={op_name="convert.313"}
-  %mul.3101.clone.3 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3926, %broadcast_in_dim.1386), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.3097.clone.3 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.1243, %broadcast_in_dim.1387), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.3096.clone.3 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%mul.3101.clone.3, %mul.3097.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.585.clone.3 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.3096.clone.3), metadata={op_name="convert.314"}
-  ROOT %tuple.864 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.1242, %convert.585.clone.3)
+%fused_computation.121.clone.1 (param_0.4927: bf16[1,128,128,32,1], param_1.5572: bf16[1,128,128,32,1], param_2.4338: f32[128,32], param_3.2931: f32[128,32]) -> (bf16[1,128,128,32], bf16[1,128,128,32]) {
+  %param_0.4927 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(0)
+  %bitcast.2383 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_0.4927)
+  %convert.1220 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.2383), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.5572 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(1)
+  %bitcast.2384 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_1.5572)
+  %convert.1219 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.2384), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %constant.1438.clone.23 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2776 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1438.clone.23), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %mul.5240 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.1219, %convert_element_type.2776), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %add.3881 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%convert.1220, %mul.5240), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %param_3.2931 = f32[128,32]{1,0:T(8,128)S(1)} parameter(3)
+  %mul.5242 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.2931), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5239 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3881, %mul.5242), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %param_2.4338 = f32[128,32]{1,0:T(8,128)S(1)} parameter(2)
+  %mul.5241 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.4338), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5238 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.1219, %mul.5241), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5237 = f32[1,128,128,32]{3,1,2,0:T(8,128)} subtract(%mul.5239, %mul.5238), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.1218 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.5237), metadata={op_name="convert.295"}
+  %mul.3189.clone.3 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3881, %mul.5241), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.3185.clone.3 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.1219, %mul.5242), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.3184.clone.3 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%mul.3189.clone.3, %mul.3185.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.567.clone.3 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.3184.clone.3), metadata={op_name="convert.296"}
+  ROOT %tuple.865 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.1218, %convert.567.clone.3)
 }
 
-%fused_computation.127.clone.1 (param_0.4930: bf16[1,128,128,32], param_1.5571: bf16[1,128,128,32], param_2.4340: bf16[1,128,128,128]) -> bf16[128,128,192] {
-  %param_2.4340 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(2)
-  %constant.4242 = bf16[]{:T(256)} constant(-inf)
-  %pad.463 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.4340, %constant.4242), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1620 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.463)
-  %param_1.5571 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %pad.462 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.5571, %constant.4242), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1621 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.462)
-  %maximum.100 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1620, %convert.1621), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_0.4930 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.461 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.4930, %constant.4242), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1622 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.461)
-  %maximum.99 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%maximum.100, %convert.1622), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %constant.1460.clone.7 = bf16[]{:T(256)} constant(0.1348)
-  %mul.5120 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1460.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.1623 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%mul.5120)
-  %mul.5119 = f32[1,128,128,192]{3,1,2,0:T(8,128)} multiply(%maximum.99, %convert.1623), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.1624 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%mul.5119)
-  ROOT %bitcast.2381 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1624), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+%fused_computation.125.clone.1 (param_0.4928: bf16[1,128,128,32], param_1.5573: bf16[1,128,128,32], param_2.4339: bf16[1,128,128,128]) -> bf16[128,128,192] {
+  %param_2.4339 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(2)
+  %constant.4224 = bf16[]{:T(256)} constant(-inf)
+  %pad.463 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.4339, %constant.4224), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1596 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.463)
+  %param_1.5573 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %pad.462 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.5573, %constant.4224), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1597 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.462)
+  %maximum.100 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1596, %convert.1597), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_0.4928 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.461 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.4928, %constant.4224), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1598 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.461)
+  %maximum.99 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%maximum.100, %convert.1598), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %constant.1442.clone.7 = bf16[]{:T(256)} constant(0.1348)
+  %mul.5244 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1442.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.1599 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%mul.5244)
+  %mul.5243 = f32[1,128,128,192]{3,1,2,0:T(8,128)} multiply(%maximum.99, %convert.1599), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.1600 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%mul.5243)
+  ROOT %bitcast.2385 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1600), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.155.clone.1 (param_0.4904: bf16[3,128,576], param_1.5554: s32[]) -> bf16[1,128,576] {
-  %param_0.4904 = bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %param_1.5554 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.45 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.527 = bf16[1,128,576]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4904, %param_1.5554, %constant.1455.clone.45, %constant.1455.clone.45), dynamic_slice_sizes={1,128,576}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.153.clone.1 (param_0.4902: bf16[3,128,576], param_1.5556: s32[]) -> bf16[1,128,576] {
+  %param_0.4902 = bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %param_1.5556 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.45 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.527 = bf16[1,128,576]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4902, %param_1.5556, %constant.1437.clone.45, %constant.1437.clone.45), dynamic_slice_sizes={1,128,576}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.170.clone.clone.1 (param_0.4906: bf16[1,128,512], param_1.5555: f32[128], param_2.4330: bf16[512]) -> bf16[128,512] {
-  %param_2.4330 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.914 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4330), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1598 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.914)
-  %param_0.4906 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.2808 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4906), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.5555 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.5104 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.5555), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.5103 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2808, %mul.5104), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2807 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.5103), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1599 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2807)
-  %dot_general.913 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1598, %convert.1599), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1600 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.913)
-  ROOT %bitcast.2362 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1600)
+%fused_computation.168.clone.clone.1 (param_0.4904: bf16[1,128,512], param_1.5557: f32[128], param_2.4329: bf16[512]) -> bf16[128,512] {
+  %param_2.4329 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
+  %dot_general.899 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4329), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1574 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.899)
+  %param_0.4904 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.2768 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4904), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.5557 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.5226 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.5557), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5225 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2768, %mul.5226), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2767 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.5225), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1575 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2767)
+  %dot_general.898 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1574, %convert.1575), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1576 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.898)
+  ROOT %bitcast.2366 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1576)
 }
 
-%fused_computation.142.clone.clone.clone.1 (param_0.4905: bf16[1,512,576]) -> bf16[512,576] {
+%fused_computation.140.clone.clone.clone.1 (param_0.4903: bf16[1,512,576]) -> bf16[512,576] {
+  %param_0.4903 = bf16[1,512,576]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.2365 = bf16[512,576]{1,0:T(8,128)(2,1)} bitcast(%param_0.4903), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+}
+
+%fused_computation.141.clone.1 (param_0.4905: bf16[1,512,576], param_1.5558: bf16[1,128,512], param_2.4330: f32[128], param_3.2926: bf16[512]) -> bf16[1,128,576] {
+  %param_1.5558 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.4330 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.2926 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
+  %fusion.1116 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5558, %param_2.4330, %param_3.2926), kind=kLoop, calls=%fused_computation.168.clone.clone.1
   %param_0.4905 = bf16[1,512,576]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.2361 = bf16[512,576]{1,0:T(8,128)(2,1)} bitcast(%param_0.4905), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %fusion.1115 = bf16[512,576]{1,0:T(8,128)(2,1)} fusion(%param_0.4905), kind=kLoop, calls=%fused_computation.140.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.322 = bf16[128,576]{0,1:T(8,128)(2,1)} convolution(%fusion.1116, %fusion.1115), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  ROOT %bitcast.2367 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.322), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.143.clone.1 (param_0.4907: bf16[1,512,576], param_1.5556: bf16[1,128,512], param_2.4331: f32[128], param_3.2927: bf16[512]) -> bf16[1,128,576] {
-  %param_1.5556 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.4331 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.2927 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
-  %fusion.1120 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5556, %param_2.4331, %param_3.2927), kind=kLoop, calls=%fused_computation.170.clone.clone.1
-  %param_0.4907 = bf16[1,512,576]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.1119 = bf16[512,576]{1,0:T(8,128)(2,1)} fusion(%param_0.4907), kind=kLoop, calls=%fused_computation.142.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.322 = bf16[128,576]{0,1:T(8,128)(2,1)} convolution(%fusion.1120, %fusion.1119), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  ROOT %bitcast.2363 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.322), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+%fused_computation.1428.clone.1 (param_0.4913: bf16[1,128,1,32,2]) -> (bf16[1,128,1,32,1], bf16[1,128,1,32,1]) {
+  %param_0.4913 = bf16[1,128,1,32,2]{1,4,3,2,0:T(2,128)(2,1)S(1)} parameter(0)
+  %slice.1444 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4913), slice={[0:1], [0:128], [0:1], [0:32], [1:2]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
+  %slice.1445 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4913), slice={[0:1], [0:128], [0:1], [0:32], [0:1]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
+  ROOT %tuple.861 = (bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}, bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}) tuple(%slice.1444, %slice.1445)
 }
 
-%fused_computation.1430.clone.1 (param_0.4915: bf16[1,128,1,32,2]) -> (bf16[1,128,1,32,1], bf16[1,128,1,32,1]) {
-  %param_0.4915 = bf16[1,128,1,32,2]{1,4,3,2,0:T(2,128)(2,1)S(1)} parameter(0)
-  %slice.1452 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4915), slice={[0:1], [0:128], [0:1], [0:32], [1:2]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
-  %slice.1453 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4915), slice={[0:1], [0:128], [0:1], [0:32], [0:1]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
-  ROOT %tuple.860 = (bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}, bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}) tuple(%slice.1452, %slice.1453)
+%fused_computation.179.clone.1 (param_0.4914: f32[1,128,1,32], param_1.5562: f32[1,128,1,32], param_2.4333: bf16[1,128,1,32,1], param_3.2928: bf16[1,128,1,32,1]) -> (bf16[1,128,32], bf16[1,128,32]) {
+  %param_2.4333 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} parameter(2)
+  %bitcast.2374 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_2.4333)
+  %convert.1217 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.2374), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_3.2928 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} parameter(3)
+  %bitcast.2375 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_3.2928)
+  %convert.1216 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.2375), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %constant.1438.clone.21 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2772 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1438.clone.21), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %mul.5232 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1216, %convert_element_type.2772), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %add.3879 = f32[1,128,32]{2,1,0:T(8,128)} add(%convert.1217, %mul.5232), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %param_1.5562 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} parameter(1)
+  %bitcast.2373 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_1.5562), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5231 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3879, %bitcast.2373), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %param_0.4914 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} parameter(0)
+  %bitcast.2372 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_0.4914), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5230 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1216, %bitcast.2372), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5229 = f32[1,128,32]{2,1,0:T(8,128)} subtract(%mul.5231, %mul.5230), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.1215 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.5229), metadata={op_name="convert.293"}
+  %mul.3287.clone.3 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3879, %bitcast.2372), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.3284.clone.3 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1216, %bitcast.2373), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.3283.clone.3 = f32[1,128,32]{2,1,0:T(8,128)} add(%mul.3287.clone.3, %mul.3284.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.592.clone.3 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.3283.clone.3), metadata={op_name="convert.294"}
+  ROOT %tuple.862 = (bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%convert.1215, %convert.592.clone.3)
 }
 
-%fused_computation.181.clone.1 (param_0.4916: f32[1,128,1,32], param_1.5560: f32[1,128,1,32], param_2.4334: bf16[1,128,1,32,1], param_3.2929: bf16[1,128,1,32,1]) -> (bf16[1,128,32], bf16[1,128,32]) {
-  %param_2.4334 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} parameter(2)
-  %bitcast.2370 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_2.4334)
-  %convert.1241 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.2370), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_3.2929 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} parameter(3)
-  %bitcast.2371 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_3.2929)
-  %convert.1240 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.2371), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %constant.1456.clone.21 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2812 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1456.clone.21), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %mul.5110 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1240, %convert_element_type.2812), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %add.3924 = f32[1,128,32]{2,1,0:T(8,128)} add(%convert.1241, %mul.5110), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  %param_1.5560 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} parameter(1)
-  %bitcast.2369 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_1.5560), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.5109 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3924, %bitcast.2369), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %param_0.4916 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} parameter(0)
-  %bitcast.2368 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_0.4916), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.5108 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1240, %bitcast.2368), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.5107 = f32[1,128,32]{2,1,0:T(8,128)} subtract(%mul.5109, %mul.5108), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.1239 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.5107), metadata={op_name="convert.311"}
-  %mul.3195.clone.3 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3924, %bitcast.2368), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.3192.clone.3 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1240, %bitcast.2369), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.3191.clone.3 = f32[1,128,32]{2,1,0:T(8,128)} add(%mul.3195.clone.3, %mul.3192.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.610.clone.3 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.3191.clone.3), metadata={op_name="convert.312"}
-  ROOT %tuple.861 = (bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%convert.1239, %convert.610.clone.3)
+%fused_computation.189.clone.1 (param_0.4915: bf16[1,128,32], param_1.5563: bf16[1,128,32]) -> bf16[128,64] {
+  %param_1.5563 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.4222 = bf16[]{:T(256)} constant(-inf)
+  %pad.458 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.5563, %constant.4222), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1601 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.458)
+  %param_0.4915 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.457 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.4915, %constant.4222), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1602 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.457)
+  %maximum.97 = f32[1,128,64]{2,1,0:T(8,128)} maximum(%convert.1601, %convert.1602), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","64"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1603 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} convert(%maximum.97)
+  ROOT %bitcast.2376 = bf16[128,64]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1603), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
 }
 
-%fused_computation.191.clone.1 (param_0.4917: bf16[1,128,32], param_1.5561: bf16[1,128,32]) -> bf16[128,64] {
-  %param_1.5561 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.4240 = bf16[]{:T(256)} constant(-inf)
-  %pad.458 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.5561, %constant.4240), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1625 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.458)
-  %param_0.4917 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.457 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.4917, %constant.4240), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1626 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.457)
-  %maximum.97 = f32[1,128,64]{2,1,0:T(8,128)} maximum(%convert.1625, %convert.1626), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","64"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1627 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} convert(%maximum.97)
-  ROOT %bitcast.2372 = bf16[128,64]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1627), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-}
-
-%fused_computation.110.clone.1 (param_0.4910: bf16[3,128,128,256], param_1.5557: s32[]) -> bf16[1,128,128,256] {
-  %param_0.4910 = bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)} parameter(0)
-  %param_1.5557 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.46 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.528 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4910, %param_1.5557, %constant.1455.clone.46, %constant.1455.clone.46, %constant.1455.clone.46), dynamic_slice_sizes={1,128,128,256}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.108.clone.1 (param_0.4908: bf16[3,128,128,256], param_1.5559: s32[]) -> bf16[1,128,128,256] {
+  %param_0.4908 = bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.5559 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.46 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.528 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4908, %param_1.5559, %constant.1437.clone.46, %constant.1437.clone.46, %constant.1437.clone.46), dynamic_slice_sizes={1,128,128,256}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %region_4.5 (reduce_sum.21: f32[], reduce_sum.22: f32[]) -> f32[] {
@@ -529,101 +529,101 @@ StackFrames
   ROOT %reduce_sum.23 = f32[]{:T(128)} add(%reduce_sum.21, %reduce_sum.22), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.160.clone.1 (param_0.4908: bf16[1,128,576]) -> f32[128] {
-  %param_0.4908 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.1448 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_0.4908), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  %convert_element_type.2809 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1448), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.701 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2809, %convert_element_type.2809), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
-  %constant.1456.clone.20 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.875 = f32[128]{0:T(128)S(1)} reduce(%square.701, %constant.1456.clone.20), dimensions={0,2}, to_apply=%region_4.5, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+%fused_computation.158.clone.1 (param_0.4906: bf16[1,128,576]) -> f32[128] {
+  %param_0.4906 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.1440 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_0.4906), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  %convert_element_type.2769 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1440), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.693 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2769, %convert_element_type.2769), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+  %constant.1438.clone.20 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.867 = f32[128]{0:T(128)S(1)} reduce(%square.693, %constant.1438.clone.20), dimensions={0,2}, to_apply=%region_4.5, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.203.clone.1 (param_0.4909: f32[128]) -> f32[128] {
-  %param_0.4909 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1457.clone.12 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4748 = f32[128]{0:T(128)} broadcast(%constant.1457.clone.12), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.2865 = f32[128]{0:T(128)} multiply(%param_0.4909, %broadcast.4748), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %constant.1458.clone.14 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4747 = f32[128]{0:T(128)} broadcast(%constant.1458.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3923 = f32[128]{0:T(128)} add(%div.2865, %broadcast.4747), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  ROOT %rsqrt.367 = f32[128]{0:T(128)S(1)} rsqrt(%add.3923), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
+%fused_computation.201.clone.1 (param_0.4907: f32[128]) -> f32[128] {
+  %param_0.4907 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1439.clone.12 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4694 = f32[128]{0:T(128)} broadcast(%constant.1439.clone.12), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.2864 = f32[128]{0:T(128)} multiply(%param_0.4907, %broadcast.4694), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %constant.1440.clone.14 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4693 = f32[128]{0:T(128)} broadcast(%constant.1440.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3878 = f32[128]{0:T(128)} add(%div.2864, %broadcast.4693), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  ROOT %rsqrt.359 = f32[128]{0:T(128)S(1)} rsqrt(%add.3878), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.201.clone.1 (param_0.4901: bf16[3,128], param_1.5553: s32[]) -> bf16[1,128] {
-  %param_0.4901 = bf16[3,128]{1,0:T(4,128)(2,1)S(1)} parameter(0)
-  %param_1.5553 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.44 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.526 = bf16[1,128]{1,0:T(2,128)(2,1)S(1)} dynamic-slice(%param_0.4901, %param_1.5553, %constant.1455.clone.44), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.199.clone.1 (param_0.4899: bf16[3,128], param_1.5555: s32[]) -> bf16[1,128] {
+  %param_0.4899 = bf16[3,128]{1,0:T(4,128)(2,1)S(1)} parameter(0)
+  %param_1.5555 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.44 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.526 = bf16[1,128]{1,0:T(2,128)(2,1)S(1)} dynamic-slice(%param_0.4899, %param_1.5555, %constant.1437.clone.44), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %all-gather.293.reduce_sub_computation (lhs.18: bf16[], rhs.18: bf16[]) -> bf16[] {
   %lhs.18 = bf16[] parameter(0)
   %rhs.18 = bf16[] parameter(1)
-  ROOT %add.3019 = bf16[] add(%lhs.18, %rhs.18), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.2974 = bf16[] add(%lhs.18, %rhs.18), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.168.clone.clone.1 (param_0.4912: f32[128], param_1.5558: bf16[1,128,576], param_2.4332: bf16[512]) -> bf16[128,512,1] {
-  %param_2.4332 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.916 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} broadcast(%param_2.4332), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1601 = f32[1,128,512]{1,2,0:T(8,128)} convert(%dot_general.916)
-  %param_1.5558 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %slice.1449 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_1.5558), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  %convert_element_type.2811 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1449), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_0.4912 = f32[128]{0:T(128)S(1)} parameter(0)
-  %mul.5106 = f32[1,128,512]{1,2,0:T(8,128)} broadcast(%param_0.4912), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.5105 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2811, %mul.5106), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2810 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%mul.5105), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1602 = f32[1,128,512]{1,2,0:T(8,128)} convert(%convert_element_type.2810)
-  %dot_general.915 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert.1601, %convert.1602), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1603 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%dot_general.915)
-  ROOT %bitcast.2365 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} bitcast(%convert.1603)
+%fused_computation.166.clone.clone.1 (param_0.4910: f32[128], param_1.5560: bf16[1,128,576], param_2.4331: bf16[512]) -> bf16[128,512,1] {
+  %param_2.4331 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
+  %dot_general.901 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} broadcast(%param_2.4331), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1577 = f32[1,128,512]{1,2,0:T(8,128)} convert(%dot_general.901)
+  %param_1.5560 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %slice.1441 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_1.5560), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  %convert_element_type.2771 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1441), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_0.4910 = f32[128]{0:T(128)S(1)} parameter(0)
+  %mul.5228 = f32[1,128,512]{1,2,0:T(8,128)} broadcast(%param_0.4910), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5227 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2771, %mul.5228), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2770 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%mul.5227), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1578 = f32[1,128,512]{1,2,0:T(8,128)} convert(%convert_element_type.2770)
+  %dot_general.900 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert.1577, %convert.1578), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1579 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%dot_general.900)
+  ROOT %bitcast.2369 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} bitcast(%convert.1579)
 }
 
-%fused_computation.101.clone.clone.clone.1 (param_0.4911: bf16[1,512,128,256]) -> bf16[512,128,256] {
+%fused_computation.99.clone.clone.clone.1 (param_0.4909: bf16[1,512,128,256]) -> bf16[512,128,256] {
+  %param_0.4909 = bf16[1,512,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.2368 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.4909), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+}
+
+%fused_computation.128.clone.1 (param_0.4911: bf16[1,512,128,256], param_1.5561: f32[128], param_2.4332: bf16[1,128,576], param_3.2927: bf16[512]) -> bf16[1,128,128,256] {
+  %param_1.5561 = f32[128]{0:T(128)S(1)} parameter(1)
+  %param_2.4332 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.2927 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
+  %fusion.1118 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} fusion(%param_1.5561, %param_2.4332, %param_3.2927), kind=kLoop, calls=%fused_computation.166.clone.clone.1
   %param_0.4911 = bf16[1,512,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.2364 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.4911), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %fusion.1117 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} fusion(%param_0.4911), kind=kLoop, calls=%fused_computation.99.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.323 = bf16[128,128,256]{2,0,1:T(8,128)(2,1)} convolution(%fusion.1118, %fusion.1117), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  ROOT %bitcast.2370 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.323), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.130.clone.1 (param_0.4913: bf16[1,512,128,256], param_1.5559: f32[128], param_2.4333: bf16[1,128,576], param_3.2928: bf16[512]) -> bf16[1,128,128,256] {
-  %param_1.5559 = f32[128]{0:T(128)S(1)} parameter(1)
-  %param_2.4333 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.2928 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
-  %fusion.1122 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} fusion(%param_1.5559, %param_2.4333, %param_3.2928), kind=kLoop, calls=%fused_computation.168.clone.clone.1
-  %param_0.4913 = bf16[1,512,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.1121 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} fusion(%param_0.4913), kind=kLoop, calls=%fused_computation.101.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.323 = bf16[128,128,256]{2,0,1:T(8,128)(2,1)} convolution(%fusion.1122, %fusion.1121), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  ROOT %bitcast.2366 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.323), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+%fused_computation.130.clone.1 (param_0.4912: bf16[1,128,128,256]) -> (bf16[128,128,128], bf16[1,128,128,128]) {
+  %param_0.4912 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.1442 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.4912), slice={[0:1], [0:128], [0:128], [128:256]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  %bitcast.2371 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%slice.1442), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %slice.1443 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.4912), slice={[0:1], [0:128], [0:128], [0:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  ROOT %tuple.860 = (bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.2371, %slice.1443)
 }
 
-%fused_computation.132.clone.1 (param_0.4914: bf16[1,128,128,256]) -> (bf16[128,128,128], bf16[1,128,128,128]) {
-  %param_0.4914 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.1450 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.4914), slice={[0:1], [0:128], [0:128], [128:256]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  %bitcast.2367 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%slice.1450), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
-  %slice.1451 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.4914), slice={[0:1], [0:128], [0:128], [0:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  ROOT %tuple.859 = (bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.2367, %slice.1451)
+%fused_computation.126.clone.1 (param_0.4916: bf16[1,128,128,64], param_1.5564: bf16[1,128,128,128]) -> bf16[128,128,192] {
+  %param_1.5564 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.4223 = bf16[]{:T(256)} constant(-inf)
+  %pad.460 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.5564, %constant.4223), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1604 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.460)
+  %param_0.4916 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.459 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.4916, %constant.4223), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1605 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.459)
+  %maximum.98 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1604, %convert.1605), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.1606 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.98)
+  ROOT %bitcast.2377 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1606), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.128.clone.1 (param_0.4918: bf16[1,128,128,64], param_1.5562: bf16[1,128,128,128]) -> bf16[128,128,192] {
-  %param_1.5562 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.4241 = bf16[]{:T(256)} constant(-inf)
-  %pad.460 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.5562, %constant.4241), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1628 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.460)
-  %param_0.4918 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.459 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.4918, %constant.4241), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1629 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.459)
-  %maximum.98 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1628, %convert.1629), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.1630 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.98)
-  ROOT %bitcast.2373 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1630), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+%fused_computation.131.clone.clone.clone.clone.clone.clone.clone.1 (param_0.4931: bf16[128,128,128]) -> bf16[128,128,128] {
+  %param_0.4931 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.2387 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.4931)
 }
 
-%fused_computation.133.clone.clone.clone.clone.clone.clone.clone.1 (param_0.4933: bf16[128,128,128]) -> bf16[128,128,128] {
-  %param_0.4933 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.2383 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.4933)
-}
-
-%fused_computation.109.clone.clone.clone.clone.clone.clone.clone.1 (param_0.4932: bf16[1,128,128,512]) -> bf16[128,128,512] {
-  %param_0.4932 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.2382 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.4932), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.107.clone.clone.clone.clone.clone.clone.clone.1 (param_0.4930: bf16[1,128,128,512]) -> bf16[128,128,512] {
+  %param_0.4930 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.2386 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.4930), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
 %region_5.7 (reduce_sum.31: f32[], reduce_sum.32: f32[]) -> f32[] {
@@ -632,246 +632,246 @@ StackFrames
   ROOT %reduce_sum.33 = f32[]{:T(128)} add(%reduce_sum.31, %reduce_sum.32), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.162.clone.1 (param_0.4934: bf16[1,128,512], param_1.5573: bf16[1,128,128,512], param_2.4341: bf16[128,128,128]) -> (f32[128], bf16[1,128,512]) {
-  %param_0.4934 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.1631 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4934)
-  %param_2.4341 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.112.clone.3 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} fusion(%param_2.4341), kind=kLoop, calls=%fused_computation.133.clone.clone.clone.clone.clone.clone.clone.1
-  %param_1.5573 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.111.clone.3 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} fusion(%param_1.5573), kind=kLoop, calls=%fused_computation.109.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.108.clone.3 = bf16[128,512,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.112.clone.3, %fusion.111.clone.3), window={size=128}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %bitcast.774.clone.3 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.108.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %convert.1632 = f32[1,128,512]{2,1,0:T(8,128)} convert(%bitcast.774.clone.3)
-  %add.3105.clone.3 = f32[1,128,512]{2,1,0:T(8,128)} add(%convert.1631, %convert.1632), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.2817 = f32[1,128,512]{2,1,0:T(8,128)} convert(%add.3105.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.703 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2817, %convert_element_type.2817), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
-  %constant.1456.clone.24 = f32[]{:T(128)} constant(0)
-  %reduce.877 = f32[128]{0:T(128)S(1)} reduce(%square.703, %constant.1456.clone.24), dimensions={0,2}, to_apply=%region_5.7, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
-  %convert.1633 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.3105.clone.3)
-  ROOT %tuple.865 = (f32[128]{0:T(128)S(1)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.877, %convert.1633)
+%fused_computation.160.clone.1 (param_0.4932: bf16[1,128,512], param_1.5575: bf16[1,128,128,512], param_2.4340: bf16[128,128,128]) -> (f32[128], bf16[1,128,512]) {
+  %param_0.4932 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.1607 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4932)
+  %param_2.4340 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.108.clone.3 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} fusion(%param_2.4340), kind=kLoop, calls=%fused_computation.131.clone.clone.clone.clone.clone.clone.clone.1
+  %param_1.5575 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.107.clone.3 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} fusion(%param_1.5575), kind=kLoop, calls=%fused_computation.107.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.108.clone.3 = bf16[128,512,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.108.clone.3, %fusion.107.clone.3), window={size=128}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %bitcast.776.clone.3 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.108.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %convert.1608 = f32[1,128,512]{2,1,0:T(8,128)} convert(%bitcast.776.clone.3)
+  %add.3060.clone.3 = f32[1,128,512]{2,1,0:T(8,128)} add(%convert.1607, %convert.1608), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.2777 = f32[1,128,512]{2,1,0:T(8,128)} convert(%add.3060.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.695 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2777, %convert_element_type.2777), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+  %constant.1438.clone.24 = f32[]{:T(128)} constant(0)
+  %reduce.869 = f32[128]{0:T(128)S(1)} reduce(%square.695, %constant.1438.clone.24), dimensions={0,2}, to_apply=%region_5.7, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+  %convert.1609 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.3060.clone.3)
+  ROOT %tuple.866 = (f32[128]{0:T(128)S(1)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.869, %convert.1609)
 }
 
-%fused_computation.118.clone.1 (param_0.4941: bf16[3,18432,128], param_1.5578: s32[]) -> bf16[1,18432,128] {
-  %param_0.4941 = bf16[3,18432,128]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.5578 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.53 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.535 = bf16[1,18432,128]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4941, %param_1.5578, %constant.1455.clone.53, %constant.1455.clone.53), dynamic_slice_sizes={1,18432,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.116.clone.1 (param_0.4939: bf16[3,18432,128], param_1.5580: s32[]) -> bf16[1,18432,128] {
+  %param_0.4939 = bf16[3,18432,128]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.5580 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.53 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.535 = bf16[1,18432,128]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4939, %param_1.5580, %constant.1437.clone.53, %constant.1437.clone.53), dynamic_slice_sizes={1,18432,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.119.clone.1 (param_0.4940: bf16[3,128,18432], param_1.5577: s32[]) -> bf16[1,128,18432] {
-  %param_0.4940 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.5577 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.52 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.534 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4940, %param_1.5577, %constant.1455.clone.52, %constant.1455.clone.52), dynamic_slice_sizes={1,128,18432}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.117.clone.1 (param_0.4938: bf16[3,128,18432], param_1.5579: s32[]) -> bf16[1,128,18432] {
+  %param_0.4938 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.5579 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.52 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.534 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4938, %param_1.5579, %constant.1437.clone.52, %constant.1437.clone.52), dynamic_slice_sizes={1,128,18432}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.120.clone.1 (param_0.4936: bf16[3,128,18432], param_1.5574: s32[]) -> bf16[1,128,18432] {
-  %param_0.4936 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.5574 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.1455.clone.51 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.533 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4936, %param_1.5574, %constant.1455.clone.51, %constant.1455.clone.51), dynamic_slice_sizes={1,128,18432}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.118.clone.1 (param_0.4934: bf16[3,128,18432], param_1.5576: s32[]) -> bf16[1,128,18432] {
+  %param_0.4934 = bf16[3,128,18432]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.5576 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.1437.clone.51 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.533 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.4934, %param_1.5576, %constant.1437.clone.51, %constant.1437.clone.51), dynamic_slice_sizes={1,128,18432}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.202.clone.1 (param_0.4935: f32[128]) -> f32[128] {
-  %param_0.4935 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1457.clone.13 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4752 = f32[128]{0:T(128)} broadcast(%constant.1457.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.2867 = f32[128]{0:T(128)} multiply(%param_0.4935, %broadcast.4752), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %constant.1458.clone.16 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4751 = f32[128]{0:T(128)} broadcast(%constant.1458.clone.16), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3927 = f32[128]{0:T(128)} add(%div.2867, %broadcast.4751), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  ROOT %rsqrt.369 = f32[128]{0:T(128)S(1)} rsqrt(%add.3927), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
+%fused_computation.200.clone.1 (param_0.4933: f32[128]) -> f32[128] {
+  %param_0.4933 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1439.clone.13 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4698 = f32[128]{0:T(128)} broadcast(%constant.1439.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.2866 = f32[128]{0:T(128)} multiply(%param_0.4933, %broadcast.4698), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %constant.1440.clone.16 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4697 = f32[128]{0:T(128)} broadcast(%constant.1440.clone.16), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3882 = f32[128]{0:T(128)} add(%div.2866, %broadcast.4697), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  ROOT %rsqrt.361 = f32[128]{0:T(128)S(1)} rsqrt(%add.3882), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.166.clone.1.clone.1 (param_0.4938: bf16[1,128,512], param_1.5575: f32[128], param_2.4342: bf16[512]) -> bf16[128,512] {
-  %param_2.4342 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.922 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4342), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1610 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.922)
-  %param_0.4938 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.2819 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4938), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.5575 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.5122 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.5575), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.5121 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2819, %mul.5122), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2818 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.5121), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1611 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2818)
-  %dot_general.921 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1610, %convert.1611), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1612 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.921)
-  ROOT %bitcast.2385 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1612)
+%fused_computation.164.clone.1.clone.1 (param_0.4936: bf16[1,128,512], param_1.5577: f32[128], param_2.4341: bf16[512]) -> bf16[128,512] {
+  %param_2.4341 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
+  %dot_general.907 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4341), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1586 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.907)
+  %param_0.4936 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.2779 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4936), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.5577 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.5246 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.5577), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5245 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2779, %mul.5246), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2778 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.5245), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1587 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2778)
+  %dot_general.906 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1586, %convert.1587), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1588 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.906)
+  ROOT %bitcast.2389 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1588)
 }
 
-%fused_computation.107.clone.clone.clone.1 (param_0.4937: bf16[1,512,18432]) -> bf16[512,18432] {
+%fused_computation.105.clone.clone.clone.1 (param_0.4935: bf16[1,512,18432]) -> bf16[512,18432] {
+  %param_0.4935 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.2388 = bf16[512,18432]{1,0:T(8,128)(2,1)} bitcast(%param_0.4935), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+}
+
+%fused_computation.112.clone.1 (param_0.4937: bf16[1,512,18432], param_1.5578: bf16[1,128,512], param_2.4342: f32[128], param_3.2932: bf16[512]) -> bf16[1,128,18432] {
+  %param_1.5578 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.4342 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.2932 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
+  %fusion.1122 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5578, %param_2.4342, %param_3.2932), kind=kLoop, calls=%fused_computation.164.clone.1.clone.1
   %param_0.4937 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.2384 = bf16[512,18432]{1,0:T(8,128)(2,1)} bitcast(%param_0.4937), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %fusion.1121 = bf16[512,18432]{1,0:T(8,128)(2,1)} fusion(%param_0.4937), kind=kLoop, calls=%fused_computation.105.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.325 = bf16[128,18432]{1,0:T(8,128)(2,1)} convolution(%fusion.1122, %fusion.1121), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  ROOT %bitcast.2390 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.325), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.114.clone.1 (param_0.4939: bf16[1,512,18432], param_1.5576: bf16[1,128,512], param_2.4343: f32[128], param_3.2933: bf16[512]) -> bf16[1,128,18432] {
-  %param_1.5576 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.4343 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.2933 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
-  %fusion.1126 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5576, %param_2.4343, %param_3.2933), kind=kLoop, calls=%fused_computation.166.clone.1.clone.1
-  %param_0.4939 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.1125 = bf16[512,18432]{1,0:T(8,128)(2,1)} fusion(%param_0.4939), kind=kLoop, calls=%fused_computation.107.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.325 = bf16[128,18432]{1,0:T(8,128)(2,1)} convolution(%fusion.1126, %fusion.1125), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  ROOT %bitcast.2386 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.325), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+%fused_computation.164.clone.clone.clone.1 (param_0.4942: bf16[1,128,512], param_1.5581: f32[128], param_2.4343: bf16[512]) -> bf16[128,512] {
+  %param_2.4343 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
+  %dot_general.909 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4343), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1589 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.909)
+  %param_0.4942 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.2781 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4942), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.5581 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.5248 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.5581), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.5247 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2781, %mul.5248), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2780 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.5247), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1590 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2780)
+  %dot_general.908 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1589, %convert.1590), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1591 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.908)
+  ROOT %bitcast.2393 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1591)
 }
 
-%fused_computation.166.clone.clone.clone.1 (param_0.4944: bf16[1,128,512], param_1.5579: f32[128], param_2.4344: bf16[512]) -> bf16[128,512] {
-  %param_2.4344 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.924 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4344), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1613 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.924)
-  %param_0.4944 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.2821 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4944), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.5579 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.5124 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.5579), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.5123 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2821, %mul.5124), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2820 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.5123), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1614 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2820)
-  %dot_general.923 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1613, %convert.1614), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1615 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.923)
-  ROOT %bitcast.2389 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1615)
+%fused_computation.103.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.1 (param_0.4941: bf16[1,512,18432]) -> bf16[512,18432] {
+  %param_0.4941 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.2392 = bf16[512,18432]{1,0:T(8,128)(2,1)} bitcast(%param_0.4941), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.105.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.1 (param_0.4943: bf16[1,512,18432]) -> bf16[512,18432] {
-  %param_0.4943 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.2388 = bf16[512,18432]{1,0:T(8,128)(2,1)} bitcast(%param_0.4943), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-}
-
-%fused_computation.117.clone.clone.clone.clone.clone.clone.clone.1 (param_0.4945: bf16[1,512,18432], param_1.5580: bf16[1,128,18432], param_2.4345: bf16[1,128,512], param_3.2934: f32[128], param_4.2219: bf16[512]) -> bf16[128,18432] {
-  %param_1.5580 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.1616 = f32[1,128,18432]{2,1,0:T(8,128)} convert(%param_1.5580)
-  %constant.1461.clone.10 = bf16[]{:T(256)} constant(1)
-  %jit_silu_.98 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)} broadcast(%constant.1461.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)" stack_frame_id=0}
-  %convert.1617 = f32[1,128,18432]{2,1,0:T(8,128)} convert(%jit_silu_.98)
-  %neg.274 = f32[1,128,18432]{2,1,0:T(8,128)} negate(%convert.1616), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %exp.567 = f32[1,128,18432]{2,1,0:T(8,128)} exponential(%neg.274), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %add.3928 = f32[1,128,18432]{2,1,0:T(8,128)} add(%exp.567, %convert.1617), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %div.2868 = f32[1,128,18432]{2,1,0:T(8,128)} divide(%convert.1617, %add.3928), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.5126 = f32[1,128,18432]{2,1,0:T(8,128)} multiply(%convert.1616, %div.2868), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %param_2.4345 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.2934 = f32[128]{0:T(128)S(1)} parameter(3)
+%fused_computation.115.clone.clone.clone.clone.clone.clone.clone.1 (param_0.4943: bf16[1,512,18432], param_1.5582: bf16[1,128,18432], param_2.4344: bf16[1,128,512], param_3.2933: f32[128], param_4.2219: bf16[512]) -> bf16[128,18432] {
+  %param_1.5582 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.1592 = f32[1,128,18432]{2,1,0:T(8,128)} convert(%param_1.5582)
+  %constant.1443.clone.10 = bf16[]{:T(256)} constant(1)
+  %jit_silu_.98 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)} broadcast(%constant.1443.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)" stack_frame_id=0}
+  %convert.1593 = f32[1,128,18432]{2,1,0:T(8,128)} convert(%jit_silu_.98)
+  %neg.273 = f32[1,128,18432]{2,1,0:T(8,128)} negate(%convert.1592), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %exp.566 = f32[1,128,18432]{2,1,0:T(8,128)} exponential(%neg.273), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %add.3883 = f32[1,128,18432]{2,1,0:T(8,128)} add(%exp.566, %convert.1593), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %div.2867 = f32[1,128,18432]{2,1,0:T(8,128)} divide(%convert.1593, %add.3883), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.5250 = f32[1,128,18432]{2,1,0:T(8,128)} multiply(%convert.1592, %div.2867), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %param_2.4344 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.2933 = f32[128]{0:T(128)S(1)} parameter(3)
   %param_4.2219 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(4)
-  %fusion.1128 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_2.4345, %param_3.2934, %param_4.2219), kind=kLoop, calls=%fused_computation.166.clone.clone.clone.1
-  %param_0.4945 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.1127 = bf16[512,18432]{1,0:T(8,128)(2,1)} fusion(%param_0.4945), kind=kLoop, calls=%fused_computation.105.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.326 = bf16[128,18432]{1,0:T(8,128)(2,1)} convolution(%fusion.1128, %fusion.1127), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %bitcast.2391 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.326), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %convert.1618 = f32[1,128,18432]{2,1,0:T(8,128)} convert(%bitcast.2391)
-  %mul.5125 = f32[1,128,18432]{2,1,0:T(8,128)} multiply(%mul.5126, %convert.1618), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1619 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)} convert(%mul.5125)
-  ROOT %bitcast.2390 = bf16[128,18432]{1,0:T(8,128)(2,1)} bitcast(%convert.1619)
+  %fusion.1124 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_2.4344, %param_3.2933, %param_4.2219), kind=kLoop, calls=%fused_computation.164.clone.clone.clone.1
+  %param_0.4943 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.1123 = bf16[512,18432]{1,0:T(8,128)(2,1)} fusion(%param_0.4943), kind=kLoop, calls=%fused_computation.103.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.326 = bf16[128,18432]{1,0:T(8,128)(2,1)} convolution(%fusion.1124, %fusion.1123), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %bitcast.2395 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.326), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %convert.1594 = f32[1,128,18432]{2,1,0:T(8,128)} convert(%bitcast.2395)
+  %mul.5249 = f32[1,128,18432]{2,1,0:T(8,128)} multiply(%mul.5250, %convert.1594), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","18432"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1595 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)} convert(%mul.5249)
+  ROOT %bitcast.2394 = bf16[128,18432]{1,0:T(8,128)(2,1)} bitcast(%convert.1595)
 }
 
-%fused_computation.103.clone.clone.clone.clone.clone.1 (param_0.4942: bf16[1,18432,512]) -> bf16[18432,512] {
-  %param_0.4942 = bf16[1,18432,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.2387 = bf16[18432,512]{1,0:T(8,128)(2,1)} bitcast(%param_0.4942), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.101.clone.clone.clone.clone.clone.1 (param_0.4940: bf16[1,18432,512]) -> bf16[18432,512] {
+  %param_0.4940 = bf16[1,18432,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.2391 = bf16[18432,512]{1,0:T(8,128)(2,1)} bitcast(%param_0.4940), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.146.clone.1 (param_0.4946: bf16[1,128,512], param_1.5581: bf16[1,18432,512], param_2.4346: bf16[1,512,18432], param_3.2935: bf16[1,128,18432], param_4.2220: f32[128], param_5.1881: bf16[512]) -> bf16[1,128,512] {
-  %param_2.4346 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.2935 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %param_0.4946 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+%fused_computation.144.clone.1 (param_0.4944: bf16[1,128,512], param_1.5583: bf16[1,18432,512], param_2.4345: bf16[1,512,18432], param_3.2934: bf16[1,128,18432], param_4.2220: f32[128], param_5.1881: bf16[512]) -> bf16[1,128,512] {
+  %param_2.4345 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.2934 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_0.4944 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
   %param_4.2220 = f32[128]{0:T(128)S(1)} parameter(4)
   %param_5.1881 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(5)
-  %fusion.65.clone.7 = bf16[128,18432]{1,0:T(8,128)(2,1)} fusion(%param_2.4346, %param_3.2935, %param_0.4946, %param_4.2220, %param_5.1881), kind=kOutput, calls=%fused_computation.117.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %param_1.5581 = bf16[1,18432,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.1129 = bf16[18432,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5581), kind=kLoop, calls=%fused_computation.103.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.327 = bf16[128,512]{1,0:T(8,128)(2,1)} convolution(%fusion.65.clone.7, %fusion.1129), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %bitcast.2392 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.327), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %convert.1634 = f32[1,128,512]{2,1,0:T(8,128)} convert(%bitcast.2392)
-  %convert.1635 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4946)
-  %add.3929 = f32[1,128,512]{2,1,0:T(8,128)} add(%convert.1634, %convert.1635), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  ROOT %convert.1636 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.3929)
+  %fusion.61.clone.7 = bf16[128,18432]{1,0:T(8,128)(2,1)} fusion(%param_2.4345, %param_3.2934, %param_0.4944, %param_4.2220, %param_5.1881), kind=kOutput, calls=%fused_computation.115.clone.clone.clone.clone.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %param_1.5583 = bf16[1,18432,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.1125 = bf16[18432,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5583), kind=kLoop, calls=%fused_computation.101.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.327 = bf16[128,512]{1,0:T(8,128)(2,1)} convolution(%fusion.61.clone.7, %fusion.1125), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %bitcast.2396 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.327), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %convert.1610 = f32[1,128,512]{2,1,0:T(8,128)} convert(%bitcast.2396)
+  %convert.1611 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4944)
+  %add.3884 = f32[1,128,512]{2,1,0:T(8,128)} add(%convert.1610, %convert.1611), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  ROOT %convert.1612 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.3884)
 }
 
-%async_computation.48 (param_0.5013: s8[16777216]) -> s8[4194304] {
+%async_computation.48 (param_0.5011: s8[16777216]) -> s8[4194304] {
+  %param_0.5011 = s8[16777216]{0:T(1024)(128)(4,1)} parameter(0)
+  ROOT %slice.1494 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} slice(%param_0.5011), slice={[0:4194304]}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+}
+
+%async_computation.49 (param_0.5012: s8[16777216]) -> s8[4194304] {
+  %param_0.5012 = s8[16777216]{0:T(1024)(128)(4,1)} parameter(0)
+  ROOT %slice.1496 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} slice(%param_0.5012), slice={[4194304:8388608]}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+}
+
+%async_computation.50 (param_0.5013: s8[16777216]) -> s8[4194304] {
   %param_0.5013 = s8[16777216]{0:T(1024)(128)(4,1)} parameter(0)
-  ROOT %slice.1502 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} slice(%param_0.5013), slice={[0:4194304]}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %slice.1498 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} slice(%param_0.5013), slice={[8388608:12582912]}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%async_computation.49 (param_0.5014: s8[16777216]) -> s8[4194304] {
+%async_computation.51 (param_0.5014: s8[16777216]) -> s8[4194304] {
   %param_0.5014 = s8[16777216]{0:T(1024)(128)(4,1)} parameter(0)
-  ROOT %slice.1504 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} slice(%param_0.5014), slice={[4194304:8388608]}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %slice.1500 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} slice(%param_0.5014), slice={[12582912:16777216]}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%async_computation.50 (param_0.5015: s8[16777216]) -> s8[4194304] {
-  %param_0.5015 = s8[16777216]{0:T(1024)(128)(4,1)} parameter(0)
-  ROOT %slice.1506 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} slice(%param_0.5015), slice={[8388608:12582912]}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-}
-
-%async_computation.51 (param_0.5016: s8[16777216]) -> s8[4194304] {
-  %param_0.5016 = s8[16777216]{0:T(1024)(128)(4,1)} parameter(0)
-  ROOT %slice.1508 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} slice(%param_0.5016), slice={[12582912:16777216]}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-}
-
-%wide.region_1.8_spmd.sunk.clone.clone.clone.sunk (wide.param.5: (s32[], bf16[1,128,512], bf16[3,1,128,512], bf16[3,512], bf16[3,384], /*index=5*/bf16[3,512], bf16[3,128,1536], bf16[3,384,128,192], bf16[3,128], bf16[3,128,576], /*index=10*/bf16[3,128,128,256], f32[1,128,1,32], f32[1,128,1,32], bf16[3,128,128,128], bf16[3,128,18432], /*index=15*/bf16[3,128,18432], bf16[3,18432,128], f32[128,32], f32[128,32], s32[128], /*index=20*/s32[], s8[1,1,1], s8[1,1,1], bf16[])) -> (s32[], bf16[1,128,512], bf16[3,1,128,512], bf16[3,512], bf16[3,384], /*index=5*/bf16[3,512], bf16[3,128,1536], bf16[3,384,128,192], bf16[3,128], bf16[3,128,576], /*index=10*/bf16[3,128,128,256], f32[1,128,1,32], f32[1,128,1,32], bf16[3,128,128,128], bf16[3,128,18432], /*index=15*/bf16[3,128,18432], bf16[3,18432,128], f32[128,32], f32[128,32], s32[128], /*index=20*/s32[], s8[1,1,1], s8[1,1,1], bf16[]) {
-  %constant.1715.clone..sunk.7 = s32[]{:T(128)} constant(1)
-  %constant.4175..sunk.1 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %wide.param.5 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, /*index=10*/bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, f32[128,32]{1,0:T(8,128)S(1)}, f32[128,32]{1,0:T(8,128)S(1)}, s32[128]{0:T(128)}, /*index=20*/s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) parameter(0)
+%wide.region_1.8_spmd.sunk.clone.clone.clone.sunk (wide.param.5: (s32[], bf16[1,128,512], bf16[3,1,128,512], bf16[3,512], bf16[3,384], /*index=5*/bf16[3,512], bf16[3,128,1536], bf16[3,384,128,192], f32[1,128,1,32], f32[1,128,1,32], /*index=10*/bf16[3,128], bf16[3,128,576], bf16[3,128,128,256], bf16[3,128,128,128], bf16[3,128,18432], /*index=15*/bf16[3,128,18432], bf16[3,18432,128], s32[128], s32[], s8[1,1,1], /*index=20*/s8[1,1,1], bf16[])) -> (s32[], bf16[1,128,512], bf16[3,1,128,512], bf16[3,512], bf16[3,384], /*index=5*/bf16[3,512], bf16[3,128,1536], bf16[3,384,128,192], f32[1,128,1,32], f32[1,128,1,32], /*index=10*/bf16[3,128], bf16[3,128,576], bf16[3,128,128,256], bf16[3,128,128,128], bf16[3,128,18432], /*index=15*/bf16[3,128,18432], bf16[3,18432,128], s32[128], s32[], s8[1,1,1], /*index=20*/s8[1,1,1], bf16[]) {
+  %constant.1697.clone..sunk.7 = s32[]{:T(128)} constant(1)
+  %constant.4157..sunk.1 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %wide.param.5 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, /*index=10*/bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, /*index=20*/s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) parameter(0)
   %copy.1629 = s32[]{:T(128)S(6)} copy(%wide.param.5#0), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add.3930 = s32[]{:T(128)} add(%copy.1629, %constant.1715.clone..sunk.7), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast_dynamic-update-slice_fusion.2 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} fusion(%wide.param.5#2, %copy.1629, %wide.param.5#1), kind=kLoop, calls=%fused_computation.171.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
-  %dynamic-slice_convert_fusion.40 = bf16[1,128,128,128]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#13, %copy.1629), kind=kLoop, calls=%fused_computation.129.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add.3885 = s32[]{:T(128)} add(%copy.1629, %constant.1697.clone..sunk.7), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast_dynamic-update-slice_fusion.2 = bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)} fusion(%wide.param.5#2, %copy.1629, %wide.param.5#1), kind=kLoop, calls=%fused_computation.169.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
+  %dynamic-slice_convert_fusion.40 = bf16[1,128,128,128]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#13, %copy.1629), kind=kLoop, calls=%fused_computation.127.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.340 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.40), channel_id=288, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={3}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.41 = bf16[1,384,128,192]{2,1,3,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#7, %copy.1629), kind=kLoop, calls=%fused_computation.99.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.41 = bf16[1,384,128,192]{2,1,3,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#7, %copy.1629), kind=kLoop, calls=%fused_computation.97.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.341 = bf16[1,1536,128,192]{2,1,3,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.41), channel_id=284, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.2393 = bf16[1536,128,192]{1,0,2:T(8,128)(2,1)} bitcast(%all-gather.341), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %copy.1598 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} copy(%bitcast.2393), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.42 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#6, %copy.1629), kind=kLoop, calls=%fused_computation.140.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.2397 = bf16[1536,128,192]{1,0,2:T(8,128)(2,1)} bitcast(%all-gather.341), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %copy.1598 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} copy(%bitcast.2397), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.42 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#6, %copy.1629), kind=kLoop, calls=%fused_computation.138.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.342 = bf16[1,512,1536]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.42), channel_id=283, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1130 = f32[128]{0:T(128)S(1)} fusion(%wide.param.5#1), kind=kLoop, calls=%fused_computation.158.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add_rsqrt_fusion.11 = f32[128]{0:T(128)S(1)} fusion(%fusion.1130), kind=kLoop, calls=%fused_computation.205.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1131 = (bf16[512]{0:T(512)(128)(2,1)S(1)}, bf16[512]{0:T(512)(128)(2,1)S(1)}) fusion(%wide.param.5#3, %copy.1629, %wide.param.5#5), kind=kLoop, calls=%fused_computation.197.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
-  %multiply_reduce_fusion.86 = (f32[128]{0:T(128)S(1)}, f32[1,128,1536]{2,1,0:T(8,128)S(1)}) fusion(%all-gather.342, %wide.param.5#1, %add_rsqrt_fusion.11, %fusion.1131#1), kind=kOutput, calls=%fused_computation.139.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add_rsqrt_fusion.12 = f32[128]{0:T(128)S(1)} fusion(%multiply_reduce_fusion.86#0), kind=kLoop, calls=%fused_computation.204.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1132 = bf16[1,384]{1,0:T(2,128)(2,1)S(1)} fusion(%wide.param.5#4, %copy.1629), kind=kLoop, calls=%fused_computation.200.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.343 = bf16[1,1536]{1,0:T(2,128)(2,1)S(1)} all-gather(%fusion.1132), channel_id=282, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %reduce.878 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} reduce(%all-gather.343, %constant.4175..sunk.1), dimensions={0}, to_apply=%all-gather.290.reduce_sub_computation, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %convolution_bitcast_fusion.10 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%copy.1598, %multiply_reduce_fusion.86#1, %add_rsqrt_fusion.12, %reduce.878), kind=kOutput, calls=%fused_computation.131.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice.1456 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%convolution_bitcast_fusion.10), slice={[0:1], [0:128], [0:128], [128:192]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy.1599 = bf16[1,128,128,64]{2,1,3,0:T(8,128)(2,1)S(1)} copy(%slice.1456), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.2439 = bf16[1,128,128,32,2]{2,1,4,3,0:T(8,128)(2,1)S(1)} bitcast(%copy.1599)
-  %fusion.1133 = (bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}) fusion(%bitcast.2439), kind=kLoop, calls=%fused_computation.1429.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy.1600 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} copy(%fusion.1133#1), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy.1601 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} copy(%fusion.1133#0), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1134 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%copy.1600, %copy.1601, %wide.param.5#18, %wide.param.5#17), kind=kLoop, calls=%fused_computation.123.clone.1, metadata={op_name="convert.313"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice.1457 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%convolution_bitcast_fusion.10), slice={[0:1], [0:128], [0:128], [0:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1135.q_ref = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} fusion(%fusion.1134#1, %fusion.1134#0, %slice.1457), kind=kLoop, calls=%fused_computation.127.clone.1, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.43 = bf16[1,128,576]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#9, %copy.1629), kind=kLoop, calls=%fused_computation.155.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1126 = f32[128]{0:T(128)S(1)} fusion(%wide.param.5#1), kind=kLoop, calls=%fused_computation.156.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add_rsqrt_fusion.11 = f32[128]{0:T(128)S(1)} fusion(%fusion.1126), kind=kLoop, calls=%fused_computation.203.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1127 = (bf16[512]{0:T(512)(128)(2,1)S(1)}, bf16[512]{0:T(512)(128)(2,1)S(1)}) fusion(%wide.param.5#3, %copy.1629, %wide.param.5#5), kind=kLoop, calls=%fused_computation.195.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
+  %multiply_reduce_fusion.86 = (f32[128]{0:T(128)S(1)}, f32[1,128,1536]{2,1,0:T(8,128)S(1)}) fusion(%all-gather.342, %wide.param.5#1, %add_rsqrt_fusion.11, %fusion.1127#1), kind=kOutput, calls=%fused_computation.137.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add_rsqrt_fusion.12 = f32[128]{0:T(128)S(1)} fusion(%multiply_reduce_fusion.86#0), kind=kLoop, calls=%fused_computation.202.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1128 = bf16[1,384]{1,0:T(2,128)(2,1)S(1)} fusion(%wide.param.5#4, %copy.1629), kind=kLoop, calls=%fused_computation.198.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.343 = bf16[1,1536]{1,0:T(2,128)(2,1)S(1)} all-gather(%fusion.1128), channel_id=282, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce.870 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} reduce(%all-gather.343, %constant.4157..sunk.1), dimensions={0}, to_apply=%all-gather.290.reduce_sub_computation, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %convolution_bitcast_fusion.10 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%copy.1598, %multiply_reduce_fusion.86#1, %add_rsqrt_fusion.12, %reduce.870), kind=kOutput, calls=%fused_computation.129.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %slice.1448 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%convolution_bitcast_fusion.10), slice={[0:1], [0:128], [0:128], [128:192]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %copy.1599 = bf16[1,128,128,64]{2,1,3,0:T(8,128)(2,1)S(1)} copy(%slice.1448), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.2445 = bf16[1,128,128,32,2]{2,1,4,3,0:T(8,128)(2,1)S(1)} bitcast(%copy.1599)
+  %fusion.1129 = (bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}) fusion(%bitcast.2445), kind=kLoop, calls=%fused_computation.1427.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %copy.1600 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} copy(%fusion.1129#1), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %copy.1601 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} copy(%fusion.1129#0), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.2506 = f32[128,32]{1,0:T(8,128)S(1)} bitcast(%wide.param.5#9)
+  %bitcast.2502 = f32[128,32]{1,0:T(8,128)S(1)} bitcast(%wide.param.5#8)
+  %fusion.1130 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%copy.1600, %copy.1601, %bitcast.2506, %bitcast.2502), kind=kLoop, calls=%fused_computation.121.clone.1, metadata={op_name="convert.295"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %slice.1449 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%convolution_bitcast_fusion.10), slice={[0:1], [0:128], [0:128], [0:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1131.q_ref = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} fusion(%fusion.1130#1, %fusion.1130#0, %slice.1449), kind=kLoop, calls=%fused_computation.125.clone.1, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.43 = bf16[1,128,576]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#11, %copy.1629), kind=kLoop, calls=%fused_computation.153.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.344 = bf16[1,512,576]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.43), channel_id=286, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1136 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} fusion(%all-gather.344, %wide.param.5#1, %add_rsqrt_fusion.11, %fusion.1131#1), kind=kOutput, calls=%fused_computation.143.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice.1458 = bf16[1,128,64]{1,2,0:T(8,128)(2,1)S(1)} slice(%fusion.1136), slice={[0:1], [0:128], [512:576]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.2512 = bf16[1,128,1,32,2]{1,4,3,2,0:T(2,128)(2,1)S(1)} bitcast(%slice.1458)
-  %fusion.1137 = (bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}, bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}) fusion(%bitcast.2512), kind=kLoop, calls=%fused_computation.1430.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy.1602 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} copy(%fusion.1137#1), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy.1603 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} copy(%fusion.1137#0), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.2499 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%wide.param.5#18)
-  %bitcast.2496 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%wide.param.5#17)
-  %fusion.1138 = (bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%bitcast.2499, %bitcast.2496, %copy.1602, %copy.1603), kind=kLoop, calls=%fused_computation.181.clone.1, metadata={op_name="convert.311"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %maximum_bitcast_fusion.27 = bf16[128,64]{1,0:T(8,128)(2,1)S(1)} fusion(%fusion.1138#1, %fusion.1138#0), kind=kLoop, calls=%fused_computation.191.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %broadcast_in_dim.1388 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} broadcast(%maximum_bitcast_fusion.27), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/broadcast_in_dim" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8","128"]},"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.44 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#10, %copy.1629), kind=kLoop, calls=%fused_computation.110.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-start.240 = (bf16[3,128]{1,0:T(4,128)(2,1)S(1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, u32[]{:S(2)}) copy-start(%wide.param.5#8), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
+  %fusion.1132 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} fusion(%all-gather.344, %wide.param.5#1, %add_rsqrt_fusion.11, %fusion.1127#1), kind=kOutput, calls=%fused_computation.141.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %slice.1450 = bf16[1,128,64]{1,2,0:T(8,128)(2,1)S(1)} slice(%fusion.1132), slice={[0:1], [0:128], [512:576]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.2520 = bf16[1,128,1,32,2]{1,4,3,2,0:T(2,128)(2,1)S(1)} bitcast(%slice.1450)
+  %fusion.1133 = (bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}, bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}) fusion(%bitcast.2520), kind=kLoop, calls=%fused_computation.1428.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %copy.1602 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} copy(%fusion.1133#1), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %copy.1603 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} copy(%fusion.1133#0), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1134 = (bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%wide.param.5#9, %wide.param.5#8, %copy.1602, %copy.1603), kind=kLoop, calls=%fused_computation.179.clone.1, metadata={op_name="convert.293"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %maximum_bitcast_fusion.27 = bf16[128,64]{1,0:T(8,128)(2,1)S(1)} fusion(%fusion.1134#1, %fusion.1134#0), kind=kLoop, calls=%fused_computation.189.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %broadcast_in_dim.1287 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} broadcast(%maximum_bitcast_fusion.27), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/broadcast_in_dim" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8","128"]},"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.44 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#12, %copy.1629), kind=kLoop, calls=%fused_computation.108.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %copy-start.240 = (bf16[3,128]{1,0:T(4,128)(2,1)S(1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, u32[]{:S(2)}) copy-start(%wide.param.5#10), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
   %all-gather.345 = bf16[1,512,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.44), channel_id=287, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1139 = f32[128]{0:T(128)S(1)} fusion(%fusion.1136), kind=kLoop, calls=%fused_computation.160.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add_rsqrt_fusion.13 = f32[128]{0:T(128)S(1)} fusion(%fusion.1139), kind=kLoop, calls=%fused_computation.203.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1135 = f32[128]{0:T(128)S(1)} fusion(%fusion.1132), kind=kLoop, calls=%fused_computation.158.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add_rsqrt_fusion.13 = f32[128]{0:T(128)S(1)} fusion(%fusion.1135), kind=kLoop, calls=%fused_computation.201.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %copy-done.240 = bf16[3,128]{1,0:T(4,128)(2,1)S(1)} copy-done(%copy-start.240), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
-  %fusion.1140 = bf16[1,128]{1,0:T(2,128)(2,1)S(1)} fusion(%copy-done.240, %copy.1629), kind=kLoop, calls=%fused_computation.201.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %all-gather.346 = bf16[1,512]{1,0:T(2,128)(2,1)S(1)} all-gather(%fusion.1140), channel_id=285, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %reduce.879 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%all-gather.346, %constant.4175..sunk.1), dimensions={0}, to_apply=%all-gather.293.reduce_sub_computation, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1141 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%all-gather.345, %add_rsqrt_fusion.13, %fusion.1136, %reduce.879), kind=kOutput, calls=%fused_computation.130.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %copy-start.214 = (s32[128]{0:T(128)S(1)}, s32[128]{0:T(128)}, u32[]{:S(2)}) copy-start(%wide.param.5#19), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
-  %slice_bitcast_fusion.11 = (bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.1141), kind=kLoop, calls=%fused_computation.132.clone.1, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.2408 = s8[16777216]{0:T(1024)(128)(4,1)} bitcast(%all-gather.340)
-  %slice-start.21 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2408), calls=%async_computation.48, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
-  %slice-start.22 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2408), calls=%async_computation.49, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
-  %maximum_bitcast_fusion.28.k_ref = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} fusion(%broadcast_in_dim.1388, %slice_bitcast_fusion.11#1), kind=kLoop, calls=%fused_computation.128.clone.1, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1136 = bf16[1,128]{1,0:T(2,128)(2,1)S(1)} fusion(%copy-done.240, %copy.1629), kind=kLoop, calls=%fused_computation.199.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %all-gather.346 = bf16[1,512]{1,0:T(2,128)(2,1)S(1)} all-gather(%fusion.1136), channel_id=285, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %reduce.871 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%all-gather.346, %constant.4157..sunk.1), dimensions={0}, to_apply=%all-gather.293.reduce_sub_computation, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1137 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%all-gather.345, %add_rsqrt_fusion.13, %fusion.1132, %reduce.871), kind=kOutput, calls=%fused_computation.128.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %copy-start.214 = (s32[128]{0:T(128)S(1)}, s32[128]{0:T(128)}, u32[]{:S(2)}) copy-start(%wide.param.5#17), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
+  %slice_bitcast_fusion.11 = (bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.1137), kind=kLoop, calls=%fused_computation.130.clone.1, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.2414 = s8[16777216]{0:T(1024)(128)(4,1)} bitcast(%all-gather.340)
+  %slice-start.21 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2414), calls=%async_computation.48, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
+  %slice-start.22 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2414), calls=%async_computation.49, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
+  %maximum_bitcast_fusion.28.k_ref = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} fusion(%broadcast_in_dim.1287, %slice_bitcast_fusion.11#1), kind=kLoop, calls=%fused_computation.126.clone.1, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %copy-done.214 = s32[128]{0:T(128)S(1)} copy-done(%copy-start.214), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
-  %squeeze.874.q_segment_ids_ref = s32[128,128]{1,0:T(8,128)S(1)} broadcast(%copy-done.214), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8"]},"aliasing_operands":{"lists":[]}}
-  %squeeze.875.kv_segment_ids_ref = s32[8,128]{1,0:T(8,128)S(1)} broadcast(%copy-done.214), dimensions={1}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["128"]},"aliasing_operands":{"lists":[]}}
+  %squeeze.850.q_segment_ids_ref = s32[128,128]{1,0:T(8,128)S(1)} broadcast(%copy-done.214), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8"]},"aliasing_operands":{"lists":[]}}
+  %squeeze.851.kv_segment_ids_ref = s32[8,128]{1,0:T(8,128)S(1)} broadcast(%copy-done.214), dimensions={1}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["128"]},"aliasing_operands":{"lists":[]}}
   %iota.374.q_sequence_ref = s32[128,128]{1,0:T(8,128)S(1)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice-start.23 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2408), calls=%async_computation.50, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
-  %slice-start.24 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2408), calls=%async_computation.51, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
-  %splash_mha_fwd_segmented_residuals.27 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[128,128,128]{2,1,0:T(8,128)}) custom-call(%wide.param.5#21, %wide.param.5#22, %fusion.1135.q_ref, %maximum_bitcast_fusion.28.k_ref, %slice_bitcast_fusion.11#0, /*index=5*/%squeeze.874.q_segment_ids_ref, %squeeze.875.kv_segment_ids_ref, %iota.374.q_sequence_ref), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[128,128,192]{2,1,0}, bf16[128,128,192]{2,1,0}, bf16[128,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
+  %slice-start.23 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2414), calls=%async_computation.50, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
+  %slice-start.24 = ((s8[16777216]{0:T(1024)(128)(4,1)}), s8[4194304]{0:T(1024)(128)(4,1)S(1)}, s32[]{:S(2)}) async-start(%bitcast.2414), calls=%async_computation.51, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
+  %splash_mha_fwd_segmented_residuals.25 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[128,128,128]{2,1,0:T(8,128)}) custom-call(%wide.param.5#19, %wide.param.5#20, %fusion.1131.q_ref, %maximum_bitcast_fusion.28.k_ref, %slice_bitcast_fusion.11#0, /*index=5*/%squeeze.850.q_segment_ids_ref, %squeeze.851.kv_segment_ids_ref, %iota.374.q_sequence_ref), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[128,128,192]{2,1,0}, bf16[128,128,192]{2,1,0}, bf16[128,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
 "xprof_metadata":"{\"block_q\": 128, \"block_kv\": 128, \"block_kv_compute\": 128, \"block_q_dkv\": 128, \"block_kv_dkv\": 128, \"block_kv_dkv_compute\": 128, \"block_q_dq\": 128, \"block_kv_dq\": 128, \"use_fused_bwd_kernel\": false, \"q_layout\": 1, \"k_layout\": 1, \"v_layout\": 1}"
 }}, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"custom_call_config":{"body":"<mosaic_body>","needs_layout_passes":true,"allow_input_fusion":[],"serialization_format":"1","output_memory_colors":[],"output_memory_space_colors":[],"input_memory_space_colors":[]},"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %slice-done.21 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} async-done(%slice-start.21), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
@@ -879,32 +879,30 @@ StackFrames
   %slice-done.23 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} async-done(%slice-start.23), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
   %slice-done.24 = s8[4194304]{0:T(1024)(128)(4,1)S(1)} async-done(%slice-start.24), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"dma_priority":1}
   %custom-call.55 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} custom-call(%slice-done.21, %slice-done.22, %slice-done.23, %slice-done.24), custom_call_target="ConcatBitcast", backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.2409 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} bitcast(%custom-call.55)
-  %fusion.1142 = (f32[128]{0:T(128)S(1)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%wide.param.5#1, %bitcast.2409, %splash_mha_fwd_segmented_residuals.27#3), kind=kOutput, calls=%fused_computation.162.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.45 = bf16[1,18432,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#16, %copy.1629), kind=kLoop, calls=%fused_computation.118.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.2415 = bf16[1,128,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} bitcast(%custom-call.55)
+  %fusion.1138 = (f32[128]{0:T(128)S(1)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%wide.param.5#1, %bitcast.2415, %splash_mha_fwd_segmented_residuals.25#3), kind=kOutput, calls=%fused_computation.160.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.45 = bf16[1,18432,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#16, %copy.1629), kind=kLoop, calls=%fused_computation.116.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.347 = bf16[1,18432,512]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.45), channel_id=291, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={2}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.46 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#15, %copy.1629), kind=kLoop, calls=%fused_computation.119.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.46 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#15, %copy.1629), kind=kLoop, calls=%fused_computation.117.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.348 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.46), channel_id=290, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.47 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#14, %copy.1629), kind=kLoop, calls=%fused_computation.120.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.47 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.5#14, %copy.1629), kind=kLoop, calls=%fused_computation.118.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.349 = bf16[1,512,18432]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.47), channel_id=289, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add_rsqrt_fusion.14 = f32[128]{0:T(128)S(1)} fusion(%fusion.1142#0), kind=kLoop, calls=%fused_computation.202.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1143 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.349, %fusion.1142#1, %add_rsqrt_fusion.14, %fusion.1131#0), kind=kOutput, calls=%fused_computation.114.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.1144 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} fusion(%fusion.1142#1, %all-gather.347, %all-gather.348, %fusion.1143, %add_rsqrt_fusion.14, /*index=5*/%fusion.1131#0), kind=kOutput, calls=%fused_computation.146.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.2497 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%wide.param.5#17)
-  %bitcast.2500 = f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)} bitcast(%wide.param.5#18)
-  ROOT %tuple.869 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, /*index=10*/bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, f32[128,32]{1,0:T(8,128)S(1)}, f32[128,32]{1,0:T(8,128)S(1)}, s32[128]{0:T(128)}, /*index=20*/s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) tuple(%add.3930, %fusion.1144, %bitcast_dynamic-update-slice_fusion.2, %wide.param.5#3, %wide.param.5#4, /*index=5*/%wide.param.5#5, %wide.param.5#6, %wide.param.5#7, %wide.param.5#8, %wide.param.5#9, /*index=10*/%wide.param.5#10, %bitcast.2497, %bitcast.2500, %wide.param.5#13, %wide.param.5#14, /*index=15*/%wide.param.5#15, %wide.param.5#16, %wide.param.5#17, %wide.param.5#18, %wide.param.5#19, /*index=20*/%wide.param.5#20, %wide.param.5#21, %wide.param.5#22, %wide.param.5#23)
+  %add_rsqrt_fusion.14 = f32[128]{0:T(128)S(1)} fusion(%fusion.1138#0), kind=kLoop, calls=%fused_computation.200.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1139 = bf16[1,128,18432]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.349, %fusion.1138#1, %add_rsqrt_fusion.14, %fusion.1127#0), kind=kOutput, calls=%fused_computation.112.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.1140 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} fusion(%fusion.1138#1, %all-gather.347, %all-gather.348, %fusion.1139, %add_rsqrt_fusion.14, /*index=5*/%fusion.1127#0), kind=kOutput, calls=%fused_computation.144.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %tuple.870 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, /*index=10*/bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, /*index=20*/s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) tuple(%add.3885, %fusion.1140, %bitcast_dynamic-update-slice_fusion.2, %wide.param.5#3, %wide.param.5#4, /*index=5*/%wide.param.5#5, %wide.param.5#6, %wide.param.5#7, %wide.param.5#8, %wide.param.5#9, /*index=10*/%wide.param.5#10, %wide.param.5#11, %wide.param.5#12, %wide.param.5#13, %wide.param.5#14, /*index=15*/%wide.param.5#15, %wide.param.5#16, %wide.param.5#17, %wide.param.5#18, %wide.param.5#19, /*index=20*/%wide.param.5#20, %wide.param.5#21)
 }
 
-%wide.region_6.9_spmd.clone.clone.clone (wide.param.733: (s32[], bf16[1,128,512], bf16[3,1,128,512], bf16[3,512], bf16[3,384], /*index=5*/bf16[3,512], bf16[3,128,1536], bf16[3,384,128,192], bf16[3,128], bf16[3,128,576], /*index=10*/bf16[3,128,128,256], f32[1,128,1,32], f32[1,128,1,32], bf16[3,128,128,128], bf16[3,128,18432], /*index=15*/bf16[3,128,18432], bf16[3,18432,128], f32[128,32], f32[128,32], s32[128], /*index=20*/s32[], s8[1,1,1], s8[1,1,1], bf16[])) -> pred[] {
-  %constant.1462.clone.4 = s32[]{:T(128)} constant(3)
-  %wide.param.733 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, /*index=10*/bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, f32[128,32]{1,0:T(8,128)S(1)}, f32[128,32]{1,0:T(8,128)S(1)}, s32[128]{0:T(128)}, /*index=20*/s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) parameter(0)
-  ROOT %lt.870 = pred[]{:T(512)} compare(%wide.param.733#0, %constant.1462.clone.4), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/cond/lt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+%wide.region_6.9_spmd.clone.clone.clone (wide.param.733: (s32[], bf16[1,128,512], bf16[3,1,128,512], bf16[3,512], bf16[3,384], /*index=5*/bf16[3,512], bf16[3,128,1536], bf16[3,384,128,192], f32[1,128,1,32], f32[1,128,1,32], /*index=10*/bf16[3,128], bf16[3,128,576], bf16[3,128,128,256], bf16[3,128,128,128], bf16[3,128,18432], /*index=15*/bf16[3,128,18432], bf16[3,18432,128], s32[128], s32[], s8[1,1,1], /*index=20*/s8[1,1,1], bf16[])) -> pred[] {
+  %constant.1444.clone.4 = s32[]{:T(128)} constant(3)
+  %wide.param.733 = (s32[]{:T(128)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,1,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,384]{1,0:T(4,128)(2,1)}, /*index=5*/bf16[3,512]{1,0:T(4,128)(2,1)}, bf16[3,128,1536]{2,1,0:T(8,128)(2,1)}, bf16[3,384,128,192]{2,1,3,0:T(8,128)(2,1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, f32[1,128,1,32]{3,1,2,0:T(8,128)S(1)}, /*index=10*/bf16[3,128]{1,0:T(4,128)(2,1)}, bf16[3,128,576]{2,1,0:T(8,128)(2,1)S(1)}, bf16[3,128,128,256]{3,1,2,0:T(8,128)(2,1)}, bf16[3,128,128,128]{3,2,1,0:T(8,128)(2,1)}, bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[3,128,18432]{2,1,0:T(8,128)(2,1)}, bf16[3,18432,128]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, /*index=20*/s8[1,1,1]{2,1,0:T(4,128)(4,1)}, bf16[]{:T(256)}) parameter(0)
+  ROOT %lt.869 = pred[]{:T(512)} compare(%wide.param.733#0, %constant.1444.clone.4), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/cond/lt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.692 (param_0.2000: f32[128,1,128,128]) -> bf16[128,1,128,128] {
-  %param_0.2000 = f32[128,1,128,128]{3,2,1,0:T(8,128)} parameter(0)
-  %bitcast.1298 = f32[128,1,128,128]{3,2,0,1:T(8,128)} bitcast(%param_0.2000), sharding={devices=[1,1,1,4]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'moe_layers\'][\'self_attention\'][\'out\'][\'kernel\'].value"}
-  ROOT %convert_element_type.2457 = bf16[128,1,128,128]{3,2,0,1:T(8,128)(2,1)S(1)} convert(%bitcast.1298), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.690 (param_0.1996: f32[128,1,128,128]) -> bf16[128,1,128,128] {
+  %param_0.1996 = f32[128,1,128,128]{3,2,1,0:T(8,128)} parameter(0)
+  %bitcast.1300 = f32[128,1,128,128]{3,2,0,1:T(8,128)} bitcast(%param_0.1996), sharding={devices=[1,1,1,4]<=[4]}, metadata={op_name="state[\'model\'][\'decoder\'][\'moe_layers\'][\'self_attention\'][\'out\'][\'kernel\'].value"}
+  ROOT %convert_element_type.2417 = bf16[128,1,128,128]{3,2,0,1:T(8,128)(2,1)S(1)} convert(%bitcast.1300), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
 %region_8.13 (reduce_sum.30: f32[], reduce_sum.34: f32[]) -> f32[] {
@@ -913,57 +911,57 @@ StackFrames
   ROOT %reduce_sum.39 = f32[]{:T(128)} add(%reduce_sum.30, %reduce_sum.34), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.914 (param_0.4559: bf16[1,128,512]) -> f32[128] {
-  %param_0.4559 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.2557 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4559), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.639 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2557, %convert_element_type.2557), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
-  %constant.1695.clone.93 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.763 = f32[128]{0:T(128)S(1)} reduce(%square.639, %constant.1695.clone.93), dimensions={0,2}, to_apply=%region_8.13, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+%fused_computation.912 (param_0.4557: bf16[1,128,512]) -> f32[128] {
+  %param_0.4557 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.2517 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4557), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.631 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2517, %convert_element_type.2517), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+  %constant.1677.clone.93 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.755 = f32[128]{0:T(128)S(1)} reduce(%square.631, %constant.1677.clone.93), dimensions={0,2}, to_apply=%region_8.13, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.1411 (param_0.4104: f32[128]) -> f32[128] {
-  %param_0.4104 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1707.clone.11 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4462 = f32[128]{0:T(128)} broadcast(%constant.1707.clone.11), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.2474 = f32[128]{0:T(128)} multiply(%param_0.4104, %broadcast.4462), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %constant.1708.clone.14 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4461 = f32[128]{0:T(128)} broadcast(%constant.1708.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3625 = f32[128]{0:T(128)} add(%div.2474, %broadcast.4461), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  ROOT %rsqrt.345 = f32[128]{0:T(128)S(1)} rsqrt(%add.3625), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
+%fused_computation.1409 (param_0.4102: f32[128]) -> f32[128] {
+  %param_0.4102 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1689.clone.11 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4408 = f32[128]{0:T(128)} broadcast(%constant.1689.clone.11), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.2473 = f32[128]{0:T(128)} multiply(%param_0.4102, %broadcast.4408), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %constant.1690.clone.14 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4407 = f32[128]{0:T(128)} broadcast(%constant.1690.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3580 = f32[128]{0:T(128)} add(%div.2473, %broadcast.4407), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  ROOT %rsqrt.337 = f32[128]{0:T(128)S(1)} rsqrt(%add.3580), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%convert_element_type.2151.reduce_sub_computation (lhs.21: bf16[], rhs.21: bf16[]) -> bf16[] {
+%convert_element_type.2111.reduce_sub_computation (lhs.21: bf16[], rhs.21: bf16[]) -> bf16[] {
   %lhs.21 = bf16[] parameter(0)
   %rhs.21 = bf16[] parameter(1)
-  ROOT %add.3022 = bf16[] add(%lhs.21, %rhs.21), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.2977 = bf16[] add(%lhs.21, %rhs.21), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.1204 (param_0.4089: f32[512,1]) -> bf16[512] {
-  %param_0.4089 = f32[512,1]{0,1:T(1,128)} parameter(0)
-  %convert_element_type.2661 = bf16[512,1]{0,1:T(2,128)(2,1)} convert(%param_0.4089), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %constant.4110 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.798 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2661, %constant.4110), dimensions={1}, to_apply=%convert_element_type.2151.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.1202 (param_0.4087: f32[512,1]) -> bf16[512] {
+  %param_0.4087 = f32[512,1]{0,1:T(1,128)} parameter(0)
+  %convert_element_type.2621 = bf16[512,1]{0,1:T(2,128)(2,1)} convert(%param_0.4087), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %constant.4092 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.790 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2621, %constant.4092), dimensions={1}, to_apply=%convert_element_type.2111.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.965.clone.1.clone.clone (param_0.4407: bf16[1,128,512], param_1.5224: f32[128], param_2.4144: bf16[512]) -> bf16[128,512] {
+%fused_computation.963.clone.1.clone.clone (param_0.4405: bf16[1,128,512], param_1.5226: f32[128], param_2.4144: bf16[512]) -> bf16[128,512] {
   %param_2.4144 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.838 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4144), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1409 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.838)
-  %param_0.4407 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.2719 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4407), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.5224 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.4882 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.5224), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.4881 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2719, %mul.4882), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2718 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4881), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1410 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2718)
-  %dot_general.837 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1409, %convert.1410), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1411 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.837)
-  ROOT %bitcast.1929 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1411), metadata={stack_frame_id=0}
+  %dot_general.823 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4144), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1385 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.823)
+  %param_0.4405 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.2679 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4405), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.5226 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.4994 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.5226), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.4993 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2679, %mul.4994), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2678 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4993), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1386 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2678)
+  %dot_general.822 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1385, %convert.1386), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1387 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.822)
+  ROOT %bitcast.1931 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1387), metadata={stack_frame_id=0}
 }
 
-%fused_computation.738.clone.clone.clone.clone.clone.clone (param_0.4406: bf16[512,1,1536]) -> bf16[512,1536] {
-  %param_0.4406 = bf16[512,1,1536]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1928 = bf16[512,1536]{1,0:T(8,128)(2,1)} bitcast(%param_0.4406), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.736.clone.clone.clone.clone.clone.clone (param_0.4404: bf16[512,1,1536]) -> bf16[512,1536] {
+  %param_0.4404 = bf16[512,1,1536]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1930 = bf16[512,1536]{1,0:T(8,128)(2,1)} bitcast(%param_0.4404), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
 %region_9.14 (reduce_sum.40: f32[], reduce_sum.41: f32[]) -> f32[] {
@@ -972,207 +970,207 @@ StackFrames
   ROOT %reduce_sum.45 = f32[]{:T(128)} add(%reduce_sum.40, %reduce_sum.41), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.780 (param_0.4558: bf16[512,1,1536], param_1.5327: bf16[1,128,512], param_2.4220: f32[128], param_3.2871: bf16[512]) -> (f32[128], f32[1,128,1536]) {
-  %param_1.5327 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.4220 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.2871 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
-  %fusion.715.clone.1 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5327, %param_2.4220, %param_3.2871), kind=kLoop, calls=%fused_computation.965.clone.1.clone.clone, metadata={stack_frame_id=0}
-  %param_0.4558 = bf16[512,1,1536]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.480.clone.1 = bf16[512,1536]{1,0:T(8,128)(2,1)} fusion(%param_0.4558), kind=kLoop, calls=%fused_computation.738.clone.clone.clone.clone.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.187.clone.1 = bf16[128,1536]{1,0:T(8,128)(2,1)} convolution(%fusion.715.clone.1, %fusion.480.clone.1), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %bitcast.1373.clone.1 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.187.clone.1)
-  %convert.890.clone.1 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} convert(%bitcast.1373.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.613 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.890.clone.1, %convert.890.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
-  %constant.1695.clone.92 = f32[]{:T(128)} constant(0)
-  %reduce.747 = f32[128]{0:T(128)S(1)} reduce(%square.613, %constant.1695.clone.92), dimensions={0,2}, to_apply=%region_9.14, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.721 = (f32[128]{0:T(128)S(1)}, f32[1,128,1536]{2,1,0:T(8,128)S(1)}) tuple(%reduce.747, %convert.890.clone.1)
+%fused_computation.778 (param_0.4556: bf16[512,1,1536], param_1.5329: bf16[1,128,512], param_2.4219: f32[128], param_3.2870: bf16[512]) -> (f32[128], f32[1,128,1536]) {
+  %param_1.5329 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.4219 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.2870 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
+  %fusion.711.clone.1 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5329, %param_2.4219, %param_3.2870), kind=kLoop, calls=%fused_computation.963.clone.1.clone.clone, metadata={stack_frame_id=0}
+  %param_0.4556 = bf16[512,1,1536]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.476.clone.1 = bf16[512,1536]{1,0:T(8,128)(2,1)} fusion(%param_0.4556), kind=kLoop, calls=%fused_computation.736.clone.clone.clone.clone.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.187.clone.1 = bf16[128,1536]{1,0:T(8,128)(2,1)} convolution(%fusion.711.clone.1, %fusion.476.clone.1), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %bitcast.1375.clone.1 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.187.clone.1)
+  %convert.872.clone.1 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} convert(%bitcast.1375.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.605 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.872.clone.1, %convert.872.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+  %constant.1677.clone.92 = f32[]{:T(128)} constant(0)
+  %reduce.739 = f32[128]{0:T(128)S(1)} reduce(%square.605, %constant.1677.clone.92), dimensions={0,2}, to_apply=%region_9.14, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.722 = (f32[128]{0:T(128)S(1)}, f32[1,128,1536]{2,1,0:T(8,128)S(1)}) tuple(%reduce.739, %convert.872.clone.1)
 }
 
-%fused_computation.1387 (param_0.4052: f32[128]) -> f32[128] {
-  %param_0.4052 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1639.clone.4 = f32[]{:T(128)} constant(0.000651041686), metadata={stack_frame_id=0}
-  %broadcast.4408 = f32[128]{0:T(128)} broadcast(%constant.1639.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %div.2431 = f32[128]{0:T(128)} multiply(%param_0.4052, %broadcast.4408), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %constant.1708.clone.3 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4419 = f32[128]{0:T(128)} broadcast(%constant.1708.clone.3), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3587 = f32[128]{0:T(128)} add(%div.2431, %broadcast.4419), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  ROOT %rsqrt.334 = f32[128]{0:T(128)S(1)} rsqrt(%add.3587), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
+%fused_computation.1385 (param_0.4050: f32[128]) -> f32[128] {
+  %param_0.4050 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1621.clone.4 = f32[]{:T(128)} constant(0.000651041686), metadata={stack_frame_id=0}
+  %broadcast.4354 = f32[128]{0:T(128)} broadcast(%constant.1621.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %div.2430 = f32[128]{0:T(128)} multiply(%param_0.4050, %broadcast.4354), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %constant.1690.clone.3 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4365 = f32[128]{0:T(128)} broadcast(%constant.1690.clone.3), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3542 = f32[128]{0:T(128)} add(%div.2430, %broadcast.4365), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  ROOT %rsqrt.326 = f32[128]{0:T(128)S(1)} rsqrt(%add.3542), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%convert_element_type.2150.reduce_sub_computation (lhs.20: bf16[], rhs.20: bf16[]) -> bf16[] {
+%convert_element_type.2110.reduce_sub_computation (lhs.20: bf16[], rhs.20: bf16[]) -> bf16[] {
   %lhs.20 = bf16[] parameter(0)
   %rhs.20 = bf16[] parameter(1)
-  ROOT %add.3021 = bf16[] add(%lhs.20, %rhs.20), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.2976 = bf16[] add(%lhs.20, %rhs.20), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.1124 (param_0.4090: f32[1536,1]) -> bf16[1536] {
-  %param_0.4090 = f32[1536,1]{0,1:T(1,128)S(1)} parameter(0)
-  %convert_element_type.2655 = bf16[1536,1]{0,1:T(2,128)(2,1)} convert(%param_0.4090), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %constant.4111 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.789 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} reduce(%convert_element_type.2655, %constant.4111), dimensions={1}, to_apply=%convert_element_type.2150.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.1122 (param_0.4088: f32[1536,1]) -> bf16[1536] {
+  %param_0.4088 = f32[1536,1]{0,1:T(1,128)S(1)} parameter(0)
+  %convert_element_type.2615 = bf16[1536,1]{0,1:T(2,128)(2,1)} convert(%param_0.4088), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %constant.4093 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.781 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} reduce(%convert_element_type.2615, %constant.4093), dimensions={1}, to_apply=%convert_element_type.2110.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.857.clone (param_0.2755: f32[1,128,1536], param_1.3020: f32[128], param_2.2085: bf16[1536]) -> bf16[128,1536,1] {
+%fused_computation.855.clone (param_0.2753: f32[1,128,1536], param_1.3022: f32[128], param_2.2085: bf16[1536]) -> bf16[128,1536,1] {
   %param_2.2085 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.739 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.2085), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1406 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%dot_general.739)
-  %param_0.2755 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} parameter(0)
-  %param_1.3020 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.4032 = f32[1,128,1536]{2,1,0:T(8,128)} broadcast(%param_1.3020), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.4028 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%param_0.2755, %mul.4032), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2498 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} convert(%mul.4028), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1407 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%convert_element_type.2498)
-  %dot_general.718 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.1406, %convert.1407), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1536"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1408 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} convert(%dot_general.718)
-  ROOT %bitcast.1512 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.1408)
+  %dot_general.724 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.2085), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1382 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%dot_general.724)
+  %param_0.2753 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} parameter(0)
+  %param_1.3022 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.4144 = f32[1,128,1536]{2,1,0:T(8,128)} broadcast(%param_1.3022), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.4140 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%param_0.2753, %mul.4144), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2458 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} convert(%mul.4140), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1383 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%convert_element_type.2458)
+  %dot_general.703 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.1382, %convert.1383), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1536"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1384 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} convert(%dot_general.703)
+  ROOT %bitcast.1514 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.1384)
 }
 
 %bitcast_fusion.12 (bitcast_input.12: bf16[1536,128,192]) -> bf16[1536,128,192] {
   %bitcast_input.12 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.1990 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} bitcast(%bitcast_input.12)
+  ROOT %bitcast.1992 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} bitcast(%bitcast_input.12)
 }
 
-%fused_computation.707 (param_0.2489: bf16[1536,128,192], param_1.3019: f32[1,128,1536], param_2.2084: f32[128], param_3.1213: bf16[1536]) -> bf16[1,128,128,192] {
-  %param_1.3019 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} parameter(1)
+%fused_computation.705 (param_0.2487: bf16[1536,128,192], param_1.3021: f32[1,128,1536], param_2.2084: f32[128], param_3.1213: bf16[1536]) -> bf16[1,128,128,192] {
+  %param_1.3021 = f32[1,128,1536]{2,1,0:T(8,128)S(1)} parameter(1)
   %param_2.2084 = f32[128]{0:T(128)S(1)} parameter(2)
   %param_3.1213 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(3)
-  %fusion.612 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.3019, %param_2.2084, %param_3.1213), kind=kLoop, calls=%fused_computation.857.clone
-  %param_0.2489 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} parameter(0)
-  %fusion.900 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} fusion(%param_0.2489), kind=kLoop, calls=%bitcast_fusion.12
-  %convolution.179 = bf16[128,128,192]{2,0,1:T(8,128)(2,1)} convolution(%fusion.612, %fusion.900), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  ROOT %bitcast.1315 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.179), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %fusion.608 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.3021, %param_2.2084, %param_3.1213), kind=kLoop, calls=%fused_computation.855.clone
+  %param_0.2487 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} parameter(0)
+  %fusion.896 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} fusion(%param_0.2487), kind=kLoop, calls=%bitcast_fusion.12
+  %convolution.179 = bf16[128,128,192]{2,0,1:T(8,128)(2,1)} convolution(%fusion.608, %fusion.896), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  ROOT %bitcast.1317 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.179), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.1441 (param_0.4385: bf16[1,128,128,32,2]) -> (bf16[1,128,128,32,1], bf16[1,128,128,32,1]) {
-  %param_0.4385 = bf16[1,128,128,32,2]{2,1,4,3,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.1349 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} slice(%param_0.4385), slice={[0:1], [0:128], [0:128], [0:32], [1:2]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
-  %slice.1350 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} slice(%param_0.4385), slice={[0:1], [0:128], [0:128], [0:32], [0:1]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
-  ROOT %tuple.675 = (bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}) tuple(%slice.1349, %slice.1350)
+%fused_computation.1439 (param_0.4383: bf16[1,128,128,32,2]) -> (bf16[1,128,128,32,1], bf16[1,128,128,32,1]) {
+  %param_0.4383 = bf16[1,128,128,32,2]{2,1,4,3,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.1341 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} slice(%param_0.4383), slice={[0:1], [0:128], [0:128], [0:32], [1:2]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
+  %slice.1342 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)} slice(%param_0.4383), slice={[0:1], [0:128], [0:128], [0:32], [0:1]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
+  ROOT %tuple.676 = (bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)S(1)}) tuple(%slice.1341, %slice.1342)
 }
 
-%fused_computation.668 (param_0.2099: bf16[1,128,128,32,1], param_1.2371: bf16[1,128,128,32,1], param_2.4219: f32[128,32], param_3.2870: f32[128,32]) -> (bf16[1,128,128,32], bf16[1,128,128,32]) {
-  %param_0.2099 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.1325 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_0.2099)
-  %convert.862 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.1325), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.2371 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(1)
-  %bitcast.1339 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_1.2371)
-  %convert.861 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.1339), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %constant.1695.clone.91 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2469 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1695.clone.91), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %mul.3900 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.861, %convert_element_type.2469), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %add.3295 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%convert.862, %mul.3900), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  %param_3.2870 = f32[128,32]{1,0:T(8,128)S(1)} parameter(3)
-  %broadcast_in_dim.1310 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.2870), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %mul.3863 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3295, %broadcast_in_dim.1310), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %param_2.4219 = f32[128,32]{1,0:T(8,128)S(1)} parameter(2)
-  %broadcast_in_dim.1308 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.4219), dimensions={1,3}, metadata={op_name="jit(train_step)/broadcast_in_dim" stack_frame_id=0}
-  %mul.3816 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.861, %broadcast_in_dim.1308), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.3815 = f32[1,128,128,32]{3,1,2,0:T(8,128)} subtract(%mul.3863, %mul.3816), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.821 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.3815), metadata={op_name="convert.346" stack_frame_id=0}
-  %mul.3862.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3295, %broadcast_in_dim.1308), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.3823.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.861, %broadcast_in_dim.1310), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.3822.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%mul.3862.clone.1, %mul.3823.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.826.clone.1 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.3822.clone.1), metadata={op_name="convert.347" stack_frame_id=0}
-  ROOT %tuple.664 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.821, %convert.826.clone.1)
+%fused_computation.666 (param_0.2093: bf16[1,128,128,32,1], param_1.2366: bf16[1,128,128,32,1], param_2.1734: f32[128,32], param_3.1022: f32[128,32]) -> (bf16[1,128,128,32], bf16[1,128,128,32]) {
+  %param_0.2093 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(0)
+  %bitcast.1327 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_0.2093)
+  %convert.844 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.1327), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.2366 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(1)
+  %bitcast.1341 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_1.2366)
+  %convert.843 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.1341), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %constant.1677.clone.91 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2429 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1677.clone.91), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %mul.4000 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.843, %convert_element_type.2429), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %add.3250 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%convert.844, %mul.4000), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %param_3.1022 = f32[128,32]{1,0:T(8,128)S(1)} parameter(3)
+  %mul.4026 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.1022), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.3963 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3250, %mul.4026), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %param_2.1734 = f32[128,32]{1,0:T(8,128)S(1)} parameter(2)
+  %mul.4024 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.1734), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.3916 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.843, %mul.4024), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.3915 = f32[1,128,128,32]{3,1,2,0:T(8,128)} subtract(%mul.3963, %mul.3916), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.803 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.3915), metadata={op_name="convert.328" stack_frame_id=0}
+  %mul.3962.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3250, %mul.4024), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.3923.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.843, %mul.4026), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.3922.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%mul.3962.clone.1, %mul.3923.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.808.clone.1 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%mul.3922.clone.1), metadata={op_name="convert.329" stack_frame_id=0}
+  ROOT %tuple.665 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.803, %convert.808.clone.1)
 }
 
-%fused_computation.679 (param_0.2092: bf16[1,128,128,32], param_1.4831: bf16[1,128,128,32], param_2.3596: bf16[1,128,128,128]) -> bf16[128,128,192] {
+%fused_computation.677 (param_0.2091: bf16[1,128,128,32], param_1.4833: bf16[1,128,128,32], param_2.3596: bf16[1,128,128,128]) -> bf16[128,128,192] {
   %param_2.3596 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(2)
-  %constant.1709.clone.13 = bf16[]{:T(256)} constant(-inf)
-  %pad.283 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.3596, %constant.1709.clone.13), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1245 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.283)
-  %param_1.4831 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %pad.282 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4831, %constant.1709.clone.13), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1246 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.282)
-  %maximum.48 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1245, %convert.1246), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_0.2092 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.281 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.2092, %constant.1709.clone.13), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1247 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.281)
-  %maximum.47 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%maximum.48, %convert.1247), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %constant.1649.clone.4 = bf16[]{:T(256)} constant(0.1348), metadata={stack_frame_id=0}
-  %mul.3924 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1649.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.1248 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%mul.3924)
-  %mul.3842 = f32[1,128,128,192]{3,1,2,0:T(8,128)} multiply(%maximum.47, %convert.1248), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.1249 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3842)
-  ROOT %bitcast.1281 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)} bitcast(%convert.1249), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %constant.1691.clone.13 = bf16[]{:T(256)} constant(-inf)
+  %pad.283 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.3596, %constant.1691.clone.13), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1221 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.283)
+  %param_1.4833 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %pad.282 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4833, %constant.1691.clone.13), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1222 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.282)
+  %maximum.48 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1221, %convert.1222), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_0.2091 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.281 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.2091, %constant.1691.clone.13), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1223 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.281)
+  %maximum.47 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%maximum.48, %convert.1223), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %constant.1631.clone.4 = bf16[]{:T(256)} constant(0.1348), metadata={stack_frame_id=0}
+  %mul.4028 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1631.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.1224 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%mul.4028)
+  %mul.3942 = f32[1,128,128,192]{3,1,2,0:T(8,128)} multiply(%maximum.47, %convert.1224), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.1225 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3942)
+  ROOT %bitcast.1283 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)} bitcast(%convert.1225), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.965.clone (param_0.3056: bf16[1,128,512], param_1.3430: f32[128], param_2.2353: bf16[512]) -> bf16[128,512] {
+%fused_computation.963.clone (param_0.3054: bf16[1,128,512], param_1.3432: f32[128], param_2.2353: bf16[512]) -> bf16[128,512] {
   %param_2.2353 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.799 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.2353), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1412 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.799)
-  %param_0.3056 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.2637 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.3056), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.3430 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.4241 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.3430), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.4240 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2637, %mul.4241), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2636 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4240), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1413 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2636)
-  %dot_general.780 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1412, %convert.1413), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1414 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.780)
-  ROOT %bitcast.1601 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1414), metadata={stack_frame_id=0}
+  %dot_general.784 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.2353), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1388 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.784)
+  %param_0.3054 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.2597 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.3054), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.3432 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.4353 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.3432), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.4352 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2597, %mul.4353), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2596 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4352), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1389 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2596)
+  %dot_general.765 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1388, %convert.1389), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1390 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.765)
+  ROOT %bitcast.1603 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1390), metadata={stack_frame_id=0}
 }
 
-%fused_computation.790.clone.clone (param_0.2287: bf16[512,1,576]) -> bf16[512,576] {
-  %param_0.2287 = bf16[512,1,576]{0,2,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1408 = bf16[512,576]{0,1:T(8,128)(2,1)} bitcast(%param_0.2287), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.788.clone.clone (param_0.2285: bf16[512,1,576]) -> bf16[512,576] {
+  %param_0.2285 = bf16[512,1,576]{0,2,1:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1410 = bf16[512,576]{0,1:T(8,128)(2,1)} bitcast(%param_0.2285), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.792 (param_0.2953: bf16[512,1,576], param_1.3429: bf16[1,128,512], param_2.2352: f32[128], param_3.1396: bf16[512]) -> bf16[1,128,576] {
-  %param_1.3429 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+%fused_computation.790 (param_0.2951: bf16[512,1,576], param_1.3431: bf16[1,128,512], param_2.2352: f32[128], param_3.1396: bf16[512]) -> bf16[1,128,576] {
+  %param_1.3431 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %param_2.2352 = f32[128]{0:T(128)S(1)} parameter(2)
   %param_3.1396 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
-  %fusion.714 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.3429, %param_2.2352, %param_3.1396), kind=kLoop, calls=%fused_computation.965.clone, metadata={stack_frame_id=0}
-  %param_0.2953 = bf16[512,1,576]{0,2,1:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.510 = bf16[512,576]{0,1:T(8,128)(2,1)} fusion(%param_0.2953), kind=kLoop, calls=%fused_computation.790.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.197 = bf16[128,576]{0,1:T(8,128)(2,1)} convolution(%fusion.714, %fusion.510), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  ROOT %bitcast.1406 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.197), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %fusion.710 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.3431, %param_2.2352, %param_3.1396), kind=kLoop, calls=%fused_computation.963.clone, metadata={stack_frame_id=0}
+  %param_0.2951 = bf16[512,1,576]{0,2,1:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.506 = bf16[512,576]{0,1:T(8,128)(2,1)} fusion(%param_0.2951), kind=kLoop, calls=%fused_computation.788.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.197 = bf16[128,576]{0,1:T(8,128)(2,1)} convolution(%fusion.710, %fusion.506), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  ROOT %bitcast.1408 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.197), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.1443 (param_0.4387: bf16[1,128,1,32,2]) -> (bf16[1,128,1,32,1], bf16[1,128,1,32,1]) {
-  %param_0.4387 = bf16[1,128,1,32,2]{1,4,3,2,0:T(2,128)(2,1)S(1)} parameter(0)
-  %slice.1353 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4387), slice={[0:1], [0:128], [0:1], [0:32], [1:2]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
-  %slice.1354 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4387), slice={[0:1], [0:128], [0:1], [0:32], [0:1]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
-  ROOT %tuple.693 = (bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}, bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}) tuple(%slice.1353, %slice.1354)
+%fused_computation.1441 (param_0.4385: bf16[1,128,1,32,2]) -> (bf16[1,128,1,32,1], bf16[1,128,1,32,1]) {
+  %param_0.4385 = bf16[1,128,1,32,2]{1,4,3,2,0:T(2,128)(2,1)S(1)} parameter(0)
+  %slice.1345 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4385), slice={[0:1], [0:128], [0:1], [0:32], [1:2]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
+  %slice.1346 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4385), slice={[0:1], [0:128], [0:1], [0:32], [0:1]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/slice" stack_frame_id=0}
+  ROOT %tuple.694 = (bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}, bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}) tuple(%slice.1345, %slice.1346)
 }
 
-%fused_computation.1036 (param_0.3139: f32[128,32], param_1.3518: f32[128,32], param_2.2449: bf16[1,128,1,32,1], param_3.1470: bf16[1,128,1,32,1]) -> (bf16[1,128,32], bf16[1,128,32]) {
+%fused_computation.1034 (param_0.3137: f32[128,32], param_1.3520: f32[128,32], param_2.2449: bf16[1,128,1,32,1], param_3.1470: bf16[1,128,1,32,1]) -> (bf16[1,128,32], bf16[1,128,32]) {
   %param_2.2449 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} parameter(2)
-  %bitcast.1661 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_2.2449)
-  %convert.1022 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.1661), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %bitcast.1663 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_2.2449)
+  %convert.1004 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.1663), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
   %param_3.1470 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} parameter(3)
-  %bitcast.1676 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_3.1470)
-  %convert.1021 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.1676), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %constant.1695.clone.90 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2646 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1695.clone.90), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %mul.4332 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1021, %convert_element_type.2646), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %add.3406 = f32[1,128,32]{2,1,0:T(8,128)} add(%convert.1022, %mul.4332), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  %param_1.3518 = f32[128,32]{1,0:T(8,128)S(1)} parameter(1)
-  %bitcast.1647 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_1.3518), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.4319 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3406, %bitcast.1647), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %param_0.3139 = f32[128,32]{1,0:T(8,128)S(1)} parameter(0)
-  %bitcast.1641 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_0.3139), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.4259 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1021, %bitcast.1641), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.4258 = f32[1,128,32]{2,1,0:T(8,128)} subtract(%mul.4319, %mul.4259), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.985 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.4258), metadata={op_name="convert.344" stack_frame_id=0}
-  %mul.4316.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3406, %bitcast.1641), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.4266.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1021, %bitcast.1647), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.4265.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} add(%mul.4316.clone.1, %mul.4266.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.990.clone.1 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.4265.clone.1), metadata={op_name="convert.345" stack_frame_id=0}
-  ROOT %tuple.685 = (bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%convert.985, %convert.990.clone.1)
+  %bitcast.1678 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_3.1470)
+  %convert.1003 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.1678), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %constant.1677.clone.90 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2606 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1677.clone.90), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %mul.4444 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1003, %convert_element_type.2606), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %add.3361 = f32[1,128,32]{2,1,0:T(8,128)} add(%convert.1004, %mul.4444), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %param_1.3520 = f32[128,32]{1,0:T(8,128)S(1)} parameter(1)
+  %bitcast.1649 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_1.3520), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.4431 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3361, %bitcast.1649), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %param_0.3137 = f32[128,32]{1,0:T(8,128)S(1)} parameter(0)
+  %bitcast.1643 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_0.3137), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.4371 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1003, %bitcast.1643), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.4370 = f32[1,128,32]{2,1,0:T(8,128)} subtract(%mul.4431, %mul.4371), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.967 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.4370), metadata={op_name="convert.326" stack_frame_id=0}
+  %mul.4428.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3361, %bitcast.1643), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.4378.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1003, %bitcast.1649), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.4377.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} add(%mul.4428.clone.1, %mul.4378.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.972.clone.1 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.4377.clone.1), metadata={op_name="convert.327" stack_frame_id=0}
+  ROOT %tuple.686 = (bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%convert.967, %convert.972.clone.1)
 }
 
-%fused_computation.1079 (param_0.3110: bf16[1,128,32], param_1.4827: bf16[1,128,32]) -> bf16[128,64] {
-  %param_1.4827 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1709.clone.6 = bf16[]{:T(256)} constant(-inf)
-  %pad.314 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.4827, %constant.1709.clone.6), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1356 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.314)
-  %param_0.3110 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.313 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.3110, %constant.1709.clone.6), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1357 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.313)
-  %maximum.64 = f32[1,128,64]{2,1,0:T(8,128)} maximum(%convert.1356, %convert.1357), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","64"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1358 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} convert(%maximum.64)
-  ROOT %bitcast.1654 = bf16[128,64]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1358), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+%fused_computation.1077 (param_0.3108: bf16[1,128,32], param_1.4829: bf16[1,128,32]) -> bf16[128,64] {
+  %param_1.4829 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1691.clone.6 = bf16[]{:T(256)} constant(-inf)
+  %pad.314 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.4829, %constant.1691.clone.6), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1332 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.314)
+  %param_0.3108 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.313 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.3108, %constant.1691.clone.6), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1333 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.313)
+  %maximum.64 = f32[1,128,64]{2,1,0:T(8,128)} maximum(%convert.1332, %convert.1333), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","64"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1334 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} convert(%maximum.64)
+  ROOT %bitcast.1656 = bf16[128,64]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1334), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
 }
 
 %region_10.15 (reduce_sum.46: f32[], reduce_sum.47: f32[]) -> f32[] {
@@ -1181,101 +1179,101 @@ StackFrames
   ROOT %reduce_sum.48 = f32[]{:T(128)} add(%reduce_sum.46, %reduce_sum.47), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.904 (param_0.4557: bf16[1,128,576]) -> f32[128] {
-  %param_0.4557 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.1225 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_0.4557), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  %convert_element_type.2536 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1225), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.627 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2536, %convert_element_type.2536), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
-  %constant.1695.clone.89 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.756 = f32[128]{0:T(128)S(1)} reduce(%square.627, %constant.1695.clone.89), dimensions={0,2}, to_apply=%region_10.15, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+%fused_computation.902 (param_0.4555: bf16[1,128,576]) -> f32[128] {
+  %param_0.4555 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.1217 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_0.4555), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  %convert_element_type.2496 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1217), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.619 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2496, %convert_element_type.2496), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+  %constant.1677.clone.89 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.748 = f32[128]{0:T(128)S(1)} reduce(%square.619, %constant.1677.clone.89), dimensions={0,2}, to_apply=%region_10.15, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.1386 (param_0.4051: f32[128]) -> f32[128] {
-  %param_0.4051 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1707.clone.3 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4428 = f32[128]{0:T(128)} broadcast(%constant.1707.clone.3), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.2430 = f32[128]{0:T(128)} multiply(%param_0.4051, %broadcast.4428), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %constant.1708.clone.4 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4418 = f32[128]{0:T(128)} broadcast(%constant.1708.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3586 = f32[128]{0:T(128)} add(%div.2430, %broadcast.4418), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  ROOT %rsqrt.333 = f32[128]{0:T(128)S(1)} rsqrt(%add.3586), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
+%fused_computation.1384 (param_0.4049: f32[128]) -> f32[128] {
+  %param_0.4049 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1689.clone.3 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4374 = f32[128]{0:T(128)} broadcast(%constant.1689.clone.3), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.2429 = f32[128]{0:T(128)} multiply(%param_0.4049, %broadcast.4374), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %constant.1690.clone.4 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4364 = f32[128]{0:T(128)} broadcast(%constant.1690.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3541 = f32[128]{0:T(128)} add(%div.2429, %broadcast.4364), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  ROOT %rsqrt.325 = f32[128]{0:T(128)S(1)} rsqrt(%add.3541), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%convert_element_type.2154.reduce_sub_computation (lhs.22: bf16[], rhs.22: bf16[]) -> bf16[] {
+%convert_element_type.2114.reduce_sub_computation (lhs.22: bf16[], rhs.22: bf16[]) -> bf16[] {
   %lhs.22 = bf16[] parameter(0)
   %rhs.22 = bf16[] parameter(1)
-  ROOT %add.3023 = bf16[] add(%lhs.22, %rhs.22), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.2978 = bf16[] add(%lhs.22, %rhs.22), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.1203 (param_0.4088: f32[512,1]) -> bf16[512] {
-  %param_0.4088 = f32[512,1]{0,1:T(1,128)} parameter(0)
-  %convert_element_type.2660 = bf16[512,1]{0,1:T(2,128)(2,1)} convert(%param_0.4088), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %constant.4109 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.797 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2660, %constant.4109), dimensions={1}, to_apply=%convert_element_type.2154.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.1201 (param_0.4086: f32[512,1]) -> bf16[512] {
+  %param_0.4086 = f32[512,1]{0,1:T(1,128)} parameter(0)
+  %convert_element_type.2620 = bf16[512,1]{0,1:T(2,128)(2,1)} convert(%param_0.4086), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %constant.4091 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.789 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2620, %constant.4091), dimensions={1}, to_apply=%convert_element_type.2114.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.969.clone (param_0.3053: f32[128], param_1.3428: bf16[1,128,576], param_2.2351: bf16[512]) -> bf16[128,512,1] {
+%fused_computation.967.clone (param_0.3051: f32[128], param_1.3430: bf16[1,128,576], param_2.2351: bf16[512]) -> bf16[128,512,1] {
   %param_2.2351 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.795 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} broadcast(%param_2.2351), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1397 = f32[1,128,512]{1,2,0:T(8,128)} convert(%dot_general.795)
-  %param_1.3428 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %slice.1224 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_1.3428), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  %convert_element_type.2599 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1224), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_0.3053 = f32[128]{0:T(128)S(1)} parameter(0)
-  %mul.4180 = f32[1,128,512]{1,2,0:T(8,128)} broadcast(%param_0.3053), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.4157 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2599, %mul.4180), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2598 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%mul.4157), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1398 = f32[1,128,512]{1,2,0:T(8,128)} convert(%convert_element_type.2598)
-  %dot_general.753 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert.1397, %convert.1398), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1399 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%dot_general.753)
-  ROOT %bitcast.1554 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} bitcast(%convert.1399)
+  %dot_general.780 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} broadcast(%param_2.2351), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1373 = f32[1,128,512]{1,2,0:T(8,128)} convert(%dot_general.780)
+  %param_1.3430 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %slice.1216 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_1.3430), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  %convert_element_type.2559 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1216), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_0.3051 = f32[128]{0:T(128)S(1)} parameter(0)
+  %mul.4292 = f32[1,128,512]{1,2,0:T(8,128)} broadcast(%param_0.3051), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.4269 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2559, %mul.4292), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2558 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%mul.4269), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1374 = f32[1,128,512]{1,2,0:T(8,128)} convert(%convert_element_type.2558)
+  %dot_general.738 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert.1373, %convert.1374), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1375 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%dot_general.738)
+  ROOT %bitcast.1556 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} bitcast(%convert.1375)
 }
 
-%fused_computation.599.clone.clone (param_0.2055: bf16[512,1,128,256]) -> bf16[512,128,256] {
-  %param_0.2055 = bf16[512,1,128,256]{3,0,2,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1310 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.2055), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.597.clone.clone (param_0.2051: bf16[512,1,128,256]) -> bf16[512,128,256] {
+  %param_0.2051 = bf16[512,1,128,256]{3,0,2,1:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1312 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.2051), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.704 (param_0.2795: bf16[512,1,128,256], param_1.3427: f32[128], param_2.2350: bf16[1,128,576], param_3.1395: bf16[512]) -> bf16[1,128,128,256] {
-  %param_1.3427 = f32[128]{0:T(128)S(1)} parameter(1)
+%fused_computation.702 (param_0.2793: bf16[512,1,128,256], param_1.3429: f32[128], param_2.2350: bf16[1,128,576], param_3.1395: bf16[512]) -> bf16[1,128,128,256] {
+  %param_1.3429 = f32[128]{0:T(128)S(1)} parameter(1)
   %param_2.2350 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(2)
   %param_3.1395 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
-  %fusion.671 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} fusion(%param_1.3427, %param_2.2350, %param_3.1395), kind=kLoop, calls=%fused_computation.969.clone
-  %param_0.2795 = bf16[512,1,128,256]{3,0,2,1:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.454 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} fusion(%param_0.2795), kind=kLoop, calls=%fused_computation.599.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.175 = bf16[128,128,256]{2,0,1:T(8,128)(2,1)} convolution(%fusion.671, %fusion.454), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  ROOT %bitcast.1308 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.175), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %fusion.667 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} fusion(%param_1.3429, %param_2.2350, %param_3.1395), kind=kLoop, calls=%fused_computation.967.clone
+  %param_0.2793 = bf16[512,1,128,256]{3,0,2,1:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.450 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} fusion(%param_0.2793), kind=kLoop, calls=%fused_computation.597.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.175 = bf16[128,128,256]{2,0,1:T(8,128)(2,1)} convolution(%fusion.667, %fusion.450), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  ROOT %bitcast.1310 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.175), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.713 (param_0.2083: bf16[1,128,128,256]) -> (bf16[128,128,128], bf16[1,128,128,128]) {
-  %param_0.2083 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.1220 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.2083), slice={[0:1], [0:128], [0:128], [128:256]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  %bitcast.1319 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%slice.1220), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
-  %slice.1346 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.2083), slice={[0:1], [0:128], [0:128], [0:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  ROOT %tuple.669 = (bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.1319, %slice.1346)
+%fused_computation.711 (param_0.2079: bf16[1,128,128,256]) -> (bf16[128,128,128], bf16[1,128,128,128]) {
+  %param_0.2079 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.1212 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.2079), slice={[0:1], [0:128], [0:128], [128:256]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  %bitcast.1321 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%slice.1212), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %slice.1338 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.2079), slice={[0:1], [0:128], [0:128], [0:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  ROOT %tuple.670 = (bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.1321, %slice.1338)
 }
 
-%fused_computation.680 (param_0.1970: bf16[1,128,128,64], param_1.4829: bf16[1,128,128,128]) -> bf16[128,128,192] {
-  %param_1.4829 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1709.clone.8 = bf16[]{:T(256)} constant(-inf)
-  %pad.285 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4829, %constant.1709.clone.8), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1250 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.285)
-  %param_0.1970 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.284 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1970, %constant.1709.clone.8), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.1251 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.284)
-  %maximum.49 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1250, %convert.1251), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.1252 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.49)
-  ROOT %bitcast.1282 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)} bitcast(%convert.1252), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+%fused_computation.678 (param_0.1966: bf16[1,128,128,64], param_1.4831: bf16[1,128,128,128]) -> bf16[128,128,192] {
+  %param_1.4831 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1691.clone.8 = bf16[]{:T(256)} constant(-inf)
+  %pad.285 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4831, %constant.1691.clone.8), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1226 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.285)
+  %param_0.1966 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.284 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1966, %constant.1691.clone.8), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.1227 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.284)
+  %maximum.49 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1226, %convert.1227), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.1228 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.49)
+  ROOT %bitcast.1284 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)} bitcast(%convert.1228), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.714.clone.clone.clone.clone.clone.clone (param_0.4411: bf16[128,128,128]) -> bf16[128,128,128] {
-  %param_0.4411 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.1933 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.4411)
+%fused_computation.712.clone.clone.clone.clone.clone.clone (param_0.4409: bf16[128,128,128]) -> bf16[128,128,128] {
+  %param_0.4409 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)} parameter(0)
+  ROOT %bitcast.1935 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.4409)
 }
 
-%fused_computation.648.clone.clone.clone.clone.clone.clone (param_0.4410: bf16[128,1,128,512]) -> bf16[128,128,512] {
-  %param_0.4410 = bf16[128,1,128,512]{3,2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1932 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.4410), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.646.clone.clone.clone.clone.clone.clone (param_0.4408: bf16[128,1,128,512]) -> bf16[128,128,512] {
+  %param_0.4408 = bf16[128,1,128,512]{3,2,0,1:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1934 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.4408), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
 %region_11.17 (reduce_sum.52: f32[], reduce_sum.53: f32[]) -> f32[] {
@@ -1284,138 +1282,138 @@ StackFrames
   ROOT %reduce_sum.54 = f32[]{:T(128)} add(%reduce_sum.52, %reduce_sum.53), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.906 (param_0.4556: bf16[1,128,512], param_1.5326: bf16[128,1,128,512], param_2.4218: bf16[128,128,128]) -> (f32[128], bf16[1,128,512]) {
-  %param_0.4556 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.1293 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4556)
+%fused_computation.904 (param_0.4554: bf16[1,128,512], param_1.5328: bf16[128,1,128,512], param_2.4218: bf16[128,128,128]) -> (f32[128], bf16[1,128,512]) {
+  %param_0.4554 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.1269 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4554)
   %param_2.4218 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)} parameter(2)
-  %fusion.603.clone.1 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} fusion(%param_2.4218), kind=kLoop, calls=%fused_computation.714.clone.clone.clone.clone.clone.clone
-  %param_1.5326 = bf16[128,1,128,512]{3,2,0,1:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.602.clone.1 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} fusion(%param_1.5326), kind=kLoop, calls=%fused_computation.648.clone.clone.clone.clone.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.253.clone.1 = bf16[128,512,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.603.clone.1, %fusion.602.clone.1), window={size=128}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %bitcast.1508.clone.1 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.253.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %convert.1294 = f32[1,128,512]{2,1,0:T(8,128)} convert(%bitcast.1508.clone.1)
-  %add.3340.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} add(%convert.1293, %convert.1294), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.2541 = f32[1,128,512]{2,1,0:T(8,128)} convert(%add.3340.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.629 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2541, %convert_element_type.2541), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
-  %constant.1695.clone.88 = f32[]{:T(128)} constant(0)
-  %reduce.757 = f32[128]{0:T(128)S(1)} reduce(%square.629, %constant.1695.clone.88), dimensions={0,2}, to_apply=%region_11.17, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
-  %convert.1295 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.3340.clone.1)
-  ROOT %tuple.722 = (f32[128]{0:T(128)S(1)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.757, %convert.1295)
+  %fusion.599.clone.1 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} fusion(%param_2.4218), kind=kLoop, calls=%fused_computation.712.clone.clone.clone.clone.clone.clone
+  %param_1.5328 = bf16[128,1,128,512]{3,2,0,1:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.598.clone.1 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} fusion(%param_1.5328), kind=kLoop, calls=%fused_computation.646.clone.clone.clone.clone.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.253.clone.1 = bf16[128,512,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.599.clone.1, %fusion.598.clone.1), window={size=128}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %bitcast.1510.clone.1 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.253.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %convert.1270 = f32[1,128,512]{2,1,0:T(8,128)} convert(%bitcast.1510.clone.1)
+  %add.3295.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} add(%convert.1269, %convert.1270), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.2501 = f32[1,128,512]{2,1,0:T(8,128)} convert(%add.3295.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.621 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2501, %convert_element_type.2501), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+  %constant.1677.clone.88 = f32[]{:T(128)} constant(0)
+  %reduce.749 = f32[128]{0:T(128)S(1)} reduce(%square.621, %constant.1677.clone.88), dimensions={0,2}, to_apply=%region_11.17, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+  %convert.1271 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.3295.clone.1)
+  ROOT %tuple.723 = (f32[128]{0:T(128)S(1)}, bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.749, %convert.1271)
 }
 
-%convert_element_type.2117.reduce_sub_computation (lhs.23: bf16[], rhs.23: bf16[]) -> bf16[] {
+%convert_element_type.2077.reduce_sub_computation (lhs.23: bf16[], rhs.23: bf16[]) -> bf16[] {
   %lhs.23 = bf16[] parameter(0)
   %rhs.23 = bf16[] parameter(1)
-  ROOT %add.3024 = bf16[] add(%lhs.23, %rhs.23), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.2979 = bf16[] add(%lhs.23, %rhs.23), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.1324 (param_0.4087: f32[1,256]) -> bf16[256] {
-  %param_0.4087 = f32[1,256]{1,0:T(1,128)S(1)} parameter(0)
-  %convert_element_type.2669 = bf16[1,256]{1,0:T(2,128)(2,1)} convert(%param_0.4087), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %constant.4108 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.822 = bf16[256]{0:T(256)(128)(2,1)S(1)} reduce(%convert_element_type.2669, %constant.4108), dimensions={0}, to_apply=%convert_element_type.2117.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.1322 (param_0.4085: f32[1,256]) -> bf16[256] {
+  %param_0.4085 = f32[1,256]{1,0:T(1,128)S(1)} parameter(0)
+  %convert_element_type.2629 = bf16[1,256]{1,0:T(2,128)(2,1)} convert(%param_0.4085), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %constant.4090 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.814 = bf16[256]{0:T(256)(128)(2,1)S(1)} reduce(%convert_element_type.2629, %constant.4090), dimensions={0}, to_apply=%convert_element_type.2077.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.1385 (param_0.4050: f32[128]) -> f32[128] {
-  %param_0.4050 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1707.clone.4 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4427 = f32[128]{0:T(128)} broadcast(%constant.1707.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.2429 = f32[128]{0:T(128)} multiply(%param_0.4050, %broadcast.4427), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %constant.1708.clone.5 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4417 = f32[128]{0:T(128)} broadcast(%constant.1708.clone.5), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3585 = f32[128]{0:T(128)} add(%div.2429, %broadcast.4417), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  ROOT %rsqrt.332 = f32[128]{0:T(128)S(1)} rsqrt(%add.3585), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
+%fused_computation.1383 (param_0.4048: f32[128]) -> f32[128] {
+  %param_0.4048 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1689.clone.4 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4373 = f32[128]{0:T(128)} broadcast(%constant.1689.clone.4), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.2428 = f32[128]{0:T(128)} multiply(%param_0.4048, %broadcast.4373), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %constant.1690.clone.5 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4363 = f32[128]{0:T(128)} broadcast(%constant.1690.clone.5), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3540 = f32[128]{0:T(128)} add(%div.2428, %broadcast.4363), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  ROOT %rsqrt.324 = f32[128]{0:T(128)S(1)} rsqrt(%add.3540), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%convert_element_type.2149.reduce_sub_computation (lhs.19: bf16[], rhs.19: bf16[]) -> bf16[] {
+%convert_element_type.2109.reduce_sub_computation (lhs.19: bf16[], rhs.19: bf16[]) -> bf16[] {
   %lhs.19 = bf16[] parameter(0)
   %rhs.19 = bf16[] parameter(1)
-  ROOT %add.3020 = bf16[] add(%lhs.19, %rhs.19), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.2975 = bf16[] add(%lhs.19, %rhs.19), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.1205 (param_0.4091: f32[512,1]) -> bf16[512] {
-  %param_0.4091 = f32[512,1]{0,1:T(1,128)S(1)} parameter(0)
-  %convert_element_type.2662 = bf16[512,1]{0,1:T(2,128)(2,1)} convert(%param_0.4091), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %constant.4112 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.799 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2662, %constant.4112), dimensions={1}, to_apply=%convert_element_type.2149.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.1203 (param_0.4089: f32[512,1]) -> bf16[512] {
+  %param_0.4089 = f32[512,1]{0,1:T(1,128)S(1)} parameter(0)
+  %convert_element_type.2622 = bf16[512,1]{0,1:T(2,128)(2,1)} convert(%param_0.4089), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %constant.4094 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.791 = bf16[512]{0:T(512)(128)(2,1)S(1)} reduce(%convert_element_type.2622, %constant.4094), dimensions={1}, to_apply=%convert_element_type.2109.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.967.clone.2 (param_0.4182: bf16[1,128,512], param_1.4951: f32[128], param_2.3712: bf16[512]) -> bf16[128,512] {
+%fused_computation.965.clone.2 (param_0.4180: bf16[1,128,512], param_1.4953: f32[128], param_2.3712: bf16[512]) -> bf16[128,512] {
   %param_2.3712 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.828 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.3712), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1427 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.828)
-  %param_0.4182 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.2695 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4182), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.4951 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.4561 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.4951), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.4560 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2695, %mul.4561), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2694 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4560), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1428 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2694)
-  %dot_general.827 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1427, %convert.1428), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1429 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.827)
-  ROOT %bitcast.1823 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1429), metadata={op_name="pallas_call/reshape" stack_frame_id=0}
+  %dot_general.813 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.3712), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1403 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.813)
+  %param_0.4180 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.2655 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4180), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.4953 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.4673 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_1.4953), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.4672 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2655, %mul.4673), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2654 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4672), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1404 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2654)
+  %dot_general.812 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1403, %convert.1404), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1405 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.812)
+  ROOT %bitcast.1825 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%convert.1405), metadata={op_name="pallas_call/reshape" stack_frame_id=0}
 }
 
-%fused_computation.920 (param_0.2662: bf16[512,1,256]) -> bf16[512,256] {
-  %param_0.2662 = bf16[512,1,256]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1540 = bf16[512,256]{1,0:T(8,128)(2,1)} bitcast(%param_0.2662), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.918 (param_0.2660: bf16[512,1,256]) -> bf16[512,256] {
+  %param_0.2660 = bf16[512,1,256]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1542 = bf16[512,256]{1,0:T(8,128)(2,1)} bitcast(%param_0.2660), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.848 (param_0.4183: bf16[512,1,256], param_1.4952: bf16[1,128,512], param_2.3713: f32[128], param_3.2310: bf16[512]) -> bf16[128,256] {
-  %constant.1652.clone.15 = bf16[]{:T(256)} constant(1), metadata={stack_frame_id=0}
-  %broadcast.4257 = bf16[128,256]{1,0:T(8,128)(2,1)} broadcast(%constant.1652.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %convert.1278 = f32[128,256]{1,0:T(8,128)} convert(%broadcast.4257)
-  %param_1.4952 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+%fused_computation.846 (param_0.4181: bf16[512,1,256], param_1.4954: bf16[1,128,512], param_2.3713: f32[128], param_3.2310: bf16[512]) -> bf16[128,256] {
+  %constant.1634.clone.15 = bf16[]{:T(256)} constant(1), metadata={stack_frame_id=0}
+  %broadcast.4203 = bf16[128,256]{1,0:T(8,128)(2,1)} broadcast(%constant.1634.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %convert.1254 = f32[128,256]{1,0:T(8,128)} convert(%broadcast.4203)
+  %param_1.4954 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %param_2.3713 = f32[128]{0:T(128)S(1)} parameter(2)
   %param_3.2310 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
-  %fusion.821 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.4952, %param_2.3713, %param_3.2310), kind=kLoop, calls=%fused_computation.967.clone.2, metadata={op_name="pallas_call/reshape" stack_frame_id=0}
-  %param_0.4183 = bf16[512,1,256]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.649 = bf16[512,256]{1,0:T(8,128)(2,1)} fusion(%param_0.4183), kind=kLoop, calls=%fused_computation.920, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.267 = bf16[128,256]{1,0:T(8,128)(2,1)} convolution(%fusion.821, %fusion.649), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %convert.1277 = f32[128,256]{1,0:T(8,128)} convert(%convolution.267)
-  %neg.218 = f32[128,256]{1,0:T(8,128)} negate(%convert.1277), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
-  %exp.511 = f32[128,256]{1,0:T(8,128)} exponential(%neg.218), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
-  %add.3346 = f32[128,256]{1,0:T(8,128)} add(%exp.511, %convert.1278), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
-  %div.2164 = f32[128,256]{1,0:T(8,128)} divide(%convert.1278, %add.3346), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
-  ROOT %convert.1279 = bf16[128,256]{1,0:T(8,128)(2,1)S(1)} convert(%div.2164)
+  %fusion.817 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.4954, %param_2.3713, %param_3.2310), kind=kLoop, calls=%fused_computation.965.clone.2, metadata={op_name="pallas_call/reshape" stack_frame_id=0}
+  %param_0.4181 = bf16[512,1,256]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.645 = bf16[512,256]{1,0:T(8,128)(2,1)} fusion(%param_0.4181), kind=kLoop, calls=%fused_computation.918, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.267 = bf16[128,256]{1,0:T(8,128)(2,1)} convolution(%fusion.817, %fusion.645), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %convert.1253 = f32[128,256]{1,0:T(8,128)} convert(%convolution.267)
+  %neg.217 = f32[128,256]{1,0:T(8,128)} negate(%convert.1253), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  %exp.510 = f32[128,256]{1,0:T(8,128)} exponential(%neg.217), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  %add.3301 = f32[128,256]{1,0:T(8,128)} add(%exp.510, %convert.1254), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  %div.2163 = f32[128,256]{1,0:T(8,128)} divide(%convert.1254, %add.3301), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  ROOT %convert.1255 = bf16[128,256]{1,0:T(8,128)(2,1)S(1)} convert(%div.2163)
 }
 
-%fused_computation.1348 (param_0.4103: f32[128]) -> f32[128] {
-  %param_0.4103 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1707.clone.1 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4458 = f32[128]{0:T(128)} broadcast(%constant.1707.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.2472 = f32[128]{0:T(128)} multiply(%param_0.4103, %broadcast.4458), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %constant.1708.clone.1 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4457 = f32[128]{0:T(128)} broadcast(%constant.1708.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3623 = f32[128]{0:T(128)} add(%div.2472, %broadcast.4457), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  %bitcast.1776 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3623), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.309 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1776), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.1745 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.309), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+%fused_computation.1346 (param_0.4101: f32[128]) -> f32[128] {
+  %param_0.4101 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1689.clone.1 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4404 = f32[128]{0:T(128)} broadcast(%constant.1689.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.2471 = f32[128]{0:T(128)} multiply(%param_0.4101, %broadcast.4404), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %constant.1690.clone.1 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4403 = f32[128]{0:T(128)} broadcast(%constant.1690.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3578 = f32[128]{0:T(128)} add(%div.2471, %broadcast.4403), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %bitcast.1778 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3578), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.301 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1778), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.1747 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.301), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.1031 (param_0.3057: f32[128], param_1.3431: bf16[1,128,512], param_2.2354: bf16[512]) -> bf16[1,128,512] {
+%fused_computation.1029 (param_0.3055: f32[128], param_1.3433: bf16[1,128,512], param_2.2354: bf16[512]) -> bf16[1,128,512] {
   %param_2.2354 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.802 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.2354), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1350 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.802)
-  %param_1.3431 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert_element_type.2635 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_1.3431), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_0.3057 = f32[128]{0:T(128)S(1)} parameter(0)
-  %mul.4239 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_0.3057), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.4238 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2635, %mul.4239), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.2634 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4238), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.1351 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2634)
-  %dot_general.779 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1350, %convert.1351), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  ROOT %convert.1352 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} convert(%dot_general.779)
+  %dot_general.787 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.2354), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1326 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.787)
+  %param_1.3433 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert_element_type.2595 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_1.3433), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_0.3055 = f32[128]{0:T(128)S(1)} parameter(0)
+  %mul.4351 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_0.3055), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.4350 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2595, %mul.4351), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.2594 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4350), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.1327 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2594)
+  %dot_general.764 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1326, %convert.1327), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  ROOT %convert.1328 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} convert(%dot_general.764)
 }
 
-%fused_computation.988.clone.clone (param_0.4399: bf16[1,128,512]) -> bf16[128,512] {
-  %param_0.4399 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1921 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%param_0.4399), metadata={stack_frame_id=0}
+%fused_computation.986.clone.clone (param_0.4397: bf16[1,128,512]) -> bf16[128,512] {
+  %param_0.4397 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1923 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%param_0.4397), metadata={stack_frame_id=0}
 }
 
-%fused_computation.736.clone.clone.clone.clone (param_0.4398: bf16[512,1,1536]) -> bf16[512,1536] {
-  %param_0.4398 = bf16[512,1,1536]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1920 = bf16[512,1536]{1,0:T(8,128)(2,1)} bitcast(%param_0.4398), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.734.clone.clone.clone.clone (param_0.4396: bf16[512,1,1536]) -> bf16[512,1536] {
+  %param_0.4396 = bf16[512,1,1536]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1922 = bf16[512,1536]{1,0:T(8,128)(2,1)} bitcast(%param_0.4396), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
 %region_43.52 (reduce_sum.104: f32[], reduce_sum.108: f32[]) -> f32[] {
@@ -1424,233 +1422,233 @@ StackFrames
   ROOT %reduce_sum.109 = f32[]{:T(128)} add(%reduce_sum.104, %reduce_sum.108), metadata={op_name="checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.771 (param_0.4555: bf16[512,1,1536], param_1.5325: bf16[1,128,512]) -> (f32[128], bf16[1,128,1536]) {
-  %param_1.5325 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.689.clone.1 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5325), kind=kLoop, calls=%fused_computation.988.clone.clone, metadata={stack_frame_id=0}
-  %param_0.4555 = bf16[512,1,1536]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.483.clone.1 = bf16[512,1536]{1,0:T(8,128)(2,1)} fusion(%param_0.4555), kind=kLoop, calls=%fused_computation.736.clone.clone.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.189.clone.1 = bf16[128,1536]{1,0:T(8,128)(2,1)} convolution(%fusion.689.clone.1, %fusion.483.clone.1), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %bitcast.1375.clone.1 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.189.clone.1)
-  %convert.896 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%bitcast.1375.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %square.612 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.896, %convert.896), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.1695.clone.87 = f32[]{:T(128)} constant(0)
-  %reduce.745 = f32[128]{0:T(128)S(1)} reduce(%square.612, %constant.1695.clone.87), dimensions={0,2}, to_apply=%region_43.52, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.719 = (f32[128]{0:T(128)S(1)}, bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.745, %bitcast.1375.clone.1)
+%fused_computation.769 (param_0.4553: bf16[512,1,1536], param_1.5327: bf16[1,128,512]) -> (f32[128], bf16[1,128,1536]) {
+  %param_1.5327 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.685.clone.1 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.5327), kind=kLoop, calls=%fused_computation.986.clone.clone, metadata={stack_frame_id=0}
+  %param_0.4553 = bf16[512,1,1536]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.479.clone.1 = bf16[512,1536]{1,0:T(8,128)(2,1)} fusion(%param_0.4553), kind=kLoop, calls=%fused_computation.734.clone.clone.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.189.clone.1 = bf16[128,1536]{1,0:T(8,128)(2,1)} convolution(%fusion.685.clone.1, %fusion.479.clone.1), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  %bitcast.1377.clone.1 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.189.clone.1)
+  %convert.878 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%bitcast.1377.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %square.604 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.878, %convert.878), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
+  %constant.1677.clone.87 = f32[]{:T(128)} constant(0)
+  %reduce.737 = f32[128]{0:T(128)S(1)} reduce(%square.604, %constant.1677.clone.87), dimensions={0,2}, to_apply=%region_43.52, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.720 = (f32[128]{0:T(128)S(1)}, bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.737, %bitcast.1377.clone.1)
 }
 
-%fused_computation.1346 (param_0.4047: f32[128]) -> f32[128] {
-  %param_0.4047 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1639.clone.2 = f32[]{:T(128)} constant(0.000651041686), metadata={stack_frame_id=0}
-  %broadcast.4407 = f32[128]{0:T(128)} broadcast(%constant.1639.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %div.2459 = f32[128]{0:T(128)} multiply(%param_0.4047, %broadcast.4407), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.1708.clone.8 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4414 = f32[128]{0:T(128)} broadcast(%constant.1708.clone.8), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3606 = f32[128]{0:T(128)} add(%div.2459, %broadcast.4414), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.1774 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3606), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.307 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1774), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.1744 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.307), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+%fused_computation.1344 (param_0.4045: f32[128]) -> f32[128] {
+  %param_0.4045 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1621.clone.2 = f32[]{:T(128)} constant(0.000651041686), metadata={stack_frame_id=0}
+  %broadcast.4353 = f32[128]{0:T(128)} broadcast(%constant.1621.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %div.2458 = f32[128]{0:T(128)} multiply(%param_0.4045, %broadcast.4353), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.1690.clone.8 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4360 = f32[128]{0:T(128)} broadcast(%constant.1690.clone.8), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3561 = f32[128]{0:T(128)} add(%div.2458, %broadcast.4360), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.1776 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3561), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.299 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1776), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.1746 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.299), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.772 (param_0.2522: bf16[1,128,1536], param_1.2772: f32[128]) -> bf16[1,128,1536] {
-  %param_0.2522 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.898 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%param_0.2522), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.2772 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.4034 = f32[1,128,1536]{2,1,0:T(8,128)} broadcast(%param_1.2772), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.3996 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.898, %mul.4034), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  ROOT %convert_element_type.2480 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.3996), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+%fused_computation.770 (param_0.2520: bf16[1,128,1536], param_1.2774: f32[128]) -> bf16[1,128,1536] {
+  %param_0.2520 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.880 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%param_0.2520), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.2774 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.4146 = f32[1,128,1536]{2,1,0:T(8,128)} broadcast(%param_1.2774), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.4108 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.880, %mul.4146), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  ROOT %convert_element_type.2440 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.4108), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.874 (param_0.2752: bf16[1,128,1536], param_1.3018: bf16[1536]) -> bf16[128,1536,1] {
-  %param_1.3018 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %dot_general.735 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} broadcast(%param_1.3018), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1403 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%dot_general.735)
-  %param_0.2752 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.1404 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%param_0.2752)
-  %dot_general.727 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.1403, %convert.1404), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1536"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1405 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} convert(%dot_general.727)
-  ROOT %bitcast.1522 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.1405)
+%fused_computation.872 (param_0.2750: bf16[1,128,1536], param_1.3020: bf16[1536]) -> bf16[128,1536,1] {
+  %param_1.3020 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %dot_general.720 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} broadcast(%param_1.3020), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1379 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%dot_general.720)
+  %param_0.2750 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.1380 = f32[1,128,1536]{2,1,0:T(8,128)} convert(%param_0.2750)
+  %dot_general.712 = f32[1,128,1536]{2,1,0:T(8,128)} multiply(%convert.1379, %convert.1380), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1536"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1381 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)} convert(%dot_general.712)
+  ROOT %bitcast.1524 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.1381)
 }
 
 %bitcast_fusion.11 (bitcast_input.11: bf16[1536,128,192]) -> bf16[1536,128,192] {
   %bitcast_input.11 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.1989 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} bitcast(%bitcast_input.11)
+  ROOT %bitcast.1991 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} bitcast(%bitcast_input.11)
 }
 
-%fused_computation.706 (param_0.2517: bf16[1536,128,192], param_1.3017: bf16[1,128,1536], param_2.2083: bf16[1536]) -> bf16[1,128,128,192] {
-  %param_1.3017 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+%fused_computation.704 (param_0.2515: bf16[1536,128,192], param_1.3019: bf16[1,128,1536], param_2.2083: bf16[1536]) -> bf16[1,128,128,192] {
+  %param_1.3019 = bf16[1,128,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
   %param_2.2083 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %fusion.616 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.3017, %param_2.2083), kind=kLoop, calls=%fused_computation.874
-  %param_0.2517 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} parameter(0)
-  %fusion.899 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} fusion(%param_0.2517), kind=kLoop, calls=%bitcast_fusion.11
-  %convolution.178 = bf16[128,128,192]{2,0,1:T(8,128)(2,1)} convolution(%fusion.616, %fusion.899), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.1314 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.178), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  %fusion.612 = bf16[128,1536,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.3019, %param_2.2083), kind=kLoop, calls=%fused_computation.872
+  %param_0.2515 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} parameter(0)
+  %fusion.895 = bf16[1536,128,192]{0,2,1:T(8,128)(2,1)} fusion(%param_0.2515), kind=kLoop, calls=%bitcast_fusion.11
+  %convolution.178 = bf16[128,128,192]{2,0,1:T(8,128)(2,1)} convolution(%fusion.612, %fusion.895), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.1316 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.178), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.1440 (param_0.4384: bf16[1,128,128,32,2]) -> (bf16[1,128,128,32,1], bf16[1,128,128,32,1]) {
-  %param_0.4384 = bf16[1,128,128,32,2]{2,1,4,3,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.1347 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)} slice(%param_0.4384), slice={[0:1], [0:128], [0:128], [0:32], [1:2]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/slice" stack_frame_id=0}
-  %slice.1348 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)} slice(%param_0.4384), slice={[0:1], [0:128], [0:128], [0:32], [0:1]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/slice" stack_frame_id=0}
-  ROOT %tuple.674 = (bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)}, bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)}) tuple(%slice.1347, %slice.1348)
+%fused_computation.1438 (param_0.4382: bf16[1,128,128,32,2]) -> (bf16[1,128,128,32,1], bf16[1,128,128,32,1]) {
+  %param_0.4382 = bf16[1,128,128,32,2]{2,1,4,3,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.1339 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)} slice(%param_0.4382), slice={[0:1], [0:128], [0:128], [0:32], [1:2]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/slice" stack_frame_id=0}
+  %slice.1340 = bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)} slice(%param_0.4382), slice={[0:1], [0:128], [0:128], [0:32], [0:1]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/slice" stack_frame_id=0}
+  ROOT %tuple.675 = (bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)}, bf16[1,128,128,32,1]{2,1,4,3,0:T(8,128)(2,1)}) tuple(%slice.1339, %slice.1340)
 }
 
-%fused_computation.1371 (param_0.4064: s32[1,128]) -> s32[128] {
-  %param_0.4064 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %bitcast.1772 = s32[1,128,1]{1,2,0:T(1,128)} bitcast(%param_0.4064), metadata={op_name="reshape.2451" stack_frame_id=0}
-  %constant.1684.clone.138 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %eval_jaxpr.209 = s32[1,128,1]{1,2,0:T(1,128)} broadcast(%constant.1684.clone.138), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %lt.836 = pred[1,128,1]{1,2,0:T(4,128)(4,1)} compare(%bitcast.1772, %eval_jaxpr.209), direction=LT, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/lt" stack_frame_id=0}
-  %constant.1706.clone.1 = s32[]{:T(128)} constant(163840)
-  %eval_jaxpr.208 = s32[1,128,1]{1,2,0:T(1,128)} broadcast(%constant.1706.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3561 = s32[1,128,1]{1,2,0:T(1,128)} add(%bitcast.1772, %eval_jaxpr.208), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %select_n.2267 = s32[1,128,1]{1,2,0:T(1,128)} select(%lt.836, %add.3561, %bitcast.1772), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
-  ROOT %bitcast.1750 = s32[128]{0:T(128)S(1)} bitcast(%select_n.2267), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
+%fused_computation.1369 (param_0.4062: s32[1,128]) -> s32[128] {
+  %param_0.4062 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
+  %bitcast.1774 = s32[1,128,1]{1,2,0:T(1,128)} bitcast(%param_0.4062), metadata={op_name="reshape.2426" stack_frame_id=0}
+  %constant.1666.clone.138 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %eval_jaxpr.205 = s32[1,128,1]{1,2,0:T(1,128)} broadcast(%constant.1666.clone.138), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
+  %lt.835 = pred[1,128,1]{1,2,0:T(4,128)(4,1)} compare(%bitcast.1774, %eval_jaxpr.205), direction=LT, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/lt" stack_frame_id=0}
+  %constant.1688.clone.1 = s32[]{:T(128)} constant(163840)
+  %eval_jaxpr.204 = s32[1,128,1]{1,2,0:T(1,128)} broadcast(%constant.1688.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3516 = s32[1,128,1]{1,2,0:T(1,128)} add(%bitcast.1774, %eval_jaxpr.204), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %select_n.2267 = s32[1,128,1]{1,2,0:T(1,128)} select(%lt.835, %add.3516, %bitcast.1774), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
+  ROOT %bitcast.1752 = s32[128]{0:T(128)S(1)} bitcast(%select_n.2267), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
 }
 
-%fused_computation.1148 (param_0.3381: s32[128]) -> s32[1024] {
-  %constant.4094 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.4293 = s32[1024]{0:T(1024)} broadcast(%constant.4094), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %param_0.3381 = s32[128]{0:T(128)S(1)} parameter(0)
-  %constant.4102 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %pad.329 = s32[1024]{0:T(1024)} pad(%param_0.3381, %constant.4102), padding=0_896, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %constant.4087 = s32[] constant(163839), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  %broadcast.4285 = s32[1024]{0:T(1024)} broadcast(%constant.4087), dimensions={}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
-  ROOT %clamp.57 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4293, %pad.329, %broadcast.4285), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+%fused_computation.1146 (param_0.3379: s32[128]) -> s32[1024] {
+  %constant.4076 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.4239 = s32[1024]{0:T(1024)} broadcast(%constant.4076), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %param_0.3379 = s32[128]{0:T(128)S(1)} parameter(0)
+  %constant.4084 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %pad.329 = s32[1024]{0:T(1024)} pad(%param_0.3379, %constant.4084), padding=0_896, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  %constant.4069 = s32[] constant(163839), metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  %broadcast.4231 = s32[1024]{0:T(1024)} broadcast(%constant.4069), dimensions={}, metadata={op_name="jit(train_step)/gather" stack_frame_id=0}
+  ROOT %clamp.57 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.4239, %pad.329, %broadcast.4231), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
 }
 
 %fused_computation.10 (param_0.32: f32[163840,32], param_1.135: s32[1024]) -> f32[128,32] {
   %param_0.32 = f32[163840,32]{1,0:T(8,128)} parameter(0)
   %param_1.135 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.32 = s32[1024]{0:T(1024)} custom-call(%param_1.135), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %slice.1081 = s32[128]{0:T(128)} slice(%custom-call.32), slice={[0:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %reshape.4291 = s32[128]{0:T(128)} reshape(%slice.1081), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
-  %transpose.893 = s32[128]{0:T(128)} transpose(%reshape.4291), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
-  %gather.234 = f32[128,32]{1,0:T(8,128)} gather(%param_0.32, %transpose.893), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %transpose.892 = f32[128,32]{1,0:T(8,128)} transpose(%gather.234), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  ROOT %reshape.4290 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.892), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  %slice.1073 = s32[128]{0:T(128)} slice(%custom-call.32), slice={[0:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  %reshape.4284 = s32[128]{0:T(128)} reshape(%slice.1073), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
+  %transpose.895 = s32[128]{0:T(128)} transpose(%reshape.4284), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
+  %gather.234 = f32[128,32]{1,0:T(8,128)} gather(%param_0.32, %transpose.895), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  %transpose.894 = f32[128,32]{1,0:T(8,128)} transpose(%gather.234), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  ROOT %reshape.4283 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.894), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
 }
 
 %fused_computation.9 (param_0.29: f32[163840,32], param_1.133: s32[1024]) -> f32[128,32] {
   %param_0.29 = f32[163840,32]{1,0:T(8,128)} parameter(0)
   %param_1.133 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.30 = s32[1024]{0:T(1024)} custom-call(%param_1.133), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %slice.1079 = s32[128]{0:T(128)} slice(%custom-call.30), slice={[0:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %reshape.4283 = s32[128]{0:T(128)} reshape(%slice.1079), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
-  %transpose.887 = s32[128]{0:T(128)} transpose(%reshape.4283), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
-  %gather.232 = f32[128,32]{1,0:T(8,128)} gather(%param_0.29, %transpose.887), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %transpose.886 = f32[128,32]{1,0:T(8,128)} transpose(%gather.232), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  ROOT %reshape.4282 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.886), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  %slice.1071 = s32[128]{0:T(128)} slice(%custom-call.30), slice={[0:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  %reshape.4276 = s32[128]{0:T(128)} reshape(%slice.1071), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
+  %transpose.889 = s32[128]{0:T(128)} transpose(%reshape.4276), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/select_n" stack_frame_id=0}
+  %gather.232 = f32[128,32]{1,0:T(8,128)} gather(%param_0.29, %transpose.889), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,32}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  %transpose.888 = f32[128,32]{1,0:T(8,128)} transpose(%gather.232), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  ROOT %reshape.4275 = f32[128,32]{1,0:T(8,128)S(1)} reshape(%transpose.888), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
 }
 
-%fused_computation.673 (param_0.2097: bf16[1,128,128,32,1], param_1.2368: bf16[1,128,128,32,1], param_2.4217: f32[128,32], param_3.2869: f32[128,32]) -> (bf16[1,128,128,32], bf16[1,128,128,32]) {
-  %param_0.2097 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.1321 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_0.2097)
-  %convert.854 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.1321), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.2368 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)} parameter(1)
-  %bitcast.1337 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_1.2368)
-  %convert.853 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.1337), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %constant.1695.clone.86 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2468 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1695.clone.86), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %mul.3896 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.853, %convert_element_type.2468), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %add.3291 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%convert.854, %mul.3896), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+%fused_computation.671 (param_0.2098: bf16[1,128,128,32,1], param_1.2374: bf16[1,128,128,32,1], param_2.4217: f32[128,32], param_3.2869: f32[128,32]) -> (bf16[1,128,128,32], bf16[1,128,128,32]) {
+  %param_0.2098 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)S(1)} parameter(0)
+  %bitcast.1323 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_0.2098)
+  %convert.836 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.1323), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.2374 = bf16[1,128,128,32,1]{3,1,2,4,0:T(8,128)(2,1)} parameter(1)
+  %bitcast.1339 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} bitcast(%param_1.2374)
+  %convert.835 = f32[1,128,128,32]{3,1,2,0:T(8,128)} convert(%bitcast.1339), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %constant.1677.clone.86 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2428 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%constant.1677.clone.86), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %mul.3996 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.835, %convert_element_type.2428), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %add.3246 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%convert.836, %mul.3996), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
   %param_3.2869 = f32[128,32]{1,0:T(8,128)S(1)} parameter(3)
-  %broadcast_in_dim.1307 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.2869), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/broadcast_in_dim" stack_frame_id=0}
-  %mul.3886 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3291, %broadcast_in_dim.1307), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.4036 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_3.2869), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.3986 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3246, %mul.4036), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %param_2.4217 = f32[128,32]{1,0:T(8,128)S(1)} parameter(2)
-  %broadcast_in_dim.1303 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.4217), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/broadcast_in_dim" stack_frame_id=0}
-  %mul.3832 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.853, %broadcast_in_dim.1303), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.3831 = f32[1,128,128,32]{3,1,2,0:T(8,128)} subtract(%mul.3886, %mul.3832), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.833 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3831), metadata={op_name="convert.374" stack_frame_id=0}
-  %mul.3885.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3291, %broadcast_in_dim.1303), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.3839.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.853, %broadcast_in_dim.1307), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.3838.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%mul.3885.clone.1, %mul.3839.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.838.clone.1 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3838.clone.1), metadata={op_name="convert.375" stack_frame_id=0}
-  ROOT %tuple.663 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)}) tuple(%convert.833, %convert.838.clone.1)
+  %mul.4032 = f32[1,128,128,32]{3,1,2,0:T(8,128)} broadcast(%param_2.4217), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.3932 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.835, %mul.4032), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.3931 = f32[1,128,128,32]{3,1,2,0:T(8,128)} subtract(%mul.3986, %mul.3932), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.815 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3931), metadata={op_name="convert.356" stack_frame_id=0}
+  %mul.3985.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%add.3246, %mul.4032), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.3939.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} multiply(%convert.835, %mul.4036), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.3938.clone.1 = f32[1,128,128,32]{3,1,2,0:T(8,128)} add(%mul.3985.clone.1, %mul.3939.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.820.clone.1 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3938.clone.1), metadata={op_name="convert.357" stack_frame_id=0}
+  ROOT %tuple.664 = (bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)}, bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)}) tuple(%convert.815, %convert.820.clone.1)
 }
 
-%fused_computation.682 (param_0.2091: bf16[1,128,128,32], param_1.4836: bf16[1,128,128,32], param_2.3598: bf16[1,128,128,128]) -> bf16[128,128,192] {
+%fused_computation.680 (param_0.2090: bf16[1,128,128,32], param_1.4838: bf16[1,128,128,32], param_2.3598: bf16[1,128,128,128]) -> bf16[128,128,192] {
   %param_2.3598 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(2)
-  %constant.1709.clone.23 = bf16[]{:T(256)} constant(-inf)
-  %pad.288 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.3598, %constant.1709.clone.23), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.1253 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.288)
-  %param_1.4836 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} parameter(1)
-  %pad.287 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4836, %constant.1709.clone.23), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.1254 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.287)
-  %maximum.53 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1253, %convert.1254), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_0.2091 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} parameter(0)
-  %pad.286 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.2091, %constant.1709.clone.23), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.1255 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.286)
-  %maximum.52 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%maximum.53, %convert.1255), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %constant.1649.clone.2 = bf16[]{:T(256)} constant(0.1348), metadata={stack_frame_id=0}
-  %mul.3923 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1649.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.1256 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%mul.3923)
-  %mul.3845 = f32[1,128,128,192]{3,1,2,0:T(8,128)} multiply(%maximum.52, %convert.1256), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.1257 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3845)
-  ROOT %bitcast.1283 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1257), metadata={op_name="splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %constant.1691.clone.23 = bf16[]{:T(256)} constant(-inf)
+  %pad.288 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_2.3598, %constant.1691.clone.23), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.1229 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.288)
+  %param_1.4838 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} parameter(1)
+  %pad.287 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4838, %constant.1691.clone.23), padding=0_0x0_0x0_0x128_32, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.1230 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.287)
+  %maximum.53 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1229, %convert.1230), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_0.2090 = bf16[1,128,128,32]{3,1,2,0:T(8,128)(2,1)} parameter(0)
+  %pad.286 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.2090, %constant.1691.clone.23), padding=0_0x0_0x0_0x160_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.1231 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.286)
+  %maximum.52 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%maximum.53, %convert.1231), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %constant.1631.clone.2 = bf16[]{:T(256)} constant(0.1348), metadata={stack_frame_id=0}
+  %mul.4027 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.1631.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.1232 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%mul.4027)
+  %mul.3945 = f32[1,128,128,192]{3,1,2,0:T(8,128)} multiply(%maximum.52, %convert.1232), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.1233 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%mul.3945)
+  ROOT %bitcast.1285 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1233), metadata={op_name="splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.987 (param_0.2826: bf16[1,128,512]) -> bf16[128,512] {
-  %param_0.2826 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1591 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%param_0.2826), metadata={stack_frame_id=0}
+%fused_computation.985 (param_0.2824: bf16[1,128,512]) -> bf16[128,512] {
+  %param_0.2824 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1593 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%param_0.2824), metadata={stack_frame_id=0}
 }
 
-%fused_computation.788.clone.clone (param_0.2292: bf16[512,1,576]) -> bf16[512,576] {
-  %param_0.2292 = bf16[512,1,576]{0,2,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1411 = bf16[512,576]{0,1:T(8,128)(2,1)} bitcast(%param_0.2292), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.786.clone.clone (param_0.2290: bf16[512,1,576]) -> bf16[512,576] {
+  %param_0.2290 = bf16[512,1,576]{0,2,1:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1413 = bf16[512,576]{0,1:T(8,128)(2,1)} bitcast(%param_0.2290), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.793 (param_0.2825: bf16[512,1,576], param_1.3117: bf16[1,128,512]) -> bf16[1,128,576] {
-  %param_1.3117 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.688 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.3117), kind=kLoop, calls=%fused_computation.987, metadata={stack_frame_id=0}
-  %param_0.2825 = bf16[512,1,576]{0,2,1:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.513 = bf16[512,576]{0,1:T(8,128)(2,1)} fusion(%param_0.2825), kind=kLoop, calls=%fused_computation.788.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.199 = bf16[128,576]{0,1:T(8,128)(2,1)} convolution(%fusion.688, %fusion.513), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.1409 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.199), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+%fused_computation.791 (param_0.2823: bf16[512,1,576], param_1.3119: bf16[1,128,512]) -> bf16[1,128,576] {
+  %param_1.3119 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.684 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_1.3119), kind=kLoop, calls=%fused_computation.985, metadata={stack_frame_id=0}
+  %param_0.2823 = bf16[512,1,576]{0,2,1:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.509 = bf16[512,576]{0,1:T(8,128)(2,1)} fusion(%param_0.2823), kind=kLoop, calls=%fused_computation.786.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.199 = bf16[128,576]{0,1:T(8,128)(2,1)} convolution(%fusion.684, %fusion.509), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.1411 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.199), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.1442 (param_0.4386: bf16[1,128,1,32,2]) -> (bf16[1,128,1,32,1], bf16[1,128,1,32,1]) {
-  %param_0.4386 = bf16[1,128,1,32,2]{1,4,3,2,0:T(2,128)(2,1)S(1)} parameter(0)
-  %slice.1351 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4386), slice={[0:1], [0:128], [0:1], [0:32], [1:2]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/slice" stack_frame_id=0}
-  %slice.1352 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4386), slice={[0:1], [0:128], [0:1], [0:32], [0:1]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/slice" stack_frame_id=0}
-  ROOT %tuple.692 = (bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}, bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}) tuple(%slice.1351, %slice.1352)
+%fused_computation.1440 (param_0.4384: bf16[1,128,1,32,2]) -> (bf16[1,128,1,32,1], bf16[1,128,1,32,1]) {
+  %param_0.4384 = bf16[1,128,1,32,2]{1,4,3,2,0:T(2,128)(2,1)S(1)} parameter(0)
+  %slice.1343 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4384), slice={[0:1], [0:128], [0:1], [0:32], [1:2]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/slice" stack_frame_id=0}
+  %slice.1344 = bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)} slice(%param_0.4384), slice={[0:1], [0:128], [0:1], [0:32], [0:1]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/slice" stack_frame_id=0}
+  ROOT %tuple.693 = (bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}, bf16[1,128,1,32,1]{1,4,3,2,0:T(2,128)(2,1)S(1)}) tuple(%slice.1343, %slice.1344)
 }
 
-%fused_computation.1041 (param_0.3137: f32[128,32], param_1.3516: f32[128,32], param_2.2448: bf16[1,128,1,32,1], param_3.1469: bf16[1,128,1,32,1]) -> (bf16[1,128,32], bf16[1,128,32]) {
+%fused_computation.1039 (param_0.3135: f32[128,32], param_1.3518: f32[128,32], param_2.2448: bf16[1,128,1,32,1], param_3.1469: bf16[1,128,1,32,1]) -> (bf16[1,128,32], bf16[1,128,32]) {
   %param_2.2448 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} parameter(2)
-  %bitcast.1658 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_2.2448)
-  %convert.1014 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.1658), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %bitcast.1660 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_2.2448)
+  %convert.996 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.1660), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %param_3.1469 = bf16[1,128,1,32,1]{3,1,4,2,0:T(8,128)(2,1)S(1)} parameter(3)
-  %bitcast.1674 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_3.1469)
-  %convert.1013 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.1674), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %constant.1695.clone.85 = f32[]{:T(128)} constant(0)
-  %convert_element_type.2645 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1695.clone.85), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %mul.4328 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1013, %convert_element_type.2645), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %add.3402 = f32[1,128,32]{2,1,0:T(8,128)} add(%convert.1014, %mul.4328), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %param_1.3516 = f32[128,32]{1,0:T(8,128)S(1)} parameter(1)
-  %bitcast.1635 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_1.3516), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %mul.4313 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3402, %bitcast.1635), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %param_0.3137 = f32[128,32]{1,0:T(8,128)S(1)} parameter(0)
-  %bitcast.1628 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_0.3137), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
-  %mul.4275 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1013, %bitcast.1628), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.4274 = f32[1,128,32]{2,1,0:T(8,128)} subtract(%mul.4313, %mul.4275), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.997 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.4274), metadata={op_name="convert.372" stack_frame_id=0}
-  %mul.4310.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3402, %bitcast.1628), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.4282.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.1013, %bitcast.1635), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.4281.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} add(%mul.4310.clone.1, %mul.4282.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.1002.clone.1 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.4281.clone.1), metadata={op_name="convert.373" stack_frame_id=0}
-  ROOT %tuple.684 = (bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%convert.997, %convert.1002.clone.1)
+  %bitcast.1676 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)} bitcast(%param_3.1469)
+  %convert.995 = f32[1,128,32]{2,1,0:T(8,128)} convert(%bitcast.1676), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %constant.1677.clone.85 = f32[]{:T(128)} constant(0)
+  %convert_element_type.2605 = f32[1,128,32]{2,1,0:T(8,128)} broadcast(%constant.1677.clone.85), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %mul.4440 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.995, %convert_element_type.2605), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %add.3357 = f32[1,128,32]{2,1,0:T(8,128)} add(%convert.996, %mul.4440), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %param_1.3518 = f32[128,32]{1,0:T(8,128)S(1)} parameter(1)
+  %bitcast.1637 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_1.3518), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  %mul.4425 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3357, %bitcast.1637), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %param_0.3135 = f32[128,32]{1,0:T(8,128)S(1)} parameter(0)
+  %bitcast.1630 = f32[1,128,32]{2,1,0:T(8,128)} bitcast(%param_0.3135), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/gather" stack_frame_id=0}
+  %mul.4387 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.995, %bitcast.1630), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.4386 = f32[1,128,32]{2,1,0:T(8,128)} subtract(%mul.4425, %mul.4387), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.979 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.4386), metadata={op_name="convert.354" stack_frame_id=0}
+  %mul.4422.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%add.3357, %bitcast.1630), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.4394.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} multiply(%convert.995, %bitcast.1637), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.4393.clone.1 = f32[1,128,32]{2,1,0:T(8,128)} add(%mul.4422.clone.1, %mul.4394.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.984.clone.1 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} convert(%mul.4393.clone.1), metadata={op_name="convert.355" stack_frame_id=0}
+  ROOT %tuple.685 = (bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%convert.979, %convert.984.clone.1)
 }
 
-%fused_computation.1080 (param_0.3113: bf16[1,128,32], param_1.4826: bf16[1,128,32]) -> bf16[128,64] {
-  %param_1.4826 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1709.clone.5 = bf16[]{:T(256)} constant(-inf)
-  %pad.316 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.4826, %constant.1709.clone.5), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.1359 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.316)
-  %param_0.3113 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.315 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.3113, %constant.1709.clone.5), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.1360 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.315)
-  %maximum.65 = f32[1,128,64]{2,1,0:T(8,128)} maximum(%convert.1359, %convert.1360), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","64"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1361 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} convert(%maximum.65)
-  ROOT %bitcast.1655 = bf16[128,64]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1361), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+%fused_computation.1078 (param_0.3111: bf16[1,128,32], param_1.4828: bf16[1,128,32]) -> bf16[128,64] {
+  %param_1.4828 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1691.clone.5 = bf16[]{:T(256)} constant(-inf)
+  %pad.316 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_1.4828, %constant.1691.clone.5), padding=0_0x0_0x0_32, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.1335 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.316)
+  %param_0.3111 = bf16[1,128,32]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.315 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} pad(%param_0.3111, %constant.1691.clone.5), padding=0_0x0_0x32_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.1336 = f32[1,128,64]{2,1,0:T(8,128)} convert(%pad.315)
+  %maximum.65 = f32[1,128,64]{2,1,0:T(8,128)} maximum(%convert.1335, %convert.1336), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","64"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1337 = bf16[1,128,64]{2,1,0:T(8,128)(2,1)} convert(%maximum.65)
+  ROOT %bitcast.1657 = bf16[128,64]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1337), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
 }
 
 %region_44.53 (reduce_sum.110: f32[], reduce_sum.111: f32[]) -> f32[] {
@@ -1659,90 +1657,90 @@ StackFrames
   ROOT %reduce_sum.115 = f32[]{:T(128)} add(%reduce_sum.110, %reduce_sum.111), metadata={op_name="checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.911 (param_0.4554: bf16[1,128,576]) -> f32[128] {
-  %param_0.4554 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.1237 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_0.4554), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
-  %convert_element_type.2546 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1237), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %square.637 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2546, %convert_element_type.2546), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.1695.clone.84 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.761 = f32[128]{0:T(128)S(1)} reduce(%square.637, %constant.1695.clone.84), dimensions={0,2}, to_apply=%region_44.53, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+%fused_computation.909 (param_0.4552: bf16[1,128,576]) -> f32[128] {
+  %param_0.4552 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.1229 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_0.4552), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
+  %convert_element_type.2506 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1229), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %square.629 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2506, %convert_element_type.2506), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
+  %constant.1677.clone.84 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.753 = f32[128]{0:T(128)S(1)} reduce(%square.629, %constant.1677.clone.84), dimensions={0,2}, to_apply=%region_44.53, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.1344 (param_0.4046: f32[128]) -> f32[128] {
-  %param_0.4046 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1707.clone.7 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4424 = f32[128]{0:T(128)} broadcast(%constant.1707.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.2463 = f32[128]{0:T(128)} multiply(%param_0.4046, %broadcast.4424), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.1708.clone.9 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4413 = f32[128]{0:T(128)} broadcast(%constant.1708.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3610 = f32[128]{0:T(128)} add(%div.2463, %broadcast.4413), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.1771 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3610), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.305 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1771), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.1743 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.305), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+%fused_computation.1342 (param_0.4044: f32[128]) -> f32[128] {
+  %param_0.4044 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1689.clone.7 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4370 = f32[128]{0:T(128)} broadcast(%constant.1689.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.2462 = f32[128]{0:T(128)} multiply(%param_0.4044, %broadcast.4370), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.1690.clone.9 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4359 = f32[128]{0:T(128)} broadcast(%constant.1690.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3565 = f32[128]{0:T(128)} add(%div.2462, %broadcast.4359), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.1773 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3565), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.297 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1773), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.1745 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.297), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.974 (param_0.3050: f32[128], param_1.3426: bf16[1,128,576], param_2.2349: bf16[512]) -> bf16[128,512,1] {
+%fused_computation.972 (param_0.3048: f32[128], param_1.3428: bf16[1,128,576], param_2.2349: bf16[512]) -> bf16[128,512,1] {
   %param_2.2349 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.791 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} broadcast(%param_2.2349), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1400 = f32[1,128,512]{1,2,0:T(8,128)} convert(%dot_general.791)
-  %param_1.3426 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %slice.1234 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_1.3426), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
-  %convert_element_type.2627 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1234), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_0.3050 = f32[128]{0:T(128)S(1)} parameter(0)
-  %mul.4224 = f32[1,128,512]{1,2,0:T(8,128)} broadcast(%param_0.3050), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.4223 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2627, %mul.4224), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.2626 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%mul.4223), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.1401 = f32[1,128,512]{1,2,0:T(8,128)} convert(%convert_element_type.2626)
-  %dot_general.768 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert.1400, %convert.1401), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1402 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%dot_general.768)
-  ROOT %bitcast.1560 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} bitcast(%convert.1402)
+  %dot_general.776 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} broadcast(%param_2.2349), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1376 = f32[1,128,512]{1,2,0:T(8,128)} convert(%dot_general.776)
+  %param_1.3428 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %slice.1226 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} slice(%param_1.3428), slice={[0:1], [0:128], [0:512]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
+  %convert_element_type.2587 = f32[1,128,512]{1,2,0:T(8,128)} convert(%slice.1226), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_0.3048 = f32[128]{0:T(128)S(1)} parameter(0)
+  %mul.4336 = f32[1,128,512]{1,2,0:T(8,128)} broadcast(%param_0.3048), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.4335 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert_element_type.2587, %mul.4336), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.2586 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%mul.4335), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.1377 = f32[1,128,512]{1,2,0:T(8,128)} convert(%convert_element_type.2586)
+  %dot_general.753 = f32[1,128,512]{1,2,0:T(8,128)} multiply(%convert.1376, %convert.1377), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1378 = bf16[1,128,512]{1,2,0:T(8,128)(2,1)} convert(%dot_general.753)
+  ROOT %bitcast.1562 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} bitcast(%convert.1378)
 }
 
-%fused_computation.597.clone.clone (param_0.2060: bf16[512,1,128,256]) -> bf16[512,128,256] {
-  %param_0.2060 = bf16[512,1,128,256]{3,0,2,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1313 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.2060), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.595.clone.clone (param_0.2056: bf16[512,1,128,256]) -> bf16[512,128,256] {
+  %param_0.2056 = bf16[512,1,128,256]{3,0,2,1:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1315 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.2056), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.705 (param_0.2804: bf16[512,1,128,256], param_1.3425: f32[128], param_2.2348: bf16[1,128,576], param_3.1394: bf16[512]) -> bf16[1,128,128,256] {
-  %param_1.3425 = f32[128]{0:T(128)S(1)} parameter(1)
+%fused_computation.703 (param_0.2802: bf16[512,1,128,256], param_1.3427: f32[128], param_2.2348: bf16[1,128,576], param_3.1394: bf16[512]) -> bf16[1,128,128,256] {
+  %param_1.3427 = f32[128]{0:T(128)S(1)} parameter(1)
   %param_2.2348 = bf16[1,128,576]{1,2,0:T(8,128)(2,1)S(1)} parameter(2)
   %param_3.1394 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(3)
-  %fusion.676 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} fusion(%param_1.3425, %param_2.2348, %param_3.1394), kind=kLoop, calls=%fused_computation.974
-  %param_0.2804 = bf16[512,1,128,256]{3,0,2,1:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.457 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} fusion(%param_0.2804), kind=kLoop, calls=%fused_computation.597.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.177 = bf16[128,128,256]{2,0,1:T(8,128)(2,1)} convolution(%fusion.676, %fusion.457), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.1311 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)} bitcast(%convolution.177), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  %fusion.672 = bf16[128,512,1]{0,1,2:T(8,128)(2,1)} fusion(%param_1.3427, %param_2.2348, %param_3.1394), kind=kLoop, calls=%fused_computation.972
+  %param_0.2802 = bf16[512,1,128,256]{3,0,2,1:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.453 = bf16[512,128,256]{2,0,1:T(8,128)(2,1)} fusion(%param_0.2802), kind=kLoop, calls=%fused_computation.595.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.177 = bf16[128,128,256]{2,0,1:T(8,128)(2,1)} convolution(%fusion.672, %fusion.453), window={size=128 pad=127_127 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.1313 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)} bitcast(%convolution.177), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.712 (param_0.2081: bf16[1,128,128,256]) -> (bf16[128,128,128], bf16[1,128,128,128]) {
-  %param_0.2081 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)} parameter(0)
-  %slice.1219 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.2081), slice={[0:1], [0:128], [0:128], [128:256]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
-  %bitcast.1318 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%slice.1219), metadata={op_name="splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
-  %slice.1345 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.2081), slice={[0:1], [0:128], [0:128], [0:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
-  ROOT %tuple.668 = (bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.1318, %slice.1345)
+%fused_computation.710 (param_0.2077: bf16[1,128,128,256]) -> (bf16[128,128,128], bf16[1,128,128,128]) {
+  %param_0.2077 = bf16[1,128,128,256]{3,1,2,0:T(8,128)(2,1)} parameter(0)
+  %slice.1211 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.2077), slice={[0:1], [0:128], [0:128], [128:256]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
+  %bitcast.1320 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%slice.1211), metadata={op_name="splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %slice.1337 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.2077), slice={[0:1], [0:128], [0:128], [0:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
+  ROOT %tuple.669 = (bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)}, bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.1320, %slice.1337)
 }
 
-%fused_computation.683 (param_0.1979: bf16[1,128,128,64], param_1.4828: bf16[1,128,128,128]) -> bf16[128,128,192] {
-  %param_1.4828 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1709.clone.7 = bf16[]{:T(256)} constant(-inf)
-  %pad.290 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4828, %constant.1709.clone.7), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.1258 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.290)
-  %param_0.1979 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.289 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1979, %constant.1709.clone.7), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.1259 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.289)
-  %maximum.54 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1258, %convert.1259), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.1260 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.54)
-  ROOT %bitcast.1284 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1260), metadata={op_name="splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+%fused_computation.681 (param_0.1975: bf16[1,128,128,64], param_1.4830: bf16[1,128,128,128]) -> bf16[128,128,192] {
+  %param_1.4830 = bf16[1,128,128,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1691.clone.7 = bf16[]{:T(256)} constant(-inf)
+  %pad.290 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.4830, %constant.1691.clone.7), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.1234 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.290)
+  %param_0.1975 = bf16[1,128,128,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.289 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1975, %constant.1691.clone.7), padding=0_0x0_0x0_0x128_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.1235 = f32[1,128,128,192]{3,1,2,0:T(8,128)} convert(%pad.289)
+  %maximum.54 = f32[1,128,128,192]{3,1,2,0:T(8,128)} maximum(%convert.1234, %convert.1235), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","128","192"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.1236 = bf16[1,128,128,192]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.54)
+  ROOT %bitcast.1286 = bf16[128,128,192]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1236), metadata={op_name="splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.717.clone.clone.clone.clone.clone.clone.clone.clone (param_0.4403: bf16[128,128,128]) -> bf16[128,128,128] {
-  %param_0.4403 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1925 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.4403)
+%fused_computation.715.clone.clone.clone.clone.clone.clone.clone.clone (param_0.4401: bf16[128,128,128]) -> bf16[128,128,128] {
+  %param_0.4401 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1927 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.4401)
 }
 
-%fused_computation.646.clone.clone.clone.clone.clone.clone.clone.clone (param_0.4402: bf16[128,1,128,512]) -> bf16[128,128,512] {
-  %param_0.4402 = bf16[128,1,128,512]{3,2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1924 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.4402), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.644.clone.clone.clone.clone.clone.clone.clone.clone (param_0.4400: bf16[128,1,128,512]) -> bf16[128,128,512] {
+  %param_0.4400 = bf16[128,1,128,512]{3,2,0,1:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1926 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.4400), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
 %region_45.56 (reduce_sum.116: f32[], reduce_sum.117: f32[]) -> f32[] {
@@ -1751,121 +1749,121 @@ StackFrames
   ROOT %reduce_sum.118 = f32[]{:T(128)} add(%reduce_sum.116, %reduce_sum.117), metadata={op_name="checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.930 (param_0.4553: bf16[1,128,512], param_1.5324: bf16[128,1,128,512], param_2.4216: bf16[128,128,128]) -> (f32[128], f32[1,128,512]) {
-  %param_0.4553 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.1303 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4553)
+%fused_computation.928 (param_0.4551: bf16[1,128,512], param_1.5326: bf16[128,1,128,512], param_2.4216: bf16[128,128,128]) -> (f32[128], f32[1,128,512]) {
+  %param_0.4551 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.1279 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_0.4551)
   %param_2.4216 = bf16[128,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.598.clone.1 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} fusion(%param_2.4216), kind=kLoop, calls=%fused_computation.717.clone.clone.clone.clone.clone.clone.clone.clone
-  %param_1.5324 = bf16[128,1,128,512]{3,2,0,1:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.597.clone.1 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} fusion(%param_1.5324), kind=kLoop, calls=%fused_computation.646.clone.clone.clone.clone.clone.clone.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.251.clone.1 = bf16[128,512,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.598.clone.1, %fusion.597.clone.1), window={size=128}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %bitcast.1502.clone.1 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.251.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convert.1304 = f32[1,128,512]{2,1,0:T(8,128)} convert(%bitcast.1502.clone.1)
-  %add.3339.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} add(%convert.1303, %convert.1304), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.2489.clone.1 = f32[1,128,512]{2,1,0:T(8,128)S(1)} convert(%add.3339.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %square.640 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2489.clone.1, %convert_element_type.2489.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
-  %constant.1695.clone.83 = f32[]{:T(128)} constant(0)
-  %reduce.765 = f32[128]{0:T(128)S(1)} reduce(%square.640, %constant.1695.clone.83), dimensions={0,2}, to_apply=%region_45.56, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.720 = (f32[128]{0:T(128)S(1)}, f32[1,128,512]{2,1,0:T(8,128)S(1)}) tuple(%reduce.765, %convert_element_type.2489.clone.1)
+  %fusion.594.clone.1 = bf16[128,128,128]{2,0,1:T(8,128)(2,1)} fusion(%param_2.4216), kind=kLoop, calls=%fused_computation.715.clone.clone.clone.clone.clone.clone.clone.clone
+  %param_1.5326 = bf16[128,1,128,512]{3,2,0,1:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.593.clone.1 = bf16[128,128,512]{2,1,0:T(8,128)(2,1)} fusion(%param_1.5326), kind=kLoop, calls=%fused_computation.644.clone.clone.clone.clone.clone.clone.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.251.clone.1 = bf16[128,512,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.594.clone.1, %fusion.593.clone.1), window={size=128}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  %bitcast.1504.clone.1 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.251.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  %convert.1280 = f32[1,128,512]{2,1,0:T(8,128)} convert(%bitcast.1504.clone.1)
+  %add.3294.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} add(%convert.1279, %convert.1280), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.2449.clone.1 = f32[1,128,512]{2,1,0:T(8,128)S(1)} convert(%add.3294.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %square.632 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2449.clone.1, %convert_element_type.2449.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
+  %constant.1677.clone.83 = f32[]{:T(128)} constant(0)
+  %reduce.757 = f32[128]{0:T(128)S(1)} reduce(%square.632, %constant.1677.clone.83), dimensions={0,2}, to_apply=%region_45.56, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.721 = (f32[128]{0:T(128)S(1)}, f32[1,128,512]{2,1,0:T(8,128)S(1)}) tuple(%reduce.757, %convert_element_type.2449.clone.1)
 }
 
-%fused_computation.1342 (param_0.4048: f32[128]) -> f32[128] {
-  %param_0.4048 = f32[128]{0:T(128)S(1)} parameter(0)
-  %constant.1707.clone.6 = f32[]{:T(128)} constant(0.001953125)
-  %broadcast.4425 = f32[128]{0:T(128)} broadcast(%constant.1707.clone.6), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.2467 = f32[128]{0:T(128)} multiply(%param_0.4048, %broadcast.4425), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %constant.1708.clone.7 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.4415 = f32[128]{0:T(128)} broadcast(%constant.1708.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.3614 = f32[128]{0:T(128)} add(%div.2467, %broadcast.4415), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.1769 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3614), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.303 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1769), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.1742 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.303), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+%fused_computation.1340 (param_0.4046: f32[128]) -> f32[128] {
+  %param_0.4046 = f32[128]{0:T(128)S(1)} parameter(0)
+  %constant.1689.clone.6 = f32[]{:T(128)} constant(0.001953125)
+  %broadcast.4371 = f32[128]{0:T(128)} broadcast(%constant.1689.clone.6), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.2466 = f32[128]{0:T(128)} multiply(%param_0.4046, %broadcast.4371), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %constant.1690.clone.7 = f32[]{:T(128)} constant(1e-06)
+  %broadcast.4361 = f32[128]{0:T(128)} broadcast(%constant.1690.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.3569 = f32[128]{0:T(128)} add(%div.2466, %broadcast.4361), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.1771 = f32[1,128]{1,0:T(1,128)} bitcast(%add.3569), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.295 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.1771), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.1744 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.295), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.1011 (param_0.3165: bf16[512], param_1.3547: f32[1,128,512], param_2.2464: f32[128], param_3.2780: f32[128], param_4.2126: bf16[1,128,512]) -> (bf16[128,512], bf16[128,512]) {
-  %param_0.3165 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(0)
-  %dot_general.809 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.3165), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.1342 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.809)
-  %param_1.3547 = f32[1,128,512]{2,1,0:T(8,128)S(1)} parameter(1)
+%fused_computation.1009 (param_0.3163: bf16[512], param_1.3549: f32[1,128,512], param_2.2464: f32[128], param_3.2780: f32[128], param_4.2126: bf16[1,128,512]) -> (bf16[128,512], bf16[128,512]) {
+  %param_0.3163 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(0)
+  %dot_general.794 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.3163), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.1318 = f32[1,128,512]{2,1,0:T(8,128)} convert(%dot_general.794)
+  %param_1.3549 = f32[1,128,512]{2,1,0:T(8,128)S(1)} parameter(1)
   %param_2.2464 = f32[128]{0:T(128)S(1)} parameter(2)
-  %mul.4373 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_2.2464), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.4372 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%param_1.3547, %mul.4373), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.2652 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4372), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.1343 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2652)
-  %dot_general.754 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1342, %convert.1343), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1344 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.754)
-  %bitcast.1598 = bf16[128,512]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1344), metadata={stack_frame_id=0}
+  %mul.4485 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_2.2464), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.4484 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%param_1.3549, %mul.4485), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.2612 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4484), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.1319 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2612)
+  %dot_general.739 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1318, %convert.1319), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1320 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.739)
+  %bitcast.1600 = bf16[128,512]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1320), metadata={stack_frame_id=0}
   %param_4.2126 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(4)
-  %convert_element_type.2589.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_4.2126), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert_element_type.2549.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} convert(%param_4.2126), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
   %param_3.2780 = f32[128]{0:T(128)S(1)} parameter(3)
-  %mul.4176.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_3.2780), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.4152.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2589.clone.1, %mul.4176.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.2588.clone.1 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4152.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.1345 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2588.clone.1)
-  %dot_general.749.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1342, %convert.1345), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.1346 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.749.clone.1)
-  %bitcast.1552.clone.1 = bf16[128,512]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1346), metadata={op_name="pallas_call/reshape" stack_frame_id=0}
-  ROOT %tuple.703 = (bf16[128,512]{1,0:T(8,128)(2,1)S(1)}, bf16[128,512]{1,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.1598, %bitcast.1552.clone.1)
+  %mul.4288.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} broadcast(%param_3.2780), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.4264.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.2549.clone.1, %mul.4288.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.2548.clone.1 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4264.clone.1), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.1321 = f32[1,128,512]{2,1,0:T(8,128)} convert(%convert_element_type.2548.clone.1)
+  %dot_general.734.clone.1 = f32[1,128,512]{2,1,0:T(8,128)} multiply(%convert.1318, %convert.1321), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","512"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.1322 = bf16[1,128,512]{2,1,0:T(8,128)(2,1)} convert(%dot_general.734.clone.1)
+  %bitcast.1554.clone.1 = bf16[128,512]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.1322), metadata={op_name="pallas_call/reshape" stack_frame_id=0}
+  ROOT %tuple.704 = (bf16[128,512]{1,0:T(8,128)(2,1)S(1)}, bf16[128,512]{1,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.1600, %bitcast.1554.clone.1)
 }
 
 %bitcast_fusion.5 (bitcast_input.5: bf16[128,512]) -> bf16[128,512] {
   %bitcast_input.5 = bf16[128,512]{1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1983 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.5)
+  ROOT %bitcast.1985 = bf16[128,512]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.5)
 }
 
-%fused_computation.919.clone.clone (param_0.4414: bf16[512,1,256]) -> bf16[512,256] {
-  %param_0.4414 = bf16[512,1,256]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.1935 = bf16[512,256]{1,0:T(8,128)(2,1)} bitcast(%param_0.4414), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.917.clone.clone (param_0.4412: bf16[512,1,256]) -> bf16[512,256] {
+  %param_0.4412 = bf16[512,1,256]{2,0,1:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.1937 = bf16[512,256]{1,0:T(8,128)(2,1)} bitcast(%param_0.4412), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.1008 (param_0.4413: bf16[256], param_1.5227: bf16[128,256], param_2.4151: bf16[128,512], param_3.2810: bf16[512,1,256]) -> (s32[1,128,256], s32[1,128,256], bf16[128,256]) {
-  %constant.1652.clone.6.clone.1 = bf16[]{:T(256)} constant(1), metadata={stack_frame_id=0}
-  %broadcast.4256.clone.1 = bf16[128,256]{1,0:T(8,128)(2,1)} broadcast(%constant.1652.clone.6.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %convert.1337 = f32[128,256]{1,0:T(8,128)} convert(%broadcast.4256.clone.1)
+%fused_computation.1006 (param_0.4411: bf16[256], param_1.5229: bf16[128,256], param_2.4151: bf16[128,512], param_3.2810: bf16[512,1,256]) -> (s32[1,128,256], s32[1,128,256], bf16[128,256]) {
+  %constant.1634.clone.6.clone.1 = bf16[]{:T(256)} constant(1), metadata={stack_frame_id=0}
+  %broadcast.4202.clone.1 = bf16[128,256]{1,0:T(8,128)(2,1)} broadcast(%constant.1634.clone.6.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %convert.1313 = f32[128,256]{1,0:T(8,128)} convert(%broadcast.4202.clone.1)
   %param_2.4151 = bf16[128,512]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.893 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_2.4151), kind=kLoop, calls=%bitcast_fusion.5
+  %fusion.889 = bf16[128,512]{1,0:T(8,128)(2,1)} fusion(%param_2.4151), kind=kLoop, calls=%bitcast_fusion.5
   %param_3.2810 = bf16[512,1,256]{2,0,1:T(8,128)(2,1)S(1)} parameter(3)
-  %fusion.648.clone.1 = bf16[512,256]{1,0:T(8,128)(2,1)} fusion(%param_3.2810), kind=kLoop, calls=%fused_computation.919.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.260.clone.1 = bf16[128,256]{1,0:T(8,128)(2,1)} convolution(%fusion.893, %fusion.648.clone.1), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convert.1336 = f32[128,256]{1,0:T(8,128)} convert(%convolution.260.clone.1)
-  %neg.211.clone.1 = f32[128,256]{1,0:T(8,128)} negate(%convert.1336), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
-  %exp.506.clone.1 = f32[128,256]{1,0:T(8,128)} exponential(%neg.211.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
-  %add.3343.clone.1 = f32[128,256]{1,0:T(8,128)} add(%exp.506.clone.1, %convert.1337), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
-  %div.2163.clone.1 = f32[128,256]{1,0:T(8,128)} divide(%convert.1337, %add.3343.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
-  %convert.1338 = bf16[128,256]{1,0:T(8,128)(2,1)} convert(%div.2163.clone.1)
-  %bitcast.1627 = bf16[1,128,256]{2,1,0:T(8,128)(2,1)} bitcast(%convert.1338), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %convert.1339 = f32[1,128,256]{2,1,0:T(8,128)} convert(%bitcast.1627)
-  %param_0.4413 = bf16[256]{0:T(256)(128)(2,1)S(1)} parameter(0)
-  %add.3419 = bf16[1,128,256]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.4413), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  %convert.1340 = f32[1,128,256]{2,1,0:T(8,128)} convert(%add.3419)
-  %add.3394 = f32[1,128,256]{2,1,0:T(8,128)} add(%convert.1339, %convert.1340), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.968 = f32[1,128,256]{2,1,0:T(8,128)} convert(%add.3394), metadata={op_name="pallas_call/convert.14" stack_frame_id=0}
-  %bitcast-convert.132 = s32[1,128,256]{2,1,0:T(8,128)} bitcast-convert(%convert.968), metadata={op_name="pallas_call/bitcast-convert.2" stack_frame_id=0}
-  %constant.1714.clone.1 = s32[]{:T(128)} constant(2147483647)
-  %broadcast.4243 = s32[1,128,256]{2,1,0:T(8,128)} broadcast(%constant.1714.clone.1), dimensions={}, metadata={op_name="pallas_call/broadcast.13" stack_frame_id=0}
-  %and.493 = s32[1,128,256]{2,1,0:T(8,128)} and(%bitcast-convert.132, %broadcast.4243), metadata={op_name="pallas_call/and.8" stack_frame_id=0}
-  %constant.1558.clone.3 = s32[]{:T(128)} constant(31), metadata={op_name="pallas_call" stack_frame_id=0}
-  %broadcast.4241 = s32[1,128,256]{2,1,0:T(8,128)} broadcast(%constant.1558.clone.3), dimensions={}, metadata={op_name="pallas_call/broadcast.14" stack_frame_id=0}
-  %shift-right-arithmetic.17 = s32[1,128,256]{2,1,0:T(8,128)} shift-right-arithmetic(%bitcast-convert.132, %broadcast.4241), metadata={op_name="pallas_call/shift-right-arithmetic.2" stack_frame_id=0}
+  %fusion.644.clone.1 = bf16[512,256]{1,0:T(8,128)(2,1)} fusion(%param_3.2810), kind=kLoop, calls=%fused_computation.917.clone.clone, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.260.clone.1 = bf16[128,256]{1,0:T(8,128)(2,1)} convolution(%fusion.889, %fusion.644.clone.1), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  %convert.1312 = f32[128,256]{1,0:T(8,128)} convert(%convolution.260.clone.1)
+  %neg.210.clone.1 = f32[128,256]{1,0:T(8,128)} negate(%convert.1312), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  %exp.505.clone.1 = f32[128,256]{1,0:T(8,128)} exponential(%neg.210.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  %add.3298.clone.1 = f32[128,256]{1,0:T(8,128)} add(%exp.505.clone.1, %convert.1313), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  %div.2162.clone.1 = f32[128,256]{1,0:T(8,128)} divide(%convert.1313, %add.3298.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  %convert.1314 = bf16[128,256]{1,0:T(8,128)(2,1)} convert(%div.2162.clone.1)
+  %bitcast.1629 = bf16[1,128,256]{2,1,0:T(8,128)(2,1)} bitcast(%convert.1314), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %convert.1315 = f32[1,128,256]{2,1,0:T(8,128)} convert(%bitcast.1629)
+  %param_0.4411 = bf16[256]{0:T(256)(128)(2,1)S(1)} parameter(0)
+  %add.3374 = bf16[1,128,256]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.4411), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %convert.1316 = f32[1,128,256]{2,1,0:T(8,128)} convert(%add.3374)
+  %add.3349 = f32[1,128,256]{2,1,0:T(8,128)} add(%convert.1315, %convert.1316), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.950 = f32[1,128,256]{2,1,0:T(8,128)} convert(%add.3349), metadata={op_name="pallas_call/convert.14" stack_frame_id=0}
+  %bitcast-convert.132 = s32[1,128,256]{2,1,0:T(8,128)} bitcast-convert(%convert.950), metadata={op_name="pallas_call/bitcast-convert.2" stack_frame_id=0}
+  %constant.1696.clone.1 = s32[]{:T(128)} constant(2147483647)
+  %broadcast.4189 = s32[1,128,256]{2,1,0:T(8,128)} broadcast(%constant.1696.clone.1), dimensions={}, metadata={op_name="pallas_call/broadcast.13" stack_frame_id=0}
+  %and.493 = s32[1,128,256]{2,1,0:T(8,128)} and(%bitcast-convert.132, %broadcast.4189), metadata={op_name="pallas_call/and.8" stack_frame_id=0}
+  %constant.1540.clone.3 = s32[]{:T(128)} constant(31), metadata={op_name="pallas_call" stack_frame_id=0}
+  %broadcast.4187 = s32[1,128,256]{2,1,0:T(8,128)} broadcast(%constant.1540.clone.3), dimensions={}, metadata={op_name="pallas_call/broadcast.14" stack_frame_id=0}
+  %shift-right-arithmetic.17 = s32[1,128,256]{2,1,0:T(8,128)} shift-right-arithmetic(%bitcast-convert.132, %broadcast.4187), metadata={op_name="pallas_call/shift-right-arithmetic.2" stack_frame_id=0}
   %xor.157 = s32[1,128,256]{2,1,0:T(8,128)} xor(%and.493, %shift-right-arithmetic.17), metadata={op_name="pallas_call/xor.4" stack_frame_id=0}
-  %constant.1559.clone.4 = s32[]{:T(128)} constant(65535), metadata={op_name="pallas_call" stack_frame_id=0}
-  %broadcast.4239 = s32[1,128,256]{2,1,0:T(8,128)} broadcast(%constant.1559.clone.4), dimensions={}, metadata={op_name="pallas_call/broadcast.15" stack_frame_id=0}
-  %or.55 = s32[1,128,256]{2,1,0:T(8,128)} or(%xor.157, %broadcast.4239), metadata={op_name="pallas_call/or.2" stack_frame_id=0}
+  %constant.1541.clone.4 = s32[]{:T(128)} constant(65535), metadata={op_name="pallas_call" stack_frame_id=0}
+  %broadcast.4185 = s32[1,128,256]{2,1,0:T(8,128)} broadcast(%constant.1541.clone.4), dimensions={}, metadata={op_name="pallas_call/broadcast.15" stack_frame_id=0}
+  %or.55 = s32[1,128,256]{2,1,0:T(8,128)} or(%xor.157, %broadcast.4185), metadata={op_name="pallas_call/or.2" stack_frame_id=0}
   %iota.345 = s32[1,128,256]{2,1,0:T(8,128)} iota(), iota_dimension=2, metadata={op_name="pallas_call/iota.1" stack_frame_id=0}
   %xor.156 = s32[1,128,256]{2,1,0:T(8,128)} xor(%or.55, %iota.345), metadata={op_name="pallas_call/xor.5" stack_frame_id=0}
-  %param_1.5227 = bf16[128,256]{1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %bitcast.1639.clone.1 = bf16[1,128,256]{2,1,0:T(8,128)(2,1)} bitcast(%param_1.5227), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %convert.1341 = f32[1,128,256]{2,1,0:T(8,128)} convert(%bitcast.1639.clone.1)
-  %add.3397.clone.1 = f32[1,128,256]{2,1,0:T(8,128)} add(%convert.1341, %convert.1340), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.967.clone.1 = f32[1,128,256]{2,1,0:T(8,128)} convert(%add.3397.clone.1), metadata={op_name="pallas_call/convert.8" stack_frame_id=0}
-  %bitcast-convert.131.clone.1 = s32[1,128,256]{2,1,0:T(8,128)} bitcast-convert(%convert.967.clone.1), metadata={op_name="pallas_call/bitcast-convert" stack_frame_id=0}
-  %and.492.clone.1 = s32[1,128,256]{2,1,0:T(8,128)} and(%bitcast-convert.131.clone.1, %broadcast.4243), metadata={op_name="pallas_call/and" stack_frame_id=0}
-  %shift-right-arithmetic.16.clone.1 = s32[1,128,256]{2,1,0:T(8,128)} shift-right-arithmetic(%bitcast-convert.131.clone.1, %broadcast.4241), metadata={op_name="pallas_call/shift-right-arithmetic" stack_frame_id=0}
+  %param_1.5229 = bf16[128,256]{1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %bitcast.1641.clone.1 = bf16[1,128,256]{2,1,0:T(8,128)(2,1)} bitcast(%param_1.5229), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %convert.1317 = f32[1,128,256]{2,1,0:T(8,128)} convert(%bitcast.1641.clone.1)
+  %add.3352.clone.1 = f32[1,128,256]{2,1,0:T(8,128)} add(%convert.1317, %convert.1316), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","256"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.949.clone.1 = f32[1,128,256]{2,1,0:T(8,128)} convert(%add.3352.clone.1), metadata={op_name="pallas_call/convert.8" stack_frame_id=0}
+  %bitcast-convert.131.clone.1 = s32[1,128,256]{2,1,0:T(8,128)} bitcast-convert(%convert.949.clone.1), metadata={op_name="pallas_call/bitcast-convert" stack_frame_id=0}
+  %and.492.clone.1 = s32[1,128,256]{2,1,0:T(8,128)} and(%bitcast-convert.131.clone.1, %broadcast.4189), metadata={op_name="pallas_call/and" stack_frame_id=0}
+  %shift-right-arithmetic.16.clone.1 = s32[1,128,256]{2,1,0:T(8,128)} shift-right-arithmetic(%bitcast-convert.131.clone.1, %broadcast.4187), metadata={op_name="pallas_call/shift-right-arithmetic" stack_frame_id=0}
   %xor.155.clone.1 = s32[1,128,256]{2,1,0:T(8,128)} xor(%and.492.clone.1, %shift-right-arithmetic.16.clone.1), metadata={op_name="pallas_call/xor" stack_frame_id=0}
-  %or.54.clone.1 = s32[1,128,256]{2,1,0:T(8,128)} or(%xor.155.clone.1, %broadcast.4239), metadata={op_name="pallas_call/or" stack_frame_id=0}
+  %or.54.clone.1 = s32[1,128,256]{2,1,0:T(8,128)} or(%xor.155.clone.1, %broadcast.4185), metadata={op_name="pallas_call/or" stack_frame_id=0}
   %iota.344.clone.1 = s32[1,128,256]{2,1,0:T(8,128)} iota(), iota_dimension=2, metadata={op_name="pallas_call/iota" stack_frame_id=0}
   %xor.154.clone.1 = s32[1,128,256]{2,1,0:T(8,128)S(1)} xor(%or.54.clone.1, %iota.344.clone.1), metadata={op_name="pallas_call/xor.1" stack_frame_id=0}
-  ROOT %tuple.723 = (s32[1,128,256]{2,1,0:T(8,128)}, s32[1,128,256]{2,1,0:T(8,128)S(1)}, bf16[128,256]{1,0:T(8,128)(2,1)}) tuple(%xor.156, %xor.154.clone.1, %convert.1338)
+  ROOT %tuple.724 = (s32[1,128,256]{2,1,0:T(8,128)}, s32[1,128,256]{2,1,0:T(8,128)S(1)}, bf16[128,256]{1,0:T(8,128)(2,1)}) tuple(%xor.156, %xor.154.clone.1, %convert.1314)
 }
 
 %region_12.18 (sort.44: s32[], sort.45: s32[]) -> pred[] {
@@ -1874,85 +1872,85 @@ StackFrames
   ROOT %compare.112 = pred[]{:T(512)} compare(%sort.44, %sort.45), direction=GT, metadata={op_name="compare.1"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.1063 (param_0.3144: s32[1,128,8]) -> (s32[1,128,8], s32[1,128,8]) {
-  %param_0.3144 = s32[1,128,8]{2,1,0:T(8,128)S(1)} parameter(0)
-  %constant.1559.clone.3 = s32[]{:T(128)} constant(65535), metadata={op_name="pallas_call" stack_frame_id=0}
-  %broadcast.4254 = s32[1,128,8]{2,1,0:T(8,128)} broadcast(%constant.1559.clone.3), dimensions={}, metadata={op_name="pallas_call/broadcast.22" stack_frame_id=0}
-  %xor.158 = s32[1,128,8]{2,1,0:T(8,128)} xor(%param_0.3144, %broadcast.4254), metadata={op_name="pallas_call/xor.3" stack_frame_id=0}
-  %top_k.14 = s32[1,128,8]{2,1,0:T(8,128)S(1)} and(%xor.158, %broadcast.4254), metadata={op_name="pallas_call/top_k" stack_frame_id=0}
-  %constant.1684.clone.27.clone.1 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %max.95.clone.1 = s32[1,128,8]{2,1,0:T(8,128)} broadcast(%constant.1684.clone.27.clone.1), dimensions={}, metadata={op_name="pallas_call/jit(clip)/max" stack_frame_id=0}
+%fused_computation.1061 (param_0.3142: s32[1,128,8]) -> (s32[1,128,8], s32[1,128,8]) {
+  %param_0.3142 = s32[1,128,8]{2,1,0:T(8,128)S(1)} parameter(0)
+  %constant.1541.clone.3 = s32[]{:T(128)} constant(65535), metadata={op_name="pallas_call" stack_frame_id=0}
+  %broadcast.4200 = s32[1,128,8]{2,1,0:T(8,128)} broadcast(%constant.1541.clone.3), dimensions={}, metadata={op_name="pallas_call/broadcast.22" stack_frame_id=0}
+  %xor.158 = s32[1,128,8]{2,1,0:T(8,128)} xor(%param_0.3142, %broadcast.4200), metadata={op_name="pallas_call/xor.3" stack_frame_id=0}
+  %top_k.14 = s32[1,128,8]{2,1,0:T(8,128)S(1)} and(%xor.158, %broadcast.4200), metadata={op_name="pallas_call/top_k" stack_frame_id=0}
+  %constant.1666.clone.27.clone.1 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %max.95.clone.1 = s32[1,128,8]{2,1,0:T(8,128)} broadcast(%constant.1666.clone.27.clone.1), dimensions={}, metadata={op_name="pallas_call/jit(clip)/max" stack_frame_id=0}
   %max.94.clone.1 = s32[1,128,8]{2,1,0:T(8,128)S(1)} maximum(%max.95.clone.1, %top_k.14), metadata={op_name="pallas_call/jit(clip)/max" stack_frame_id=0}
-  ROOT %tuple.691 = (s32[1,128,8]{2,1,0:T(8,128)S(1)}, s32[1,128,8]{2,1,0:T(8,128)S(1)}) tuple(%top_k.14, %max.94.clone.1)
+  ROOT %tuple.692 = (s32[1,128,8]{2,1,0:T(8,128)S(1)}, s32[1,128,8]{2,1,0:T(8,128)S(1)}) tuple(%top_k.14, %max.94.clone.1)
 }
 
-%fused_computation.1095 (param_0.3239: s32[1024,1]) -> s32[1024,1] {
-  %param_0.3239 = s32[1024,1]{0,1:T(1,128)S(1)} parameter(0)
-  %constant.1684.clone.110 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %broadcast.4309 = s32[1024,1]{0,1:T(1,128)} broadcast(%constant.1684.clone.110), dimensions={}, metadata={op_name="pallas_call/broadcast.2401" stack_frame_id=0}
-  %lt.780 = pred[1024,1]{0,1:T(4,128)(4,1)} compare(%param_0.3239, %broadcast.4309), direction=LT, metadata={op_name="pallas_call/lt" stack_frame_id=0}
-  %constant.1564.clone.6 = s32[]{:T(128)} constant(256), metadata={op_name="pallas_call" stack_frame_id=0}
-  %add.3471 = s32[1024,1]{0,1:T(1,128)} broadcast(%constant.1564.clone.6), dimensions={}, metadata={op_name="pallas_call/add" stack_frame_id=0}
-  %add.3438 = s32[1024,1]{0,1:T(1,128)} add(%param_0.3239, %add.3471), metadata={op_name="pallas_call/add" stack_frame_id=0}
-  ROOT %select_n.2107 = s32[1024,1]{0,1:T(1,128)} select(%lt.780, %add.3438, %param_0.3239), metadata={op_name="pallas_call/select_n" stack_frame_id=0}
+%fused_computation.1093 (param_0.3237: s32[1024,1]) -> s32[1024,1] {
+  %param_0.3237 = s32[1024,1]{0,1:T(1,128)S(1)} parameter(0)
+  %constant.1666.clone.110 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %broadcast.4255 = s32[1024,1]{0,1:T(1,128)} broadcast(%constant.1666.clone.110), dimensions={}, metadata={op_name="pallas_call/broadcast.2345" stack_frame_id=0}
+  %lt.779 = pred[1024,1]{0,1:T(4,128)(4,1)} compare(%param_0.3237, %broadcast.4255), direction=LT, metadata={op_name="pallas_call/lt" stack_frame_id=0}
+  %constant.1546.clone.6 = s32[]{:T(128)} constant(256), metadata={op_name="pallas_call" stack_frame_id=0}
+  %add.3426 = s32[1024,1]{0,1:T(1,128)} broadcast(%constant.1546.clone.6), dimensions={}, metadata={op_name="pallas_call/add" stack_frame_id=0}
+  %add.3393 = s32[1024,1]{0,1:T(1,128)} add(%param_0.3237, %add.3426), metadata={op_name="pallas_call/add" stack_frame_id=0}
+  ROOT %select_n.2107 = s32[1024,1]{0,1:T(1,128)} select(%lt.779, %add.3393, %param_0.3237), metadata={op_name="pallas_call/select_n" stack_frame_id=0}
 }
 
-%called_computation.21 (param_0.4977: s32[256]) -> s32[256] {
-  %param_0.4977 = s32[256]{0:T(256)} parameter(0)
-  ROOT %copy.1985 = s32[256]{0:T(256)} copy(%param_0.4977), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"1134","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0","buffering_level":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+%called_computation.21 (param_0.4975: s32[256]) -> s32[256] {
+  %param_0.4975 = s32[256]{0:T(256)} parameter(0)
+  ROOT %copy.1985 = s32[256]{0:T(256)} copy(%param_0.4975), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"1134","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0","buffering_level":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%async_computation.21 (param_0.4978: s32[256]) -> s32[256] {
-  %param_0.4978 = s32[256]{0:T(256)} parameter(0)
-  ROOT %copy.1986.cloned.1 = s32[256]{0:T(256)} call(%param_0.4978), to_apply=%called_computation.21
+%async_computation.21 (param_0.4976: s32[256]) -> s32[256] {
+  %param_0.4976 = s32[256]{0:T(256)} parameter(0)
+  ROOT %copy.1986.cloned.1 = s32[256]{0:T(256)} call(%param_0.4976), to_apply=%called_computation.21
 }, execution_thread="sparsecore"
 
 %region_14.20 (scatter-add.0: s32[], scatter-add.1: s32[]) -> s32[] {
   %scatter-add.0 = s32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.1 = s32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.1328 = s32[]{:T(128)S(7)} add(%scatter-add.0, %scatter-add.1), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"13600","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0","buffering_level":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.1283 = s32[]{:T(128)S(7)} add(%scatter-add.0, %scatter-add.1), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"13600","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0","buffering_level":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.19.clone.clone.clone (param_0.4979: s32[256], param_1.5600: s32[1024], param_2.4365: s32[1024]) -> s32[256] {
-  %param_0.4979 = s32[256]{0:T(256)} parameter(0)
-  %param_1.5600 = s32[1024]{0:T(1024)} parameter(1)
-  %reshape.4972 = s32[1024]{0:T(1024)} reshape(%param_1.5600), metadata={op_name="pallas_call/select_n" stack_frame_id=0}
-  %transpose.1142 = s32[1024]{0:T(1024)} transpose(%reshape.4972), dimensions={0}, metadata={op_name="pallas_call/select_n" stack_frame_id=0}
-  %param_2.4365 = s32[1024]{0:T(1024)} parameter(2)
-  %reshape.4973 = s32[1024]{0:T(1024)} reshape(%param_2.4365), metadata={op_name="jit(train_step)/shard_map/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1143 = s32[1024]{0:T(1024)} transpose(%reshape.4973), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/broadcast_in_dim" stack_frame_id=0}
-  ROOT %scatter-add.261 = s32[256]{0:T(256)} scatter(%param_0.4979, %transpose.1142, %transpose.1143), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_14.20, metadata={op_name="pallas_call/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.22 (param_0.4980: s32[256], param_1.5601: s32[1024], param_2.4366: s32[1024]) -> s32[256] {
-  %param_0.4980 = s32[256]{0:T(256)} parameter(0)
-  %param_1.5601 = s32[1024]{0:T(1024)} parameter(1)
-  %param_2.4366 = s32[1024]{0:T(1024)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.39 = s32[256]{0:T(256)} fusion(%param_0.4980, %param_1.5601, %param_2.4366), kind=kCustom, calls=%fused_computation.19.clone.clone.clone, metadata={op_name="pallas_call/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["64"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"1088","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0","buffering_level":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
-}, execution_thread="sparsecore"
-
-%async_computation.22 (param_0.4981: s32[256], param_1.5602: s32[1024], param_2.4367: s32[1024]) -> s32[256] {
-  %param_0.4981 = s32[256]{0:T(256)} parameter(0)
+%fused_computation.19.clone.clone.clone (param_0.4977: s32[256], param_1.5602: s32[1024], param_2.4364: s32[1024]) -> s32[256] {
+  %param_0.4977 = s32[256]{0:T(256)} parameter(0)
   %param_1.5602 = s32[1024]{0:T(1024)} parameter(1)
-  %param_2.4367 = s32[1024]{0:T(1024)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.40.cloned.1 = s32[256]{0:T(256)} call(%param_0.4981, %param_1.5602, %param_2.4367), to_apply=%called_computation.22, metadata={op_name="pallas_call/scatter-add" stack_frame_id=0}
+  %reshape.4971 = s32[1024]{0:T(1024)} reshape(%param_1.5602), metadata={op_name="pallas_call/select_n" stack_frame_id=0}
+  %transpose.1144 = s32[1024]{0:T(1024)} transpose(%reshape.4971), dimensions={0}, metadata={op_name="pallas_call/select_n" stack_frame_id=0}
+  %param_2.4364 = s32[1024]{0:T(1024)} parameter(2)
+  %reshape.4972 = s32[1024]{0:T(1024)} reshape(%param_2.4364), metadata={op_name="jit(train_step)/shard_map/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1145 = s32[1024]{0:T(1024)} transpose(%reshape.4972), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/broadcast_in_dim" stack_frame_id=0}
+  ROOT %scatter-add.261 = s32[256]{0:T(256)} scatter(%param_0.4977, %transpose.1144, %transpose.1145), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_14.20, metadata={op_name="pallas_call/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%called_computation.6 (param_0.109: s32[256], param_1.167: s32[1024], param_2.112: s32[1024]) -> s32[256] {
-  %param_0.109 = s32[256]{0:T(256)} parameter(0), backend_config={"flag_configs":[],"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_SCALAR","used_scoped_memory_configs":[]}
+%called_computation.22 (param_0.4978: s32[256], param_1.5603: s32[1024], param_2.4365: s32[1024]) -> s32[256] {
+  %param_0.4978 = s32[256]{0:T(256)} parameter(0)
+  %param_1.5603 = s32[1024]{0:T(1024)} parameter(1)
+  %param_2.4365 = s32[1024]{0:T(1024)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.39 = s32[256]{0:T(256)} fusion(%param_0.4978, %param_1.5603, %param_2.4365), kind=kCustom, calls=%fused_computation.19.clone.clone.clone, metadata={op_name="pallas_call/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["64"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"1088","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0","buffering_level":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.22 (param_0.4979: s32[256], param_1.5604: s32[1024], param_2.4366: s32[1024]) -> s32[256] {
+  %param_0.4979 = s32[256]{0:T(256)} parameter(0)
+  %param_1.5604 = s32[1024]{0:T(1024)} parameter(1)
+  %param_2.4366 = s32[1024]{0:T(1024)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.40.cloned.1 = s32[256]{0:T(256)} call(%param_0.4979, %param_1.5604, %param_2.4366), to_apply=%called_computation.22, metadata={op_name="pallas_call/scatter-add" stack_frame_id=0}
+}, execution_thread="sparsecore"
+
+%called_computation.6 (param_0.105: s32[256], param_1.167: s32[1024], param_2.112: s32[1024]) -> s32[256] {
+  %param_0.105 = s32[256]{0:T(256)} parameter(0), backend_config={"flag_configs":[],"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_SCALAR","used_scoped_memory_configs":[]}
   %param_1.167 = s32[1024]{0:T(1024)} parameter(1), backend_config={"flag_configs":[],"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_SCALAR","used_scoped_memory_configs":[]}
   %param_2.112 = s32[1024]{0:T(1024)} parameter(2), backend_config={"flag_configs":[],"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_SCALAR","used_scoped_memory_configs":[]}
-  %copy.1986.cloned.1.call-start = ((s32[256]{0:T(256)}), s32[256]{0:T(256)}, u32[]{:S(8)}) async-start(%param_0.109), async_execution_thread="sparsecore", calls=%async_computation.21
+  %copy.1986.cloned.1.call-start = ((s32[256]{0:T(256)}), s32[256]{0:T(256)}, u32[]{:S(8)}) async-start(%param_0.105), async_execution_thread="sparsecore", calls=%async_computation.21
   %copy.1986.cloned.1.call-done = s32[256]{0:T(256)} async-done(%copy.1986.cloned.1.call-start)
   %scatter_offload_custom_fusion.40.cloned.1.call-start = ((s32[256]{0:T(256)}, s32[1024]{0:T(1024)}, s32[1024]{0:T(1024)}), s32[256]{0:T(256)}, u32[]{:S(8)}) async-start(%copy.1986.cloned.1.call-done, %param_1.167, %param_2.112), async_execution_thread="sparsecore", calls=%async_computation.22, metadata={op_name="pallas_call/scatter-add" stack_frame_id=0}
   ROOT %scatter_offload_custom_fusion.40.cloned.1.call-done = s32[256]{0:T(256)} async-done(%scatter_offload_custom_fusion.40.cloned.1.call-start), metadata={op_name="pallas_call/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.6 (param_0.110: s32[256], param_1.168: s32[1024], param_2.113: s32[1024]) -> s32[256] {
-  %param_0.110 = s32[256]{0:T(256)} parameter(0)
+%async_computation.6 (param_0.106: s32[256], param_1.168: s32[1024], param_2.113: s32[1024]) -> s32[256] {
+  %param_0.106 = s32[256]{0:T(256)} parameter(0)
   %param_1.168 = s32[1024]{0:T(1024)} parameter(1)
   %param_2.113 = s32[1024]{0:T(1024)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.20.cloned.1 = s32[256]{0:T(256)} call(%param_0.110, %param_1.168, %param_2.113), to_apply=%called_computation.6, metadata={op_name="pallas_call/scatter-add" stack_frame_id=0}
+  ROOT %scatter_offload_custom_fusion.20.cloned.1 = s32[256]{0:T(256)} call(%param_0.106, %param_1.168, %param_2.113), to_apply=%called_computation.6, metadata={op_name="pallas_call/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %region_15.21.clone.1 (reduce-window.252: s32[], reduce-window.253: s32[]) -> s32[] {
@@ -1967,34 +1965,36 @@ StackFrames
   ROOT %reduce_window_sum.211 = s32[]{:T(128)} add(%reduce-window.254, %reduce-window.255), metadata={op_name="reduce_window_sum"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%slice.1007.reduce_sub_computation (lhs.24: s32[], rhs.24: s32[]) -> s32[] {
+%slice.999.reduce_sub_computation (lhs.24: s32[], rhs.24: s32[]) -> s32[] {
   %lhs.24 = s32[] parameter(0)
   %rhs.24 = s32[] parameter(1)
-  ROOT %add.3025 = s32[] add(%lhs.24, %rhs.24), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.2980 = s32[] add(%lhs.24, %rhs.24), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.1323 (param_0.4455: s32[3,1]) -> s32[2] {
-  %param_0.4455 = s32[3,1]{1,0:T(4,128)S(1)} parameter(0)
-  %slice.1281 = s32[2,1]{1,0:T(2,128)} slice(%param_0.4455), slice={[0:2], [0:1]}, metadata={op_name="pallas_call/slice.173" stack_frame_id=0}
-  %constant.1684.clone.105 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  ROOT %reduce.821 = s32[2]{0:T(128)S(1)} reduce(%slice.1281, %constant.1684.clone.105), dimensions={1}, to_apply=%slice.1007.reduce_sub_computation, metadata={op_name="pallas_call/slice.173" stack_frame_id=0}
+%fused_computation.1321 (param_0.4453: s32[3,1]) -> s32[2] {
+  %param_0.4453 = s32[3,1]{1,0:T(4,128)S(1)} parameter(0)
+  %slice.1273 = s32[2,1]{1,0:T(2,128)} slice(%param_0.4453), slice={[0:2], [0:1]}, metadata={op_name="pallas_call/slice.173" stack_frame_id=0}
+  %constant.1666.clone.105 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  ROOT %reduce.813 = s32[2]{0:T(128)S(1)} reduce(%slice.1273, %constant.1666.clone.105), dimensions={1}, to_apply=%slice.999.reduce_sub_computation, metadata={op_name="pallas_call/slice.173" stack_frame_id=0}
 }
 
-%fused_computation.1322 (param_0.3742: s32[2,128], param_1.4534: s32[2]) -> s32[256] {
-  %param_0.3742 = s32[2,128]{1,0:T(2,128)S(1)} parameter(0)
-  %param_1.4534 = s32[2]{0:T(128)S(1)} parameter(1)
-  %broadcast.4394 = s32[2,128]{1,0:T(2,128)} broadcast(%param_1.4534), dimensions={0}, metadata={op_name="pallas_call/broadcast.748" stack_frame_id=0}
-  %reduce_window_sum.464 = s32[2,128]{1,0:T(2,128)} add(%param_0.3742, %broadcast.4394), metadata={op_name="pallas_call/reduce_window_sum" stack_frame_id=0}
-  ROOT %bitcast.1728 = s32[256]{0:T(256)S(1)} bitcast(%reduce_window_sum.464), metadata={op_name="pallas_call/reduce_window_sum" stack_frame_id=0}
+%fused_computation.1320 (param_0.3740: s32[2,128], param_1.4536: s32[2]) -> s32[256] {
+  %param_0.3740 = s32[2,128]{1,0:T(2,128)S(1)} parameter(0)
+  %param_1.4536 = s32[2]{0:T(128)S(1)} parameter(1)
+  %broadcast.4340 = s32[2,128]{1,0:T(2,128)} broadcast(%param_1.4536), dimensions={0}, metadata={op_name="pallas_call/broadcast.748" stack_frame_id=0}
+  %reduce_window_sum.464 = s32[2,128]{1,0:T(2,128)} add(%param_0.3740, %broadcast.4340), metadata={op_name="pallas_call/reduce_window_sum" stack_frame_id=0}
+  ROOT %bitcast.1730 = s32[256]{0:T(256)S(1)} bitcast(%reduce_window_sum.464), metadata={op_name="pallas_call/reduce_window_sum" stack_frame_id=0}
 }
 
-%fused_computation.1188 (param_0.3387: s32[1], param_1.5266: s32[256]) -> s32[257] {
-  %param_0.3387 = s32[1]{0:T(128)} parameter(0)
-  %constant.1684.clone.133 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
-  %pad.348 = s32[257]{0:T(512)} pad(%param_0.3387, %constant.1684.clone.133), padding=0_256, metadata={op_name="pallas_call/concatenate" stack_frame_id=0}
-  %param_1.5266 = s32[256]{0:T(256)S(1)} parameter(1)
-  %pad.349 = s32[257]{0:T(512)} pad(%param_1.5266, %constant.1684.clone.133), padding=1_0, metadata={op_name="pallas_call/concatenate" stack_frame_id=0}
-  ROOT %add.3466 = s32[257]{0:T(512)S(1)} add(%pad.348, %pad.349), metadata={op_name="pallas_call/concatenate" stack_frame_id=0}
+%fused_computation.1186 (param_0.3385: s32[1], param_1.5268: s32[256]) -> s32[257] {
+  %param_0.3385 = s32[1]{0:T(128)} parameter(0)
+  %constant.1666.clone.133 = s32[]{:T(128)} constant(0), metadata={op_name="jit(train_step)/shard_map/jit(gmm)" stack_frame_id=0}
+  %pad.348 = s32[257]{0:T(512)} pad(%param_0.3385, %constant.1666.clone.133), padding=0_256, metadata={op_name="pallas_call/concatenate" stack_frame_id=0}
+  %param_1.5268 = s32[256]{0:T(256)S(1)} parameter(1)
+  %pad.349 = s32[257]{0:T(512)} pad(%param_1.5268, %constant.1666.clone.133), padding=1_0, metadata={op_name="pallas_call/concatenate" stack_frame_id=0}
+  ROOT %add.3421 = s32[257]{0:T(512)S(1)} add(%pad.348, %pad.349), metadata={op_name="pallas_call/concatenate" stack_frame_id=0}
 }
 
 %region_17.23.clone.1 (reduce_sum.1368: s32[], reduce_sum.1369: s32[]) -> s32[] {
+  %reduce_sum.1368 = s32[]{:T(128)} parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.1369 = s32[]{:T(128)} parameter(1), metadata={op_name="reduce_sum"}

--- a/tests/utils/sharding_info/gpt-oss-20b/tpu7x-16/slice_1/rule_default/input_shardings.json
+++ b/tests/utils/sharding_info/gpt-oss-20b/tpu7x-16/slice_1/rule_default/input_shardings.json
@@ -1,6 +1,12 @@
 {
   "Activation Sharding Dump": [
     {
+      "Unknown: bfloat16[192,2048,2880]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
+        "PartitionSpec": "P('fsdp', None, None)"
+      }
+    },
+    {
       "attentions/inputs_q: bfloat16[192,2048,2880]": {
         "logic_axes": "('activation_batch_attn', 'activation_input_length_attn', 'activation_embed_attn')",
         "PartitionSpec": "P('fsdp', None, None)"

--- a/tests/utils/sharding_info/gpt-oss-20b/tpu7x-16/slice_1/rule_default_ici_fsdp_parallelism=-1_ici_expert_parallelism=2/input_shardings.json
+++ b/tests/utils/sharding_info/gpt-oss-20b/tpu7x-16/slice_1/rule_default_ici_fsdp_parallelism=-1_ici_expert_parallelism=2/input_shardings.json
@@ -1,6 +1,12 @@
 {
   "Activation Sharding Dump": [
     {
+      "Unknown: bfloat16[192,2048,2880]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
+        "PartitionSpec": "P(('fsdp', 'expert'), None, None)"
+      }
+    },
+    {
       "attentions/inputs_q: bfloat16[192,2048,2880]": {
         "logic_axes": "('activation_batch_attn', 'activation_input_length_attn', 'activation_embed_attn')",
         "PartitionSpec": "P(('fsdp', 'expert'), None, None)"


### PR DESCRIPTION
## What

Onboards the **gpt3** and **gpt-oss** decoder layers to `shard_mode=explicit`, and closes the two shared gaps that blocked them: biased `DenseGeneral` layers and YaRN rope under tensor parallelism.

## Why

`shard_mode=explicit` was already supported for `simple`, `simple_mlp`, `llama2`, `deepseek`, the Qwen3 family, Mistral/Mixtral and the Gemma family, but `decoder_block=gpt3` / `gpt_oss` were rejected by config validation. Explicit sharding is also the gate for the efficient ZeRO-1 + gradient accumulation path (`maxtext.utils.gradient_accumulation` only applies the `reduced` / `unreduced` `PartitionSpec` labels when `shard_mode == ShardMode.EXPLICIT`), so these two families were cut off from it.

## Changes

**`src/maxtext/models/gpt3.py`, `src/maxtext/models/gpt_oss.py`** — the same transformation llama2/deepseek/qwen3/mistral/gemma already use:

- `nn.with_logical_constraint(x, names)` → `self._maybe_shard_with_logical(x, names)`, a `functools.partial` of `maybe_shard_with_logical` bound to the mesh and `config.shard_mode`. It is a no-op under `ShardMode.AUTO` and emits a reshard under `ShardMode.EXPLICIT`.
- Activation `NamedSharding`s are built once in `__init__` via `create_sharding(..., rules=get_logical_axis_rules())` and threaded into the sublayers as `out_sharding=` (norms, attention, `MlpBlock`, `RoutedMoE`) and `intermediate_sharding=` (the gpt3 `MlpBlock`), so the sublayers pin their output layout instead of leaving it to GSPMD.
- `shard_mode` is threaded into `Gpt3LayerNorm` (which gains the parameter) and both gpt-oss `RMSNorm`s.

The one structural difference is gpt3's fused QKV projection. Unlike the fused path in `layers/attentions.py`, which packs q, k and v into a single flat `heads` axis and needs a `shard_map` to split them apart, gpt3 emits `(batch, length, 3, heads, head_dim)` and slices the size-3 axis. That axis is never sharded, so its `out_sharding` maps it to `None` and the existing slice stays valid under any tensor parallelism.

**`src/maxtext/layers/linears.py`** — `DenseGeneral` builds its bias in the *parameter* layout, e.g. `embed_attn -> fsdp` for an out projection, while the activation it is added to carries `activation_embed -> tensor` on that same axis. Adding them directly puts one mesh axis on two axes of the result and JAX rejects it:

```
ShardingTypeError: add operation with inputs: bf16[48@fsdp,256,256], bf16[1,1,256@fsdp]
produces an illegally sharded result: bf16[48@fsdp,256,256@fsdp]
```

The bias is now resharded onto the layout of the output before the add via `maybe_shard_with_pspec`, under `ShardMode.EXPLICIT` only (GSPMD inserts the same all-gather on its own in auto mode, and the reshard is a no-op whenever the two already agree). gpt3 is the first explicit-sharding decoder with biased projections, which is why nothing hit this before.

**`src/maxtext/layers/embeddings.py`** — `YarnRotaryEmbedding` labelled the trailing axis of its gathered frequencies `q_heads`, but that axis is `head_dim // 2`, not heads. Under any tensor parallelism the frequencies came back sharded on `tensor` and the broadcast onto the activations failed:

```
ValueError: Incompatible types for broadcasting:
input type=complex64[48,256,1,64@tensor] and requested type=complex64[48,256,8,64]
```

The frequencies are now replicated over the head dim, and the two explicit `jnp.broadcast_to(..., out_sharding=...)` calls (the complex path and the pairwise path) are deleted rather than re-targeted: once `freqs_sharding` is correct, the implicit size-1 broadcast in the elementwise op already yields the activation's own sharding, so a sharded heads axis is preserved for free.

Deleting them is also strictly more permissive. On a mesh whose sequence axis is sharded over `context_usp_ulysses` — which `activation_input_length_attn` does not list — the frequencies come back sharded on that axis while the activations are replicated on it, and `broadcast_to` cannot un-shard, so it raises where the plain multiply succeeds. A 192-configuration CPU sweep over 7 meshes x QKV / MLA-key / decode shapes x the interleave, pairwise, attention-scaling and cast variants found 12 cases that only work after the deletion, none that only work before it, and bitwise-identical values and output shardings (and identical optimized-HLO instruction counts under `ShardMode.AUTO`) everywhere else.

This also unblocks **deepseek** under `shard_mode=explicit` with tensor parallelism, which fails the same way on main today (verified below).

**`src/maxtext/configs/types.py`** — add `gpt3` and `gpt_oss` to `supported_decoders` for `shard_mode=explicit`.

**`src/maxtext/layers/nnx_decoders.py`** — the GPT3 branch of `get_norm_layer` now passes `shard_mode`, like every other branch already does.

## Tests

**`tests/integration/train_tests.py`** — `test_tpu_gpt_explicit_sharding_matches_auto` trains a tiny `gpt3-6b` and `gpt-oss-20b` for 3 steps under both shard modes and asserts the loss trajectories match. gpt3 is covered with and without the fused QKV projection, and gpt-oss under both expert parallelism (MoE dispatch) and tensor parallelism (the YaRN broadcast above).

**`tests/unit/decoder_layer_model_mode_test.py`** — `Gpt3DecoderLayer` (both QKV layouts), `GptOssDecoderLayer` and `GptOssScannableBlock` join the auto-vs-explicit forward-parity cases.

**`tests/unit/train_compile_test.py`** — AOT compilation of `gpt3-6b` (fused and unfused QKV, `v5p-8`, TP=4) and `gpt-oss-20b` (`v5p-16`, EP=8 and TP=8) under `shard_mode=explicit`.

**`tests/unit/pyconfig_test.py`** — both decoders are accepted under `shard_mode=explicit`.

### Local results (v5p-8, 4 devices)

```
[gpt3_fused_qkv] auto     losses: [145.85739135742188, 145.15592956542969, 144.79559326171875]
[gpt3_fused_qkv] explicit losses: [145.86479187011719, 145.15234375000000, 144.79580688476562]
[gpt3]           auto     losses: [145.75158691406250, 145.01895141601562, 144.65382385253906]
[gpt3]           explicit losses: [145.75024414062500, 145.02005004882812, 144.65979003906250]
[gpt_oss]        auto     losses: [8.107898712158203, 8.095435142517090, 8.088655471801758]
[gpt_oss]        explicit losses: [8.107898712158203, 8.095432281494141, 8.088606834411621]
[gpt_oss_tensor] auto     losses: [8.107820510864258, 8.095223426818848, 8.088468551635742]
[gpt_oss_tensor] explicit losses: [8.107820510864258, 8.095223426818848, 8.088468551635742]
```

gpt-oss under tensor parallelism is bit-for-bit. Under expert parallelism the grouped matmul reassociates its own reductions and drifts by 3.1e-6 relative by the third step. gpt3 is bit-for-bit at step 0 and drifts to ~5e-5 relative by step 2 in both cases, because resharding the biases reassociates the bias-gradient reductions; those two subtests use `rtol=1e-4` and the reason is documented in the test.

The four new AOT tests pass, and so do `tests/unit/decoder_layer_model_mode_test.py`, `tests/unit/pyconfig_test.py`, `tests/unit/linears_test.py` and `tests/unit/embeddings_test.py`.

For the rope fix, on main:

```
$ python3 -m maxtext.trainers.pre_train.train_compile src/maxtext/configs/base.yml \
    compile_topology=v5p-16 compile_topology_num_slices=1 model_name=deepseek3-test \
    sparse_matmul=True megablox=False attention=flash scan_layers=True \
    shard_mode=explicit ici_fsdp_parallelism=1 ici_tensor_parallelism=8
ValueError: Incompatible types for broadcasting:
input type=complex64[8,1024,1,32@tensor] and requested type=complex64[8,1024,128,32]
```

The same command compiles successfully with this change.

## Known gap

`RoutedMoE.dense_matmul` (`sparse_matmul=False`) is still not onboarded to explicit sharding — a pre-existing gap shared with mixtral and qwen3_moe — so the gpt-oss tests here use the `sparse_matmul` path.

## Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files). No doc change is needed: the set of decoders supported under `shard_mode=explicit` is not enumerated in the docs, only in the `supported_decoders` validation error message, which this PR updates.

