### PR TITLE
Onboard Qwen2 and Kimi-K2 to explicit sharding

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4336,6 +4336,7 @@ class MaxTextConfig(
           "deepseek",
           "mistral",
           "mixtral",
+          "qwen2",
           "qwen3",
           "qwen3_moe",
           "qwen3_custom_moe",

--- a/src/maxtext/models/qwen2.py
+++ b/src/maxtext/models/qwen2.py
@@ -16,13 +16,13 @@
 # pylint: disable=arguments-differ
 # pylint: disable=no-name-in-module
 
+import functools
 from typing import Any
 
 from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh
 import jax.numpy as jnp
 
-from flax import linen as nn
 from flax import nnx
 
 from maxtext.common.common_types import Config
@@ -34,6 +34,7 @@ from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.layers.attentions import Attention
 from maxtext.layers.linears import MlpBlock
 from maxtext.utils import max_utils
+from maxtext.utils.sharding import create_sharding, get_logical_axis_rules, maybe_shard_with_logical
 
 
 # -----------------------------------------
@@ -57,12 +58,26 @@ class AttentionWithNorm(nnx.Module):
     batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
     self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    self.mlp_activation_axis_names = ("activation_batch", "activation_norm_length", "activation_mlp")
+
+    # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore these and let GSPMD infer the layout.
+    self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
+    self.mlp_intermediate_sharding = create_sharding(mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules())
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
 
     # Corresponds to Qwen2's `input_layernorm`
     self.pre_self_attention_layer_norm = RMSNorm(
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=rngs,
@@ -104,6 +119,7 @@ class AttentionWithNorm(nnx.Module):
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=rngs,
@@ -120,11 +136,11 @@ class AttentionWithNorm(nnx.Module):
       attention_metadata: None | dict[str, Any] = None,
   ):
     """Applies self-attention with pre and post-layer normalization."""
-    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     # Pre attention norm
-    lnx = self.pre_self_attention_layer_norm(inputs)
-    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+    lnx = self.pre_self_attention_layer_norm(inputs, out_sharding=self.out_sharding)
+    lnx = self._maybe_shard_with_logical(lnx, self.activation_axis_names)
     # Self attention
     attention_lnx, kv_cache = self.self_attention(
         lnx,
@@ -133,15 +149,16 @@ class AttentionWithNorm(nnx.Module):
         decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
         model_mode=model_mode,
+        out_sharding=self.out_sharding,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
     )
-    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
+    attention_lnx = self._maybe_shard_with_logical(attention_lnx, self.activation_axis_names)
     # Residual connection after attention
     intermediate_inputs = inputs + attention_lnx
     # Post attention norm
-    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
     return hidden_states, intermediate_inputs, kv_cache
 
 
@@ -199,11 +216,16 @@ class Qwen2DecoderLayer(AttentionWithNorm):
         attention_metadata=attention_metadata,
     )
 
-    mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+    mlp_lnx = self.mlp(
+        hidden_states,
+        deterministic=deterministic,
+        intermediate_sharding=self.mlp_intermediate_sharding,
+        out_sharding=self.out_sharding,
+    )
+    mlp_lnx = self._maybe_shard_with_logical(mlp_lnx, self.activation_axis_names)
 
     layer_output = intermediate_inputs + mlp_lnx
-    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+    layer_output = self._maybe_shard_with_logical(layer_output, self.activation_axis_names)
 
     if self.config.scan_layers:
       return layer_output, None

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -149,6 +149,52 @@ class TrainTests(unittest.TestCase):
       rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.mistral-v1')}",
   ]
 
