### PR TITLE
Onboard the Llama4 decoder to explicit sharding

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4335,6 +4335,7 @@ class MaxTextConfig(
           "simple",
           "simple_mlp",
           "llama2",
+          "llama4",
           "deepseek",
           "mistral",
           "mixtral",

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -694,14 +694,22 @@ class LLaMARotaryEmbedding(RotaryEmbedding):
     # Shift the inputs left and right as per LLaMA's specific behavior
     inputs_shifted_left = jnp.concatenate([inputs[..., 1:], inputs[..., :1]], axis=-1)
     inputs_shifted_right = jnp.concatenate([inputs[..., -1:], inputs[..., :-1]], axis=-1)
-    inputs_shifted = jax.lax.select(
-        jnp.tile(
-            jnp.mod(jnp.arange(self.embedding_dims, dtype=jnp.int32), 2),
-            inputs.shape[:-1] + (1,),
-        ),
-        inputs_shifted_right,
-        inputs_shifted_left,
-    )
+    # `lax.select` requires the predicate to match the cases in shape and, under
+    # ShardMode.EXPLICIT, in sharding too. Tiling the 1-D mask to the full input shape yields a
+    # replicated [B, S, N, H] predicate, which is rejected once the inputs are sharded.
+    # Broadcasting the 1-D mask through `jnp.where` selects exactly the same elements -- verified
+    # bit-for-bit in both the forward pass and the gradient -- and carries no sharding of its own.
+    # It is used only under explicit sharding so that ShardMode.AUTO keeps the XLA fusion, and
+    # hence the exact floating-point rounding, it has today.
+    is_odd_dim = jnp.mod(jnp.arange(self.embedding_dims, dtype=jnp.int32), 2)
+    if self.shard_mode == ShardMode.EXPLICIT:
+      inputs_shifted = jnp.where(is_odd_dim.astype(bool), inputs_shifted_right, inputs_shifted_left)
+    else:
+      inputs_shifted = jax.lax.select(
+          jnp.tile(is_odd_dim, inputs.shape[:-1] + (1,)),
+          inputs_shifted_right,
+          inputs_shifted_left,
+      )
 
     # Determine positions if not provided
     if position is None:

--- a/src/maxtext/models/llama4.py
+++ b/src/maxtext/models/llama4.py
@@ -15,6 +15,7 @@
 """Llama4 decoder layer definition."""
 # pylint: disable=arguments-differ, disable=no-name-in-module, missing-function-docstring
 
+import functools
 import math
 
 from flax import linen as nn
@@ -37,6 +38,7 @@ from maxtext.layers.moe import RoutedAndSharedMoE
 from maxtext.layers.normalizations import RMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.utils import max_utils
+from maxtext.utils.sharding import create_sharding, get_logical_axis_rules, maybe_shard_with_logical
 
 #### Multi modal model implementation
 
@@ -340,10 +342,29 @@ class Llama4DecoderLayer(nnx.Module):
     batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
+    if model_mode == MODEL_MODE_PREFILL:
+      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
+    else:
+      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    self.mlp_activation_axis_names = self.activation_axis_names[:-1] + ("activation_mlp",)
+
+    # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore these and let GSPMD infer the layout.
+    self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
+    self.mlp_intermediate_sharding = create_sharding(mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules())
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
+
     self.pre_self_attention_layer_norm = RMSNorm(
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=rngs,
@@ -392,6 +413,7 @@ class Llama4DecoderLayer(nnx.Module):
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=self.rngs,
@@ -426,10 +448,6 @@ class Llama4DecoderLayer(nnx.Module):
       )
 
     self.dropout = Dropout(rate=config.dropout_rate, broadcast_dims=(-2,), rngs=self.rngs)
-    if model_mode == MODEL_MODE_PREFILL:
-      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
-    else:
-      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
 
   @property
   def moe_block(self):
@@ -459,11 +477,11 @@ class Llama4DecoderLayer(nnx.Module):
       is_scan_carry = True
     elif isinstance(inputs, tuple):
       inputs = inputs[0]
-    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 
-    lnx = self.pre_self_attention_layer_norm(inputs)
-    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+    lnx = self.pre_self_attention_layer_norm(inputs, out_sharding=self.out_sharding)
+    lnx = self._maybe_shard_with_logical(lnx, self.activation_axis_names)
 
     # Self-attention block
     attention_lnx, kv_cache = self.self_attention(
@@ -473,28 +491,38 @@ class Llama4DecoderLayer(nnx.Module):
         decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
         model_mode=model_mode,
+        out_sharding=self.out_sharding,
         slot=slot,
         previous_chunk=previous_chunk,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
     )
-    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
+    attention_lnx = self._maybe_shard_with_logical(attention_lnx, self.activation_axis_names)
     intermediate_inputs = inputs + attention_lnx
 
     # Fully Connected
-    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     load_balance_loss = None
     if self.is_moe_layer:
-      mlp_lnx, load_balance_loss, _ = self.moe_block(hidden_states)
+      mlp_lnx, load_balance_loss, _ = self.moe_block(
+          hidden_states,
+          intermediate_sharding=self.mlp_intermediate_sharding,
+          out_sharding=self.out_sharding,
+      )
     else:
-      mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+      mlp_lnx = self.mlp(
+          hidden_states,
+          deterministic=deterministic,
+          intermediate_sharding=self.mlp_intermediate_sharding,
+          out_sharding=self.out_sharding,
+      )
+    mlp_lnx = self._maybe_shard_with_logical(mlp_lnx, self.activation_axis_names)
 
     layer_output = mlp_lnx + intermediate_inputs
     layer_output = self.dropout(layer_output, deterministic=deterministic)
-    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+    layer_output = self._maybe_shard_with_logical(layer_output, self.activation_axis_names)
 
     if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
       self.sow(nnx.Intermediate, "moe_lb_loss", load_balance_loss)
@@ -560,6 +588,13 @@ class Llama4ScannableBlock(nnx.Module):
     self.rngs = rngs
     self.nope_layer_interval = nope_layer_interval
     self.interleave_moe_layer_step = interleave_moe_layer_step
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
 
     for layer_id in range(self.config.inhomogeneous_layer_cycle_interval):
       nope_layer = determine_is_nope_layer(layer_id, self.nope_layer_interval)
@@ -591,7 +626,9 @@ class Llama4ScannableBlock(nnx.Module):
 
     cfg = self.config
 
-    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    # The per-layer constraints below are model_mode aware; this block-level one deliberately is
+    # not, matching the axis names this code has always used so ShardMode.AUTO is unchanged.
+    inputs = self._maybe_shard_with_logical(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     y = inputs
     for layer_id in range(cfg.inhomogeneous_layer_cycle_interval):

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -166,6 +166,31 @@ class TrainTests(unittest.TestCase):
       rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
   ]
 
+  _llama4_overrides = [
+      "model_name=llama4-17b-16e",
+      "override_model_config=True",
+      # Four layers with a MoE step of 2 covers every Llama4 layer variant exactly once:
+      # chunked+dense, chunked+MoE, chunked+dense and global (NoPE) + MoE. The NoPE
+      # interval and the layer cycle interval are both 4 in the model config already.
+      "base_num_decoder_layers=4",
+      "interleave_moe_layer_step=2",
+      "base_emb_dim=256",
+      "base_mlp_dim=512",
+      "base_moe_mlp_dim=256",
+      "base_num_query_heads=8",
+      "base_num_kv_heads=8",
+      "num_experts=8",
+      "vocab_size=2048",
+      "max_target_length=256",
+      # Keep the chunked attention window under the sequence length so the chunk mask
+      # is actually exercised rather than degenerating into full attention.
+      "chunk_attn_window_size=128",
+      # The Llama4 model configs default to a HuggingFace tokenizer that is not
+      # vendored in the repo; use the checked-in tiktoken asset instead.
+      "tokenizer_type=tiktoken",
+      rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+  ]
+
   # Kimi-K2 runs on the deepseek decoder block, so this is the explicit-sharding coverage
   # for MLA attention and for the shared-expert, sigmoid-routed MoE. Keeping
   # first_num_dense_layers=1 below four layers leaves one dense and three MoE layers, so
@@ -982,6 +1007,37 @@ class TrainTests(unittest.TestCase):
 
   @pytest.mark.integration_test
   @pytest.mark.tpu_only
+  def test_tpu_llama4_explicit_sharding_matches_auto(self):
+    """Explicit sharding only changes how layouts are expressed, so the losses must not move.
+
+    A Llama4 model interleaves dense and MoE layers, so it is run under both of the
+    parallelisms that stress them: tensor parallelism shards the dense MLP
+    intermediate, and expert parallelism shards the MoE dispatch.
+    """
+    parallelism = {
+        "tensor": ["ici_fsdp_parallelism=1", "ici_tensor_parallelism=-1"],
+        "expert": ["ici_fsdp_parallelism=1", "ici_expert_parallelism=-1"],
+    }
+    # Under tensor parallelism the two modes are bit-for-bit. Under expert parallelism
+    # pinning the activations reassociates the reductions inside the MoE block, so the
+    # loss drifts by a few ULPs by the third step. The drift is ~5e-7 at this size but
+    # grows with the expert dimensions, so leave the bound loose.
+    rtol = {"tensor": 1e-6, "expert": 1e-4}
+    for name, parallelism_args in parallelism.items():
+      with self.subTest(parallelism=name):
+        auto_losses = self._losses(
+            f"llama4_{name}_auto", self._llama4_overrides, parallelism_args + ["shard_mode=auto"]
+        )
+        explicit_losses = self._losses(
+            f"llama4_{name}_explicit", self._llama4_overrides, parallelism_args + ["shard_mode=explicit"]
+        )
+        print(f"[llama4/{name}] auto losses: {auto_losses}", flush=True)
+        print(f"[llama4/{name}] explicit losses: {explicit_losses}", flush=True)
+        self.assertTrue(auto_losses, "auto run produced no metrics")
+        np.testing.assert_allclose(explicit_losses, auto_losses, rtol=rtol[name], atol=0.0)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
   # TODO(b/517509898): Skip ZeRo-1 compiler Segfault on TPU7x SparseCore platforms
   @pytest.mark.skip_on_tpu7x
   def test_tpu_qwen2_kimi_zero1_gradient_accumulation(self):
@@ -1018,6 +1074,39 @@ class TrainTests(unittest.TestCase):
         self.assertTrue(baseline, "baseline run produced no metrics")
         # ZeRO-1 reassociates the gradient all-reduce, so allow a little float slack.
         np.testing.assert_allclose(sharded, baseline, rtol=1e-4, atol=0.0)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  # TODO(b/517509898): Skip ZeRo-1 compiler Segfault on TPU7x SparseCore platforms
+  @pytest.mark.skip_on_tpu7x
+  def test_tpu_llama4_zero1_gradient_accumulation(self):
+    """ZeRO-1 only shards the optimizer state, so it must not change the loss trajectory.
+
+    Under explicit sharding this routes the accumulated gradients through the
+    `reduced`/`unreduced` PartitionSpec labels applied in
+    `maxtext.utils.gradient_accumulation`, and casts the parameters to bf16 before the
+    accumulation scan so the all-gather happens once in low precision.
+    """
+    zero1_ga = [
+        "remat_policy=minimal",
+        "per_device_batch_size=2",
+        "ici_data_parallelism=-1",
+        "dcn_data_parallelism=1",
+        "ici_fsdp_parallelism=1",
+        "dcn_fsdp_parallelism=1",
+        "gradient_accumulation_steps=8",
+    ]
+    baseline = self._losses(
+        "llama4_ga", self._llama4_overrides, zero1_ga + ["shard_mode=auto", "shard_optimizer_over_data=False"]
+    )
+    sharded = self._losses(
+        "llama4_ga_zero1", self._llama4_overrides, zero1_ga + ["shard_mode=explicit", "shard_optimizer_over_data=True"]
+    )
+    print(f"[llama4] auto + GA losses: {baseline}", flush=True)
+    print(f"[llama4] explicit + ZeRO-1 + GA losses: {sharded}", flush=True)
+    self.assertTrue(baseline, "baseline run produced no metrics")
+    # ZeRO-1 reassociates the gradient all-reduce, so allow a little float slack.
+    np.testing.assert_allclose(sharded, baseline, rtol=1e-4, atol=0.0)
 
   @pytest.mark.integration_test
   @pytest.mark.tpu_only

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -295,6 +295,27 @@ class PyconfigTest(unittest.TestCase):
     )
     self.assertEqual(config.decoder_block.value, "qwen2")
 