+  _qwen2_overrides = [
+      "model_name=qwen2.5-7b",
+      "override_model_config=True",
+      "base_num_decoder_layers=2",
+      "base_emb_dim=256",
+      "base_mlp_dim=512",
+      "base_num_query_heads=8",
+      "base_num_kv_heads=8",
+      "head_dim=128",
+      "vocab_size=2048",
+      "max_target_length=256",
+      # The Qwen2.5 model configs default to a HuggingFace tokenizer that is not
+      # vendored in the repo; use the checked-in tiktoken asset instead.
+      "tokenizer_type=tiktoken",
+      rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+  ]
+
+  # Kimi-K2 runs on the deepseek decoder block, so this is the explicit-sharding coverage
+  # for MLA attention and for the shared-expert, sigmoid-routed MoE. Keeping
+  # first_num_dense_layers=1 below four layers leaves one dense and three MoE layers, so
+  # both deepseek sublayers run.
+  _kimi_overrides = [
+      "model_name=kimi-k2-1t",
+      "override_model_config=True",
+      "base_num_decoder_layers=4",
+      "first_num_dense_layers=1",
+      "base_emb_dim=256",
+      "base_mlp_dim=512",
+      "base_moe_mlp_dim=256",
+      "base_num_query_heads=4",
+      "base_num_kv_heads=4",
+      "q_lora_rank=32",
+      "kv_lora_rank=16",
+      "num_experts=8",
+      "num_experts_per_tok=2",
+      "vocab_size=2048",
+      "max_target_length=256",
+      # RoutedMoE.dense_matmul is not onboarded to explicit sharding yet, so exercise the
+      # sparse_matmul path.
+      "sparse_matmul=True",
+      "megablox=True",
+      # Kimi-K2 defaults to a HuggingFace tokenizer that is not vendored in the repo.
+      "tokenizer_type=tiktoken",
+      rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+  ]
+
   CONFIGS = {
       "base": [  # short test for train.py with TFDS c4
           None,
@@ -871,6 +917,104 @@ class TrainTests(unittest.TestCase):
         )
         print(f"[{decoder_block}] auto + GA losses: {baseline}", flush=True)
         print(f"[{decoder_block}] explicit + ZeRO-1 + GA losses: {sharded}", flush=True)
+        self.assertTrue(baseline, "baseline run produced no metrics")
+        # ZeRO-1 reassociates the gradient all-reduce, so allow a little float slack.
+        np.testing.assert_allclose(sharded, baseline, rtol=1e-4, atol=0.0)
+
+  def _losses(self, run_name, model_overrides, extra_args):
+    """Trains a tiny model for a few steps and returns its per-step losses."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      metrics_file = os.path.join(tmp_dir, "metrics.txt")
+      train_main(
+          [
+              None,
+              get_test_config_path(),
+              f"base_output_directory={self._base_output_directory}",
+              f"dataset_path={self.dataset_path}",
+              f"run_name={run_name}",
+              f"metrics_file={metrics_file}",
+              "dataset_type=synthetic",
+              "steps=3",
+              "enable_checkpointing=False",
+              "enable_goodput_recording=False",
+          ]
+          + list(model_overrides)
+          + list(extra_args)
+      )
+      with open(metrics_file, "rt", encoding="utf8") as f:
+        return [json.loads(line)["learning/loss"] for line in f if line.strip()]
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  def test_tpu_qwen2_explicit_sharding_matches_auto(self):
+    """Explicit sharding only changes how layouts are expressed, so the losses must not move.
+
+    Tensor parallelism is what stresses the Qwen2 decoder: it shards the MLP intermediate
+    and the attention heads, which are the two activations the layer now pins itself.
+    """
+    args = ["ici_fsdp_parallelism=1", "ici_tensor_parallelism=-1"]
+    auto_losses = self._losses("qwen2_auto", self._qwen2_overrides, args + ["shard_mode=auto"])
+    explicit_losses = self._losses("qwen2_explicit", self._qwen2_overrides, args + ["shard_mode=explicit"])
+    print(f"[qwen2] auto losses: {auto_losses}", flush=True)
+    print(f"[qwen2] explicit losses: {explicit_losses}", flush=True)
+    self.assertTrue(auto_losses, "auto run produced no metrics")
+    # Same as the mistral case: pinning the MLP intermediate reassociates the backward
+    # reduction over the tensor axis, so the last step drifts by a few ULPs. Under FSDP
+    # instead of tensor parallelism the two runs are bit-for-bit.
+    np.testing.assert_allclose(explicit_losses, auto_losses, rtol=1e-5, atol=0.0)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  def test_tpu_kimi_explicit_sharding_matches_auto(self):
+    """Kimi-K2 under explicit sharding, exercising the deepseek block's MLA and MoE paths.
+
+    Expert parallelism shards the MoE dispatch, which is where the deepseek layer's pinned
+    output shardings have to line up with what RoutedMoE returns.
+    """
+    args = ["ici_fsdp_parallelism=1", "ici_expert_parallelism=-1"]
+    auto_losses = self._losses("kimi_auto", self._kimi_overrides, args + ["shard_mode=auto"])
+    explicit_losses = self._losses("kimi_explicit", self._kimi_overrides, args + ["shard_mode=explicit"])
+    print(f"[kimi-k2] auto losses: {auto_losses}", flush=True)
+    print(f"[kimi-k2] explicit losses: {explicit_losses}", flush=True)
+    self.assertTrue(auto_losses, "auto run produced no metrics")
+    # Expert parallelism does not reassociate any reduction, so the two runs are bit-for-bit.
+    np.testing.assert_allclose(explicit_losses, auto_losses, rtol=1e-6, atol=0.0)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  # TODO(b/517509898): Skip ZeRo-1 compiler Segfault on TPU7x SparseCore platforms
+  @pytest.mark.skip_on_tpu7x
+  def test_tpu_qwen2_kimi_zero1_gradient_accumulation(self):
+    """ZeRO-1 only shards the optimizer state, so it must not change the loss trajectory.
+
+    Under explicit sharding this routes the accumulated gradients through the
+    `reduced`/`unreduced` PartitionSpec labels applied in
+    `maxtext.utils.gradient_accumulation`, and casts the parameters to bf16 before the
+    accumulation scan so the all-gather happens once in low precision.
+    """
+    zero1_ga = [
+        "remat_policy=minimal",
+        "per_device_batch_size=2",
+        "ici_data_parallelism=-1",
+        "dcn_data_parallelism=1",
+        "ici_fsdp_parallelism=1",
+        "dcn_fsdp_parallelism=1",
+        "gradient_accumulation_steps=8",
+    ]
+    for case, model_overrides in (("qwen2", self._qwen2_overrides), ("kimi-k2", self._kimi_overrides)):
+      with self.subTest(case=case):
+        baseline = self._losses(
+            f"{case}_ga",
+            model_overrides,
+            zero1_ga + ["shard_mode=auto", "shard_optimizer_over_data=False"],
+        )
+        sharded = self._losses(
+            f"{case}_ga_zero1",
+            model_overrides,
+            zero1_ga + ["shard_mode=explicit", "shard_optimizer_over_data=True"],
+        )
+        print(f"[{case}] auto + GA losses: {baseline}", flush=True)
+        print(f"[{case}] explicit + ZeRO-1 + GA losses: {sharded}", flush=True)
         self.assertTrue(baseline, "baseline run produced no metrics")
         # ZeRO-1 reassociates the gradient all-reduce, so allow a little float slack.
         np.testing.assert_allclose(sharded, baseline, rtol=1e-4, atol=0.0)

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -285,6 +285,26 @@ class PyconfigTest(unittest.TestCase):
         )
         self.assertEqual(config.decoder_block.value, decoder_block)
 
+  def test_explicit_sharding_qwen2_decoder_support(self):
+    """The Qwen2 decoder is accepted under explicit sharding."""
+    config = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+        shard_mode="explicit",
+        decoder_block="qwen2",
+    )
+    self.assertEqual(config.decoder_block.value, "qwen2")
+
+  def test_explicit_sharding_kimi_k2_support(self):
+    """Kimi-K2 runs on the deepseek decoder block, so it is accepted under explicit sharding."""
+    config = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+        shard_mode="explicit",
+        model_name="kimi-k2-1t",
+    )
+    self.assertEqual(config.decoder_block.value, "deepseek")
+
   def test_resolve_config_path(self):
     self.assertEqual(resolve_config_path("foo"), os.path.join("src", "foo"))
     self.assertEqual(resolve_config_path(__file__), __file__)

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -32,6 +32,7 @@ from tempfile import gettempdir, NamedTemporaryFile
 
 from maxtext.configs import pyconfig
 from maxtext.trainers.pre_train.train_compile import main as train_compile_main
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from tests.utils.test_helpers import get_test_config_path
 
 # Enable JAX compilation cache for testing to speed up AOT compilation
@@ -1194,6 +1195,69 @@ class TrainCompile(parameterized.TestCase):
             "ici_fsdp_parallelism=1",
             "shard_optimizer_over_data=true",
             "shard_mode=explicit",
+        )
+    )
+
+  def test_qwen2_explicit_sharding_zero1(self):
+    """AOT test for Qwen2 under explicit sharding with ZeRO-1 and gradient accumulation.
+
+    Explicit sharding type-checks every operation's layout rather than letting GSPMD infer
+    one, so a missing `out_sharding` in the Qwen2 decoder fails the trace here rather than
+    silently costing a collective at a scale we cannot reach in a test.
+    """
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_qwen2_explicit_sharding_zero1.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-256",
+            "compile_topology_num_slices=1",
+            "model_name=qwen2.5-7b",
+            "override_model_config=True",
+            "per_device_batch_size=1",
+            "max_target_length=4096",
+            "attention=flash",
+            "shard_mode=explicit",
+            # ZeRO-1 needs a "data" axis to shard the moments over, and MaxTextConfig
+            # rejects combining it with FSDP.
+            "ici_data_parallelism=-1",
+            "ici_fsdp_parallelism=1",
+            "gradient_accumulation_steps=4",
+            "shard_optimizer_over_data=True",
+            # The Qwen2.5 configs default to a HuggingFace tokenizer that is not vendored.
+            "tokenizer_type=tiktoken",
+            f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+        )
+    )
+
+  def test_kimi_k2_explicit_sharding(self):
+    """AOT test for Kimi-K2 at full size under explicit sharding.
+
+    Kimi-K2 runs on the deepseek decoder block, so this is the large-scale explicit-sharding
+    check for MLA attention and the shared-expert, sigmoid-routed MoE. The mesh is FSDP 64 x
+    expert 8, both of which have to divide the v5p-1024 physical mesh.
+    """
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_kimi_k2_explicit_sharding.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-1024",
+            "compile_topology_num_slices=1",
+            "model_name=kimi-k2-1t",
+            "per_device_batch_size=1",
+            "max_target_length=4096",
+            "ici_fsdp_parallelism=64",
+            "ici_expert_parallelism=8",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "shard_mode=explicit",
+            # Kimi-K2 defaults to a HuggingFace tokenizer that is not vendored.
+            "tokenizer_type=tiktoken",
+            f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
         )
     )
 


### PR DESCRIPTION
# Description

Onboards the **Qwen2** decoder block and the **Kimi-K2** model to `shard_mode=explicit`.

**Qwen2** needed real work. `AttentionWithNorm` and `Qwen2DecoderLayer` still expressed their
activation layouts with `nn.with_logical_constraint`, which is an AUTO-mode hint, so `qwen2` was
rejected by config validation under explicit sharding. This change moves the layer to the same
pattern `qwen3.py` and `deepseek.py` already use:

- cache the physical `NamedSharding`s once in `__init__` via
  `create_sharding(mesh, axis_names, rules=get_logical_axis_rules())`,
- replace every `nn.with_logical_constraint` with `maybe_shard_with_logical`,
- pass `out_sharding=` / `intermediate_sharding=` down into the two `RMSNorm`s, the attention block
  and the MLP, and thread `shard_mode=config.shard_mode` into the norms,
- add `"qwen2"` to `supported_decoders` in `configs/types.py`.

Under `ShardMode.AUTO` the callees discard those arguments, so the AUTO path is byte-identical to
before — confirmed by the parity tests below.

**Kimi-K2** needed no model change: `kimi-k2-1t.yml` sets `decoder_block: "deepseek"`, and the
deepseek layer is already onboarded. It is worth covering explicitly anyway, because it is the first
explicit-sharding test of MLA attention (`q_lora_rank`/`kv_lora_rank`) combined with a
shared-expert, sigmoid-routed MoE with a routed bias. The deliverable here is verification plus
regression coverage, not new annotations.

**Known gap (pre-existing, not introduced here):** `RoutedMoE.dense_matmul` — the
`sparse_matmul=False` path — is still not onboarded to explicit sharding. This is shared with
`qwen3_moe`, so the Kimi tests run with `sparse_matmul=True megablox=True`. Left for a follow-up.

No documentation lists the explicit-sharding decoders (only the validation error message
enumerates them), so there is no doc change to make.

BUGS: b/517509898

# Tests

**New tests**

| Test | File | What it covers |
| --- | --- | --- |
| `test_explicit_sharding_qwen2_decoder_support` | `tests/unit/pyconfig_test.py` | config validation accepts `decoder_block=qwen2` |
| `test_explicit_sharding_kimi_k2_support` | `tests/unit/pyconfig_test.py` | config validation accepts `model_name=kimi-k2-1t` |
| `test_qwen2_explicit_sharding_zero1` | `tests/unit/train_compile_test.py` | AOT on v5p-256: qwen2.5-7b, explicit + ZeRO-1 + grad accumulation |
| `test_kimi_k2_explicit_sharding` | `tests/unit/train_compile_test.py` | AOT on v5p-1024: full-size kimi-k2-1t (61 layers, 384 experts, MLA), fsdp=64 × ep=8 |
| `test_tpu_qwen2_explicit_sharding_matches_auto` | `tests/integration/train_tests.py` | explicit vs auto loss parity under tensor parallelism |
| `test_tpu_kimi_explicit_sharding_matches_auto` | `tests/integration/train_tests.py` | explicit vs auto loss parity under expert parallelism |
| `test_tpu_qwen2_kimi_zero1_gradient_accumulation` | `tests/integration/train_tests.py` | explicit + `shard_optimizer_over_data=True` + `gradient_accumulation_steps=8` vs the auto/unsharded baseline |

**Results** (local TPU v7-8, 8 devices)

Explicit-vs-auto loss parity, 3 steps of synthetic data:

```
[qwen2]   auto     [8.117835998535156, 8.109989166259766, 8.105623245239258]
[qwen2]   explicit [8.117835998535156, 8.109989166259766, 8.105628967285156]
[kimi-k2] auto     [8.126579284667969, 8.114963531494140, 8.108431816101074]
[kimi-k2] explicit [8.126579284667969, 8.114963531494140, 8.108431816101074]
```

Kimi is bit-for-bit under expert parallelism. Qwen2 drifts ~7e-7 relative by the third step under
*tensor* parallelism, because pinning the MLP intermediate reassociates the backward reduction over
the tensor axis — the same effect already documented for `mistral` in this file. Re-running the same
qwen2 model under FSDP instead gives bit-for-bit equality, which is what the comment on the
assertion records:

```
[qwen2 fsdp] auto     [8.11419677734375, 8.106307029724121, 8.101974487304688]
[qwen2 fsdp] explicit [8.11419677734375, 8.106307029724121, 8.101974487304688]
```

Accordingly the qwen2 assertion uses `rtol=1e-5` (matching mistral) and kimi keeps `rtol=1e-6`.

ZeRO-1 + gradient accumulation (`gradient_accumulation_steps=8`, `ici_data_parallelism=-1`),
explicit + `shard_optimizer_over_data=True` against the auto + unsharded-optimizer baseline:

```
[qwen2]   auto+GA        [8.120068550109863, 8.113206863403320, 8.109447479248047]
[qwen2]   explicit+ZeRO1 [8.120068550109863, 8.113282203674316, 8.109483718871090]   max rel diff 9.3e-06
[kimi-k2] auto+GA        [8.121309280395508, 8.111110687255860, 8.105545997619629]
[kimi-k2] explicit+ZeRO1 [8.121270179748535, 8.111163139343262, 8.105513572692871]   max rel diff 6.5e-06
```

Both are well inside the `rtol=1e-4` the sibling ZeRO-1 tests use for the reassociated gradient
all-reduce.

**Commands**

```bash
# unit
JAX_PLATFORMS=cpu python -m pytest tests/unit/pyconfig_test.py -k explicit_sharding
# => 4 passed, 7 subtests passed

# AOT
JAX_PLATFORMS=cpu python -m pytest tests/unit/train_compile_test.py \
  -k "qwen2_explicit_sharding_zero1 or kimi_k2_explicit_sharding"
# => 2 passed

# local TPU v7-8, including the pre-existing qwen3/mistral tests as a regression check
python -m pytest tests/integration/train_tests.py -k "explicit or zero1"
# => 4 passed, 6 skipped, 5 subtests passed
```

**On the `skip_on_tpu7x` marker.** The new ZeRO-1 test carries
`@pytest.mark.skip_on_tpu7x` for consistency with the existing gemma/qwen3/mistral ZeRO-1 tests
(b/517509898). For what it is worth, it does *not* reproduce here — with the marker temporarily
lifted, the test passes on this TPU7x v7-8 host:

```
test_tpu_qwen2_kimi_zero1_gradient_accumulation PASSED  (2 subtests passed)
```

I left the marker in place rather than diverging from its siblings; whoever closes b/517509898 can
drop them together.

`pyink --check --pyink-indentation=2 --line-length=122` is clean on all five files. `pylint` scores
9.97/10, with the only two warnings (`R0917` in `qwen2.py`) confirmed pre-existing on `main`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