+  def test_explicit_sharding_llama4_decoder_support(self):
+    """The Llama4 decoder is accepted by explicit sharding, but its vision encoder is not."""
+    config = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+        shard_mode="explicit",
+        decoder_block="llama4",
+    )
+    self.assertEqual(config.decoder_block.value, "llama4")
+
+    # Only the text stack is onboarded; the Llama4 vision encoder is not.
+    with self.assertRaisesRegex(Exception, "not supported with `use_multimodal`"):
+      pyconfig.initialize(
+          [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+          skip_jax_distributed_system=True,
+          shard_mode="explicit",
+          model_name="llama4-17b-16e",
+          override_model_config=True,
+          use_multimodal=True,
+      )
+
   def test_explicit_sharding_kimi_k2_support(self):
     """Kimi-K2 runs on the deepseek decoder block, so it is accepted under explicit sharding."""
     config = pyconfig.initialize(

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -1261,6 +1261,78 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
+  def test_llama4_explicit_sharding_zero1(self):
+    """AOT test for Llama4 under explicit sharding with ZeRO-1 and gradient accumulation.
+
+    Explicit sharding type-checks every operation's layout rather than letting GSPMD infer
+    one, so a missing `out_sharding` in the Llama4 decoder fails the trace here rather than
+    silently costing a collective at a scale we cannot reach in a test.
+    """
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_llama4_explicit_sharding_zero1.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-256",
+            "compile_topology_num_slices=1",
+            "model_name=llama4-17b-16e",
+            "override_model_config=True",
+            # ZeRO-1 replicates the parameters over the data axis, so the full 16-expert
+            # model does not fit in HBM. Keep four experts and eight layers, which with a
+            # MoE step of 2 still covers both the dense and the MoE layer variant.
+            "base_num_decoder_layers=8",
+            "interleave_moe_layer_step=2",
+            "num_experts=4",
+            "per_device_batch_size=1",
+            "max_target_length=4096",
+            "attention=flash",
+            "remat_policy=full",
+            "shard_mode=explicit",
+            # ZeRO-1 needs a "data" axis to shard the moments over, and MaxTextConfig
+            # rejects combining it with FSDP.
+            "ici_data_parallelism=-1",
+            "ici_fsdp_parallelism=1",
+            "gradient_accumulation_steps=4",
+            "shard_optimizer_over_data=True",
+            # The Llama4 configs default to a HuggingFace tokenizer that is not vendored.
+            "tokenizer_type=tiktoken",
+            f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+        )
+    )
+
+  def test_llama4_17b_128e_explicit_sharding(self):
+    """AOT test for Llama4 Maverick at full size under explicit sharding.
+
+    The 128-expert config interleaves dense and MoE layers, so this covers both layer
+    variants at a scale where the expert axis is actually sharded. The mesh is FSDP 64 x
+    expert 8, both of which have to divide the v5p-1024 physical mesh.
+    """
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_llama4_17b_128e_explicit_sharding.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-1024",
+            "compile_topology_num_slices=1",
+            "model_name=llama4-17b-128e",
+            # Only needed so the tokenizer below can replace the model config's default.
+            "override_model_config=True",
+            "per_device_batch_size=1",
+            "max_target_length=4096",
+            "ici_fsdp_parallelism=64",
+            "ici_expert_parallelism=8",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "shard_mode=explicit",
+            # The Llama4 configs default to a HuggingFace tokenizer that is not vendored.
+            "tokenizer_type=tiktoken",
+            f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+        )
+    )
+
   def test_vocab_tiling_bf16_nnx(self):
     """AOT compile vocab tiling on the NNX path (vocab_tiling_nnx_loss + custom_vjp).
 


### PR DESCRIPTION
# Description

Onboards the Llama4 decoder to `shard_mode=explicit`, following the same pattern as the Qwen3, Mistral and DeepSeek blocks that are already supported.

`Llama4DecoderLayer` and `Llama4ScannableBlock` now route their activation constraints through `maybe_shard_with_logical` instead of `nn.with_logical_constraint`, cache the `NamedSharding`s for the activation and MLP-intermediate layouts in `__init__`, and thread `out_sharding` / `intermediate_sharding` into the attention, `RMSNorm`, dense MLP and `RoutedAndSharedMoE` sublayers. Under `ShardMode.AUTO` every one of those arguments is ignored and GSPMD infers exactly the layouts it does today, so this is a no-op for existing runs.

`RoutedAndSharedMoE` already accepts both sharding arguments (it is shared with DeepSeek), so no MoE changes were needed.

## The rotary embedding fix

`LLaMARotaryEmbedding` — which Llama4 reaches via `rope_type: "llama3.1"` — could not run under explicit sharding at all. It built the `lax.select` predicate by tiling a 1-D parity mask up to the full input shape:

```python
jax.lax.select(jnp.tile(mask, inputs.shape[:-1] + (1,)), shifted_right, shifted_left)
```

That produces a replicated `[B, S, N, H]` predicate, and sharding-in-types requires the predicate to match the cases in sharding as well as shape, so the trace fails with:

```
ShardingTypeError: select 'which' must be scalar or have the same sharding as cases,
got P(None, None, None, None) and P('expert', None, None, None)
```

Broadcasting the same 1-D mask through `jnp.where` selects identical elements and carries no sharding of its own. The two formulations are mathematically identical — verified elementwise-equal in the forward pass, in the gradient, and in bf16 — but they fuse differently in XLA, and swapping unconditionally shifted `llama3.1` losses by ~1e-5 in `ShardMode.AUTO`. Since `llama3.1` is out of scope here, the rewrite is gated on `shard_mode` so `AUTO` keeps byte-identical behaviour; this was confirmed by re-running the auto path against pristine `main`.

## Testing

- **`tests/unit/pyconfig_test.py`** — `decoder_block=llama4` is accepted under explicit sharding, and `use_multimodal=True` is still rejected (only the text stack is onboarded; the Llama4 vision encoder is not).
- **`tests/unit/train_compile_test.py`** — two AOT compiles: `llama4-17b-16e` with ZeRO-1 + gradient accumulation on `v5p-256`, and `llama4-17b-128e` at FSDP 64 × expert 8 on `v5p-1024`.
- **`tests/integration/train_tests.py`** — the integration model uses 4 layers with `interleave_moe_layer_step=2`, which covers all four Llama4 layer variants in one run: chunked+dense, chunked+MoE, chunked+dense and global (NoPE) + MoE.

Measured on a local TPU v7-8, 3 steps of synthetic data:

| Configuration | auto | explicit | max rel. diff |
| --- | --- | --- | --- |
| tensor parallelism | `[8.119888, 8.105545, 8.097639]` | `[8.119888, 8.105545, 8.097639]` | bit-for-bit |
| expert parallelism | `[8.119880, 8.105589, 8.097667]` | `[8.119880, 8.105585, 8.097659]` | 4.7e-7 |
| ZeRO-1 + grad accum (vs. unsharded auto) | `[8.120317, 8.107924, 8.101201]` | `[8.120396, 8.107988, 8.101174]` | 9.6e-6 |

The ZeRO-1 test carries `@pytest.mark.skip_on_tpu7x` for consistency with the other ZeRO-1 tests (b/517509898); the numbers above were produced by temporarily lifting that marker, and the marker was restored afterwards.

Regression sweep: the pre-existing `qwen3`, `qwen3_moe`, `qwen3_custom_moe`, `mistral` and `mixtral` explicit-vs-auto parity tests, and the existing AOT explicit/ZeRO-1 compiles, all still pass. `pyink` is clean and `pylint` reports only pre-existing `R0917`/`W0613` findings on untouched signatures.

## Known gaps

- `RoutedMoE.dense_matmul` (`sparse_matmul=False`) is still not onboarded to explicit sharding — a gap Llama4 shares with `qwen3_moe` and `mixtral`.
- Llama4 supports top-1 routing only (`num_experts_per_tok=1`), so the top-k dispatch path is not exercised.
- The Llama4 vision encoder is untouched; `use_multimodal` remains rejected under explicit sharding.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

```
# Unit
JAX_PLATFORMS=cpu pytest tests/unit/pyconfig_test.py -k explicit_sharding
JAX_PLATFORMS=cpu pytest tests/unit/train_compile_test.py -k "explicit or zero1 or llama4"

# Integration, on a TPU host
pytest tests/integration/train_tests.py -k "explicit or zero1"
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
