### PR TITLE
Fix KL divergence regression for Qwen3 in AUTO shard mode

### DIFF
--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -32,7 +32,7 @@ from flax import linen as nn
 from flax import nnx
 
 from maxtext.common.common_types import AttentionType, Config, DType, Array, BATCH, EMBED, MODEL_MODE_TRAIN, LENGTH, MODEL_MODE_AUTOREGRESSIVE
-from maxtext.common.common_types import KV_BATCH, KV_HEAD
+from maxtext.common.common_types import KV_BATCH, KV_HEAD, ShardMode
 from maxtext.utils.sharding import (
     create_sharding,
     get_logical_axis_rules,
@@ -1457,15 +1457,22 @@ class AttentionWithNorm(nnx.Module):
 
     # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
     # ShardMode.AUTO the callees ignore these and let GSPMD infer the layout.
-    self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
-    self.mlp_intermediate_sharding = create_sharding(mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules())
-    self._maybe_shard_with_logical = functools.partial(
-        maybe_shard_with_logical,
-        mesh=mesh,
-        shard_mode=config.shard_mode,
-        debug_sharding=config.debug_sharding,
-        extra_stack_level=1,
-    )
+    if config.shard_mode == ShardMode.EXPLICIT:
+      self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
+      self.mlp_intermediate_sharding = create_sharding(
+          mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules()
+      )
+      self._maybe_shard_with_logical = functools.partial(
+          maybe_shard_with_logical,
+          mesh=mesh,
+          shard_mode=config.shard_mode,
+          debug_sharding=config.debug_sharding,
+          extra_stack_level=1,
+      )
+    else:
+      self.out_sharding = None
+      self.mlp_intermediate_sharding = None
+      self._maybe_shard_with_logical = lambda inputs, *args, **kwargs: inputs
 
     # Corresponds to Qwen3's `input_layernorm`
     self.pre_self_attention_layer_norm = RMSNorm(

--- a/tests/utils/reference_hlo_qwen3_1.7b.txt
+++ b/tests/utils/reference_hlo_qwen3_1.7b.txt
@@ -9,27 +9,27 @@ FileLocations
 StackFrames
 
 
-%fused_computation.483 (param_0.1359: s32[1,128]) -> s32[1,1,128] {
-  %param_0.1359 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
+%fused_computation.484 (param_0.1367: s32[1,128]) -> s32[1,1,128] {
+  %param_0.1367 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
   %constant.433.clone.9 = s32[]{:T(128)} constant(0)
-  %broadcast.976 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.9), dimensions={}, metadata={op_name="broadcast.95"}
-  %lt.32 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1359, %broadcast.976), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
+  %broadcast.977 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.9), dimensions={}, metadata={op_name="broadcast.95"}
+  %lt.32 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1367, %broadcast.977), direction=LT, metadata={op_name="jit(train_step)/jvp()/lt" stack_frame_id=0}
   %constant.445.clone.1 = s32[]{:T(128)} constant(151936)
   %add.940 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.445.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %add.930 = s32[1,128]{1,0:T(1,128)} add(%param_0.1359, %add.940), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %select_n.180 = s32[1,128]{1,0:T(1,128)} select(%lt.32, %add.930, %param_0.1359), metadata={op_name="jit(train_step)/jvp()/select_n" stack_frame_id=0}
-  ROOT %bitcast.586 = s32[1,1,128]{2,1,0:T(1,128)S(1)} bitcast(%select_n.180)
+  %add.930 = s32[1,128]{1,0:T(1,128)} add(%param_0.1367, %add.940), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %select_n.180 = s32[1,128]{1,0:T(1,128)} select(%lt.32, %add.930, %param_0.1367), metadata={op_name="jit(train_step)/jvp()/select_n" stack_frame_id=0}
+  ROOT %bitcast.601 = s32[1,1,128]{2,1,0:T(1,128)S(1)} bitcast(%select_n.180)
 }
 
-%fused_computation.453 (param_0.1292: s32[512]) -> s32[1024] {
-  %constant.1043 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+%fused_computation.454 (param_0.1300: s32[512]) -> s32[1024] {
+  %constant.1044 = s32[] constant(0), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %broadcast.947 = s32[1024]{0:T(1024)} broadcast(%constant.1044), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %param_0.1300 = s32[512]{0:T(512)S(1)} parameter(0)
+  %constant.1045 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %pad.57 = s32[1024]{0:T(1024)} pad(%param_0.1300, %constant.1045), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %constant.1043 = s32[] constant(151935), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %broadcast.946 = s32[1024]{0:T(1024)} broadcast(%constant.1043), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %param_0.1292 = s32[512]{0:T(512)S(1)} parameter(0)
-  %constant.1044 = s32[] constant(2147483647), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %pad.57 = s32[1024]{0:T(1024)} pad(%param_0.1292, %constant.1044), padding=0_512, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %constant.1042 = s32[] constant(151935), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %broadcast.945 = s32[1024]{0:T(1024)} broadcast(%constant.1042), dimensions={}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  ROOT %clamp.3 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.946, %pad.57, %broadcast.945), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  ROOT %clamp.3 = s32[1024]{0:T(1024)S(1)} clamp(%broadcast.947, %pad.57, %broadcast.946), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
 %fused_computation (param_0.2: bf16[151936,512], param_1.7: s32[1024]) -> bf16[512,512] {
@@ -38,114 +38,114 @@ StackFrames
   %custom-call.1 = s32[1024]{0:T(1024)} custom-call(%param_1.7), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %slice.34 = s32[512]{0:T(512)} slice(%custom-call.1), slice={[0:512]}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
   %reshape.781 = s32[4,128]{1,0:T(4,128)} reshape(%slice.34), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/broadcast_in_dim" stack_frame_id=0}
-  %transpose.442 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.781), dimensions={0,1}, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/broadcast_in_dim" stack_frame_id=0}
-  %gather.4 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} gather(%param_0.2, %transpose.442), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  %transpose.441 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} transpose(%gather.4), dimensions={0,1,2}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
-  ROOT %reshape.780 = bf16[512,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.441), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %transpose.461 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.781), dimensions={0,1}, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/broadcast_in_dim" stack_frame_id=0}
+  %gather.4 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} gather(%param_0.2, %transpose.461), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  %transpose.460 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} transpose(%gather.4), dimensions={0,1,2}, metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
+  ROOT %reshape.780 = bf16[512,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.460), metadata={op_name="jit(train_step)/jvp()/gather" stack_frame_id=0}
 }
 
-%fused_computation.499 (param_0.1540: f32[128,4]) -> bf16[4,128] {
-  %param_0.1540 = f32[128,4]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.725 = f32[4,128]{1,0:T(4,128)} bitcast(%param_0.1540), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.285 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.725)
+%fused_computation.500 (param_0.1548: f32[128,4]) -> bf16[4,128] {
+  %param_0.1548 = f32[128,4]{0,1:T(4,128)S(1)} parameter(0)
+  %bitcast.740 = f32[4,128]{1,0:T(4,128)} bitcast(%param_0.1548), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.286 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.740)
 }
 
-%fused_computation.496 (param_0.1538: f32[2048,4]) -> bf16[4,2048] {
-  %param_0.1538 = f32[2048,4]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.723 = f32[4,2048]{1,0:T(4,128)} bitcast(%param_0.1538), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.279 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.723)
+%fused_computation.497 (param_0.1546: f32[2048,4]) -> bf16[4,2048] {
+  %param_0.1546 = f32[2048,4]{0,1:T(4,128)S(1)} parameter(0)
+  %bitcast.738 = f32[4,2048]{1,0:T(4,128)} bitcast(%param_0.1546), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.280 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.738)
 }
 
-%fused_computation.490 (param_0.1374: s32[1,128]) -> (f32[1,128,1,1], f32[128]) {
-  %param_0.1374 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
-  %convert_element_type.1272 = f32[1,128]{1,0:T(1,128)} convert(%param_0.1374), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  %bitcast.596 = f32[1,128,1,1]{1,3,2,0:T(1,128)} bitcast(%convert_element_type.1272), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %bitcast.597.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%convert_element_type.1272), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.170 = (f32[1,128,1,1]{1,3,2,0:T(1,128)}, f32[128]{0:T(128)S(1)}) tuple(%bitcast.596, %bitcast.597.clone.1)
+%fused_computation.491 (param_0.1382: s32[1,128]) -> (f32[1,128,1,1], f32[128]) {
+  %param_0.1382 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
+  %convert_element_type.1276 = f32[1,128]{1,0:T(1,128)} convert(%param_0.1382), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
+  %bitcast.611 = f32[1,128,1,1]{1,3,2,0:T(1,128)} bitcast(%convert_element_type.1276), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %bitcast.612.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%convert_element_type.1276), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.169 = (f32[1,128,1,1]{1,3,2,0:T(1,128)}, f32[128]{0:T(128)S(1)}) tuple(%bitcast.611, %bitcast.612.clone.1)
 }
 
-%fused_computation.489 () -> f32[64] {
+%fused_computation.490 () -> f32[64] {
   %constant.449.clone.1 = f32[]{:T(128)} constant(1e+06)
-  %broadcast.969 = f32[64]{0:T(128)} broadcast(%constant.449.clone.1), dimensions={}, metadata={op_name="broadcast.407"}
+  %broadcast.970 = f32[64]{0:T(128)} broadcast(%constant.449.clone.1), dimensions={}, metadata={op_name="broadcast.407"}
   %iota.56 = s32[64]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/iota" stack_frame_id=0}
   %constant.450.clone.1 = s32[]{:T(128)} constant(2)
-  %broadcast.968 = s32[64]{0:T(128)} broadcast(%constant.450.clone.1), dimensions={}, metadata={op_name="broadcast.408"}
-  %mul.1974 = s32[64]{0:T(128)} multiply(%iota.56, %broadcast.968), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %convert_element_type.1271 = f32[64]{0:T(128)} convert(%mul.1974), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
+  %broadcast.969 = s32[64]{0:T(128)} broadcast(%constant.450.clone.1), dimensions={}, metadata={op_name="broadcast.408"}
+  %mul.1974 = s32[64]{0:T(128)} multiply(%iota.56, %broadcast.969), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %convert_element_type.1275 = f32[64]{0:T(128)} convert(%mul.1974), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
   %constant.451.clone.1 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.967 = f32[64]{0:T(128)} broadcast(%constant.451.clone.1), dimensions={}, metadata={op_name="broadcast.409"}
-  %div.778 = f32[64]{0:T(128)} multiply(%convert_element_type.1271, %broadcast.967), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  ROOT %pow.36 = f32[64]{0:T(128)S(1)} power(%broadcast.969, %div.778), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
+  %broadcast.968 = f32[64]{0:T(128)} broadcast(%constant.451.clone.1), dimensions={}, metadata={op_name="broadcast.409"}
+  %div.778 = f32[64]{0:T(128)} multiply(%convert_element_type.1275, %broadcast.968), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  ROOT %pow.36 = f32[64]{0:T(128)S(1)} power(%broadcast.970, %div.778), metadata={op_name="jit(train_step)/pow" stack_frame_id=0}
 }
 
-%fused_computation.426 (param_0.1261: f32[128], param_1.1324: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
-  %param_0.1261 = f32[128]{0:T(128)S(1)} parameter(0)
-  %div.732 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_0.1261), dimensions={1}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %param_1.1324 = f32[64]{0:T(128)S(1)} parameter(1)
-  %div.738 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_1.1324), dimensions={3}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+%fused_computation.427 (param_0.1269: f32[128], param_1.1328: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
+  %param_0.1269 = f32[128]{0:T(128)S(1)} parameter(0)
+  %div.732 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_0.1269), dimensions={1}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %param_1.1328 = f32[64]{0:T(128)S(1)} parameter(1)
+  %div.738 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_1.1328), dimensions={3}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
   %div.729 = f32[1,128,1,64]{3,1,2,0:T(8,128)} divide(%div.732, %div.738), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
   %sin.38 = f32[1,128,1,64]{3,1,2,0:T(8,128)} sine(%div.729), metadata={op_name="jit(train_step)/sin" stack_frame_id=0}
-  %convert_element_type.1257 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%sin.38), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
+  %convert_element_type.1261 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%sin.38), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
   %cos.41.clone.1 = f32[1,128,1,64]{3,1,2,0:T(8,128)} cosine(%div.729), metadata={op_name="jit(train_step)/cos" stack_frame_id=0}
-  %convert_element_type.1256.clone.1 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%cos.41.clone.1), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.167 = (bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert_element_type.1257, %convert_element_type.1256.clone.1)
+  %convert_element_type.1260.clone.1 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%cos.41.clone.1), metadata={op_name="jit(train_step)/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.166 = (bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert_element_type.1261, %convert_element_type.1260.clone.1)
 }
 
-%fused_computation.429 (param_0.1232: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
-  %param_0.1232 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+%fused_computation.430 (param_0.1240: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
+  %param_0.1240 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
   %constant.454.clone.2 = bf16[]{:T(256)} constant(-inf)
-  %pad.54 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1232, %constant.454.clone.2), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
-  %convert.372 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.54)
-  %pad.53 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1232, %constant.454.clone.2), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
-  %convert.373 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.53)
-  %maximum.46 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.372, %convert.373), metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  ROOT %convert.374 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%maximum.46)
+  %pad.54 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1240, %constant.454.clone.2), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %convert.373 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.54)
+  %pad.53 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1240, %constant.454.clone.2), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %convert.374 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.53)
+  %maximum.46 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.373, %convert.374), metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  ROOT %convert.375 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%maximum.46)
 }
 
-%fused_computation.430 (param_0.1234: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
-  %param_0.1234 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+%fused_computation.431 (param_0.1242: bf16[1,128,1,64]) -> bf16[1,128,1,128] {
+  %param_0.1242 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
   %constant.454.clone.1 = bf16[]{:T(256)} constant(-inf)
-  %pad.56 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1234, %constant.454.clone.1), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
-  %convert.375 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.56)
-  %pad.55 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1234, %constant.454.clone.1), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
-  %convert.376 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.55)
-  %maximum.47 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.375, %convert.376), metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  ROOT %convert.377 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%maximum.47)
+  %pad.56 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1242, %constant.454.clone.1), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %convert.376 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.56)
+  %pad.55 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1242, %constant.454.clone.1), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}
+  %convert.377 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.55)
+  %maximum.47 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.376, %convert.377), metadata={op_name="jit(train_step)/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  ROOT %convert.378 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%maximum.47)
 }
 
-%fused_computation.498 (param_0.1539: f32[128,4]) -> bf16[4,128] {
-  %param_0.1539 = f32[128,4]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.724 = f32[4,128]{1,0:T(4,128)} bitcast(%param_0.1539), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.283 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.724)
+%fused_computation.499 (param_0.1547: f32[128,4]) -> bf16[4,128] {
+  %param_0.1547 = f32[128,4]{0,1:T(4,128)S(1)} parameter(0)
+  %bitcast.739 = f32[4,128]{1,0:T(4,128)} bitcast(%param_0.1547), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.284 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.739)
 }
 
-%fused_computation.497 (param_0.1537: f32[2048,4]) -> bf16[4,2048] {
-  %param_0.1537 = f32[2048,4]{0,1:T(4,128)S(1)} parameter(0)
-  %bitcast.722 = f32[4,2048]{1,0:T(4,128)} bitcast(%param_0.1537), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
-  ROOT %convert.281 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.722)
+%fused_computation.498 (param_0.1545: f32[2048,4]) -> bf16[4,2048] {
+  %param_0.1545 = f32[2048,4]{0,1:T(4,128)S(1)} parameter(0)
+  %bitcast.737 = f32[4,2048]{1,0:T(4,128)} bitcast(%param_0.1545), metadata={op_name="jit(train_step)/jvp()/transpose" stack_frame_id=0}
+  ROOT %convert.282 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} convert(%bitcast.737)
 }
 
-%fused_computation.64.clone.1 (param_0.1831: bf16[4,1,128,2048], param_1.1908: s32[], param_2.1453: bf16[1,128,2048]) -> bf16[4,1,128,2048] {
-  %param_0.1831 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_2.1453 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %bitcast.959 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.1453), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/broadcast_in_dim" stack_frame_id=0}
-  %param_1.1908 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.64.clone.1 (param_0.1841: bf16[4,1,128,2048], param_1.1914: s32[], param_2.1458: bf16[1,128,2048]) -> bf16[4,1,128,2048] {
+  %param_0.1841 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_2.1458 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %bitcast.980 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_2.1458), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/broadcast_in_dim" stack_frame_id=0}
+  %param_1.1914 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.35 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-update-slice.32 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.1831, %bitcast.959, %param_1.1908, %constant.404.clone.35, %constant.404.clone.35, /*index=5*/%constant.404.clone.35), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-update-slice.32 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-update-slice(%param_0.1841, %bitcast.980, %param_1.1914, %constant.404.clone.35, %constant.404.clone.35, /*index=5*/%constant.404.clone.35), metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.22.clone.1 (param_0.1856: bf16[4,16,128,512], param_1.1924: s32[]) -> bf16[1,16,128,512] {
-  %param_0.1856 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1924 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.22.clone.1 (param_0.1866: bf16[4,16,128,512], param_1.1930: s32[]) -> bf16[1,16,128,512] {
+  %param_0.1866 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %param_1.1930 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.41 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.210 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1856, %param_1.1924, %constant.404.clone.41, %constant.404.clone.41, %constant.404.clone.41), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.210 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1866, %param_1.1930, %constant.404.clone.41, %constant.404.clone.41, %constant.404.clone.41), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.23.clone.1 (param_0.1848: bf16[4,512,16,128], param_1.1919: s32[]) -> bf16[1,512,16,128] {
-  %param_0.1848 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %param_1.1919 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.23.clone.1 (param_0.1858: bf16[4,512,16,128], param_1.1925: s32[]) -> bf16[1,512,16,128] {
+  %param_0.1858 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1925 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.40 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.209 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1848, %param_1.1919, %constant.404.clone.40, %constant.404.clone.40, %constant.404.clone.40), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.209 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1858, %param_1.1925, %constant.404.clone.40, %constant.404.clone.40, %constant.404.clone.40), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %region_2.3 (reduce_sum.143: f32[], reduce_sum.144: f32[]) -> f32[] {
@@ -154,69 +154,69 @@ StackFrames
   ROOT %reduce_sum.145 = f32[]{:T(128)} add(%reduce_sum.143, %reduce_sum.144), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.40.clone.1 (param_0.1833: bf16[1,128,2048]) -> f32[128] {
-  %param_0.1833 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1440 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1833), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.285 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1440, %convert_element_type.1440), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+%fused_computation.40.clone.1 (param_0.1843: bf16[1,128,2048]) -> f32[128] {
+  %param_0.1843 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1450 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1843), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.285 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1450, %convert_element_type.1450), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
   %constant.405.clone.13 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.276 = f32[128]{0:T(128)S(1)} reduce(%square.285, %constant.405.clone.13), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.275 = f32[128]{0:T(128)S(1)} reduce(%square.285, %constant.405.clone.13), dimensions={0,2}, to_apply=%region_2.3, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.85.clone.1 (param_0.1834: f32[128]) -> f32[128] {
-  %param_0.1834 = f32[128]{0:T(128)S(1)} parameter(0)
+%fused_computation.85.clone.1 (param_0.1844: f32[128]) -> f32[128] {
+  %param_0.1844 = f32[128]{0:T(128)S(1)} parameter(0)
   %constant.406.clone.9 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.1087 = f32[128]{0:T(128)} broadcast(%constant.406.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.1030 = f32[128]{0:T(128)} multiply(%param_0.1834, %broadcast.1087), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %broadcast.1088 = f32[128]{0:T(128)} broadcast(%constant.406.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.1030 = f32[128]{0:T(128)} multiply(%param_0.1844, %broadcast.1088), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
   %constant.407.clone.13 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1086 = f32[128]{0:T(128)} broadcast(%constant.407.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.1061 = f32[128]{0:T(128)} add(%div.1030, %broadcast.1086), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %broadcast.1087 = f32[128]{0:T(128)} broadcast(%constant.407.clone.13), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.1061 = f32[128]{0:T(128)} add(%div.1030, %broadcast.1087), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
   ROOT %rsqrt.222 = f32[128]{0:T(128)S(1)} rsqrt(%add.1061), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%convert_element_type.932.reduce_sub_computation (lhs.3: bf16[], rhs.3: bf16[]) -> bf16[] {
+%convert_element_type.938.reduce_sub_computation (lhs.3: bf16[], rhs.3: bf16[]) -> bf16[] {
   %lhs.3 = bf16[] parameter(0)
   %rhs.3 = bf16[] parameter(1)
   ROOT %add.795 = bf16[] add(%lhs.3, %rhs.3), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%convert_element_type.920.reduce_sub_computation (lhs.2: bf16[], rhs.2: bf16[]) -> bf16[] {
+%convert_element_type.926.reduce_sub_computation (lhs.2: bf16[], rhs.2: bf16[]) -> bf16[] {
   %lhs.2 = bf16[] parameter(0)
   %rhs.2 = bf16[] parameter(1)
   ROOT %add.794 = bf16[] add(%lhs.2, %rhs.2), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.75.clone.1 (param_0.1832: bf16[4,2048], param_1.1909: s32[], param_2.1454: bf16[4,2048]) -> (bf16[2048], bf16[2048]) {
-  %param_0.1832 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} parameter(0)
-  %param_1.1909 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.75.clone.1 (param_0.1842: bf16[4,2048], param_1.1915: s32[], param_2.1459: bf16[4,2048]) -> (bf16[2048], bf16[2048]) {
+  %param_0.1842 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} parameter(0)
+  %param_1.1915 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.36 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.203 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1832, %param_1.1909, %constant.404.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %constant.1122 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %reduce.275 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.203, %constant.1122), dimensions={0}, to_apply=%convert_element_type.932.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_2.1454 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} parameter(2)
-  %dynamic_slice.174.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1454, %param_1.1909, %constant.404.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %reduce.181.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.174.clone.3, %constant.1122), dimensions={0}, to_apply=%convert_element_type.920.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.240 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) tuple(%reduce.275, %reduce.181.clone.3)
+  %dynamic_slice.203 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1842, %param_1.1915, %constant.404.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1123 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %reduce.274 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.203, %constant.1123), dimensions={0}, to_apply=%convert_element_type.938.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_2.1459 = bf16[4,2048]{1,0:T(4,128)(2,1)S(1)} parameter(2)
+  %dynamic_slice.174.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1459, %param_1.1915, %constant.404.clone.36), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %reduce.180.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.174.clone.3, %constant.1123), dimensions={0}, to_apply=%convert_element_type.926.reduce_sub_computation, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.237 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) tuple(%reduce.274, %reduce.180.clone.3)
 }
 
-%fused_computation.57.clone.2.clone.clone.clone.1 (param_0.1850: bf16[1,128,2048], param_1.1920: f32[128], param_2.1462: bf16[2048]) -> bf16[128,2048,1] {
-  %param_2.1462 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.644 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1462), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.547 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.644)
-  %param_0.1850 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1448 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1850), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.1920 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2414 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1920), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.2413 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1448, %mul.2414), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.1447 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2413), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.548 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1447)
-  %dot_general.643 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.547, %convert.548), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.549 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.643)
-  ROOT %bitcast.968 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.549)
+%fused_computation.57.clone.2.clone.clone.clone.1 (param_0.1860: bf16[1,128,2048], param_1.1926: f32[128], param_2.1467: bf16[2048]) -> bf16[128,2048,1] {
+  %param_2.1467 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.636 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1467), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.549 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.636)
+  %param_0.1860 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1458 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1860), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.1926 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2416 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1926), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.2415 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1458, %mul.2416), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.1457 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2415), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.550 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1457)
+  %dot_general.635 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.549, %convert.550), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.551 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.635)
+  ROOT %bitcast.989 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.551)
 }
 
-%fused_computation.17.clone.clone.clone.clone.clone.1 (param_0.1849: bf16[1,2048,16,128]) -> bf16[2048,16,128] {
-  %param_0.1849 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.967 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1849), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.17.clone.clone.clone.clone.clone.1 (param_0.1859: bf16[1,2048,16,128]) -> bf16[2048,16,128] {
+  %param_0.1859 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.988 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1859), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
 %region_3.4 (reduce_sum.146: f32[], reduce_sum.150: f32[]) -> f32[] {
@@ -225,133 +225,133 @@ StackFrames
   ROOT %reduce_sum.151 = f32[]{:T(128)} add(%reduce_sum.146, %reduce_sum.150), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.44.clone.1 (param_0.1851: bf16[1,2048,16,128], param_1.1921: bf16[1,128,2048], param_2.1463: f32[128], param_3.961: bf16[2048]) -> (f32[128,16], bf16[1,128,16,128]) {
-  %param_1.1921 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.1463 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.961 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
-  %fusion.93.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1921, %param_2.1463, %param_3.961), kind=kLoop, calls=%fused_computation.57.clone.2.clone.clone.clone.1
-  %param_0.1851 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.61.clone.3 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1851), kind=kLoop, calls=%fused_computation.17.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.44.clone.1 (param_0.1861: bf16[1,2048,16,128], param_1.1927: bf16[1,128,2048], param_2.1468: f32[128], param_3.965: bf16[2048]) -> (f32[128,16], bf16[1,128,16,128]) {
+  %param_1.1927 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.1468 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.965 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
+  %fusion.93.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1927, %param_2.1468, %param_3.965), kind=kLoop, calls=%fused_computation.57.clone.2.clone.clone.clone.1
+  %param_0.1861 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.61.clone.3 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1861), kind=kLoop, calls=%fused_computation.17.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
   %convolution.56.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.93.clone.3, %fusion.61.clone.3), window={size=16 pad=15_15 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %bitcast.260.clone.3 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.56.clone.3)
-  %convert.362 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%bitcast.260.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.287 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.362, %convert.362), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+  %bitcast.262.clone.3 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.56.clone.3)
+  %convert.363 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%bitcast.262.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.287 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.363, %convert.363), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
   %constant.405.clone.15 = f32[]{:T(128)} constant(0)
-  %reduce.278 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.287, %constant.405.clone.15), dimensions={0,3}, to_apply=%region_3.4, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.244 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%reduce.278, %bitcast.260.clone.3)
+  %reduce.277 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.287, %constant.405.clone.15), dimensions={0,3}, to_apply=%region_3.4, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.241 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%reduce.277, %bitcast.262.clone.3)
 }
 
-%fused_computation.74.clone.1 (param_0.1852: f32[128,16]) -> f32[128,16] {
-  %param_0.1852 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
+%fused_computation.74.clone.1 (param_0.1862: f32[128,16]) -> f32[128,16] {
+  %param_0.1862 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
   %constant.408.clone.10 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.1091 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.408.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %div.1032 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1852, %broadcast.1091), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %broadcast.1092 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.408.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %div.1032 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1862, %broadcast.1092), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
   %constant.407.clone.15 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1090 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.407.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  %add.1064 = f32[128,16]{0,1:T(8,128)} add(%div.1032, %broadcast.1090), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %broadcast.1091 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.407.clone.15), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %add.1064 = f32[128,16]{0,1:T(8,128)} add(%div.1032, %broadcast.1091), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
   ROOT %rsqrt.224 = f32[128,16]{0,1:T(8,128)S(1)} rsqrt(%add.1064), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.81.clone.1 (param_0.1839: bf16[4,128], param_1.1913: s32[], param_2.1457: bf16[4,128]) -> (bf16[128], bf16[128]) {
-  %param_0.1839 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(0)
-  %param_1.1913 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.81.clone.1 (param_0.1849: bf16[4,128], param_1.1919: s32[], param_2.1462: bf16[4,128]) -> (bf16[128], bf16[128]) {
+  %param_0.1849 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(0)
+  %param_1.1919 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.38 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.204 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1839, %param_1.1913, %constant.404.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.963 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.204), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_2.1457 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(2)
-  %dynamic_slice.184.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1457, %param_1.1913, %constant.404.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.283.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.184.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.241 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) tuple(%bitcast.963, %bitcast.283.clone.3)
+  %dynamic_slice.204 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1849, %param_1.1919, %constant.404.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.984 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.204), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_2.1462 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(2)
+  %dynamic_slice.184.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1462, %param_1.1919, %constant.404.clone.38), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.285.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.184.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.238 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) tuple(%bitcast.984, %bitcast.285.clone.3)
 }
 
-%fused_computation.53.clone.2 (param_0.1853: bf16[1,128,16,128], param_1.1922: f32[128,16], param_2.1464: bf16[128]) -> bf16[1,128,16,128] {
-  %param_2.1464 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
-  %dot_general.646 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1464), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.560 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.646)
-  %param_0.1853 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.363 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%param_0.1853), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.1922 = f32[128,16]{0,1:T(8,128)S(1)} parameter(1)
-  %mul.2416 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1922), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.2415 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.363, %mul.2416), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.1449 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2415), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.561 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1449)
-  %dot_general.645 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.560, %convert.561), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  ROOT %convert.562 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.645)
+%fused_computation.53.clone.2 (param_0.1863: bf16[1,128,16,128], param_1.1928: f32[128,16], param_2.1469: bf16[128]) -> bf16[1,128,16,128] {
+  %param_2.1469 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
+  %dot_general.638 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1469), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.562 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.638)
+  %param_0.1863 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.364 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%param_0.1863), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.1928 = f32[128,16]{0,1:T(8,128)S(1)} parameter(1)
+  %mul.2418 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1928), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.2417 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.364, %mul.2418), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.1459 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2417), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.563 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1459)
+  %dot_general.637 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.562, %convert.563), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  ROOT %convert.564 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.637)
 }
 
-%fused_computation.58.clone.1 (param_0.1854: bf16[1,128,16,128]) -> (bf16[1,128,16,64], bf16[1,128,16,64]) {
-  %param_0.1854 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.82 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1854), slice={[0:1], [0:128], [0:16], [64:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  %convert.563 = f32[1,128,16,64]{3,1,2,0:T(8,128)} convert(%slice.82)
-  %neg.134 = f32[1,128,16,64]{3,1,2,0:T(8,128)} negate(%convert.563), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.564 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.134)
-  %slice.83 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1854), slice={[0:1], [0:128], [0:16], [0:64]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  ROOT %tuple.245 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.564, %slice.83)
+%fused_computation.58.clone.1 (param_0.1864: bf16[1,128,16,128]) -> (bf16[1,128,16,64], bf16[1,128,16,64]) {
+  %param_0.1864 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.82 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1864), slice={[0:1], [0:128], [0:16], [64:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  %convert.565 = f32[1,128,16,64]{3,1,2,0:T(8,128)} convert(%slice.82)
+  %neg.134 = f32[1,128,16,64]{3,1,2,0:T(8,128)} negate(%convert.565), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.566 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.134)
+  %slice.83 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1864), slice={[0:1], [0:128], [0:16], [0:64]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  ROOT %tuple.242 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.566, %slice.83)
 }
 
-%fused_computation.62.clone.1 (param_0.1855: bf16[1,128,16,64], param_1.1923: bf16[1,128,16,64], param_2.1465: bf16[128,128], param_3.962: bf16[128,128], param_4.574: f32[128,16], param_5.498: bf16[1,128,16,128], param_6.348: bf16[128]) -> bf16[16,128,128] {
-  %param_6.348 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
-  %dot_general.648 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.348), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.565 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.648)
-  %param_5.498 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
-  %convert.364 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%param_5.498), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_4.574 = f32[128,16]{0,1:T(8,128)S(1)} parameter(4)
-  %mul.2424 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_4.574), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.2423 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.364, %mul.2424), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.1450 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2423), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.566 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1450)
-  %dot_general.647 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.565, %convert.566), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_3.962 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %mul.2421 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.962), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.567 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2421)
-  %mul.2419 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%dot_general.647, %convert.567), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_1.1923 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1124 = bf16[]{:T(256)} constant(-inf)
-  %pad.85 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1923, %constant.1124), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.568 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.85)
-  %param_0.1855 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.84 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1855, %constant.1124), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.569 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.84)
-  %maximum.61 = f32[1,128,16,128]{3,1,2,0:T(8,128)} maximum(%convert.568, %convert.569), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_2.1465 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %mul.2420 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1465), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.570 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2420)
-  %mul.2418 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%maximum.61, %convert.570), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %add.1065 = f32[1,128,16,128]{3,1,2,0:T(8,128)} add(%mul.2419, %mul.2418), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+%fused_computation.62.clone.1 (param_0.1865: bf16[1,128,16,64], param_1.1929: bf16[1,128,16,64], param_2.1470: bf16[128,128], param_3.966: bf16[128,128], param_4.570: f32[128,16], param_5.492: bf16[1,128,16,128], param_6.342: bf16[128]) -> bf16[16,128,128] {
+  %param_6.342 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
+  %dot_general.640 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.342), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.567 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.640)
+  %param_5.492 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
+  %convert.365 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%param_5.492), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_4.570 = f32[128,16]{0,1:T(8,128)S(1)} parameter(4)
+  %mul.2426 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_4.570), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.2425 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.365, %mul.2426), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.1460 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2425), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.568 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1460)
+  %dot_general.639 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.567, %convert.568), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_3.966 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %mul.2423 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.966), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.569 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2423)
+  %mul.2421 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%dot_general.639, %convert.569), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_1.1929 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1125 = bf16[]{:T(256)} constant(-inf)
+  %pad.85 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1929, %constant.1125), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.570 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.85)
+  %param_0.1865 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.84 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1865, %constant.1125), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.571 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.84)
+  %maximum.61 = f32[1,128,16,128]{3,1,2,0:T(8,128)} maximum(%convert.570, %convert.571), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_2.1470 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %mul.2422 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1470), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.572 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2422)
+  %mul.2420 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%maximum.61, %convert.572), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %add.1065 = f32[1,128,16,128]{3,1,2,0:T(8,128)} add(%mul.2421, %mul.2420), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %constant.409.clone.7 = bf16[]{:T(256)} constant(0.08838)
-  %mul.2422 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.409.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.571 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2422)
-  %mul.2417 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%add.1065, %convert.571), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.572 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2417)
-  ROOT %bitcast.969 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.572), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %mul.2424 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.409.clone.7), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.573 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2424)
+  %mul.2419 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%add.1065, %convert.573), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.574 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2419)
+  ROOT %bitcast.990 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.574), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.29.clone.1 (param_0.1840: bf16[4,512,8,128], param_1.1914: s32[]) -> bf16[1,512,8,128] {
-  %param_0.1840 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1914 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.29.clone.1 (param_0.1850: bf16[4,512,8,128], param_1.1920: s32[]) -> bf16[1,512,8,128] {
+  %param_0.1850 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1920 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.39 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.208 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1840, %param_1.1914, %constant.404.clone.39, %constant.404.clone.39, %constant.404.clone.39), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.208 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1850, %param_1.1920, %constant.404.clone.39, %constant.404.clone.39, %constant.404.clone.39), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.57.clone.1.clone.clone.clone.1 (param_0.1842: bf16[1,128,2048], param_1.1915: f32[128], param_2.1458: bf16[2048]) -> bf16[128,2048,1] {
-  %param_2.1458 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.638 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1458), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.544 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.638)
-  %param_0.1842 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1444 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1842), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.1915 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2404 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1915), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.2403 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1444, %mul.2404), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.1443 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2403), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.545 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1443)
-  %dot_general.637 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.544, %convert.545), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.546 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.637)
-  ROOT %bitcast.965 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.546)
+%fused_computation.57.clone.1.clone.clone.clone.1 (param_0.1852: bf16[1,128,2048], param_1.1921: f32[128], param_2.1463: bf16[2048]) -> bf16[128,2048,1] {
+  %param_2.1463 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.630 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1463), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.546 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.630)
+  %param_0.1852 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1454 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1852), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.1921 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2406 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1921), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.2405 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1454, %mul.2406), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.1453 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2405), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.547 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1453)
+  %dot_general.629 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.546, %convert.547), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.548 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.629)
+  ROOT %bitcast.986 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.548)
 }
 
-%fused_computation.21.clone.clone.clone.clone.clone.1 (param_0.1841: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
-  %param_0.1841 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.964 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1841), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.21.clone.clone.clone.clone.clone.1 (param_0.1851: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
+  %param_0.1851 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.985 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1851), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
 %region_4.5 (reduce_sum.152: f32[], reduce_sum.153: f32[]) -> f32[] {
@@ -360,138 +360,138 @@ StackFrames
   ROOT %reduce_sum.157 = f32[]{:T(128)} add(%reduce_sum.152, %reduce_sum.153), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.51.clone.1 (param_0.1843: bf16[1,2048,8,128], param_1.1916: bf16[1,128,2048], param_2.1459: f32[128], param_3.959: bf16[2048]) -> (f32[128,8], bf16[1,128,8,128]) {
-  %param_1.1916 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.1459 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.959 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
-  %fusion.92.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1916, %param_2.1459, %param_3.959), kind=kLoop, calls=%fused_computation.57.clone.1.clone.clone.clone.1
-  %param_0.1843 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.64.clone.3 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1843), kind=kLoop, calls=%fused_computation.21.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.51.clone.1 (param_0.1853: bf16[1,2048,8,128], param_1.1922: bf16[1,128,2048], param_2.1464: f32[128], param_3.963: bf16[2048]) -> (f32[128,8], bf16[1,128,8,128]) {
+  %param_1.1922 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.1464 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.963 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
+  %fusion.92.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1922, %param_2.1464, %param_3.963), kind=kLoop, calls=%fused_computation.57.clone.1.clone.clone.clone.1
+  %param_0.1853 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.64.clone.3 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1853), kind=kLoop, calls=%fused_computation.21.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
   %convolution.58.clone.3 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.92.clone.3, %fusion.64.clone.3), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %bitcast.263.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.58.clone.3)
-  %convert.359 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%bitcast.263.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.286 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.359, %convert.359), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+  %bitcast.265.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.58.clone.3)
+  %convert.360 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%bitcast.265.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.286 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.360, %convert.360), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
   %constant.405.clone.14 = f32[]{:T(128)} constant(0)
-  %reduce.277 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.286, %constant.405.clone.14), dimensions={0,3}, to_apply=%region_4.5, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.242 = (f32[128,8]{0,1:T(8,128)S(1)}, bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%reduce.277, %bitcast.263.clone.3)
+  %reduce.276 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.286, %constant.405.clone.14), dimensions={0,3}, to_apply=%region_4.5, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.239 = (f32[128,8]{0,1:T(8,128)S(1)}, bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%reduce.276, %bitcast.265.clone.3)
 }
 
-%fused_computation.77.clone.1 (param_0.1844: f32[128,8]) -> f32[128,8] {
-  %param_0.1844 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
+%fused_computation.77.clone.1 (param_0.1854: f32[128,8]) -> f32[128,8] {
+  %param_0.1854 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
   %constant.408.clone.9 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.1089 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.408.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
-  %div.1031 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1844, %broadcast.1089), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %broadcast.1090 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.408.clone.9), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %div.1031 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1854, %broadcast.1090), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
   %constant.407.clone.14 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1088 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.407.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
-  %add.1062 = f32[128,8]{0,1:T(8,128)} add(%div.1031, %broadcast.1088), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %broadcast.1089 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.407.clone.14), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %add.1062 = f32[128,8]{0,1:T(8,128)} add(%div.1031, %broadcast.1089), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
   ROOT %rsqrt.223 = f32[128,8]{0,1:T(8,128)S(1)} rsqrt(%add.1062), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.67.clone.2 (param_0.1845: bf16[1,128,8,128], param_1.1917: f32[128,8], param_2.1460: bf16[128]) -> bf16[1,128,8,128] {
-  %param_2.1460 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
-  %dot_general.640 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1460), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.573 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.640)
-  %param_0.1845 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.360 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_0.1845), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.1917 = f32[128,8]{0,1:T(8,128)S(1)} parameter(1)
-  %mul.2406 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1917), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.2405 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.360, %mul.2406), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.1445 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2405), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.574 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1445)
-  %dot_general.639 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.573, %convert.574), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  ROOT %convert.575 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.639)
+%fused_computation.67.clone.2 (param_0.1855: bf16[1,128,8,128], param_1.1923: f32[128,8], param_2.1465: bf16[128]) -> bf16[1,128,8,128] {
+  %param_2.1465 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
+  %dot_general.632 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1465), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.575 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.632)
+  %param_0.1855 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.361 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_0.1855), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.1923 = f32[128,8]{0,1:T(8,128)S(1)} parameter(1)
+  %mul.2408 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1923), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.2407 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.361, %mul.2408), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.1455 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2407), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.576 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1455)
+  %dot_general.631 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.575, %convert.576), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  ROOT %convert.577 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.631)
 }
 
-%fused_computation.68.clone.1 (param_0.1846: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
-  %param_0.1846 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.80 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1846), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  %convert.576 = f32[1,128,8,64]{3,1,2,0:T(8,128)} convert(%slice.80)
-  %neg.133 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.576), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.577 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.133)
-  %slice.81 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1846), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
-  ROOT %tuple.243 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.577, %slice.81)
+%fused_computation.68.clone.1 (param_0.1856: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
+  %param_0.1856 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.80 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1856), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  %convert.578 = f32[1,128,8,64]{3,1,2,0:T(8,128)} convert(%slice.80)
+  %neg.133 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.578), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.579 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.133)
+  %slice.81 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1856), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/split" stack_frame_id=0}
+  ROOT %tuple.240 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.579, %slice.81)
 }
 
-%fused_computation.71.clone.1 (param_0.1847: bf16[1,128,8,64], param_1.1918: bf16[1,128,8,64], param_2.1461: bf16[128,128], param_3.960: bf16[128,128], param_4.573: f32[128,8], param_5.497: bf16[1,128,8,128], param_6.347: bf16[128]) -> bf16[8,128,128] {
-  %param_6.347 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
-  %dot_general.642 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.347), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.578 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.642)
-  %param_5.497 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
-  %convert.361 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_5.497), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_4.573 = f32[128,8]{0,1:T(8,128)S(1)} parameter(4)
-  %mul.2412 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_4.573), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.2411 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.361, %mul.2412), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.1446 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2411), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.579 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1446)
-  %dot_general.641 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.578, %convert.579), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_3.960 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %mul.2410 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.960), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.580 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2410)
-  %mul.2408 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%dot_general.641, %convert.580), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_1.1918 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1123 = bf16[]{:T(256)} constant(-inf)
-  %pad.83 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1918, %constant.1123), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.581 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.83)
-  %param_0.1847 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.82 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1847, %constant.1123), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
-  %convert.582 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.82)
-  %maximum.60 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.581, %convert.582), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_2.1461 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %mul.2409 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1461), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert.583 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2409)
-  %mul.2407 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%maximum.60, %convert.583), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %add.1063 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.2408, %mul.2407), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.584 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.1063)
-  ROOT %bitcast.966 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.584), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+%fused_computation.71.clone.1 (param_0.1857: bf16[1,128,8,64], param_1.1924: bf16[1,128,8,64], param_2.1466: bf16[128,128], param_3.964: bf16[128,128], param_4.569: f32[128,8], param_5.491: bf16[1,128,8,128], param_6.341: bf16[128]) -> bf16[8,128,128] {
+  %param_6.341 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
+  %dot_general.634 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.341), dimensions={3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.580 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.634)
+  %param_5.491 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
+  %convert.362 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_5.491), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_4.569 = f32[128,8]{0,1:T(8,128)S(1)} parameter(4)
+  %mul.2414 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_4.569), dimensions={1,2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.2413 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.362, %mul.2414), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.1456 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2413), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.581 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1456)
+  %dot_general.633 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.580, %convert.581), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_3.964 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %mul.2412 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.964), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.582 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2412)
+  %mul.2410 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%dot_general.633, %convert.582), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_1.1924 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1124 = bf16[]{:T(256)} constant(-inf)
+  %pad.83 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1924, %constant.1124), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.583 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.83)
+  %param_0.1857 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.82 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1857, %constant.1124), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}
+  %convert.584 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.82)
+  %maximum.60 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.583, %convert.584), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_2.1466 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %mul.2411 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1466), dimensions={1,3}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert.585 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2411)
+  %mul.2409 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%maximum.60, %convert.585), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %add.1063 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.2410, %mul.2409), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.586 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.1063)
+  ROOT %bitcast.987 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.586), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.28.clone.1 (param_0.1835: bf16[4,512,8,128], param_1.1910: s32[]) -> bf16[1,512,8,128] {
-  %param_0.1835 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1910 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.28.clone.1 (param_0.1845: bf16[4,512,8,128], param_1.1916: s32[]) -> bf16[1,512,8,128] {
+  %param_0.1845 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1916 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.37 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.207 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1835, %param_1.1910, %constant.404.clone.37, %constant.404.clone.37, %constant.404.clone.37), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.207 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1845, %param_1.1916, %constant.404.clone.37, %constant.404.clone.37, %constant.404.clone.37), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.57.clone.clone.1 (param_0.1837: bf16[1,128,2048], param_1.1911: f32[128], param_2.1455: bf16[2048]) -> bf16[128,2048,1] {
-  %param_2.1455 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.636 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1455), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.541 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.636)
-  %param_0.1837 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1442 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1837), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.1911 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2402 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1911), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.2401 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1442, %mul.2402), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.1441 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2401), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.542 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1441)
-  %dot_general.635 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.541, %convert.542), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.543 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.635)
-  ROOT %bitcast.961 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.543)
+%fused_computation.57.clone.clone.1 (param_0.1847: bf16[1,128,2048], param_1.1917: f32[128], param_2.1460: bf16[2048]) -> bf16[128,2048,1] {
+  %param_2.1460 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.628 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1460), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.543 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.628)
+  %param_0.1847 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1452 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1847), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.1917 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2404 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1917), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.2403 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1452, %mul.2404), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.1451 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2403), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.544 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1451)
+  %dot_general.627 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.543, %convert.544), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.545 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.627)
+  ROOT %bitcast.982 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.545)
 }
 
-%fused_computation.19.clone.clone.clone.1 (param_0.1836: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
-  %param_0.1836 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.960 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1836), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.19.clone.clone.clone.1 (param_0.1846: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
+  %param_0.1846 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.981 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1846), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.50.clone.1 (param_0.1838: bf16[1,2048,8,128], param_1.1912: bf16[1,128,2048], param_2.1456: f32[128], param_3.958: bf16[2048]) -> bf16[8,128,128] {
-  %param_1.1912 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.1456 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.958 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
-  %fusion.517 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1912, %param_2.1456, %param_3.958), kind=kLoop, calls=%fused_computation.57.clone.clone.1
-  %param_0.1838 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.516 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1838), kind=kLoop, calls=%fused_computation.19.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.148 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.517, %fusion.516), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  ROOT %bitcast.962 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.148), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+%fused_computation.50.clone.1 (param_0.1848: bf16[1,2048,8,128], param_1.1918: bf16[1,128,2048], param_2.1461: f32[128], param_3.962: bf16[2048]) -> bf16[8,128,128] {
+  %param_1.1918 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.1461 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.962 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
+  %fusion.526 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1918, %param_2.1461, %param_3.962), kind=kLoop, calls=%fused_computation.57.clone.clone.1
+  %param_0.1848 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.525 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1848), kind=kLoop, calls=%fused_computation.19.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.148 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.526, %fusion.525), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  ROOT %bitcast.983 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.148), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.63.clone.clone.clone.1 (param_0.1858: bf16[16,128,128]) -> bf16[128,16,128] {
-  %param_0.1858 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.971 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1858)
+%fused_computation.63.clone.clone.clone.1 (param_0.1868: bf16[16,128,128]) -> bf16[128,16,128] {
+  %param_0.1868 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.992 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1868)
 }
 
-%fused_computation.15.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1857: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
-  %param_0.1857 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.970 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1857), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.15.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1867: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
+  %param_0.1867 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.991 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1867), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
 %region_5.7 (reduce_sum.158: f32[], reduce_sum.159: f32[]) -> f32[] {
@@ -500,212 +500,212 @@ StackFrames
   ROOT %reduce_sum.160 = f32[]{:T(128)} add(%reduce_sum.158, %reduce_sum.159), metadata={op_name="reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.42.clone.1 (param_0.1859: bf16[1,128,2048], param_1.1925: bf16[1,16,128,2048], param_2.1466: bf16[16,128,128]) -> (f32[128], bf16[1,128,2048]) {
-  %param_0.1859 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.585 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1859)
-  %param_2.1466 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.81.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} fusion(%param_2.1466), kind=kLoop, calls=%fused_computation.63.clone.clone.clone.1
-  %param_1.1925 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.47.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_1.1925), kind=kLoop, calls=%fused_computation.15.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.42.clone.1 (param_0.1869: bf16[1,128,2048], param_1.1931: bf16[1,16,128,2048], param_2.1471: bf16[16,128,128]) -> (f32[128], bf16[1,128,2048]) {
+  %param_0.1869 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.587 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1869)
+  %param_2.1471 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.81.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} fusion(%param_2.1471), kind=kLoop, calls=%fused_computation.63.clone.clone.clone.1
+  %param_1.1931 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.47.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_1.1931), kind=kLoop, calls=%fused_computation.15.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
   %convolution.50.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.81.clone.3, %fusion.47.clone.3), window={size=16}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %bitcast.248.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.50.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %convert.586 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.248.clone.3)
-  %add.797.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.585, %convert.586), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.1451 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%add.797.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %square.288 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1451, %convert_element_type.1451), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
+  %bitcast.250.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.50.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %convert.588 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.250.clone.3)
+  %add.797.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.587, %convert.588), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.1461 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%add.797.clone.3), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %square.288 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1461, %convert_element_type.1461), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/square" stack_frame_id=0}
   %constant.405.clone.16 = f32[]{:T(128)} constant(0)
-  %reduce.279 = f32[128]{0:T(128)S(1)} reduce(%square.288, %constant.405.clone.16), dimensions={0,2}, to_apply=%region_5.7, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
-  %convert.587 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.797.clone.3)
-  ROOT %tuple.246 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.279, %convert.587)
+  %reduce.278 = f32[128]{0:T(128)S(1)} reduce(%square.288, %constant.405.clone.16), dimensions={0,2}, to_apply=%region_5.7, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}
+  %convert.589 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.797.clone.3)
+  ROOT %tuple.243 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.278, %convert.589)
 }
 
-%fused_computation.11.clone.1 (param_0.1866: bf16[4,6144,512], param_1.1930: s32[]) -> bf16[1,6144,512] {
-  %param_0.1866 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1930 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.11.clone.1 (param_0.1876: bf16[4,6144,512], param_1.1936: s32[]) -> bf16[1,6144,512] {
+  %param_0.1876 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1936 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.44 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.213 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1866, %param_1.1930, %constant.404.clone.44, %constant.404.clone.44), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.213 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1876, %param_1.1936, %constant.404.clone.44, %constant.404.clone.44), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.12.clone.1 (param_0.1865: bf16[4,512,6144], param_1.1929: s32[]) -> bf16[1,512,6144] {
-  %param_0.1865 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1929 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.12.clone.1 (param_0.1875: bf16[4,512,6144], param_1.1935: s32[]) -> bf16[1,512,6144] {
+  %param_0.1875 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1935 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.43 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.212 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1865, %param_1.1929, %constant.404.clone.43, %constant.404.clone.43), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.212 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1875, %param_1.1935, %constant.404.clone.43, %constant.404.clone.43), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.13.clone.1 (param_0.1861: bf16[4,512,6144], param_1.1926: s32[]) -> bf16[1,512,6144] {
-  %param_0.1861 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1926 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.13.clone.1 (param_0.1871: bf16[4,512,6144], param_1.1932: s32[]) -> bf16[1,512,6144] {
+  %param_0.1871 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1932 = s32[]{:T(128)S(6)} parameter(1)
   %constant.404.clone.42 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.211 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1861, %param_1.1926, %constant.404.clone.42, %constant.404.clone.42), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  ROOT %dynamic-slice.211 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1871, %param_1.1932, %constant.404.clone.42, %constant.404.clone.42), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.84.clone.1 (param_0.1860: f32[128]) -> f32[128] {
-  %param_0.1860 = f32[128]{0:T(128)S(1)} parameter(0)
+%fused_computation.84.clone.1 (param_0.1870: f32[128]) -> f32[128] {
+  %param_0.1870 = f32[128]{0:T(128)S(1)} parameter(0)
   %constant.406.clone.10 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.1093 = f32[128]{0:T(128)} broadcast(%constant.406.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.1033 = f32[128]{0:T(128)} multiply(%param_0.1860, %broadcast.1093), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
+  %broadcast.1094 = f32[128]{0:T(128)} broadcast(%constant.406.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.1033 = f32[128]{0:T(128)} multiply(%param_0.1870, %broadcast.1094), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/div" stack_frame_id=0}
   %constant.407.clone.16 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1092 = f32[128]{0:T(128)} broadcast(%constant.407.clone.16), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.1066 = f32[128]{0:T(128)} add(%div.1033, %broadcast.1092), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
+  %broadcast.1093 = f32[128]{0:T(128)} broadcast(%constant.407.clone.16), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.1066 = f32[128]{0:T(128)} add(%div.1033, %broadcast.1093), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}
   ROOT %rsqrt.225 = f32[128]{0:T(128)S(1)} rsqrt(%add.1066), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.55.clone.1.clone.1 (param_0.1863: bf16[1,128,2048], param_1.1927: f32[128], param_2.1467: bf16[2048]) -> bf16[128,2048] {
-  %param_2.1467 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.650 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1467), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.550 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.650)
-  %param_0.1863 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1453 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1863), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.1927 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2426 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1927), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.2425 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1453, %mul.2426), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.1452 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2425), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.551 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1452)
-  %dot_general.649 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.550, %convert.551), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.552 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.649)
-  ROOT %bitcast.973 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.552)
+%fused_computation.55.clone.1.clone.1 (param_0.1873: bf16[1,128,2048], param_1.1933: f32[128], param_2.1472: bf16[2048]) -> bf16[128,2048] {
+  %param_2.1472 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.642 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1472), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.552 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.642)
+  %param_0.1873 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1463 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1873), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.1933 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2428 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1933), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.2427 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1463, %mul.2428), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.1462 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2427), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.553 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1462)
+  %dot_general.641 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.552, %convert.553), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.554 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.641)
+  ROOT %bitcast.994 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.554)
 }
 
-%fused_computation.10.clone.clone.clone.1 (param_0.1862: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1862 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.972 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1862), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.10.clone.clone.clone.1 (param_0.1872: bf16[1,2048,6144]) -> bf16[2048,6144] {
+  %param_0.1872 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.993 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1872), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.24.clone.1 (param_0.1864: bf16[1,2048,6144], param_1.1928: bf16[1,128,2048], param_2.1468: f32[128], param_3.963: bf16[2048]) -> bf16[1,128,6144] {
-  %param_1.1928 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.1468 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.963 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
-  %fusion.519 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1928, %param_2.1468, %param_3.963), kind=kLoop, calls=%fused_computation.55.clone.1.clone.1
-  %param_0.1864 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.518 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1864), kind=kLoop, calls=%fused_computation.10.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.149 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.519, %fusion.518), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  ROOT %bitcast.974 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.149), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+%fused_computation.24.clone.1 (param_0.1874: bf16[1,2048,6144], param_1.1934: bf16[1,128,2048], param_2.1473: f32[128], param_3.967: bf16[2048]) -> bf16[1,128,6144] {
+  %param_1.1934 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.1473 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.967 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(3)
+  %fusion.528 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1934, %param_2.1473, %param_3.967), kind=kLoop, calls=%fused_computation.55.clone.1.clone.1
+  %param_0.1874 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.527 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1874), kind=kLoop, calls=%fused_computation.10.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.149 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.528, %fusion.527), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  ROOT %bitcast.995 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.149), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.55.clone.clone.clone.1 (param_0.1869: bf16[1,128,2048], param_1.1931: f32[128], param_2.1469: bf16[2048]) -> bf16[128,2048] {
-  %param_2.1469 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.652 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1469), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.553 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.652)
-  %param_0.1869 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1455 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1869), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %param_1.1931 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2428 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1931), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %mul.2427 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1455, %mul.2428), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
-  %convert_element_type.1454 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2427), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convert.554 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1454)
-  %dot_general.651 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.553, %convert.554), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.555 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.651)
-  ROOT %bitcast.977 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.555)
+%fused_computation.55.clone.clone.clone.1 (param_0.1879: bf16[1,128,2048], param_1.1937: f32[128], param_2.1474: bf16[2048]) -> bf16[128,2048] {
+  %param_2.1474 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.644 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1474), dimensions={2}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.555 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.644)
+  %param_0.1879 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1465 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1879), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %param_1.1937 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2430 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1937), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %mul.2429 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1465, %mul.2430), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}
+  %convert_element_type.1464 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2429), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convert.556 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1464)
+  %dot_general.643 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.555, %convert.556), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.557 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.643)
+  ROOT %bitcast.998 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.557)
 }
 
-%fused_computation.8.clone.clone.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1868: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1868 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.976 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1868), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.8.clone.clone.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1878: bf16[1,2048,6144]) -> bf16[2048,6144] {
+  %param_0.1878 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
+  ROOT %bitcast.997 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1878), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.27.clone.clone.clone.1 (param_0.1870: bf16[1,2048,6144], param_1.1932: bf16[1,128,6144], param_2.1470: bf16[1,128,2048], param_3.964: f32[128], param_4.575: bf16[2048]) -> bf16[128,6144] {
-  %param_1.1932 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.556 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1932)
+%fused_computation.27.clone.clone.clone.1 (param_0.1880: bf16[1,2048,6144], param_1.1938: bf16[1,128,6144], param_2.1475: bf16[1,128,2048], param_3.968: f32[128], param_4.571: bf16[2048]) -> bf16[128,6144] {
+  %param_1.1938 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.558 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1938)
   %constant.410.clone.10 = bf16[]{:T(256)} constant(1)
   %jit_silu_.46 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.410.clone.10), dimensions={}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)" stack_frame_id=0}
-  %convert.557 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.46)
-  %neg.135 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.556), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.559 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.46)
+  %neg.135 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.558), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %exp.79 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.135), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %add.1067 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.79, %convert.557), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %div.1034 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.557, %add.1067), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2430 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.556, %div.1034), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %param_2.1470 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.964 = f32[128]{0:T(128)S(1)} parameter(3)
-  %param_4.575 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(4)
-  %fusion.521 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_2.1470, %param_3.964, %param_4.575), kind=kLoop, calls=%fused_computation.55.clone.clone.clone.1
-  %param_0.1870 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %fusion.520 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1870), kind=kLoop, calls=%fused_computation.8.clone.clone.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.150 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.521, %fusion.520), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %bitcast.979 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.150), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %convert.558 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%bitcast.979)
-  %mul.2429 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2430, %convert.558), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.559 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2429)
-  ROOT %bitcast.978 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.559)
+  %add.1067 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.79, %convert.559), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %div.1034 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.559, %add.1067), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2432 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.558, %div.1034), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %param_2.1475 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.968 = f32[128]{0:T(128)S(1)} parameter(3)
+  %param_4.571 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(4)
+  %fusion.530 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_2.1475, %param_3.968, %param_4.571), kind=kLoop, calls=%fused_computation.55.clone.clone.clone.1
+  %param_0.1880 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %fusion.529 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1880), kind=kLoop, calls=%fused_computation.8.clone.clone.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.150 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.530, %fusion.529), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %bitcast.1000 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.150), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %convert.560 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%bitcast.1000)
+  %mul.2431 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2432, %convert.560), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.561 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2431)
+  ROOT %bitcast.999 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.561)
 }
 
-%fused_computation.6.clone.clone.clone.clone.clone.1 (param_0.1867: bf16[1,6144,2048]) -> bf16[6144,2048] {
-  %param_0.1867 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.975 = bf16[6144,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1867), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+%fused_computation.6.clone.clone.clone.clone.clone.1 (param_0.1877: bf16[1,6144,2048]) -> bf16[6144,2048] {
+  %param_0.1877 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.996 = bf16[6144,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1877), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.39.clone.1 (param_0.1871: bf16[1,128,2048], param_1.1933: bf16[1,6144,2048], param_2.1471: bf16[1,2048,6144], param_3.965: bf16[1,128,6144], param_4.576: f32[128], param_5.499: bf16[2048]) -> bf16[1,128,2048] {
-  %param_0.1871 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.588 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1871)
-  %param_2.1471 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} parameter(2)
-  %param_3.965 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %param_4.576 = f32[128]{0:T(128)S(1)} parameter(4)
-  %param_5.499 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(5)
-  %fusion.36.clone.3 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_2.1471, %param_3.965, %param_0.1871, %param_4.576, %param_5.499), kind=kOutput, calls=%fused_computation.27.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %param_1.1933 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.522 = bf16[6144,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1933), kind=kLoop, calls=%fused_computation.6.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
-  %convolution.151 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.36.clone.3, %fusion.522), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %bitcast.980 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.151), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
-  %convert.589 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.980)
-  %add.1068 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.588, %convert.589), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  ROOT %convert.590 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.1068)
+%fused_computation.39.clone.1 (param_0.1881: bf16[1,128,2048], param_1.1939: bf16[1,6144,2048], param_2.1476: bf16[1,2048,6144], param_3.969: bf16[1,128,6144], param_4.572: f32[128], param_5.493: bf16[2048]) -> bf16[1,128,2048] {
+  %param_0.1881 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.590 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1881)
+  %param_2.1476 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} parameter(2)
+  %param_3.969 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_4.572 = f32[128]{0:T(128)S(1)} parameter(4)
+  %param_5.493 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(5)
+  %fusion.36.clone.3 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_2.1476, %param_3.969, %param_0.1881, %param_4.572, %param_5.493), kind=kOutput, calls=%fused_computation.27.clone.clone.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %param_1.1939 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.531 = bf16[6144,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1939), kind=kLoop, calls=%fused_computation.6.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}
+  %convolution.151 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.36.clone.3, %fusion.531), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %bitcast.1001 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.151), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}
+  %convert.591 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.1001)
+  %add.1068 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.590, %convert.591), metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  ROOT %convert.592 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.1068)
 }
 
 %wide.region_1.8_spmd.sunk.clone.clone.clone.sunk (wide.param.1: (s32[], bf16[1,128,2048], bf16[4,1,128,2048], bf16[4,128], bf16[4,2048], /*index=5*/bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,128], bf16[4,512,8,128], /*index=10*/bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], bf16[4,512,6144], bf16[4,512,6144], /*index=15*/bf16[4,6144,512], s32[128], s32[], s8[1,1,1], s8[1,1,1])) -> (s32[], bf16[1,128,2048], bf16[4,1,128,2048], bf16[4,128], bf16[4,2048], /*index=5*/bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,128], bf16[4,512,8,128], /*index=10*/bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], bf16[4,512,6144], bf16[4,512,6144], /*index=15*/bf16[4,6144,512], s32[128], s32[], s8[1,1,1], s8[1,1,1]) {
   %constant.460.clone..sunk.1 = s32[]{:T(128)} constant(1)
-  %wide.param.1 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) parameter(0)
-  %copy.248 = s32[]{:T(128)S(6)} copy(%wide.param.1#0), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add.1069 = s32[]{:T(128)} add(%copy.248, %constant.460.clone..sunk.1), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast_dynamic-update-slice_fusion.2 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} fusion(%wide.param.1#2, %copy.248, %wide.param.1#1), kind=kLoop, calls=%fused_computation.64.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
-  %dynamic-slice_convert_fusion.35 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#11, %copy.248), kind=kLoop, calls=%fused_computation.22.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %wide.param.1 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) parameter(0)
+  %copy.256 = s32[]{:T(128)S(6)} copy(%wide.param.1#0), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add.1069 = s32[]{:T(128)} add(%copy.256, %constant.460.clone..sunk.1), metadata={op_name="jit(train_step)/jvp()/while/body/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast_dynamic-update-slice_fusion.2 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)} fusion(%wide.param.1#2, %copy.256, %wide.param.1#1), kind=kLoop, calls=%fused_computation.64.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/jit(dynamic_update_index_in_dim)/dynamic_update_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["0","3"]}]}}
+  %dynamic-slice_convert_fusion.35 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#11, %copy.256), kind=kLoop, calls=%fused_computation.22.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.97 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.35), channel_id=101, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={3}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.36 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#5, %copy.248), kind=kLoop, calls=%fused_computation.23.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.36 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#5, %copy.256), kind=kLoop, calls=%fused_computation.23.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.98 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.36), channel_id=98, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.523 = f32[128]{0:T(128)S(1)} fusion(%wide.param.1#1), kind=kLoop, calls=%fused_computation.40.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add_rsqrt_fusion.8 = f32[128]{0:T(128)S(1)} fusion(%fusion.523), kind=kLoop, calls=%fused_computation.85.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %convert_reduce_fusion.7 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) fusion(%wide.param.1#12, %copy.248, %wide.param.1#4), kind=kLoop, calls=%fused_computation.75.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
-  %fusion.524 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%all-gather.98, %wide.param.1#1, %add_rsqrt_fusion.8, %convert_reduce_fusion.7#1), kind=kOutput, calls=%fused_computation.44.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add_rsqrt_fusion.9 = f32[128,16]{0,1:T(8,128)S(1)} fusion(%fusion.524#0), kind=kLoop, calls=%fused_computation.74.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.525 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) fusion(%wide.param.1#3, %copy.248, %wide.param.1#8), kind=kLoop, calls=%fused_computation.81.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
-  %fusion.526 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%fusion.524#1, %add_rsqrt_fusion.9, %fusion.525#0), kind=kLoop, calls=%fused_computation.53.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice_negate_fusion.12 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.526), kind=kLoop, calls=%fused_computation.58.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.1018 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%wide.param.1#7)
-  %bitcast.1016 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%wide.param.1#6)
-  %fusion.527.q_ref = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%slice_negate_fusion.12#1, %slice_negate_fusion.12#0, %bitcast.1018, %bitcast.1016, %add_rsqrt_fusion.9, /*index=5*/%fusion.524#1, %fusion.525#0), kind=kLoop, calls=%fused_computation.62.clone.1, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.37 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#9, %copy.248), kind=kLoop, calls=%fused_computation.29.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.532 = f32[128]{0:T(128)S(1)} fusion(%wide.param.1#1), kind=kLoop, calls=%fused_computation.40.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add_rsqrt_fusion.8 = f32[128]{0:T(128)S(1)} fusion(%fusion.532), kind=kLoop, calls=%fused_computation.85.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %convert_reduce_fusion.7 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) fusion(%wide.param.1#12, %copy.256, %wide.param.1#4), kind=kLoop, calls=%fused_computation.75.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
+  %fusion.533 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%all-gather.98, %wide.param.1#1, %add_rsqrt_fusion.8, %convert_reduce_fusion.7#1), kind=kOutput, calls=%fused_computation.44.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add_rsqrt_fusion.9 = f32[128,16]{0,1:T(8,128)S(1)} fusion(%fusion.533#0), kind=kLoop, calls=%fused_computation.74.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.534 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) fusion(%wide.param.1#3, %copy.256, %wide.param.1#8), kind=kLoop, calls=%fused_computation.81.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"fusion_formation_source":{"fusion_creating_compiler_pass":"TpuAdvancedMOF","fusion_id":"42"},"aliasing_operands":{"lists":[]}}
+  %fusion.535 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%fusion.533#1, %add_rsqrt_fusion.9, %fusion.534#0), kind=kLoop, calls=%fused_computation.53.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %slice_negate_fusion.12 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.535), kind=kLoop, calls=%fused_computation.58.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.1041 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%wide.param.1#7)
+  %bitcast.1039 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%wide.param.1#6)
+  %fusion.536.q_ref = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%slice_negate_fusion.12#1, %slice_negate_fusion.12#0, %bitcast.1041, %bitcast.1039, %add_rsqrt_fusion.9, /*index=5*/%fusion.533#1, %fusion.534#0), kind=kLoop, calls=%fused_computation.62.clone.1, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.37 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#9, %copy.256), kind=kLoop, calls=%fused_computation.29.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.99 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.37), channel_id=99, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.528 = (f32[128,8]{0,1:T(8,128)S(1)}, bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%all-gather.99, %wide.param.1#1, %add_rsqrt_fusion.8, %convert_reduce_fusion.7#1), kind=kOutput, calls=%fused_computation.51.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add_rsqrt_fusion.10 = f32[128,8]{0,1:T(8,128)S(1)} fusion(%fusion.528#0), kind=kLoop, calls=%fused_computation.77.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.529 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%fusion.528#1, %add_rsqrt_fusion.10, %fusion.525#1), kind=kLoop, calls=%fused_computation.67.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %slice_negate_fusion.13 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.529), kind=kLoop, calls=%fused_computation.68.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %bitcast.1019 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%wide.param.1#7)
-  %bitcast.1017 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%wide.param.1#6)
-  %fusion.530.k_ref = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%slice_negate_fusion.13#1, %slice_negate_fusion.13#0, %bitcast.1019, %bitcast.1017, %add_rsqrt_fusion.10, /*index=5*/%fusion.528#1, %fusion.525#1), kind=kLoop, calls=%fused_computation.71.clone.1, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.38 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#10, %copy.248), kind=kLoop, calls=%fused_computation.28.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.537 = (f32[128,8]{0,1:T(8,128)S(1)}, bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%all-gather.99, %wide.param.1#1, %add_rsqrt_fusion.8, %convert_reduce_fusion.7#1), kind=kOutput, calls=%fused_computation.51.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %add_rsqrt_fusion.10 = f32[128,8]{0,1:T(8,128)S(1)} fusion(%fusion.537#0), kind=kLoop, calls=%fused_computation.77.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.538 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%fusion.537#1, %add_rsqrt_fusion.10, %fusion.534#1), kind=kLoop, calls=%fused_computation.67.clone.2, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %slice_negate_fusion.13 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) fusion(%fusion.538), kind=kLoop, calls=%fused_computation.68.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %bitcast.1042 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%wide.param.1#7)
+  %bitcast.1040 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%wide.param.1#6)
+  %fusion.539.k_ref = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%slice_negate_fusion.13#1, %slice_negate_fusion.13#0, %bitcast.1042, %bitcast.1040, %add_rsqrt_fusion.10, /*index=5*/%fusion.537#1, %fusion.534#1), kind=kLoop, calls=%fused_computation.71.clone.1, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.38 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#10, %copy.256), kind=kLoop, calls=%fused_computation.28.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.100 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.38), channel_id=100, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.531.v_ref = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.100, %wide.param.1#1, %add_rsqrt_fusion.8, %convert_reduce_fusion.7#1), kind=kOutput, calls=%fused_computation.50.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.540.v_ref = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.100, %wide.param.1#1, %add_rsqrt_fusion.8, %convert_reduce_fusion.7#1), kind=kOutput, calls=%fused_computation.50.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %squeeze.274.q_segment_ids_ref = s32[128,128]{1,0:T(8,128)S(1)} broadcast(%wide.param.1#16), dimensions={0}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["8"]},"aliasing_operands":{"lists":[]}}
   %squeeze.275.kv_segment_ids_ref = s32[8,128]{1,0:T(8,128)S(1)} broadcast(%wide.param.1#16), dimensions={1}, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"output_chunk_bound_config":{"output_chunk_bound":["128"]},"aliasing_operands":{"lists":[]}}
   %iota.68.q_sequence_ref = s32[128,128]{1,0:T(8,128)S(1)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %splash_mha_fwd_segmented_residuals.15 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[16,128,128]{2,1,0:T(8,128)}) custom-call(%wide.param.1#18, %wide.param.1#19, %fusion.527.q_ref, %fusion.530.k_ref, %fusion.531.v_ref, /*index=5*/%squeeze.274.q_segment_ids_ref, %squeeze.275.kv_segment_ids_ref, %iota.68.q_sequence_ref), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[16,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
+  %splash_mha_fwd_segmented_residuals.15 = (f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, f32[128,128]{1,0:T(8,128)}, bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)}, f32[16,128,128]{2,1,0:T(8,128)}) custom-call(%wide.param.1#18, %wide.param.1#19, %fusion.536.q_ref, %fusion.539.k_ref, %fusion.540.v_ref, /*index=5*/%squeeze.274.q_segment_ids_ref, %squeeze.275.kv_segment_ids_ref, %iota.68.q_sequence_ref), custom_call_target="tpu_custom_call", operand_layout_constraints={s8[1,1,1]{2,1,0}, s8[1,1,1]{2,1,0}, bf16[16,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, bf16[8,128,128]{2,1,0}, s32[128,128]{1,0}, s32[8,128]{1,0}, s32[128,128]{1,0}}, frontend_attributes={kernel_metadata={
 "xprof_metadata":"{\"block_q\": 128, \"block_kv\": 128, \"block_kv_compute\": 128, \"block_q_dkv\": 128, \"block_kv_dkv\": 128, \"block_kv_dkv_compute\": 128, \"block_q_dq\": 128, \"block_kv_dq\": 128, \"use_fused_bwd_kernel\": false, \"q_layout\": 1, \"k_layout\": 1, \"v_layout\": 1}"
 }}, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"custom_call_config":{"body":"<mosaic_body>","needs_layout_passes":true,"allow_input_fusion":[],"serialization_format":"1","output_memory_colors":[],"output_memory_space_colors":[],"input_memory_space_colors":[]},"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.532 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%wide.param.1#1, %all-gather.97, %splash_mha_fwd_segmented_residuals.15#3), kind=kOutput, calls=%fused_computation.42.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.39 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#15, %copy.248), kind=kLoop, calls=%fused_computation.11.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.541 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) fusion(%wide.param.1#1, %all-gather.97, %splash_mha_fwd_segmented_residuals.15#3), kind=kOutput, calls=%fused_computation.42.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.39 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#15, %copy.256), kind=kLoop, calls=%fused_computation.11.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.101 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.39), channel_id=104, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={2}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.40 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#14, %copy.248), kind=kLoop, calls=%fused_computation.12.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.40 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#14, %copy.256), kind=kLoop, calls=%fused_computation.12.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.102 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)} all-gather(%dynamic-slice_convert_fusion.40), channel_id=103, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %dynamic-slice_convert_fusion.41 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#13, %copy.248), kind=kLoop, calls=%fused_computation.13.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %dynamic-slice_convert_fusion.41 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%wide.param.1#13, %copy.256), kind=kLoop, calls=%fused_computation.13.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %all-gather.103 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} all-gather(%dynamic-slice_convert_fusion.41), channel_id=102, replica_groups=mesh['axis_0'=4] {'axis_0'}, dimensions={1}, use_global_device_ids=true, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/convert_element_type" stack_frame_id=0}, backend_config={"flag_configs":[],"barrier_config":{"barrier_type":"CUSTOM","id":"0"},"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %add_rsqrt_fusion.11 = f32[128]{0:T(128)S(1)} fusion(%fusion.532#0), kind=kLoop, calls=%fused_computation.84.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.533 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.103, %fusion.532#1, %add_rsqrt_fusion.11, %convert_reduce_fusion.7#0), kind=kOutput, calls=%fused_computation.24.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %fusion.534 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} fusion(%fusion.532#1, %all-gather.101, %all-gather.102, %fusion.533, %add_rsqrt_fusion.11, /*index=5*/%convert_reduce_fusion.7#0), kind=kOutput, calls=%fused_computation.39.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  ROOT %tuple.250 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) tuple(%add.1069, %fusion.534, %bitcast_dynamic-update-slice_fusion.2, %wide.param.1#3, %wide.param.1#4, /*index=5*/%wide.param.1#5, %wide.param.1#6, %wide.param.1#7, %wide.param.1#8, %wide.param.1#9, /*index=10*/%wide.param.1#10, %wide.param.1#11, %wide.param.1#12, %wide.param.1#13, %wide.param.1#14, /*index=15*/%wide.param.1#15, %wide.param.1#16, %wide.param.1#17, %wide.param.1#18, %wide.param.1#19)
+  %add_rsqrt_fusion.11 = f32[128]{0:T(128)S(1)} fusion(%fusion.541#0), kind=kLoop, calls=%fused_computation.84.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/rsqrt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.542 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} fusion(%all-gather.103, %fusion.541#1, %add_rsqrt_fusion.11, %convert_reduce_fusion.7#0), kind=kOutput, calls=%fused_computation.24.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %fusion.543 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} fusion(%fusion.541#1, %all-gather.101, %all-gather.102, %fusion.542, %add_rsqrt_fusion.11, /*index=5*/%convert_reduce_fusion.7#0), kind=kOutput, calls=%fused_computation.39.clone.1, metadata={op_name="jit(train_step)/jvp()/while/body/eval_jaxpr/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %tuple.247 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) tuple(%add.1069, %fusion.543, %bitcast_dynamic-update-slice_fusion.2, %wide.param.1#3, %wide.param.1#4, /*index=5*/%wide.param.1#5, %wide.param.1#6, %wide.param.1#7, %wide.param.1#8, %wide.param.1#9, /*index=10*/%wide.param.1#10, %wide.param.1#11, %wide.param.1#12, %wide.param.1#13, %wide.param.1#14, /*index=15*/%wide.param.1#15, %wide.param.1#16, %wide.param.1#17, %wide.param.1#18, %wide.param.1#19)
 }
 
 %wide.region_6.9_spmd.clone.clone.clone (wide.param.113: (s32[], bf16[1,128,2048], bf16[4,1,128,2048], bf16[4,128], bf16[4,2048], /*index=5*/bf16[4,512,16,128], bf16[1,128,1,128], bf16[1,128,1,128], bf16[4,128], bf16[4,512,8,128], /*index=10*/bf16[4,512,8,128], bf16[4,16,128,512], bf16[4,2048], bf16[4,512,6144], bf16[4,512,6144], /*index=15*/bf16[4,6144,512], s32[128], s32[], s8[1,1,1], s8[1,1,1])) -> pred[] {
   %constant.411.clone.4 = s32[]{:T(128)} constant(4)
-  %wide.param.113 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) parameter(0)
+  %wide.param.113 = (s32[]{:T(128)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}, bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, /*index=5*/bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[4,128]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)}, /*index=10*/bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)}, bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)}, bf16[4,2048]{1,0:T(4,128)(2,1)S(1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, bf16[4,512,6144]{2,1,0:T(8,128)(2,1)}, /*index=15*/bf16[4,6144,512]{2,1,0:T(8,128)(2,1)}, s32[128]{0:T(128)S(1)}, s32[]{:T(128)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}, s8[1,1,1]{2,1,0:T(4,128)(4,1)}) parameter(0)
   ROOT %lt.34 = pred[]{:T(512)} compare(%wide.param.113#0, %constant.411.clone.4), direction=LT, metadata={op_name="jit(train_step)/jvp()/while/cond/lt" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
@@ -715,46 +715,46 @@ StackFrames
   ROOT %reduce_sum.185 = f32[]{:T(128)} add(%reduce_sum.171, %reduce_sum.184), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.411 (param_0.1573: bf16[1,128,2048]) -> f32[128] {
-  %param_0.1573 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1230 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1573), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %square.247 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1230, %convert_element_type.1230), metadata={op_name="jit(train_step)/jvp()/square" stack_frame_id=0}
+%fused_computation.412 (param_0.1581: bf16[1,128,2048]) -> f32[128] {
+  %param_0.1581 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1234 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1581), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %square.247 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1234, %convert_element_type.1234), metadata={op_name="jit(train_step)/jvp()/square" stack_frame_id=0}
   %constant.444.clone.29 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.222 = f32[128]{0:T(128)S(1)} reduce(%square.247, %constant.444.clone.29), dimensions={0,2}, to_apply=%region_7.10, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.221 = f32[128]{0:T(128)S(1)} reduce(%square.247, %constant.444.clone.29), dimensions={0,2}, to_apply=%region_7.10, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.472 (param_0.1386: f32[128]) -> f32[128] {
-  %param_0.1386 = f32[128]{0:T(128)S(1)} parameter(0)
+%fused_computation.473 (param_0.1394: f32[128]) -> f32[128] {
+  %param_0.1394 = f32[128]{0:T(128)S(1)} parameter(0)
   %constant.452.clone.2 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.966 = f32[128]{0:T(128)} broadcast(%constant.452.clone.2), dimensions={}, metadata={op_name="broadcast.416"}
-  %div.784 = f32[128]{0:T(128)} multiply(%param_0.1386, %broadcast.966), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
+  %broadcast.967 = f32[128]{0:T(128)} broadcast(%constant.452.clone.2), dimensions={}, metadata={op_name="broadcast.416"}
+  %div.784 = f32[128]{0:T(128)} multiply(%param_0.1394, %broadcast.967), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
   %constant.453.clone.2 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.964 = f32[128]{0:T(128)} broadcast(%constant.453.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %add.939 = f32[128]{0:T(128)} add(%div.784, %broadcast.964), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %bitcast.594 = f32[1,128]{1,0:T(1,128)} bitcast(%add.939), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %rsqrt.195 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.594), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.584 = f32[128]{0:T(128)} bitcast(%rsqrt.195), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
+  %broadcast.965 = f32[128]{0:T(128)} broadcast(%constant.453.clone.2), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %add.939 = f32[128]{0:T(128)} add(%div.784, %broadcast.965), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %bitcast.609 = f32[1,128]{1,0:T(1,128)} bitcast(%add.939), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %rsqrt.195 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.609), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.599 = f32[128]{0:T(128)} bitcast(%rsqrt.195), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.417.clone.clone (param_0.1533: bf16[2048], param_1.1710: f32[128], param_2.1291: bf16[1,128,2048]) -> bf16[128,2048] {
-  %param_0.1533 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.510 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1533), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
-  %convert.381 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.510)
-  %param_2.1291 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(2)
-  %convert_element_type.1307 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1291), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_1.1710 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2138 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1710), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %mul.2137 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1307, %mul.2138), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %convert_element_type.1306 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2137), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %convert.382 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1306)
-  %dot_general.509 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.381, %convert.382), metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.383 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.509)
-  ROOT %bitcast.717 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.383)
+%fused_computation.418.clone.clone (param_0.1541: bf16[2048], param_1.1714: f32[128], param_2.1294: bf16[1,128,2048]) -> bf16[128,2048] {
+  %param_0.1541 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.498 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1541), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
+  %convert.382 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.498)
+  %param_2.1294 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(2)
+  %convert_element_type.1311 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1294), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_1.1714 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2132 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1714), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %mul.2131 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1311, %mul.2132), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %convert_element_type.1310 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2131), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %convert.383 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1310)
+  %dot_general.497 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.382, %convert.383), metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.384 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.497)
+  ROOT %bitcast.732 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.384)
 }
 
 %bitcast_fusion.1 (bitcast_input.1: bf16[151936,2048]) -> bf16[151936,2048] {
   %bitcast_input.1 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.727 = bf16[151936,2048]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.1)
+  ROOT %bitcast.742 = bf16[151936,2048]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input.1)
 }
 
 %region_8.11 (reduce_max.6: bf16[], reduce_max.8: bf16[]) -> bf16[] {
@@ -763,17 +763,17 @@ StackFrames
   ROOT %reduce_max.9 = bf16[]{:T(256)} maximum(%reduce_max.6, %reduce_max.8), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.501 (param_0.1541: bf16[151936,2048], param_1.1715: bf16[2048], param_2.1308: f32[128], param_3.870: bf16[1,128,2048]) -> (bf16[128], bf16[128,151936]) {
-  %param_1.1715 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_2.1308 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.870 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(3)
-  %fusion.326.clone.1 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1715, %param_2.1308, %param_3.870), kind=kLoop, calls=%fused_computation.417.clone.clone
-  %param_0.1541 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(0)
-  %fusion.362 = bf16[151936,2048]{1,0:T(8,128)(2,1)} fusion(%param_0.1541), kind=kLoop, calls=%bitcast_fusion.1
-  %convolution.115.clone.1 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} convolution(%fusion.326.clone.1, %fusion.362), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/jvp()/dot_general" stack_frame_id=0}
+%fused_computation.502 (param_0.1549: bf16[151936,2048], param_1.1719: bf16[2048], param_2.1311: f32[128], param_3.872: bf16[1,128,2048]) -> (bf16[128], bf16[128,151936]) {
+  %param_1.1719 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_2.1311 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.872 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(3)
+  %fusion.331.clone.1 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1719, %param_2.1311, %param_3.872), kind=kLoop, calls=%fused_computation.418.clone.clone
+  %param_0.1549 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(0)
+  %fusion.367 = bf16[151936,2048]{1,0:T(8,128)(2,1)} fusion(%param_0.1549), kind=kLoop, calls=%bitcast_fusion.1
+  %convolution.115.clone.1 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} convolution(%fusion.331.clone.1, %fusion.367), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/jvp()/dot_general" stack_frame_id=0}
   %constant.454.clone.3 = bf16[]{:T(256)} constant(-inf)
-  %reduce.243 = bf16[128]{0:T(256)(128)(2,1)S(1)} reduce(%convolution.115.clone.1, %constant.454.clone.3), dimensions={1}, to_apply=%region_8.11, metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
-  ROOT %tuple.171 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128,151936]{1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.243, %convolution.115.clone.1)
+  %reduce.242 = bf16[128]{0:T(256)(128)(2,1)S(1)} reduce(%convolution.115.clone.1, %constant.454.clone.3), dimensions={1}, to_apply=%region_8.11, metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
+  ROOT %tuple.170 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128,151936]{1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.242, %convolution.115.clone.1)
 }
 
 %region_9.12 (reduce_sum.186: f32[], reduce_sum.190: f32[]) -> f32[] {
@@ -782,31 +782,31 @@ StackFrames
   ROOT %reduce_sum.191 = f32[]{:T(128)} add(%reduce_sum.186, %reduce_sum.190), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.333 (param_0.1572: bf16[128,151936], param_1.1741: f32[128]) -> f32[128] {
-  %param_0.1572 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.520 = bf16[1,128,151936]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1572)
-  %convert.192 = f32[1,128,151936]{2,1,0:T(8,128)} convert(%bitcast.520), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_1.1741 = f32[128]{0:T(128)S(1)} parameter(1)
-  %sub.100 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1741), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.71 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%convert.192, %sub.100), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+%fused_computation.334 (param_0.1580: bf16[128,151936], param_1.1745: f32[128]) -> f32[128] {
+  %param_0.1580 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %bitcast.535 = bf16[1,128,151936]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1580)
+  %convert.193 = f32[1,128,151936]{2,1,0:T(8,128)} convert(%bitcast.535), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_1.1745 = f32[128]{0:T(128)S(1)} parameter(1)
+  %sub.100 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1745), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.71 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%convert.193, %sub.100), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %exp.51 = f32[1,128,151936]{2,1,0:T(8,128)} exponential(%sub.71), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
   %constant.444.clone.28 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.199 = f32[128]{0:T(128)S(1)} reduce(%exp.51, %constant.444.clone.28), dimensions={0,2}, to_apply=%region_9.12, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.198 = f32[128]{0:T(128)S(1)} reduce(%exp.51, %constant.444.clone.28), dimensions={0,2}, to_apply=%region_9.12, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.500 (param_0.1529: f32[128], param_1.1740: bf16[128]) -> (f32[128], f32[128]) {
-  %param_0.1529 = f32[128]{0:T(128)S(1)} parameter(0)
-  %log.23 = f32[128]{0:T(128)S(1)} log(%param_0.1529), metadata={op_name="jit(train_step)/jvp()/log" stack_frame_id=0}
-  %param_1.1740 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
-  %reduce_max.18.clone.1 = f32[128]{0:T(128)} convert(%param_1.1740), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
+%fused_computation.501 (param_0.1537: f32[128], param_1.1744: bf16[128]) -> (f32[128], f32[128]) {
+  %param_0.1537 = f32[128]{0:T(128)S(1)} parameter(0)
+  %log.23 = f32[128]{0:T(128)S(1)} log(%param_0.1537), metadata={op_name="jit(train_step)/jvp()/log" stack_frame_id=0}
+  %param_1.1744 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
+  %reduce_max.18.clone.1 = f32[128]{0:T(128)} convert(%param_1.1744), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
   %add.945.clone.1 = f32[128]{0:T(128)} add(%log.23, %reduce_max.18.clone.1), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %constant.444.clone.27 = f32[]{:T(128)} constant(0)
-  %broadcast.962.clone.1 = f32[128]{0:T(128)} broadcast(%constant.444.clone.27), dimensions={}, metadata={op_name="broadcast.118"}
-  %mul.1972.clone.1 = f32[128]{0:T(128)} multiply(%add.945.clone.1, %broadcast.962.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %broadcast.963.clone.1 = f32[128]{0:T(128)} broadcast(%constant.444.clone.27), dimensions={}, metadata={op_name="broadcast.118"}
+  %mul.1972.clone.1 = f32[128]{0:T(128)} multiply(%add.945.clone.1, %broadcast.963.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %constant.432.clone.1.clone.1 = f32[]{:T(128)} constant(1)
-  %broadcast.959.clone.1 = f32[128]{0:T(128)} broadcast(%constant.432.clone.1.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
-  %add.934.clone.1 = f32[128]{0:T(128)S(1)} add(%mul.1972.clone.1, %broadcast.959.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
-  ROOT %tuple.169 = (f32[128]{0:T(128)S(1)}, f32[128]{0:T(128)S(1)}) tuple(%log.23, %add.934.clone.1)
+  %broadcast.960.clone.1 = f32[128]{0:T(128)} broadcast(%constant.432.clone.1.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
+  %add.934.clone.1 = f32[128]{0:T(128)S(1)} add(%mul.1972.clone.1, %broadcast.960.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/add" stack_frame_id=0}
+  ROOT %tuple.168 = (f32[128]{0:T(128)S(1)}, f32[128]{0:T(128)S(1)}) tuple(%log.23, %add.934.clone.1)
 }
 
 %region_54.59 (reduce_sum.389: f32[], reduce_sum.393: f32[]) -> f32[] {
@@ -815,24 +815,24 @@ StackFrames
   ROOT %reduce_sum.394 = f32[]{:T(128)} add(%reduce_sum.389, %reduce_sum.393), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.339 (param_0.1571: bf16[128,151936], param_1.1739: f32[128], param_2.1333: f32[128], param_3.889: s32[128]) -> f32[128] {
-  %param_3.889 = s32[128]{0:T(128)S(1)} parameter(3)
-  %eq.26 = s32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_3.889), dimensions={1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
+%fused_computation.340 (param_0.1579: bf16[128,151936], param_1.1743: f32[128], param_2.1336: f32[128], param_3.891: s32[128]) -> f32[128] {
+  %param_3.891 = s32[128]{0:T(128)S(1)} parameter(3)
+  %eq.26 = s32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_3.891), dimensions={1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %iota.51 = s32[1,128,151936]{2,1,0:T(8,128)} iota(), iota_dimension=2, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %eq.21 = pred[1,128,151936]{2,1,0:T(8,128)(4,1)} compare(%eq.26, %iota.51), direction=EQ, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
-  %param_0.1571 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.519 = bf16[1,128,151936]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1571)
-  %convert.204 = f32[1,128,151936]{2,1,0:T(8,128)} convert(%bitcast.519), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_2.1333 = f32[128]{0:T(128)S(1)} parameter(2)
-  %sub.99 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_2.1333), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.92 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%convert.204, %sub.99), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %param_1.1739 = f32[128]{0:T(128)S(1)} parameter(1)
-  %sub.97 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1739), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %param_0.1579 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %bitcast.534 = bf16[1,128,151936]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1579)
+  %convert.205 = f32[1,128,151936]{2,1,0:T(8,128)} convert(%bitcast.534), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_2.1336 = f32[128]{0:T(128)S(1)} parameter(2)
+  %sub.99 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_2.1336), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.92 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%convert.205, %sub.99), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %param_1.1743 = f32[128]{0:T(128)S(1)} parameter(1)
+  %sub.97 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1743), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %sub.91 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%sub.92, %sub.97), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %constant.444.clone.26 = f32[]{:T(128)} constant(0)
-  %broadcast.900 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%constant.444.clone.26), dimensions={}, metadata={op_name="broadcast.128"}
-  %mul.1822 = f32[1,128,151936]{2,1,0:T(8,128)} select(%eq.21, %sub.91, %broadcast.900), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  ROOT %reduce.200 = f32[128]{0:T(128)S(1)} reduce(%mul.1822, %constant.444.clone.26), dimensions={0,2}, to_apply=%region_54.59, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %broadcast.901 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%constant.444.clone.26), dimensions={}, metadata={op_name="broadcast.128"}
+  %mul.1822 = f32[1,128,151936]{2,1,0:T(8,128)} select(%eq.21, %sub.91, %broadcast.901), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  ROOT %reduce.199 = f32[128]{0:T(128)S(1)} reduce(%mul.1822, %constant.444.clone.26), dimensions={0,2}, to_apply=%region_54.59, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %region_0.1 (reduce_sum.137: s32[], reduce_sum.138: s32[]) -> s32[] {
@@ -841,13 +841,13 @@ StackFrames
   ROOT %reduce_sum.139 = s32[]{:T(128)} add(%reduce_sum.137, %reduce_sum.138), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.477 (param_0.1391: s32[1,128]) -> s32[] {
-  %param_0.1391 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
+%fused_computation.478 (param_0.1399: s32[1,128]) -> s32[] {
+  %param_0.1399 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
   %constant.433.clone.8 = s32[]{:T(128)} constant(0)
-  %broadcast.977 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.8), dimensions={}, metadata={op_name="broadcast.95"}
-  %ne.10 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1391, %broadcast.977), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
-  %convert_element_type.1270 = s32[1,128]{1,0:T(1,128)} convert(%ne.10), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  ROOT %reduce.240 = s32[]{:T(128)} reduce(%convert_element_type.1270, %constant.433.clone.8), dimensions={0,1}, to_apply=%region_0.1, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %broadcast.978 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.8), dimensions={}, metadata={op_name="broadcast.95"}
+  %ne.10 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1399, %broadcast.978), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
+  %convert_element_type.1274 = s32[1,128]{1,0:T(1,128)} convert(%ne.10), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  ROOT %reduce.239 = s32[]{:T(128)} reduce(%convert_element_type.1274, %constant.433.clone.8), dimensions={0,1}, to_apply=%region_0.1, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %region_0.1.clone (reduce_sum.612: s32[], reduce_sum.613: s32[]) -> s32[] {
@@ -868,100 +868,100 @@ StackFrames
   ROOT %reduce_sum.400 = f32[]{:T(128)} add(%reduce_sum.395, %reduce_sum.396), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.480 (param_0.1570: s32[1,128], param_1.1738: bf16[128], param_2.1332: f32[128], param_3.888: f32[128], param_4.526: f32[]) -> (f32[], f32[], f32[128]) {
-  %param_0.1570 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
+%fused_computation.481 (param_0.1578: s32[1,128], param_1.1742: bf16[128], param_2.1335: f32[128], param_3.890: f32[128], param_4.522: f32[]) -> (f32[], f32[], f32[128]) {
+  %param_0.1578 = s32[1,128]{1,0:T(1,128)S(1)} parameter(0)
   %constant.433.clone.1 = s32[]{:T(128)} constant(0)
-  %broadcast.975 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.1), dimensions={}, metadata={op_name="broadcast.95"}
-  %ne.16 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1570, %broadcast.975), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
-  %param_2.1332 = f32[128]{0:T(128)S(1)} parameter(2)
-  %log.18 = f32[128]{0:T(128)} log(%param_2.1332), metadata={op_name="jit(train_step)/jvp()/log" stack_frame_id=0}
-  %param_1.1738 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
-  %reduce_max.16 = f32[128]{0:T(128)} convert(%param_1.1738), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
+  %broadcast.976 = s32[1,128]{1,0:T(1,128)} broadcast(%constant.433.clone.1), dimensions={}, metadata={op_name="broadcast.95"}
+  %ne.16 = pred[1,128]{1,0:T(4,128)(4,1)} compare(%param_0.1578, %broadcast.976), direction=NE, metadata={op_name="jit(train_step)/jvp()/ne" stack_frame_id=0}
+  %param_2.1335 = f32[128]{0:T(128)S(1)} parameter(2)
+  %log.18 = f32[128]{0:T(128)} log(%param_2.1335), metadata={op_name="jit(train_step)/jvp()/log" stack_frame_id=0}
+  %param_1.1742 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(1)
+  %reduce_max.16 = f32[128]{0:T(128)} convert(%param_1.1742), metadata={op_name="jit(train_step)/jvp()/reduce_max" stack_frame_id=0}
   %add.943 = f32[128]{0:T(128)} add(%log.18, %reduce_max.16), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
   %square.270 = f32[128]{0:T(128)} multiply(%add.943, %add.943), metadata={op_name="jit(train_step)/jvp()/square" stack_frame_id=0}
   %constant.444.clone.25 = f32[]{:T(128)} constant(0)
-  %broadcast.960 = f32[128]{0:T(128)} broadcast(%constant.444.clone.25), dimensions={}, metadata={op_name="broadcast.118"}
-  %mul.1980 = f32[128]{0:T(128)} multiply(%square.270, %broadcast.960), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %bitcast.587 = f32[1,128]{1,0:T(1,128)} bitcast(%mul.1980), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %broadcast.971 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.444.clone.25), dimensions={}, metadata={op_name="broadcast.118"}
-  %mul.1966 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %bitcast.587, %broadcast.971), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %reduce.242 = f32[]{:T(128)} reduce(%mul.1966, %constant.444.clone.25), dimensions={0,1}, to_apply=%region_69.74, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
-  %param_3.888 = f32[128]{0:T(128)S(1)} parameter(3)
-  %neg.113.clone.1 = f32[128]{0:T(128)} negate(%param_3.888), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
-  %bitcast.591.clone.1 = f32[1,128]{1,0:T(1,128)} bitcast(%neg.113.clone.1), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
-  %add.933.clone.1 = f32[1,128]{1,0:T(1,128)} add(%bitcast.591.clone.1, %bitcast.587), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %mul.1964.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %add.933.clone.1, %broadcast.971), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %reduce.241.clone.1 = f32[]{:T(128)} reduce(%mul.1964.clone.1, %constant.444.clone.25), dimensions={0,1}, to_apply=%region_55.60, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
-  %param_4.526 = f32[]{:T(128)S(6)} parameter(4)
-  %broadcast_in_dim.276.clone.1 = f32[1,128]{1,0:T(1,128)} broadcast(%param_4.526), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/broadcast_in_dim" stack_frame_id=0}
-  %mul.1962.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %broadcast_in_dim.276.clone.1, %broadcast.971), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %bitcast.585.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%mul.1962.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  ROOT %tuple.168 = (f32[]{:T(128)}, f32[]{:T(128)}, f32[128]{0:T(128)S(1)}) tuple(%reduce.242, %reduce.241.clone.1, %bitcast.585.clone.1)
+  %broadcast.961 = f32[128]{0:T(128)} broadcast(%constant.444.clone.25), dimensions={}, metadata={op_name="broadcast.118"}
+  %mul.1980 = f32[128]{0:T(128)} multiply(%square.270, %broadcast.961), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %bitcast.602 = f32[1,128]{1,0:T(1,128)} bitcast(%mul.1980), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %broadcast.972 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.444.clone.25), dimensions={}, metadata={op_name="broadcast.118"}
+  %mul.1966 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %bitcast.602, %broadcast.972), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %reduce.241 = f32[]{:T(128)} reduce(%mul.1966, %constant.444.clone.25), dimensions={0,1}, to_apply=%region_69.74, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %param_3.890 = f32[128]{0:T(128)S(1)} parameter(3)
+  %neg.113.clone.1 = f32[128]{0:T(128)} negate(%param_3.890), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
+  %bitcast.606.clone.1 = f32[1,128]{1,0:T(1,128)} bitcast(%neg.113.clone.1), metadata={op_name="jit(train_step)/jvp()/neg" stack_frame_id=0}
+  %add.933.clone.1 = f32[1,128]{1,0:T(1,128)} add(%bitcast.606.clone.1, %bitcast.602), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %mul.1964.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %add.933.clone.1, %broadcast.972), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %reduce.240.clone.1 = f32[]{:T(128)} reduce(%mul.1964.clone.1, %constant.444.clone.25), dimensions={0,1}, to_apply=%region_55.60, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %param_4.522 = f32[]{:T(128)S(6)} parameter(4)
+  %broadcast_in_dim.276.clone.1 = f32[1,128]{1,0:T(1,128)} broadcast(%param_4.522), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/broadcast_in_dim" stack_frame_id=0}
+  %mul.1962.clone.1 = f32[1,128]{1,0:T(1,128)} select(%ne.16, %broadcast_in_dim.276.clone.1, %broadcast.972), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %bitcast.600.clone.1 = f32[128]{0:T(128)S(1)} bitcast(%mul.1962.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  ROOT %tuple.167 = (f32[]{:T(128)}, f32[]{:T(128)}, f32[128]{0:T(128)S(1)}) tuple(%reduce.241, %reduce.240.clone.1, %bitcast.600.clone.1)
 }
 
-%fused_computation.368.clone.1.clone.clone (param_0.1536: bf16[128,151936], param_1.1714: f32[128], param_2.1296: f32[128], param_3.868: f32[128], param_4.503: s32[128], param_5.435: f32[128]) -> bf16[128,151936] {
-  %param_5.435 = f32[128]{0:T(128)S(1)} parameter(5)
-  %mul.2146 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_5.435), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %param_1.1714 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2145 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1714), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %param_0.1536 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.721 = bf16[1,128,151936]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1536)
-  %convert.288 = f32[1,128,151936]{2,1,0:T(8,128)} convert(%bitcast.721), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_3.868 = f32[128]{0:T(128)S(1)} parameter(3)
-  %sub.114 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_3.868), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.113 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%convert.288, %sub.114), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %exp.67 = f32[1,128,151936]{2,1,0:T(8,128)} exponential(%sub.113), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
-  %mul.2144 = f32[1,128,151936]{2,1,0:T(8,128)} multiply(%mul.2145, %exp.67), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %param_2.1296 = f32[128]{0:T(128)S(1)} parameter(2)
-  %div.982 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_2.1296), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
-  %div.981 = f32[1,128,151936]{2,1,0:T(8,128)} divide(%mul.2144, %div.982), metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
-  %param_4.503 = s32[128]{0:T(128)S(1)} parameter(4)
-  %eq.35 = s32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_4.503), dimensions={1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
+%fused_computation.369.clone.1.clone.clone (param_0.1544: bf16[128,151936], param_1.1718: f32[128], param_2.1299: f32[128], param_3.870: f32[128], param_4.499: s32[128], param_5.429: f32[128]) -> bf16[128,151936] {
+  %param_5.429 = f32[128]{0:T(128)S(1)} parameter(5)
+  %mul.2140 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_5.429), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %param_1.1718 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2139 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_1.1718), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %param_0.1544 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %bitcast.736 = bf16[1,128,151936]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1544)
+  %convert.289 = f32[1,128,151936]{2,1,0:T(8,128)} convert(%bitcast.736), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_3.870 = f32[128]{0:T(128)S(1)} parameter(3)
+  %sub.112 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_3.870), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.111 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%convert.289, %sub.112), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %exp.67 = f32[1,128,151936]{2,1,0:T(8,128)} exponential(%sub.111), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
+  %mul.2138 = f32[1,128,151936]{2,1,0:T(8,128)} multiply(%mul.2139, %exp.67), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %param_2.1299 = f32[128]{0:T(128)S(1)} parameter(2)
+  %div.982 = f32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_2.1299), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
+  %div.981 = f32[1,128,151936]{2,1,0:T(8,128)} divide(%mul.2138, %div.982), metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
+  %param_4.499 = s32[128]{0:T(128)S(1)} parameter(4)
+  %eq.35 = s32[1,128,151936]{2,1,0:T(8,128)} broadcast(%param_4.499), dimensions={1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %iota.60 = s32[1,128,151936]{2,1,0:T(8,128)} iota(), iota_dimension=2, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %eq.34 = pred[1,128,151936]{2,1,0:T(8,128)(4,1)} compare(%eq.35, %iota.60), direction=EQ, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
-  %convert_element_type.1311 = f32[1,128,151936]{2,1,0:T(8,128)} convert(%eq.34), metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/convert_element_type" stack_frame_id=0}
-  %sub.112 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%div.981, %convert_element_type.1311), metadata={op_name="jit(train_step)/transpose(jvp())/sub" stack_frame_id=0}
-  %mul.2143 = f32[1,128,151936]{2,1,0:T(8,128)} multiply(%mul.2146, %sub.112), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %convert_element_type.1310 = bf16[1,128,151936]{2,1,0:T(8,128)(2,1)} convert(%mul.2143), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
-  ROOT %bitcast.720 = bf16[128,151936]{1,0:T(8,128)(2,1)} bitcast(%convert_element_type.1310)
+  %convert_element_type.1315 = f32[1,128,151936]{2,1,0:T(8,128)} convert(%eq.34), metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/convert_element_type" stack_frame_id=0}
+  %sub.110 = f32[1,128,151936]{2,1,0:T(8,128)} subtract(%div.981, %convert_element_type.1315), metadata={op_name="jit(train_step)/transpose(jvp())/sub" stack_frame_id=0}
+  %mul.2137 = f32[1,128,151936]{2,1,0:T(8,128)} multiply(%mul.2140, %sub.110), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %convert_element_type.1314 = bf16[1,128,151936]{2,1,0:T(8,128)(2,1)} convert(%mul.2137), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
+  ROOT %bitcast.735 = bf16[128,151936]{1,0:T(8,128)(2,1)} bitcast(%convert_element_type.1314)
 }
 
 %bitcast_fusion (bitcast_input: bf16[151936,2048]) -> bf16[151936,2048] {
   %bitcast_input = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.726 = bf16[151936,2048]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input)
+  ROOT %bitcast.741 = bf16[151936,2048]{1,0:T(8,128)(2,1)} bitcast(%bitcast_input)
 }
 
-%region_10.13 (dot_general.204: bf16[], dot_general.205: bf16[]) -> bf16[] {
-  %dot_general.204 = bf16[]{:T(256)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general"}
-  %dot_general.205 = bf16[]{:T(256)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general"}
-  ROOT %add.416 = bf16[]{:T(256)} add(%dot_general.204, %dot_general.205), metadata={op_name="add.79"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+%region_10.13 (dot_general.190: bf16[], dot_general.191: bf16[]) -> bf16[] {
+  %dot_general.190 = bf16[]{:T(256)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general"}
+  %dot_general.191 = bf16[]{:T(256)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general"}
+  ROOT %add.416 = bf16[]{:T(256)} add(%dot_general.190, %dot_general.191), metadata={op_name="add.79"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.418 (param_0.1535: f32[128], param_1.1713: bf16[1,128,2048], param_2.1297: bf16[151936,2048], param_3.869: bf16[128,151936], param_4.504: f32[128], param_5.436: f32[128], param_6.301: f32[128], param_7.190: s32[128], param_8.112: f32[128]) -> (bf16[2048], bf16[1,128,2048]) {
-  %param_3.869 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %param_4.504 = f32[128]{0:T(128)S(1)} parameter(4)
-  %param_5.436 = f32[128]{0:T(128)S(1)} parameter(5)
-  %param_6.301 = f32[128]{0:T(128)S(1)} parameter(6)
+%fused_computation.419 (param_0.1543: f32[128], param_1.1717: bf16[1,128,2048], param_2.1300: bf16[151936,2048], param_3.871: bf16[128,151936], param_4.500: f32[128], param_5.430: f32[128], param_6.297: f32[128], param_7.190: s32[128], param_8.112: f32[128]) -> (bf16[2048], bf16[1,128,2048]) {
+  %param_3.871 = bf16[128,151936]{1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_4.500 = f32[128]{0:T(128)S(1)} parameter(4)
+  %param_5.430 = f32[128]{0:T(128)S(1)} parameter(5)
+  %param_6.297 = f32[128]{0:T(128)S(1)} parameter(6)
   %param_7.190 = s32[128]{0:T(128)S(1)} parameter(7)
   %param_8.112 = f32[128]{0:T(128)S(1)} parameter(8)
-  %fusion.348.clone.1 = bf16[128,151936]{1,0:T(8,128)(2,1)} fusion(%param_3.869, %param_4.504, %param_5.436, %param_6.301, %param_7.190, /*index=5*/%param_8.112), kind=kLoop, calls=%fused_computation.368.clone.1.clone.clone
-  %param_2.1297 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(2)
-  %fusion.361 = bf16[151936,2048]{1,0:T(8,128)(2,1)} fusion(%param_2.1297), kind=kLoop, calls=%bitcast_fusion
-  %convolution.113.clone.1 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.348.clone.1, %fusion.361), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/dot_general" stack_frame_id=0}
-  %bitcast.563.clone.1 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.113.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/dot_general" stack_frame_id=0}
-  %convert.369 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.563.clone.1)
-  %param_1.1713 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert_element_type.1249 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_1.1713), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_0.1535 = f32[128]{0:T(128)S(1)} parameter(0)
-  %mul.1913 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_0.1535), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %mul.1912 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1249, %mul.1913), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %convert_element_type.1248 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.1912), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %convert.370 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1248)
-  %multiply.436 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.369, %convert.370), metadata={op_name="multiply.354"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.371 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%multiply.436)
+  %fusion.353.clone.1 = bf16[128,151936]{1,0:T(8,128)(2,1)} fusion(%param_3.871, %param_4.500, %param_5.430, %param_6.297, %param_7.190, /*index=5*/%param_8.112), kind=kLoop, calls=%fused_computation.369.clone.1.clone.clone
+  %param_2.1300 = bf16[151936,2048]{1,0:T(8,128)(2,1)} parameter(2)
+  %fusion.366 = bf16[151936,2048]{1,0:T(8,128)(2,1)} fusion(%param_2.1300), kind=kLoop, calls=%bitcast_fusion
+  %convolution.113.clone.1 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.353.clone.1, %fusion.366), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/dot_general" stack_frame_id=0}
+  %bitcast.578.clone.1 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.113.clone.1), metadata={op_name="jit(train_step)/transpose(jvp())/dot_general" stack_frame_id=0}
+  %convert.370 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.578.clone.1)
+  %param_1.1717 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert_element_type.1253 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_1.1717), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_0.1543 = f32[128]{0:T(128)S(1)} parameter(0)
+  %mul.1913 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_0.1543), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %mul.1912 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1253, %mul.1913), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %convert_element_type.1252 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.1912), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %convert.371 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1252)
+  %multiply.438 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.370, %convert.371), metadata={op_name="multiply.353"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.372 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%multiply.438)
   %constant.446.clone.1 = bf16[]{:T(256)} constant(0)
-  %reduce.224 = bf16[2048]{0:T(1024)(128)(2,1)} reduce(%convert.371, %constant.446.clone.1), dimensions={0,1}, to_apply=%region_10.13, metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}
-  ROOT %tuple.172 = (bf16[2048]{0:T(1024)(128)(2,1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.224, %bitcast.563.clone.1)
+  %reduce.223 = bf16[2048]{0:T(1024)(128)(2,1)} reduce(%convert.372, %constant.446.clone.1), dimensions={0,1}, to_apply=%region_10.13, metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}
+  ROOT %tuple.171 = (bf16[2048]{0:T(1024)(128)(2,1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.223, %bitcast.578.clone.1)
 }
 
 %region_12.15 (reduce_sum.198: f32[], reduce_sum.199: f32[]) -> f32[] {
@@ -970,108 +970,108 @@ StackFrames
   ROOT %reduce_sum.200 = f32[]{:T(128)} add(%reduce_sum.198, %reduce_sum.199), metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.413 (param_0.1569: bf16[1,128,2048], param_1.1737: bf16[1,128,2048], param_2.1331: bf16[2048]) -> f32[128] {
-  %param_0.1569 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1237 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1569), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_1.1737 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.367 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_1.1737)
-  %param_2.1331 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.481 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1331), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
-  %convert.368 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.481)
-  %dot_general.467 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.367, %convert.368), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.1236 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.467), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
-  %mul.1898 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1237, %convert_element_type.1236), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+%fused_computation.414 (param_0.1577: bf16[1,128,2048], param_1.1741: bf16[1,128,2048], param_2.1334: bf16[2048]) -> f32[128] {
+  %param_0.1577 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1241 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1577), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_1.1741 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.368 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_1.1741)
+  %param_2.1334 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.469 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.1334), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
+  %convert.369 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.469)
+  %dot_general.455 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.368, %convert.369), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.1240 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.455), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
+  %mul.1898 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1241, %convert_element_type.1240), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %constant.444.clone.24 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.223 = f32[128]{0:T(128)S(1)} reduce(%mul.1898, %constant.444.clone.24), dimensions={0,2}, to_apply=%region_12.15, metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.222 = f32[128]{0:T(128)S(1)} reduce(%mul.1898, %constant.444.clone.24), dimensions={0,2}, to_apply=%region_12.15, metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.488 (param_0.1388: f32[128], param_1.1491: f32[128]) -> f32[128] {
-  %param_0.1388 = f32[128]{0:T(128)S(1)} parameter(0)
-  %bitcast.601 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1388), metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
-  %param_1.1491 = f32[128]{0:T(128)S(1)} parameter(1)
+%fused_computation.489 (param_0.1396: f32[128], param_1.1495: f32[128]) -> f32[128] {
+  %param_0.1396 = f32[128]{0:T(128)S(1)} parameter(0)
+  %bitcast.616 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1396), metadata={op_name="jit(train_step)/transpose(jvp())/reduce_sum" stack_frame_id=0}
+  %param_1.1495 = f32[128]{0:T(128)S(1)} parameter(1)
   %constant.452.clone.1 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.965 = f32[128]{0:T(128)} broadcast(%constant.452.clone.1), dimensions={}, metadata={op_name="broadcast.416"}
-  %div.782 = f32[128]{0:T(128)} multiply(%param_1.1491, %broadcast.965), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
+  %broadcast.966 = f32[128]{0:T(128)} broadcast(%constant.452.clone.1), dimensions={}, metadata={op_name="broadcast.416"}
+  %div.782 = f32[128]{0:T(128)} multiply(%param_1.1495, %broadcast.966), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
   %constant.453.clone.1 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.963 = f32[128]{0:T(128)} broadcast(%constant.453.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %add.937 = f32[128]{0:T(128)} add(%div.782, %broadcast.963), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %bitcast.600 = f32[1,128]{1,0:T(1,128)} bitcast(%add.937), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
-  %rsqrt.201 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.600), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
-  %div.780 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.201, %bitcast.600), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
+  %broadcast.964 = f32[128]{0:T(128)} broadcast(%constant.453.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %add.937 = f32[128]{0:T(128)} add(%div.782, %broadcast.964), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %bitcast.615 = f32[1,128]{1,0:T(1,128)} bitcast(%add.937), metadata={op_name="jit(train_step)/jvp()/add" stack_frame_id=0}
+  %rsqrt.201 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.615), metadata={op_name="jit(train_step)/jvp()/rsqrt" stack_frame_id=0}
+  %div.780 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.201, %bitcast.615), metadata={op_name="jit(train_step)/jvp()/div" stack_frame_id=0}
   %constant.455.clone.1 = f32[]{:T(128)} constant(-0.5)
   %mul.1984 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.455.clone.1), dimensions={}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
   %mul.1978 = f32[1,128]{1,0:T(1,128)} multiply(%div.780, %mul.1984), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %mul.1977 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.601, %mul.1978), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %mul.1977 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.616, %mul.1978), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %constant.456.clone.1 = f32[]{:T(128)} constant(0.0009765625)
   %mul.1983 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.456.clone.1), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %mul.1973 = f32[1,128]{1,0:T(1,128)} multiply(%mul.1977, %mul.1983), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  ROOT %bitcast.595 = f32[128]{0:T(128)S(1)} bitcast(%mul.1973), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  ROOT %bitcast.610 = f32[128]{0:T(128)S(1)} bitcast(%mul.1973), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
 }
 
-%fused_computation.410 (param_0.1197: bf16[1,128,2048], param_1.1254: f32[128], param_2.811: f32[128], param_3.438: bf16[1,128,2048], param_4.247: bf16[2048]) -> bf16[1,128,2048] {
-  %param_3.438 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %convert.365 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_3.438)
+%fused_computation.411 (param_0.1205: bf16[1,128,2048], param_1.1258: f32[128], param_2.815: f32[128], param_3.441: bf16[1,128,2048], param_4.247: bf16[2048]) -> bf16[1,128,2048] {
+  %param_3.441 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %convert.366 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_3.441)
   %param_4.247 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(4)
-  %dot_general.482 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_4.247), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
-  %convert.366 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.482)
-  %dot_general.468 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.365, %convert.366), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.1228 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.468), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
-  %param_2.811 = f32[128]{0:T(128)S(1)} parameter(2)
-  %mul.1902 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_2.811), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  %mul.1894 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1228, %mul.1902), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %param_0.1197 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1239 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1197), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
-  %param_1.1254 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.1901 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1254), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %mul.1900 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1239, %mul.1901), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %add_any.195 = f32[1,128,2048]{2,1,0:T(8,128)} add(%mul.1894, %mul.1900), metadata={op_name="jit(train_step)/transpose(jvp())/add_any" stack_frame_id=0}
-  ROOT %convert_element_type.1226 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%add_any.195), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
+  %dot_general.470 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_4.247), dimensions={2}, metadata={op_name="jit(train_step)/jvp(...k,k->...k)/dot_general" stack_frame_id=0}
+  %convert.367 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.470)
+  %dot_general.456 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.366, %convert.367), metadata={op_name="jit(train_step)/transpose(jvp(...k,k->...k))/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.1232 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.456), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
+  %param_2.815 = f32[128]{0:T(128)S(1)} parameter(2)
+  %mul.1902 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_2.815), dimensions={1}, metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  %mul.1894 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1232, %mul.1902), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %param_0.1205 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1243 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1205), metadata={op_name="jit(train_step)/jvp()/convert_element_type" stack_frame_id=0}
+  %param_1.1258 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.1901 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1258), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %mul.1900 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1243, %mul.1901), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %add_any.204 = f32[1,128,2048]{2,1,0:T(8,128)} add(%mul.1894, %mul.1900), metadata={op_name="jit(train_step)/transpose(jvp())/add_any" stack_frame_id=0}
+  ROOT %convert_element_type.1230 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add_any.204), metadata={op_name="jit(train_step)/transpose(jvp())/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.97.clone.1 (param_0.1755: bf16[4,512,6144], param_1.1857: s32[]) -> bf16[1,512,6144] {
-  %param_0.1755 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1857 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.415.clone.87 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.192 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1755, %param_1.1857, %constant.415.clone.87, %constant.415.clone.87), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.99.clone.1 (param_0.1735: bf16[4,512,6144], param_1.1845: s32[]) -> bf16[1,512,6144] {
+  %param_0.1735 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1845 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.415.clone.79 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.185 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1735, %param_1.1845, %constant.415.clone.79, %constant.415.clone.79), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%convert_element_type.762.reduce_sub_computation (lhs.1: bf16[], rhs.1: bf16[]) -> bf16[] {
+%convert_element_type.767.reduce_sub_computation (lhs.1: bf16[], rhs.1: bf16[]) -> bf16[] {
   %lhs.1 = bf16[] parameter(0)
   %rhs.1 = bf16[] parameter(1)
   ROOT %add.793 = bf16[] add(%lhs.1, %rhs.1), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%convert_element_type.758.reduce_sub_computation (lhs: bf16[], rhs: bf16[]) -> bf16[] {
+%convert_element_type.763.reduce_sub_computation (lhs: bf16[], rhs: bf16[]) -> bf16[] {
   %lhs = bf16[] parameter(0)
   %rhs = bf16[] parameter(1)
   ROOT %add.792 = bf16[] add(%lhs, %rhs), backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.290.clone.1 (param_0.1725: bf16[4,2048], param_1.1839: s32[], param_2.1403: bf16[4,2048]) -> (bf16[2048], bf16[2048]) {
-  %param_0.1725 = bf16[4,2048]{1,0:T(4,128)(2,1)} parameter(0)
-  %param_1.1839 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.291.clone.1 (param_0.1734: bf16[4,2048], param_1.1844: s32[], param_2.1407: bf16[4,2048]) -> (bf16[2048], bf16[2048]) {
+  %param_0.1734 = bf16[4,2048]{1,0:T(4,128)(2,1)} parameter(0)
+  %param_1.1844 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.78 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.201 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1725, %param_1.1839, %constant.415.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %constant.1109 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %reduce.263 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.201, %constant.1109), dimensions={0}, to_apply=%convert_element_type.762.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_2.1403 = bf16[4,2048]{1,0:T(4,128)(2,1)} parameter(2)
-  %dynamic_slice.186.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1403, %param_1.1839, %constant.415.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %reduce.195.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.186.clone.3, %constant.1109), dimensions={0}, to_apply=%convert_element_type.758.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.216 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) tuple(%reduce.263, %reduce.195.clone.3)
+  %dynamic_slice.201 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1734, %param_1.1844, %constant.415.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %constant.1110 = bf16[]{:T(256)} constant(-0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %reduce.262 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.201, %constant.1110), dimensions={0}, to_apply=%convert_element_type.767.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_2.1407 = bf16[4,2048]{1,0:T(4,128)(2,1)} parameter(2)
+  %dynamic_slice.186.clone.3 = bf16[1,2048]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1407, %param_1.1844, %constant.415.clone.78), dynamic_slice_sizes={1,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %reduce.194.clone.3 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%dynamic_slice.186.clone.3, %constant.1110), dimensions={0}, to_apply=%convert_element_type.763.reduce_sub_computation, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.214 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[2048]{0:T(1024)(128)(2,1)S(1)}) tuple(%reduce.262, %reduce.194.clone.3)
 }
 
-%fused_computation.121.clone.1 (param_0.1750: bf16[4,16,128,512], param_1.1855: s32[]) -> bf16[1,16,128,512] {
-  %param_0.1750 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1855 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.415.clone.86 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.191 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1750, %param_1.1855, %constant.415.clone.86, %constant.415.clone.86, %constant.415.clone.86), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.121.clone.1 (param_0.1760: bf16[4,16,128,512], param_1.1861: s32[]) -> bf16[1,16,128,512] {
+  %param_0.1760 = bf16[4,16,128,512]{3,2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1861 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.415.clone.87 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.192 = bf16[1,16,128,512]{3,2,1,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1760, %param_1.1861, %constant.415.clone.87, %constant.415.clone.87, %constant.415.clone.87), dynamic_slice_sizes={1,16,128,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.122.clone.1 (param_0.1742: bf16[4,512,16,128], param_1.1850: s32[]) -> bf16[1,512,16,128] {
-  %param_0.1742 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1850 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.415.clone.84 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.189 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1742, %param_1.1850, %constant.415.clone.84, %constant.415.clone.84, %constant.415.clone.84), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.122.clone.1 (param_0.1752: bf16[4,512,16,128], param_1.1856: s32[]) -> bf16[1,512,16,128] {
+  %param_0.1752 = bf16[4,512,16,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1856 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.415.clone.85 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.190 = bf16[1,512,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1752, %param_1.1856, %constant.415.clone.85, %constant.415.clone.85, %constant.415.clone.85), dynamic_slice_sizes={1,512,16,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
 %region_14.16 (reduce_sum.204: f32[], reduce_sum.205: f32[]) -> f32[] {
@@ -1080,54 +1080,54 @@ StackFrames
   ROOT %reduce_sum.206 = f32[]{:T(128)} add(%reduce_sum.204, %reduce_sum.205), metadata={op_name="checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.174.clone.1 (param_0.1723: bf16[4,1,128,2048], param_1.1838: s32[]) -> f32[128] {
-  %param_0.1723 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %param_1.1838 = s32[]{:T(128)S(6)} parameter(1)
+%fused_computation.171.clone.1 (param_0.1732: bf16[4,1,128,2048], param_1.1843: s32[]) -> f32[128] {
+  %param_0.1732 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %param_1.1843 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.77 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.184 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1723, %param_1.1838, %constant.415.clone.77, %constant.415.clone.77, %constant.415.clone.77), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.858 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.184), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1388 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.858), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %square.281 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1388, %convert_element_type.1388), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
+  %dynamic-slice.184 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1732, %param_1.1843, %constant.415.clone.77, %constant.415.clone.77, %constant.415.clone.77), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.876 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.184), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1395 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.876), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %square.281 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1395, %convert_element_type.1395), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
   %constant.416.clone.19 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.262 = f32[128]{0:T(128)S(1)} reduce(%square.281, %constant.416.clone.19), dimensions={0,2}, to_apply=%region_14.16, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.261 = f32[128]{0:T(128)S(1)} reduce(%square.281, %constant.416.clone.19), dimensions={0,2}, to_apply=%region_14.16, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.304.clone.1 (param_0.1724: f32[128]) -> f32[128] {
-  %param_0.1724 = f32[128]{0:T(128)S(1)} parameter(0)
+%fused_computation.305.clone.1 (param_0.1733: f32[128]) -> f32[128] {
+  %param_0.1733 = f32[128]{0:T(128)S(1)} parameter(0)
   %constant.417.clone.9 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.1067 = f32[128]{0:T(128)} broadcast(%constant.417.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.1009 = f32[128]{0:T(128)} multiply(%param_0.1724, %broadcast.1067), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %broadcast.1068 = f32[128]{0:T(128)} broadcast(%constant.417.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.1009 = f32[128]{0:T(128)} multiply(%param_0.1733, %broadcast.1068), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
   %constant.418.clone.17 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1066 = f32[128]{0:T(128)} broadcast(%constant.418.clone.17), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.1045 = f32[128]{0:T(128)} add(%div.1009, %broadcast.1066), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.860 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1045), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.214 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.860), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.859 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.214), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %broadcast.1067 = f32[128]{0:T(128)} broadcast(%constant.418.clone.17), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.1045 = f32[128]{0:T(128)} add(%div.1009, %broadcast.1067), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.878 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1045), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.214 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.878), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.877 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.214), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.234.clone.clone.clone.1 (param_0.1744: bf16[2048], param_1.1851: f32[128], param_2.1411: bf16[4,1,128,2048], param_3.933: s32[]) -> bf16[128,2048,1] {
-  %param_0.1744 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.599 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1744), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.390 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.599)
-  %param_2.1411 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.933 = s32[]{:T(128)S(6)} parameter(3)
-  %constant.415.clone.85 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.190 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1411, %param_3.933, %constant.415.clone.85, %constant.415.clone.85, %constant.415.clone.85), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.876 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.190), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1398 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.876), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1851 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2313 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1851), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2312 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1398, %mul.2313), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1397 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2312), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.391 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1397)
-  %dot_general.598 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.390, %convert.391), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.392 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.598)
-  ROOT %bitcast.875 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.392)
+%fused_computation.236.clone.clone.clone.1 (param_0.1754: bf16[2048], param_1.1857: f32[128], param_2.1415: bf16[4,1,128,2048], param_3.936: s32[]) -> bf16[128,2048,1] {
+  %param_0.1754 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.589 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1754), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.391 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.589)
+  %param_2.1415 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.936 = s32[]{:T(128)S(6)} parameter(3)
+  %constant.415.clone.86 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.191 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1415, %param_3.936, %constant.415.clone.86, %constant.415.clone.86, %constant.415.clone.86), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.894 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.191), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1405 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.894), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1857 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2311 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1857), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2310 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1405, %mul.2311), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1404 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2310), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.392 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1404)
+  %dot_general.588 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.391, %convert.392), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.393 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.588)
+  ROOT %bitcast.893 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.393)
 }
 
-%fused_computation.107.clone.clone.clone.clone.clone.1 (param_0.1743: bf16[1,2048,16,128]) -> bf16[2048,16,128] {
-  %param_0.1743 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.874 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1743), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+%fused_computation.107.clone.clone.clone.clone.clone.1 (param_0.1753: bf16[1,2048,16,128]) -> bf16[2048,16,128] {
+  %param_0.1753 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.892 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1753), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
 %region_15.17 (reduce_sum.207: f32[], reduce_sum.211: f32[]) -> f32[] {
@@ -1136,205 +1136,205 @@ StackFrames
   ROOT %reduce_sum.212 = f32[]{:T(128)} add(%reduce_sum.207, %reduce_sum.211), metadata={op_name="checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.180.clone.1 (param_0.1745: bf16[1,2048,16,128], param_1.1852: bf16[2048], param_2.1412: f32[128], param_3.934: bf16[4,1,128,2048], param_4.555: s32[]) -> (f32[128,16], bf16[1,128,16,128]) {
-  %param_1.1852 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_2.1412 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.934 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %param_4.555 = s32[]{:T(128)S(6)} parameter(4)
-  %fusion.232.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1852, %param_2.1412, %param_3.934, %param_4.555), kind=kLoop, calls=%fused_computation.234.clone.clone.clone.1
-  %param_0.1745 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.193.clone.3 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1745), kind=kLoop, calls=%fused_computation.107.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convolution.103.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.232.clone.3, %fusion.193.clone.3), window={size=16 pad=15_15 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %bitcast.367.clone.3 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.103.clone.3)
-  %convert.339 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%bitcast.367.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %square.283 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.339, %convert.339), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
+%fused_computation.179.clone.1 (param_0.1755: bf16[1,2048,16,128], param_1.1858: bf16[2048], param_2.1416: f32[128], param_3.937: bf16[4,1,128,2048], param_4.551: s32[]) -> (f32[128,16], bf16[1,128,16,128]) {
+  %param_1.1858 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_2.1416 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.937 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_4.551 = s32[]{:T(128)S(6)} parameter(4)
+  %fusion.237.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1858, %param_2.1416, %param_3.937, %param_4.551), kind=kLoop, calls=%fused_computation.236.clone.clone.clone.1
+  %param_0.1755 = bf16[1,2048,16,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.197.clone.3 = bf16[2048,16,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1755), kind=kLoop, calls=%fused_computation.107.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convolution.103.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.237.clone.3, %fusion.197.clone.3), window={size=16 pad=15_15 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  %bitcast.377.clone.3 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.103.clone.3)
+  %convert.340 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%bitcast.377.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %square.283 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.340, %convert.340), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
   %constant.416.clone.21 = f32[]{:T(128)} constant(0)
-  %reduce.265 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.283, %constant.416.clone.21), dimensions={0,3}, to_apply=%region_15.17, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.223 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%reduce.265, %bitcast.367.clone.3)
+  %reduce.264 = f32[128,16]{0,1:T(8,128)S(1)} reduce(%square.283, %constant.416.clone.21), dimensions={0,3}, to_apply=%region_15.17, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.221 = (f32[128,16]{0,1:T(8,128)S(1)}, bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%reduce.264, %bitcast.377.clone.3)
 }
 
-%fused_computation.284.clone.1 (param_0.1746: f32[128,16]) -> f32[128,16] {
-  %param_0.1746 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
+%fused_computation.285.clone.1 (param_0.1756: f32[128,16]) -> f32[128,16] {
+  %param_0.1756 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
   %constant.419.clone.13 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.1073 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.419.clone.13), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.1015 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1746, %broadcast.1073), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %broadcast.1074 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.419.clone.13), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.1015 = f32[128,16]{0,1:T(8,128)} multiply(%param_0.1756, %broadcast.1074), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
   %constant.418.clone.19 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1072 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.418.clone.19), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %add.1048 = f32[128,16]{0,1:T(8,128)} add(%div.1015, %broadcast.1072), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.878 = f32[1,128,16]{1,2,0:T(8,128)} bitcast(%add.1048), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.216 = f32[1,128,16]{1,2,0:T(8,128)} rsqrt(%bitcast.878), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.877 = f32[128,16]{0,1:T(8,128)S(1)} bitcast(%rsqrt.216), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %broadcast.1073 = f32[128,16]{0,1:T(8,128)} broadcast(%constant.418.clone.19), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %add.1048 = f32[128,16]{0,1:T(8,128)} add(%div.1015, %broadcast.1073), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.896 = f32[1,128,16]{1,2,0:T(8,128)} bitcast(%add.1048), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.216 = f32[1,128,16]{1,2,0:T(8,128)} rsqrt(%bitcast.896), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.895 = f32[128,16]{0,1:T(8,128)S(1)} bitcast(%rsqrt.216), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.310.clone.1 (param_0.1730: bf16[4,128], param_1.1843: s32[], param_2.1406: bf16[4,128]) -> (bf16[128], bf16[128]) {
-  %param_0.1730 = bf16[4,128]{1,0:T(4,128)(2,1)} parameter(0)
-  %param_1.1843 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.415.clone.81 = s32[]{:T(128)} constant(0)
-  %dynamic_slice.202 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1730, %param_1.1843, %constant.415.clone.81), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.865 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.202), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_2.1406 = bf16[4,128]{1,0:T(4,128)(2,1)} parameter(2)
-  %dynamic_slice.196.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1406, %param_1.1843, %constant.415.clone.81), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.460.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.196.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.217 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) tuple(%bitcast.865, %bitcast.460.clone.3)
+%fused_computation.311.clone.1 (param_0.1740: bf16[4,128], param_1.1849: s32[], param_2.1410: bf16[4,128]) -> (bf16[128], bf16[128]) {
+  %param_0.1740 = bf16[4,128]{1,0:T(4,128)(2,1)} parameter(0)
+  %param_1.1849 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.415.clone.82 = s32[]{:T(128)} constant(0)
+  %dynamic_slice.202 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_0.1740, %param_1.1849, %constant.415.clone.82), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.883 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.202), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_2.1410 = bf16[4,128]{1,0:T(4,128)(2,1)} parameter(2)
+  %dynamic_slice.196.clone.3 = bf16[1,128]{1,0:T(2,128)(2,1)} dynamic-slice(%param_2.1410, %param_1.1849, %constant.415.clone.82), dynamic_slice_sizes={1,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.475.clone.3 = bf16[128]{0:T(256)(128)(2,1)S(1)} bitcast(%dynamic_slice.196.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.215 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[128]{0:T(256)(128)(2,1)S(1)}) tuple(%bitcast.883, %bitcast.475.clone.3)
 }
 
-%fused_computation.238.clone.2 (param_0.1747: f32[128,16], param_1.1853: bf16[1,128,16,128], param_2.1413: bf16[128]) -> bf16[1,128,16,128] {
-  %param_2.1413 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
-  %dot_general.601 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1413), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.449 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.601)
-  %param_1.1853 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.340 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%param_1.1853), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_0.1747 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
-  %mul.2315 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_0.1747), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2314 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.340, %mul.2315), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1399 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2314), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.450 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1399)
-  %dot_general.600 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.449, %convert.450), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  ROOT %convert.451 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.600)
+%fused_computation.239.clone.2 (param_0.1757: f32[128,16], param_1.1859: bf16[1,128,16,128], param_2.1417: bf16[128]) -> bf16[1,128,16,128] {
+  %param_2.1417 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
+  %dot_general.591 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1417), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.450 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.591)
+  %param_1.1859 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.341 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%param_1.1859), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_0.1757 = f32[128,16]{0,1:T(8,128)S(1)} parameter(0)
+  %mul.2313 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_0.1757), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2312 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.341, %mul.2313), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1406 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2312), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.451 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1406)
+  %dot_general.590 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.450, %convert.451), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  ROOT %convert.452 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.590)
 }
 
-%fused_computation.205.clone.1 (param_0.1748: bf16[1,128,16,128]) -> (bf16[1,128,16,64], bf16[1,128,16,64]) {
-  %param_0.1748 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.75 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1748), slice={[0:1], [0:128], [0:16], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
-  %convert.452 = f32[1,128,16,64]{3,1,2,0:T(8,128)} convert(%slice.75)
-  %neg.127 = f32[1,128,16,64]{3,1,2,0:T(8,128)} negate(%convert.452), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.453 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.127)
-  %slice.76 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1748), slice={[0:1], [0:128], [0:16], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
-  ROOT %tuple.224 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.453, %slice.76)
+%fused_computation.205.clone.1 (param_0.1758: bf16[1,128,16,128]) -> (bf16[1,128,16,64], bf16[1,128,16,64]) {
+  %param_0.1758 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.75 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1758), slice={[0:1], [0:128], [0:16], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
+  %convert.453 = f32[1,128,16,64]{3,1,2,0:T(8,128)} convert(%slice.75)
+  %neg.127 = f32[1,128,16,64]{3,1,2,0:T(8,128)} negate(%convert.453), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.454 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.127)
+  %slice.76 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1758), slice={[0:1], [0:128], [0:16], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
+  ROOT %tuple.222 = (bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.454, %slice.76)
 }
 
-%fused_computation.319.clone.1 () -> f32[64] {
+%fused_computation.320.clone.1 () -> f32[64] {
   %constant.420.clone.3 = f32[]{:T(128)} constant(1e+06)
   %eval_jaxpr.56 = f32[64]{0:T(128)} broadcast(%constant.420.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
   %iota.65 = s32[64]{0:T(128)} iota(), iota_dimension=0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/iota" stack_frame_id=0}
   %constant.421.clone.3 = s32[]{:T(128)} constant(2)
   %eval_jaxpr.55 = s32[64]{0:T(128)} broadcast(%constant.421.clone.3), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %mul.2301 = s32[64]{0:T(128)} multiply(%iota.65, %eval_jaxpr.55), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1393 = f32[64]{0:T(128)} convert(%mul.2301), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %mul.2299 = s32[64]{0:T(128)} multiply(%iota.65, %eval_jaxpr.55), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1400 = f32[64]{0:T(128)} convert(%mul.2299), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %constant.419.clone.12 = f32[]{:T(128)} constant(0.0078125)
   %eval_jaxpr.54 = f32[64]{0:T(128)} broadcast(%constant.419.clone.12), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.1011 = f32[64]{0:T(128)} multiply(%convert_element_type.1393, %eval_jaxpr.54), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %div.1011 = f32[64]{0:T(128)} multiply(%convert_element_type.1400, %eval_jaxpr.54), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
   ROOT %pow.38 = f32[64]{0:T(128)S(1)} power(%eval_jaxpr.56, %div.1011), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/pow" stack_frame_id=0}
 }
 
-%fused_computation.275.clone.1 (param_0.1736: f32[128], param_1.1847: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
-  %param_0.1736 = f32[128]{0:T(128)S(1)} parameter(0)
-  %div.1013 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_0.1736), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
-  %param_1.1847 = f32[64]{0:T(128)S(1)} parameter(1)
-  %div.1014 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_1.1847), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+%fused_computation.276.clone.1 (param_0.1746: f32[128], param_1.1853: f32[64]) -> (bf16[1,128,1,64], bf16[1,128,1,64]) {
+  %param_0.1746 = f32[128]{0:T(128)S(1)} parameter(0)
+  %div.1013 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_0.1746), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %param_1.1853 = f32[64]{0:T(128)S(1)} parameter(1)
+  %div.1014 = f32[1,128,1,64]{3,1,2,0:T(8,128)} broadcast(%param_1.1853), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
   %div.1012 = f32[1,128,1,64]{3,1,2,0:T(8,128)} divide(%div.1013, %div.1014), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
   %cos.43 = f32[1,128,1,64]{3,1,2,0:T(8,128)} cosine(%div.1012), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/cos" stack_frame_id=0}
-  %convert_element_type.1394 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%cos.43), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert_element_type.1401 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%cos.43), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
   %sin.35.clone.3 = f32[1,128,1,64]{3,1,2,0:T(8,128)} sine(%div.1012), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/sin" stack_frame_id=0}
-  %convert_element_type.1112.clone.3 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%sin.35.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  ROOT %tuple.219 = (bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert_element_type.1394, %convert_element_type.1112.clone.3)
+  %convert_element_type.1116.clone.3 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%sin.35.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  ROOT %tuple.217 = (bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert_element_type.1401, %convert_element_type.1116.clone.3)
 }
 
-%fused_computation.280.clone.1 (param_0.1738: bf16[1,128,1,64]) -> (bf16[128,128], bf16[128,128]) {
-  %param_0.1738 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.1111 = bf16[]{:T(256)} constant(-inf)
-  %pad.77 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1738, %constant.1111), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.454 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.77)
-  %pad.76 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1738, %constant.1111), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.455 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.76)
-  %maximum.57 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.454, %convert.455), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+%fused_computation.281.clone.1 (param_0.1748: bf16[1,128,1,64]) -> (bf16[128,128], bf16[128,128]) {
+  %param_0.1748 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %constant.1112 = bf16[]{:T(256)} constant(-inf)
+  %pad.77 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1748, %constant.1112), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.455 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.77)
+  %pad.76 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1748, %constant.1112), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.456 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.76)
+  %maximum.57 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.455, %convert.456), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %constant.422.clone.8 = bf16[]{:T(256)} constant(0.08838)
-  %broadcast.1071 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.8), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %convert.457 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%broadcast.1071)
-  %mul.2303 = f32[1,128,1,128]{3,1,2,0:T(8,128)} multiply(%maximum.57, %convert.457), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.458 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2303)
-  %bitcast.872 = bf16[128,128]{1,0:T(8,128)(2,1)} bitcast(%convert.458), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %convert.456 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.57)
-  %bitcast.445.clone.3 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.456), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  ROOT %tuple.221 = (bf16[128,128]{1,0:T(8,128)(2,1)}, bf16[128,128]{1,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.872, %bitcast.445.clone.3)
+  %broadcast.1072 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.8), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %convert.458 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%broadcast.1072)
+  %mul.2301 = f32[1,128,1,128]{3,1,2,0:T(8,128)} multiply(%maximum.57, %convert.458), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.459 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2301)
+  %bitcast.890 = bf16[128,128]{1,0:T(8,128)(2,1)} bitcast(%convert.459), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %convert.457 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.57)
+  %bitcast.460.clone.3 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.457), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  ROOT %tuple.219 = (bf16[128,128]{1,0:T(8,128)(2,1)}, bf16[128,128]{1,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.890, %bitcast.460.clone.3)
 }
 
-%fused_computation.279.clone.1 (param_0.1737: bf16[1,128,1,64]) -> (bf16[128,128], bf16[128,128]) {
-  %param_0.1737 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %constant.1110 = bf16[]{:T(256)} constant(-inf)
-  %pad.75 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1737, %constant.1110), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.444 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.75)
-  %pad.74 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1737, %constant.1110), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.445 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.74)
-  %maximum.56 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.444, %convert.445), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+%fused_computation.280.clone.1 (param_0.1747: bf16[1,128,1,64]) -> (bf16[128,128], bf16[128,128]) {
+  %param_0.1747 = bf16[1,128,1,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %constant.1111 = bf16[]{:T(256)} constant(-inf)
+  %pad.75 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1747, %constant.1111), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.445 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.75)
+  %pad.74 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1747, %constant.1111), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.446 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%pad.74)
+  %maximum.56 = f32[1,128,1,128]{3,1,2,0:T(8,128)} maximum(%convert.445, %convert.446), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %constant.422.clone.7 = bf16[]{:T(256)} constant(0.08838)
-  %broadcast.1070 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.7), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %convert.447 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%broadcast.1070)
-  %mul.2302 = f32[1,128,1,128]{3,1,2,0:T(8,128)} multiply(%maximum.56, %convert.447), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.448 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2302)
-  %bitcast.871 = bf16[128,128]{1,0:T(8,128)(2,1)} bitcast(%convert.448), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %convert.446 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.56)
-  %bitcast.446.clone.3 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.446), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  ROOT %tuple.220 = (bf16[128,128]{1,0:T(8,128)(2,1)}, bf16[128,128]{1,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.871, %bitcast.446.clone.3)
+  %broadcast.1071 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.7), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %convert.448 = f32[1,128,1,128]{3,1,2,0:T(8,128)} convert(%broadcast.1071)
+  %mul.2300 = f32[1,128,1,128]{3,1,2,0:T(8,128)} multiply(%maximum.56, %convert.448), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.449 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2300)
+  %bitcast.889 = bf16[128,128]{1,0:T(8,128)(2,1)} bitcast(%convert.449), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %convert.447 = bf16[1,128,1,128]{3,1,2,0:T(8,128)(2,1)} convert(%maximum.56)
+  %bitcast.461.clone.3 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} bitcast(%convert.447), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  ROOT %tuple.218 = (bf16[128,128]{1,0:T(8,128)(2,1)}, bf16[128,128]{1,0:T(8,128)(2,1)S(1)}) tuple(%bitcast.889, %bitcast.461.clone.3)
 }
 
-%fused_computation.209.clone.1 (param_0.1749: bf16[1,128,16,64], param_1.1854: bf16[1,128,16,64], param_2.1414: bf16[128,128], param_3.935: bf16[128,128], param_4.556: f32[128,16], param_5.486: bf16[1,128,16,128], param_6.341: bf16[128]) -> bf16[16,128,128] {
-  %param_6.341 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
-  %dot_general.603 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.341), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.459 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.603)
-  %param_5.486 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
-  %convert.341 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%param_5.486), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_4.556 = f32[128,16]{0,1:T(8,128)S(1)} parameter(4)
-  %mul.2322 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_4.556), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2321 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.341, %mul.2322), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1400 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2321), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.460 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1400)
-  %dot_general.602 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.459, %convert.460), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_3.935 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %mul.2320 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.935), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.461 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2320)
-  %mul.2318 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%dot_general.602, %convert.461), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_1.1854 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1113 = bf16[]{:T(256)} constant(-inf)
-  %pad.81 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1854, %constant.1113), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.462 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.81)
-  %param_0.1749 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.80 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1749, %constant.1113), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.463 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.80)
-  %maximum.59 = f32[1,128,16,128]{3,1,2,0:T(8,128)} maximum(%convert.462, %convert.463), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_2.1414 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %mul.2319 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1414), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.464 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2319)
-  %mul.2317 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%maximum.59, %convert.464), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %add.1049 = f32[1,128,16,128]{3,1,2,0:T(8,128)} add(%mul.2318, %mul.2317), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+%fused_computation.209.clone.1 (param_0.1759: bf16[1,128,16,64], param_1.1860: bf16[1,128,16,64], param_2.1418: bf16[128,128], param_3.938: bf16[128,128], param_4.552: f32[128,16], param_5.480: bf16[1,128,16,128], param_6.336: bf16[128]) -> bf16[16,128,128] {
+  %param_6.336 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
+  %dot_general.593 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.336), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.460 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%dot_general.593)
+  %param_5.480 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
+  %convert.342 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%param_5.480), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_4.552 = f32[128,16]{0,1:T(8,128)S(1)} parameter(4)
+  %mul.2320 = f32[1,128,16,128]{3,1,2,0:T(8,128)} broadcast(%param_4.552), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2319 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.342, %mul.2320), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1407 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2319), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.461 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1407)
+  %dot_general.592 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%convert.460, %convert.461), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_3.938 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %mul.2318 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.938), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.462 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2318)
+  %mul.2316 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%dot_general.592, %convert.462), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_1.1860 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1114 = bf16[]{:T(256)} constant(-inf)
+  %pad.81 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1860, %constant.1114), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.463 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.81)
+  %param_0.1759 = bf16[1,128,16,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.80 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1759, %constant.1114), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.464 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%pad.80)
+  %maximum.59 = f32[1,128,16,128]{3,1,2,0:T(8,128)} maximum(%convert.463, %convert.464), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_2.1418 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %mul.2317 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1418), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.465 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%mul.2317)
+  %mul.2315 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%maximum.59, %convert.465), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %add.1049 = f32[1,128,16,128]{3,1,2,0:T(8,128)} add(%mul.2316, %mul.2315), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
   %constant.422.clone.9 = bf16[]{:T(256)} constant(0.08838)
   %eval_jaxpr.57 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%constant.422.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %convert.465 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%eval_jaxpr.57)
-  %mul.2316 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%add.1049, %convert.465), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.466 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2316)
-  ROOT %bitcast.879 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.466), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+  %convert.466 = f32[1,128,16,128]{3,1,2,0:T(8,128)} convert(%eval_jaxpr.57)
+  %mul.2314 = f32[1,128,16,128]{3,1,2,0:T(8,128)} multiply(%add.1049, %convert.466), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","16","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.467 = bf16[1,128,16,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2314)
+  ROOT %bitcast.897 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.467), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.131.clone.1 (param_0.1731: bf16[4,512,8,128], param_1.1844: s32[]) -> bf16[1,512,8,128] {
-  %param_0.1731 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1844 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.415.clone.82 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.187 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1731, %param_1.1844, %constant.415.clone.82, %constant.415.clone.82, %constant.415.clone.82), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-}
-
-%fused_computation.233.clone.clone.clone.1 (param_0.1733: bf16[2048], param_1.1845: f32[128], param_2.1407: bf16[4,1,128,2048], param_3.930: s32[]) -> bf16[128,2048,1] {
-  %param_0.1733 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.593 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1733), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.387 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.593)
-  %param_2.1407 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.930 = s32[]{:T(128)S(6)} parameter(3)
+%fused_computation.131.clone.1 (param_0.1741: bf16[4,512,8,128], param_1.1850: s32[]) -> bf16[1,512,8,128] {
+  %param_0.1741 = bf16[4,512,8,128]{1,3,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1850 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.83 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.188 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1407, %param_3.930, %constant.415.clone.83, %constant.415.clone.83, %constant.415.clone.83), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.868 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.188), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1392 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.868), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1845 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2300 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1845), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2299 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1392, %mul.2300), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1391 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2299), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.388 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1391)
-  %dot_general.592 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.387, %convert.388), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.389 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.592)
-  ROOT %bitcast.867 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.389)
+  ROOT %dynamic-slice.188 = bf16[1,512,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1741, %param_1.1850, %constant.415.clone.83, %constant.415.clone.83, %constant.415.clone.83), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.120.clone.clone.clone.clone.clone.1 (param_0.1732: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
-  %param_0.1732 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.866 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1732), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+%fused_computation.235.clone.clone.clone.1 (param_0.1743: bf16[2048], param_1.1851: f32[128], param_2.1411: bf16[4,1,128,2048], param_3.933: s32[]) -> bf16[128,2048,1] {
+  %param_0.1743 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.583 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1743), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.388 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.583)
+  %param_2.1411 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.933 = s32[]{:T(128)S(6)} parameter(3)
+  %constant.415.clone.84 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.189 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1411, %param_3.933, %constant.415.clone.84, %constant.415.clone.84, %constant.415.clone.84), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.886 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.189), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1399 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.886), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1851 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2298 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1851), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2297 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1399, %mul.2298), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1398 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2297), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.389 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1398)
+  %dot_general.582 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.388, %convert.389), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.390 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.582)
+  ROOT %bitcast.885 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.390)
+}
+
+%fused_computation.120.clone.clone.clone.clone.clone.1 (param_0.1742: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
+  %param_0.1742 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.884 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1742), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
 %region_16.18 (reduce_sum.213: f32[], reduce_sum.214: f32[]) -> f32[] {
@@ -1343,146 +1343,146 @@ StackFrames
   ROOT %reduce_sum.218 = f32[]{:T(128)} add(%reduce_sum.213, %reduce_sum.214), metadata={op_name="checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.198.clone.1 (param_0.1734: bf16[1,2048,8,128], param_1.1846: bf16[2048], param_2.1408: f32[128], param_3.931: bf16[4,1,128,2048], param_4.553: s32[]) -> (f32[128,8], bf16[1,128,8,128]) {
-  %param_1.1846 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_2.1408 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.931 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %param_4.553 = s32[]{:T(128)S(6)} parameter(4)
-  %fusion.231.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1846, %param_2.1408, %param_3.931, %param_4.553), kind=kLoop, calls=%fused_computation.233.clone.clone.clone.1
-  %param_0.1734 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.196.clone.3 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1734), kind=kLoop, calls=%fused_computation.120.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convolution.105.clone.3 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.231.clone.3, %fusion.196.clone.3), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %bitcast.370.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.105.clone.3)
-  %convert.336 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%bitcast.370.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %square.282 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.336, %convert.336), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
+%fused_computation.198.clone.1 (param_0.1744: bf16[1,2048,8,128], param_1.1852: bf16[2048], param_2.1412: f32[128], param_3.934: bf16[4,1,128,2048], param_4.549: s32[]) -> (f32[128,8], bf16[1,128,8,128]) {
+  %param_1.1852 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_2.1412 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.934 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_4.549 = s32[]{:T(128)S(6)} parameter(4)
+  %fusion.236.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1852, %param_2.1412, %param_3.934, %param_4.549), kind=kLoop, calls=%fused_computation.235.clone.clone.clone.1
+  %param_0.1744 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.200.clone.3 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1744), kind=kLoop, calls=%fused_computation.120.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convolution.105.clone.3 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.236.clone.3, %fusion.200.clone.3), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  %bitcast.380.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convolution.105.clone.3)
+  %convert.337 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%bitcast.380.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %square.282 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.337, %convert.337), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
   %constant.416.clone.20 = f32[]{:T(128)} constant(0)
-  %reduce.264 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.282, %constant.416.clone.20), dimensions={0,3}, to_apply=%region_16.18, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.218 = (f32[128,8]{0,1:T(8,128)S(1)}, bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%reduce.264, %bitcast.370.clone.3)
+  %reduce.263 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%square.282, %constant.416.clone.20), dimensions={0,3}, to_apply=%region_16.18, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.216 = (f32[128,8]{0,1:T(8,128)S(1)}, bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%reduce.263, %bitcast.380.clone.3)
 }
 
-%fused_computation.293.clone.1 (param_0.1735: f32[128,8]) -> f32[128,8] {
-  %param_0.1735 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
+%fused_computation.294.clone.1 (param_0.1745: f32[128,8]) -> f32[128,8] {
+  %param_0.1745 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
   %constant.419.clone.11 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.1069 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.419.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.1010 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1735, %broadcast.1069), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %broadcast.1070 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.419.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.1010 = f32[128,8]{0,1:T(8,128)} multiply(%param_0.1745, %broadcast.1070), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
   %constant.418.clone.18 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1068 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.418.clone.18), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %add.1046 = f32[128,8]{0,1:T(8,128)} add(%div.1010, %broadcast.1068), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.870 = f32[1,128,8]{1,2,0:T(8,128)} bitcast(%add.1046), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.215 = f32[1,128,8]{1,2,0:T(8,128)} rsqrt(%bitcast.870), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.869 = f32[128,8]{0,1:T(8,128)S(1)} bitcast(%rsqrt.215), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %broadcast.1069 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.418.clone.18), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %add.1046 = f32[128,8]{0,1:T(8,128)} add(%div.1010, %broadcast.1069), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.888 = f32[1,128,8]{1,2,0:T(8,128)} bitcast(%add.1046), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.215 = f32[1,128,8]{1,2,0:T(8,128)} rsqrt(%bitcast.888), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.887 = f32[128,8]{0,1:T(8,128)S(1)} bitcast(%rsqrt.215), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.272.clone.2 (param_0.1739: f32[128,8], param_1.1848: bf16[1,128,8,128], param_2.1409: bf16[128]) -> bf16[1,128,8,128] {
-  %param_2.1409 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
-  %dot_general.595 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1409), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.467 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.595)
-  %param_1.1848 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.337 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_1.1848), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_0.1739 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
-  %mul.2305 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_0.1739), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2304 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.337, %mul.2305), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1395 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2304), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.468 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1395)
-  %dot_general.594 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.467, %convert.468), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  ROOT %convert.469 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.594)
+%fused_computation.273.clone.2 (param_0.1749: f32[128,8], param_1.1854: bf16[1,128,8,128], param_2.1413: bf16[128]) -> bf16[1,128,8,128] {
+  %param_2.1413 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
+  %dot_general.585 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1413), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.468 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.585)
+  %param_1.1854 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.338 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_1.1854), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_0.1749 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
+  %mul.2303 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_0.1749), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2302 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.338, %mul.2303), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1402 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2302), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.469 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1402)
+  %dot_general.584 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.468, %convert.469), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  ROOT %convert.470 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%dot_general.584)
 }
 
-%fused_computation.251.clone.1 (param_0.1740: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
-  %param_0.1740 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.73 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1740), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
-  %convert.470 = f32[1,128,8,64]{3,1,2,0:T(8,128)} convert(%slice.73)
-  %neg.126 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.470), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.471 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.126)
-  %slice.74 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1740), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
-  ROOT %tuple.222 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.471, %slice.74)
+%fused_computation.252.clone.1 (param_0.1750: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
+  %param_0.1750 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.73 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1750), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
+  %convert.471 = f32[1,128,8,64]{3,1,2,0:T(8,128)} convert(%slice.73)
+  %neg.126 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.471), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.472 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.126)
+  %slice.74 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1750), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/split" stack_frame_id=0}
+  ROOT %tuple.220 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%convert.472, %slice.74)
 }
 
-%fused_computation.254.clone.1 (param_0.1741: bf16[1,128,8,64], param_1.1849: bf16[1,128,8,64], param_2.1410: bf16[128,128], param_3.932: bf16[128,128], param_4.554: f32[128,8], param_5.485: bf16[1,128,8,128], param_6.340: bf16[128]) -> bf16[8,128,128] {
-  %param_6.340 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
-  %dot_general.597 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.340), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.472 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.597)
-  %param_5.485 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
-  %convert.338 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_5.485), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_4.554 = f32[128,8]{0,1:T(8,128)S(1)} parameter(4)
-  %mul.2311 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_4.554), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2310 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.338, %mul.2311), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1396 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2310), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.473 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1396)
-  %dot_general.596 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.472, %convert.473), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_3.932 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %mul.2309 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.932), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.474 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2309)
-  %mul.2307 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%dot_general.596, %convert.474), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_1.1849 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %constant.1112 = bf16[]{:T(256)} constant(-inf)
-  %pad.79 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1849, %constant.1112), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.475 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.79)
-  %param_0.1741 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %pad.78 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1741, %constant.1112), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
-  %convert.476 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.78)
-  %maximum.58 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.475, %convert.476), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_2.1410 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %mul.2308 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1410), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.477 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2308)
-  %mul.2306 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%maximum.58, %convert.477), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %add.1047 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.2307, %mul.2306), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.478 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.1047)
-  ROOT %bitcast.873 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.478), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+%fused_computation.255.clone.1 (param_0.1751: bf16[1,128,8,64], param_1.1855: bf16[1,128,8,64], param_2.1414: bf16[128,128], param_3.935: bf16[128,128], param_4.550: f32[128,8], param_5.479: bf16[1,128,8,128], param_6.335: bf16[128]) -> bf16[8,128,128] {
+  %param_6.335 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(6)
+  %dot_general.587 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_6.335), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.473 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.587)
+  %param_5.479 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
+  %convert.339 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_5.479), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_4.550 = f32[128,8]{0,1:T(8,128)S(1)} parameter(4)
+  %mul.2309 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_4.550), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2308 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.339, %mul.2309), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1403 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2308), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.474 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1403)
+  %dot_general.586 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.473, %convert.474), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_3.935 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %mul.2307 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_3.935), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.475 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2307)
+  %mul.2305 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%dot_general.586, %convert.475), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_1.1855 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %constant.1113 = bf16[]{:T(256)} constant(-inf)
+  %pad.79 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_1.1855, %constant.1113), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.476 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.79)
+  %param_0.1751 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %pad.78 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_0.1751, %constant.1113), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}
+  %convert.477 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.78)
+  %maximum.58 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.476, %convert.477), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_2.1414 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %mul.2306 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1414), dimensions={1,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.478 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%mul.2306)
+  %mul.2304 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%maximum.58, %convert.478), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %add.1047 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.2305, %mul.2304), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.479 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add.1047)
+  ROOT %bitcast.891 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.479), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.130.clone.1 (param_0.1726: bf16[4,512,8,128], param_1.1840: s32[]) -> bf16[1,512,8,128] {
-  %param_0.1726 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1840 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.415.clone.79 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.185 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1726, %param_1.1840, %constant.415.clone.79, %constant.415.clone.79, %constant.415.clone.79), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-}
-
-%fused_computation.232.clone.1 (param_0.1728: bf16[2048], param_1.1841: f32[128], param_2.1404: bf16[4,1,128,2048], param_3.928: s32[]) -> bf16[128,2048,1] {
-  %param_0.1728 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.591 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1728), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.384 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.591)
-  %param_2.1404 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.928 = s32[]{:T(128)S(6)} parameter(3)
+%fused_computation.130.clone.1 (param_0.1736: bf16[4,512,8,128], param_1.1846: s32[]) -> bf16[1,512,8,128] {
+  %param_0.1736 = bf16[4,512,8,128]{3,1,2,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1846 = s32[]{:T(128)S(6)} parameter(1)
   %constant.415.clone.80 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.186 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1404, %param_3.928, %constant.415.clone.80, %constant.415.clone.80, %constant.415.clone.80), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.863 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.186), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert_element_type.1390 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.863), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1841 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2298 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1841), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2297 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1390, %mul.2298), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1389 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2297), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.385 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1389)
-  %dot_general.590 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.384, %convert.385), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.386 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.590)
-  ROOT %bitcast.862 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.386)
+  ROOT %dynamic-slice.186 = bf16[1,512,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} dynamic-slice(%param_0.1736, %param_1.1846, %constant.415.clone.80, %constant.415.clone.80, %constant.415.clone.80), dynamic_slice_sizes={1,512,8,128}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.116.clone.clone.clone.1 (param_0.1727: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
-  %param_0.1727 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.861 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1727), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+%fused_computation.234.clone.1 (param_0.1738: bf16[2048], param_1.1847: f32[128], param_2.1408: bf16[4,1,128,2048], param_3.931: s32[]) -> bf16[128,2048,1] {
+  %param_0.1738 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.581 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1738), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.385 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.581)
+  %param_2.1408 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.931 = s32[]{:T(128)S(6)} parameter(3)
+  %constant.415.clone.81 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.187 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1408, %param_3.931, %constant.415.clone.81, %constant.415.clone.81, %constant.415.clone.81), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.881 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.187), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert_element_type.1397 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.881), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1847 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2296 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1847), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2295 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1397, %mul.2296), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1396 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2295), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.386 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1396)
+  %dot_general.580 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.385, %convert.386), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.387 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.580)
+  ROOT %bitcast.880 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%convert.387)
 }
 
-%fused_computation.195.clone.1 (param_0.1729: bf16[1,2048,8,128], param_1.1842: bf16[2048], param_2.1405: f32[128], param_3.929: bf16[4,1,128,2048], param_4.552: s32[]) -> bf16[8,128,128] {
-  %param_1.1842 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_2.1405 = f32[128]{0:T(128)S(1)} parameter(2)
-  %param_3.929 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %param_4.552 = s32[]{:T(128)S(6)} parameter(4)
-  %fusion.450 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1842, %param_2.1405, %param_3.929, %param_4.552), kind=kLoop, calls=%fused_computation.232.clone.1
-  %param_0.1729 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.449 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1729), kind=kLoop, calls=%fused_computation.116.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convolution.134 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.450, %fusion.449), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.864 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.134), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
+%fused_computation.116.clone.clone.clone.1 (param_0.1737: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
+  %param_0.1737 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.879 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1737), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.213.clone.clone.clone.1 (param_0.1752: bf16[16,128,128]) -> bf16[128,16,128] {
-  %param_0.1752 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.881 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1752)
+%fused_computation.195.clone.1 (param_0.1739: bf16[1,2048,8,128], param_1.1848: bf16[2048], param_2.1409: f32[128], param_3.932: bf16[4,1,128,2048], param_4.548: s32[]) -> bf16[8,128,128] {
+  %param_1.1848 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_2.1409 = f32[128]{0:T(128)S(1)} parameter(2)
+  %param_3.932 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_4.548 = s32[]{:T(128)S(6)} parameter(4)
+  %fusion.457 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_1.1848, %param_2.1409, %param_3.932, %param_4.548), kind=kLoop, calls=%fused_computation.234.clone.1
+  %param_0.1739 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.456 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_0.1739), kind=kLoop, calls=%fused_computation.116.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convolution.134 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} convolution(%fusion.457, %fusion.456), window={size=8 pad=7_7 rhs_reversal=1}, dim_labels=bf0_i0o->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.882 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.134), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/squeeze" stack_frame_id=0}
 }
 
-%fused_computation.103.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1751: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
-  %param_0.1751 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.880 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1751), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+%fused_computation.213.clone.clone.clone.1 (param_0.1762: bf16[16,128,128]) -> bf16[128,16,128] {
+  %param_0.1762 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.899 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1762)
+}
+
+%fused_computation.103.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1761: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
+  %param_0.1761 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.898 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1761), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
 %region_17.20 (reduce_sum.219: f32[], reduce_sum.220: f32[]) -> f32[] {
@@ -1491,238 +1491,239 @@ StackFrames
   ROOT %reduce_sum.221 = f32[]{:T(128)} add(%reduce_sum.219, %reduce_sum.220), metadata={op_name="checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.177.clone.1 (param_0.1753: bf16[1,16,128,2048], param_1.1856: bf16[16,128,128], param_2.1415: bf16[4,1,128,2048], param_3.936: s32[]) -> (f32[128], bf16[1,128,2048]) {
-  %param_2.1415 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %param_3.936 = s32[]{:T(128)S(6)} parameter(3)
-  %constant.415.clone.16.clone.3 = s32[]{:T(128)} constant(0)
-  %dynamic-slice.113.clone.3 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1415, %param_3.936, %constant.415.clone.16.clone.3, %constant.415.clone.16.clone.3, %constant.415.clone.16.clone.3), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
-  %bitcast.424.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.113.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
-  %convert.479 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.424.clone.3)
-  %param_1.1856 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.213.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} fusion(%param_1.1856), kind=kLoop, calls=%fused_computation.213.clone.clone.clone.1
-  %param_0.1753 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.158.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_0.1753), kind=kLoop, calls=%fused_computation.103.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convolution.91.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.213.clone.3, %fusion.158.clone.3), window={size=16}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %bitcast.345.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.91.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  %convert.480 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.345.clone.3)
-  %add.818.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.479, %convert.480), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.1401 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%add.818.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %square.284 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1401, %convert_element_type.1401), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
+%fused_computation.174.clone.1 (param_0.1763: bf16[1,16,128,2048], param_1.1862: bf16[16,128,128], param_2.1419: bf16[4,1,128,2048], param_3.939: s32[]) -> (f32[128], bf16[1,128,2048]) {
+  %param_2.1419 = bf16[4,1,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.939 = s32[]{:T(128)S(6)} parameter(3)
+  %constant.415.clone.4.clone.3 = s32[]{:T(128)} constant(0)
+  %dynamic-slice.109.clone.3 = bf16[1,1,128,2048]{3,2,1,0:T(8,128)(2,1)} dynamic-slice(%param_2.1419, %param_3.939, %constant.415.clone.4.clone.3, %constant.415.clone.4.clone.3, %constant.415.clone.4.clone.3), dynamic_slice_sizes={1,1,128,2048}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+  %bitcast.438.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%dynamic-slice.109.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/squeeze" stack_frame_id=0}
+  %convert.480 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.438.clone.3)
+  %param_1.1862 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.217.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)} fusion(%param_1.1862), kind=kLoop, calls=%fused_computation.213.clone.clone.clone.1
+  %param_0.1763 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.158.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_0.1763), kind=kLoop, calls=%fused_computation.103.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convolution.91.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.217.clone.3, %fusion.158.clone.3), window={size=16}, dim_labels=b0f_0io->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  %bitcast.347.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%convolution.91.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  %convert.481 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.347.clone.3)
+  %add.818.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.480, %convert.481), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.1408 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%add.818.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %square.284 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1408, %convert_element_type.1408), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/square" stack_frame_id=0}
   %constant.416.clone.22 = f32[]{:T(128)} constant(0)
-  %reduce.266 = f32[128]{0:T(128)S(1)} reduce(%square.284, %constant.416.clone.22), dimensions={0,2}, to_apply=%region_17.20, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
-  %convert.481 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.818.clone.3)
-  ROOT %tuple.225 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.266, %convert.481)
+  %reduce.265 = f32[128]{0:T(128)S(1)} reduce(%square.284, %constant.416.clone.22), dimensions={0,2}, to_apply=%region_17.20, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/reduce_sum" stack_frame_id=0}
+  %convert.482 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add.818.clone.3)
+  ROOT %tuple.223 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.265, %convert.482)
 }
 
-%fused_computation.302.clone.1 (param_0.1754: f32[128]) -> f32[128] {
-  %param_0.1754 = f32[128]{0:T(128)S(1)} parameter(0)
+%fused_computation.303.clone.1 (param_0.1764: f32[128]) -> f32[128] {
+  %param_0.1764 = f32[128]{0:T(128)S(1)} parameter(0)
   %constant.417.clone.10 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.1075 = f32[128]{0:T(128)} broadcast(%constant.417.clone.10), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.1016 = f32[128]{0:T(128)} multiply(%param_0.1754, %broadcast.1075), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %broadcast.1076 = f32[128]{0:T(128)} broadcast(%constant.417.clone.10), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.1016 = f32[128]{0:T(128)} multiply(%param_0.1764, %broadcast.1076), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
   %constant.418.clone.20 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1074 = f32[128]{0:T(128)} broadcast(%constant.418.clone.20), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.1050 = f32[128]{0:T(128)} add(%div.1016, %broadcast.1074), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.883 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1050), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.217 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.883), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  ROOT %bitcast.882 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.217), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %broadcast.1075 = f32[128]{0:T(128)} broadcast(%constant.418.clone.20), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.1050 = f32[128]{0:T(128)} add(%div.1016, %broadcast.1075), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.901 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1050), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.217 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.901), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  ROOT %bitcast.900 = f32[128]{0:T(128)S(1)} bitcast(%rsqrt.217), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
 }
 
-%fused_computation.224.clone.1 (param_0.1757: bf16[2048], param_1.1858: f32[128], param_2.1416: bf16[1,128,2048]) -> bf16[128,2048] {
-  %param_0.1757 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.605 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1757), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.393 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.605)
-  %param_2.1416 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %convert_element_type.1403 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1416), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1858 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2324 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1858), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2323 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1403, %mul.2324), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1402 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2323), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.394 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1402)
-  %dot_general.604 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.393, %convert.394), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.395 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.604)
-  ROOT %bitcast.885 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.395)
+%fused_computation.226.clone.1 (param_0.1774: bf16[2048], param_1.1868: f32[128], param_2.1422: bf16[1,128,2048]) -> bf16[128,2048] {
+  %param_0.1774 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.597 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1774), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.397 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.597)
+  %param_2.1422 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %convert_element_type.1412 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1422), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1868 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2324 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1868), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2323 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1412, %mul.2324), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1411 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2323), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.398 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1411)
+  %dot_general.596 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.397, %convert.398), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.399 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.596)
+  ROOT %bitcast.909 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.399)
 }
 
-%fused_computation.88.clone.clone.clone.1 (param_0.1756: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1756 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.884 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1756), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+%fused_computation.94.clone.clone.clone.1 (param_0.1773: bf16[1,2048,6144]) -> bf16[2048,6144] {
+  %param_0.1773 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.908 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1773), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.125.clone.1 (param_0.1758: bf16[1,2048,6144], param_1.1859: bf16[2048], param_2.1417: bf16[1,128,2048], param_3.937: f32[128]) -> bf16[1,128,6144] {
-  %param_1.1859 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_3.937 = f32[128]{0:T(128)S(1)} parameter(3)
-  %param_2.1417 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.452 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1859, %param_3.937, %param_2.1417), kind=kLoop, calls=%fused_computation.224.clone.1
-  %param_0.1758 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.451 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1758), kind=kLoop, calls=%fused_computation.88.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convolution.135 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.452, %fusion.451), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.886 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.135), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+%fused_computation.124.clone.1 (param_0.1775: bf16[1,2048,6144], param_1.1869: bf16[2048], param_2.1423: bf16[1,128,2048], param_3.941: f32[128]) -> bf16[1,128,6144] {
+  %param_1.1869 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_3.941 = f32[128]{0:T(128)S(1)} parameter(3)
+  %param_2.1423 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.463 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1869, %param_3.941, %param_2.1423), kind=kLoop, calls=%fused_computation.226.clone.1
+  %param_0.1775 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.462 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1775), kind=kLoop, calls=%fused_computation.94.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convolution.137 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.463, %fusion.462), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.910 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.137), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.99.clone.1 (param_0.1763: bf16[4,512,6144], param_1.1862: s32[]) -> bf16[1,512,6144] {
-  %param_0.1763 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1862 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.415.clone.89 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.194 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1763, %param_1.1862, %constant.415.clone.89, %constant.415.clone.89), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.98.clone.1 (param_0.1765: bf16[4,512,6144], param_1.1863: s32[]) -> bf16[1,512,6144] {
+  %param_0.1765 = bf16[4,512,6144]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1863 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.415.clone.88 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.193 = bf16[1,512,6144]{2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1765, %param_1.1863, %constant.415.clone.88, %constant.415.clone.88), dynamic_slice_sizes={1,512,6144}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.225.clone.1 (param_0.1765: bf16[2048], param_1.1863: f32[128], param_2.1418: bf16[1,128,2048]) -> bf16[128,2048] {
-  %param_0.1765 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
-  %dot_general.607 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1765), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.396 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.607)
-  %param_2.1418 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %convert_element_type.1405 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1418), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1863 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2326 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1863), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2325 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1405, %mul.2326), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1404 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2325), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.397 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1404)
-  %dot_general.606 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.396, %convert.397), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.398 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.606)
-  ROOT %bitcast.891 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.398)
+%fused_computation.227.clone.1 (param_0.1767: bf16[2048], param_1.1864: f32[128], param_2.1420: bf16[1,128,2048]) -> bf16[128,2048] {
+  %param_0.1767 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(0)
+  %dot_general.595 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_0.1767), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.394 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.595)
+  %param_2.1420 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %convert_element_type.1410 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1420), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1864 = f32[128]{0:T(128)S(1)} parameter(1)
+  %mul.2322 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1864), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2321 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1410, %mul.2322), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1409 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2321), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.395 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1409)
+  %dot_general.594 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.394, %convert.395), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.396 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%dot_general.594)
+  ROOT %bitcast.903 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%convert.396)
 }
 
-%fused_computation.96.clone.clone.clone.1 (param_0.1764: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1764 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.890 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1764), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-}
-
-%fused_computation.124.clone.1 (param_0.1766: bf16[1,2048,6144], param_1.1864: bf16[2048], param_2.1419: bf16[1,128,2048], param_3.938: f32[128]) -> bf16[1,128,6144] {
-  %param_1.1864 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %param_3.938 = f32[128]{0:T(128)S(1)} parameter(3)
-  %param_2.1419 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.456 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1864, %param_3.938, %param_2.1419), kind=kLoop, calls=%fused_computation.225.clone.1
+%fused_computation.92.clone.clone.clone.1 (param_0.1766: bf16[1,2048,6144]) -> bf16[2048,6144] {
   %param_0.1766 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.455 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1766), kind=kLoop, calls=%fused_computation.96.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convolution.137 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.456, %fusion.455), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
-  ROOT %bitcast.892 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.137), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.902 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1766), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.148.clone.1 (param_0.1826: bf16[1,128,6144], param_1.1906: bf16[1,128,6144]) -> bf16[128,6144] {
-  %param_1.1906 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.440 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1906)
+%fused_computation.125.clone.1 (param_0.1768: bf16[1,2048,6144], param_1.1865: bf16[2048], param_2.1421: bf16[1,128,2048], param_3.940: f32[128]) -> bf16[1,128,6144] {
+  %param_1.1865 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %param_3.940 = f32[128]{0:T(128)S(1)} parameter(3)
+  %param_2.1421 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.459 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1865, %param_3.940, %param_2.1421), kind=kLoop, calls=%fused_computation.227.clone.1
+  %param_0.1768 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.458 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1768), kind=kLoop, calls=%fused_computation.92.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convolution.135 = bf16[128,6144]{1,0:T(8,128)(2,1)} convolution(%fusion.459, %fusion.458), dim_labels=bf_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+  ROOT %bitcast.904 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.135), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/dot_general" stack_frame_id=0}
+}
+
+%fused_computation.148.clone.1 (param_0.1836: bf16[1,128,6144], param_1.1912: bf16[1,128,6144]) -> bf16[128,6144] {
+  %param_1.1912 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.441 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1912)
   %constant.425.clone.25 = bf16[]{:T(256)} constant(1)
   %jit_silu_.45 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.25), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
-  %convert.441 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.45)
-  %neg.132 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.440), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.442 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.45)
+  %neg.132 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.441), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %exp.78 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.132), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %add.1059 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.78, %convert.441), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %div.1029 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.441, %add.1059), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2400 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.440, %div.1029), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %param_0.1826 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.442 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1826)
-  %mul.2399 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2400, %convert.442), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.443 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2399)
-  ROOT %bitcast.947 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.443)
+  %add.1059 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.78, %convert.442), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %div.1029 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.442, %add.1059), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2402 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.441, %div.1029), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %param_0.1836 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.443 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1836)
+  %mul.2401 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2402, %convert.443), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.444 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2401)
+  ROOT %bitcast.968 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.444)
 }
 
-%fused_computation.219.clone.1 (param_0.1825: bf16[1,128,2048]) -> bf16[128,2048] {
-  %param_0.1825 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.946 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1825)
+%fused_computation.221.clone.1 (param_0.1835: bf16[1,128,2048]) -> bf16[128,2048] {
+  %param_0.1835 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.967 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1835)
 }
 
-%fused_computation.147.clone.1 (param_0.1827: bf16[1,128,6144], param_1.1907: bf16[1,128,2048], param_2.1452: bf16[1,128,6144]) -> bf16[6144,2048] {
-  %param_0.1827 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %param_2.1452 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.475 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1827, %param_2.1452), kind=kLoop, calls=%fused_computation.148.clone.1
-  %param_1.1907 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %fusion.476 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1907), kind=kLoop, calls=%fused_computation.219.clone.1
-  ROOT %convolution.147 = bf16[6144,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.475, %fusion.476), dim_labels=fb_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.147.clone.1 (param_0.1837: bf16[1,128,6144], param_1.1913: bf16[1,128,2048], param_2.1457: bf16[1,128,6144]) -> bf16[6144,2048] {
+  %param_0.1837 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %param_2.1457 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.482 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1837, %param_2.1457), kind=kLoop, calls=%fused_computation.148.clone.1
+  %param_1.1913 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.483 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1913), kind=kLoop, calls=%fused_computation.221.clone.1
+  ROOT %convolution.147 = bf16[6144,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.482, %fusion.483), dim_labels=fb_io->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.493.clone.1 (param_0.1778: f32[1,16,128,128]) -> (f32[1,16,128,1], f32[16,128]) {
-  %param_0.1778 = f32[1,16,128,128]{2,1,3,0:T(8,128)S(1)} parameter(0)
-  %slice.77 = f32[1,16,128,1]{2,1,3,0:T(8,128)} slice(%param_0.1778), slice={[0:1], [0:16], [0:128], [0:1]}, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/slice" stack_frame_id=0}
-  %bitcast.479.clone.3 = f32[16,128]{1,0:T(8,128)S(1)} bitcast(%slice.77), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}
-  ROOT %tuple.229 = (f32[1,16,128,1]{2,1,3,0:T(8,128)}, f32[16,128]{1,0:T(8,128)S(1)}) tuple(%slice.77, %bitcast.479.clone.3)
+%fused_computation.494.clone.1 (param_0.1787: f32[1,16,128,128]) -> (f32[1,16,128,1], f32[16,128]) {
+  %param_0.1787 = f32[1,16,128,128]{2,1,3,0:T(8,128)S(1)} parameter(0)
+  %slice.77 = f32[1,16,128,1]{2,1,3,0:T(8,128)} slice(%param_0.1787), slice={[0:1], [0:16], [0:128], [0:1]}, metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/slice" stack_frame_id=0}
+  %bitcast.494.clone.3 = f32[16,128]{1,0:T(8,128)S(1)} bitcast(%slice.77), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/broadcast_in_dim" stack_frame_id=0}
+  ROOT %tuple.226 = (f32[1,16,128,1]{2,1,3,0:T(8,128)}, f32[16,128]{1,0:T(8,128)S(1)}) tuple(%slice.77, %bitcast.494.clone.3)
 }
 
-%fused_computation.98.clone.1 (param_0.1759: bf16[4,6144,512], param_1.1860: s32[]) -> bf16[1,6144,512] {
-  %param_0.1759 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.1860 = s32[]{:T(128)S(6)} parameter(1)
-  %constant.415.clone.88 = s32[]{:T(128)} constant(0)
-  ROOT %dynamic-slice.193 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1759, %param_1.1860, %constant.415.clone.88, %constant.415.clone.88), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
+%fused_computation.97.clone.1 (param_0.1769: bf16[4,6144,512], param_1.1866: s32[]) -> bf16[1,6144,512] {
+  %param_0.1769 = bf16[4,6144,512]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.1866 = s32[]{:T(128)S(6)} parameter(1)
+  %constant.415.clone.89 = s32[]{:T(128)} constant(0)
+  ROOT %dynamic-slice.194 = bf16[1,6144,512]{2,1,0:T(8,128)(2,1)} dynamic-slice(%param_0.1769, %param_1.1866, %constant.415.clone.89, %constant.415.clone.89), dynamic_slice_sizes={1,6144,512}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/jit(dynamic_index_in_dim)/dynamic_slice" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"indices_config":{"index_known_bits":[{"zeroes":"4294967292","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"},{"zeroes":"4294967295","ones":"0","bitwidth":"32"}],"is_index_aligned":[]},"used_scoped_memory_configs":[]}
 }
 
-%fused_computation.92.clone.clone.clone.1 (param_0.1761: bf16[1,6144,2048]) -> bf16[6144,2048] {
-  %param_0.1761 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.888 = bf16[6144,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1761), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+%fused_computation.88.clone.clone.clone.1 (param_0.1771: bf16[1,6144,2048]) -> bf16[6144,2048] {
+  %param_0.1771 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
+  ROOT %bitcast.906 = bf16[6144,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1771), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.220.clone.1 (param_0.1760: bf16[1,128,2048]) -> bf16[128,2048] {
-  %param_0.1760 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.887 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1760)
+%fused_computation.222.clone.1 (param_0.1770: bf16[1,128,2048]) -> bf16[128,2048] {
+  %param_0.1770 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.905 = bf16[128,2048]{1,0:T(8,128)(2,1)} bitcast(%param_0.1770)
 }
 
-%fused_computation.123.clone.1 (param_0.1762: bf16[1,6144,2048], param_1.1861: bf16[1,128,2048]) -> bf16[1,128,6144] {
-  %param_0.1762 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %fusion.453 = bf16[6144,2048]{1,0:T(8,128)(2,1)} fusion(%param_0.1762), kind=kLoop, calls=%fused_computation.92.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1861 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(1)
-  %fusion.454 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1861), kind=kLoop, calls=%fused_computation.220.clone.1
-  %convolution.136 = bf16[6144,128]{0,1:T(8,128)(2,1)} convolution(%fusion.453, %fusion.454), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
-  ROOT %bitcast.889 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.136), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.123.clone.1 (param_0.1772: bf16[1,6144,2048], param_1.1867: bf16[1,128,2048]) -> bf16[1,128,6144] {
+  %param_0.1772 = bf16[1,6144,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %fusion.460 = bf16[6144,2048]{1,0:T(8,128)(2,1)} fusion(%param_0.1772), kind=kLoop, calls=%fused_computation.88.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1867 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.461 = bf16[128,2048]{1,0:T(8,128)(2,1)} fusion(%param_1.1867), kind=kLoop, calls=%fused_computation.222.clone.1
+  %convolution.136 = bf16[6144,128]{0,1:T(8,128)(2,1)} convolution(%fusion.460, %fusion.461), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
+  ROOT %bitcast.907 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.136), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.151.clone.1 (param_0.1768: bf16[1,128,6144], param_1.1865: bf16[1,128,6144]) -> bf16[128,6144] {
-  %param_1.1865 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.399 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1865)
+%fused_computation.90.clone.1 (param_0.1777: bf16[1,2048,6144]) -> bf16[2048,6144] {
+  %param_0.1777 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.912 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1777), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+}
+
+%fused_computation.146.clone.1.clone.1 (param_0.1776: bf16[1,128,6144], param_1.1870: bf16[1,128,6144], param_2.1424: bf16[1,128,6144]) -> bf16[128,6144] {
+  %param_1.1870 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.400 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1870)
+  %param_2.1424 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} parameter(2)
+  %convert.401 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_2.1424)
+  %mul.2329 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.400, %convert.401), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %constant.425.clone.21 = bf16[]{:T(256)} constant(1)
   %jit_silu_.41 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
-  %convert.400 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.41)
-  %neg.128 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.399), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.403 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.41)
+  %param_0.1776 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.402 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1776)
+  %neg.128 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.402), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %exp.74 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.128), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %add.1051 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.74, %convert.400), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %div.1017 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.400, %add.1051), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2328 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.399, %div.1017), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %param_0.1768 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.401 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1768)
-  %mul.2327 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2328, %convert.401), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.402 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2327)
-  ROOT %bitcast.894 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.402)
+  %add.1051 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.74, %convert.403), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %div.1017 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.403, %add.1051), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2328 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2329, %div.1017), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2327 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.402, %mul.2329), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %sub.116 = f32[1,128,6144]{2,1,0:T(8,128)} subtract(%convert.403, %div.1017), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/sub" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2326 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%div.1017, %sub.116), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %mul.2325 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2327, %mul.2326), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %add_any.220 = f32[1,128,6144]{2,1,0:T(8,128)} add(%mul.2328, %mul.2325), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/jit(silu)/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.404 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%add_any.220)
+  ROOT %bitcast.911 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.404)
 }
 
-%fused_computation.90.clone.1 (param_0.1767: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1767 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.893 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1767), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+%fused_computation.89.clone.1 (param_0.1778: bf16[1,2048,6144], param_1.1871: bf16[1,128,6144], param_2.1425: bf16[1,128,6144], param_3.942: bf16[1,128,6144]) -> bf16[2048,128] {
+  %param_0.1778 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.464 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1778), kind=kLoop, calls=%fused_computation.90.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1871 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.1425 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %param_3.942 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} parameter(3)
+  %fusion.465 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_1.1871, %param_2.1425, %param_3.942), kind=kLoop, calls=%fused_computation.146.clone.1.clone.1
+  ROOT %convolution.138 = bf16[2048,128]{0,1:T(8,128)(2,1)} convolution(%fusion.464, %fusion.465), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.89.clone.1 (param_0.1769: bf16[1,2048,6144], param_1.1866: bf16[1,128,6144], param_2.1420: bf16[1,128,6144]) -> bf16[128,2048] {
-  %param_1.1866 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.1420 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.458 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_1.1866, %param_2.1420), kind=kLoop, calls=%fused_computation.151.clone.1
-  %param_0.1769 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.457 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_0.1769), kind=kLoop, calls=%fused_computation.90.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  ROOT %convolution.138 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.458, %fusion.457), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.96.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1780: bf16[1,2048,6144]) -> bf16[2048,6144] {
+  %param_0.1780 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.914 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1780), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.146.clone.1.clone.clone.clone.1 (param_0.1771: bf16[1,128,6144], param_1.1867: bf16[1,128,6144], param_2.1421: bf16[1,128,6144]) -> bf16[128,6144] {
-  %param_1.1867 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.403 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1867)
-  %param_2.1421 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %convert.404 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_2.1421)
-  %mul.2333 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.403, %convert.404), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+%fused_computation.151.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1779: bf16[1,128,6144], param_1.1872: bf16[1,128,6144]) -> bf16[128,6144] {
+  %param_1.1872 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.405 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_1.1872)
   %constant.425.clone.22 = bf16[]{:T(256)} constant(1)
   %jit_silu_.42 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} broadcast(%constant.425.clone.22), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)" stack_frame_id=0}
   %convert.406 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%jit_silu_.42)
-  %param_0.1771 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.405 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1771)
   %neg.129 = f32[1,128,6144]{2,1,0:T(8,128)} negate(%convert.405), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %exp.75 = f32[1,128,6144]{2,1,0:T(8,128)} exponential(%neg.129), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/exp" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %add.1052 = f32[1,128,6144]{2,1,0:T(8,128)} add(%exp.75, %convert.406), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
   %div.1018 = f32[1,128,6144]{2,1,0:T(8,128)} divide(%convert.406, %add.1052), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/div" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2332 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2333, %div.1018), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2331 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.405, %mul.2333), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %sub.118 = f32[1,128,6144]{2,1,0:T(8,128)} subtract(%convert.406, %div.1018), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/sub" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2330 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%div.1018, %sub.118), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %mul.2329 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2331, %mul.2330), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %add_any.211 = f32[1,128,6144]{2,1,0:T(8,128)} add(%mul.2332, %mul.2329), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/jit(silu)/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.407 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%add_any.211)
-  ROOT %bitcast.896 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.407)
-}
-
-%fused_computation.94.clone.clone.clone.clone.clone.clone.clone.1 (param_0.1770: bf16[1,2048,6144]) -> bf16[2048,6144] {
-  %param_0.1770 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.895 = bf16[2048,6144]{1,0:T(8,128)(2,1)} bitcast(%param_0.1770), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %mul.2331 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%convert.405, %div.1018), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/jit(silu)/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %param_0.1779 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.407 = f32[1,128,6144]{2,1,0:T(8,128)} convert(%param_0.1779)
+  %mul.2330 = f32[1,128,6144]{2,1,0:T(8,128)} multiply(%mul.2331, %convert.407), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","6144"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert.408 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)} convert(%mul.2330)
+  ROOT %bitcast.913 = bf16[128,6144]{1,0:T(8,128)(2,1)} bitcast(%convert.408)
 }
 
 %region_18.21 (reduce_sum.225: f32[], reduce_sum.226: f32[]) -> f32[] {
@@ -1731,190 +1732,177 @@ StackFrames
   ROOT %reduce_sum.227 = f32[]{:T(128)} add(%reduce_sum.225, %reduce_sum.226), metadata={op_name="checkpoint/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.179.clone.1 (param_0.1772: bf16[1,128,2048], param_1.1868: bf16[2048], param_2.1422: bf16[128,2048], param_3.939: bf16[1,2048,6144], param_4.557: bf16[1,128,6144], param_5.487: bf16[1,128,6144], param_6.342: bf16[1,128,6144]) -> (f32[128], bf16[1,128,2048]) {
-  %param_0.1772 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert_element_type.1407 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1772), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_2.1422 = bf16[128,2048]{1,0:T(8,128)(2,1)} parameter(2)
-  %convert.482 = f32[128,2048]{1,0:T(8,128)} convert(%param_2.1422)
-  %param_4.557 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(4)
-  %param_5.487 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(5)
-  %param_6.342 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(6)
-  %fusion.299.clone.3 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_4.557, %param_5.487, %param_6.342), kind=kLoop, calls=%fused_computation.146.clone.1.clone.clone.clone.1
-  %param_3.939 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %fusion.173.clone.3 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_3.939), kind=kLoop, calls=%fused_computation.94.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convolution.101.clone.3 = bf16[128,2048]{1,0:T(8,128)(2,1)} convolution(%fusion.299.clone.3, %fusion.173.clone.3), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
-  %convert.483 = f32[128,2048]{1,0:T(8,128)} convert(%convolution.101.clone.3)
-  %add_any.151.clone.3 = f32[128,2048]{1,0:T(8,128)} add(%convert.482, %convert.483), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
-  %convert.484 = bf16[128,2048]{1,0:T(8,128)(2,1)} convert(%add_any.151.clone.3)
-  %bitcast.362.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} bitcast(%convert.484), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}
-  %convert.485 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%bitcast.362.clone.3)
-  %param_1.1868 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
-  %dot_general.609 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_1.1868), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.486 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.609)
-  %dot_general.608 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.485, %convert.486), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.1406 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.608), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
-  %mul.2334 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1407, %convert_element_type.1406), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+%fused_computation.176.clone.1 (param_0.1781: bf16[1,128,2048], param_1.1873: bf16[2048], param_2.1426: bf16[2048,128], param_3.943: bf16[1,128,6144], param_4.553: bf16[1,128,6144], param_5.481: bf16[1,2048,6144]) -> (f32[128], bf16[2048,1,128]) {
+  %param_0.1781 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert_element_type.1413 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1781), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_5.481 = bf16[1,2048,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(5)
+  %fusion.177.clone.3 = bf16[2048,6144]{1,0:T(8,128)(2,1)} fusion(%param_5.481), kind=kLoop, calls=%fused_computation.96.clone.clone.clone.clone.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_3.943 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %param_4.553 = bf16[1,128,6144]{2,1,0:T(8,128)(2,1)S(1)} parameter(4)
+  %fusion.176.clone.3 = bf16[128,6144]{1,0:T(8,128)(2,1)} fusion(%param_3.943, %param_4.553), kind=kLoop, calls=%fused_computation.151.clone.clone.clone.clone.clone.clone.clone.1
+  %convolution.101.clone.3 = bf16[2048,128]{0,1:T(8,128)(2,1)} convolution(%fusion.177.clone.3, %fusion.176.clone.3), dim_labels=bf_oi->bf, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
+  %convert.483 = f32[2048,128]{0,1:T(8,128)} convert(%convolution.101.clone.3)
+  %param_2.1426 = bf16[2048,128]{0,1:T(8,128)(2,1)} parameter(2)
+  %convert.484 = f32[2048,128]{0,1:T(8,128)} convert(%param_2.1426)
+  %add_any.160.clone.3 = f32[2048,128]{0,1:T(8,128)} add(%convert.483, %convert.484), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["2048","128"],"tuple_shapes":[],"layout":{"minor_to_major":["0","1"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false]}}}
+  %convert.485 = bf16[2048,128]{0,1:T(8,128)(2,1)} convert(%add_any.160.clone.3)
+  %bitcast.366.clone.3 = bf16[2048,1,128]{0,2,1:T(8,128)(2,1)S(1)} bitcast(%convert.485), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}
+  %convert.486 = f32[2048,1,128]{0,2,1:T(8,128)} convert(%bitcast.366.clone.3)
+  %param_1.1873 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(1)
+  %dot_general.599 = bf16[2048,1,128]{0,2,1:T(8,128)(2,1)} broadcast(%param_1.1873), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.487 = f32[2048,1,128]{0,2,1:T(8,128)} convert(%dot_general.599)
+  %dot_general.598 = f32[2048,1,128]{0,2,1:T(8,128)} multiply(%convert.486, %convert.487), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["2048","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["0","2","1"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.1414 = f32[2048,1,128]{0,2,1:T(8,128)} convert(%dot_general.598), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
+  %bitcast.915 = f32[1,128,2048]{2,1,0:T(8,128)} bitcast(%convert_element_type.1414), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
+  %mul.2332 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1413, %bitcast.915), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
   %constant.416.clone.23 = f32[]{:T(128)} constant(0)
-  %reduce.267 = f32[128]{0:T(128)S(1)} reduce(%mul.2334, %constant.416.clone.23), dimensions={0,2}, to_apply=%region_18.21, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.226 = (f32[128]{0:T(128)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.267, %bitcast.362.clone.3)
+  %reduce.266 = f32[128]{0:T(128)S(1)} reduce(%mul.2332, %constant.416.clone.23), dimensions={0,2}, to_apply=%region_18.21, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.224 = (f32[128]{0:T(128)S(1)}, bf16[2048,1,128]{0,2,1:T(8,128)(2,1)S(1)}) tuple(%reduce.266, %bitcast.366.clone.3)
 }
 
-%fused_computation.318.clone.1 (param_0.1773: f32[128], param_1.1869: f32[128]) -> f32[128] {
-  %param_0.1773 = f32[128]{0:T(128)S(1)} parameter(0)
-  %bitcast.899 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1773), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/reduce_sum" stack_frame_id=0}
-  %param_1.1869 = f32[128]{0:T(128)S(1)} parameter(1)
+%fused_computation.319.clone.1 (param_0.1782: f32[128], param_1.1874: f32[128]) -> f32[128] {
+  %param_0.1782 = f32[128]{0:T(128)S(1)} parameter(0)
+  %bitcast.918 = f32[1,128]{1,0:T(1,128)} bitcast(%param_0.1782), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/reduce_sum" stack_frame_id=0}
+  %param_1.1874 = f32[128]{0:T(128)S(1)} parameter(1)
   %constant.417.clone.11 = f32[]{:T(128)} constant(0.00048828125)
-  %broadcast.1077 = f32[128]{0:T(128)} broadcast(%constant.417.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.1020 = f32[128]{0:T(128)} multiply(%param_1.1869, %broadcast.1077), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %broadcast.1078 = f32[128]{0:T(128)} broadcast(%constant.417.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.1020 = f32[128]{0:T(128)} multiply(%param_1.1874, %broadcast.1078), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
   %constant.418.clone.21 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1076 = f32[128]{0:T(128)} broadcast(%constant.418.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %add.1053 = f32[128]{0:T(128)} add(%div.1020, %broadcast.1076), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.898 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1053), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.218 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.898), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  %div.1019 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.218, %bitcast.898), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %broadcast.1077 = f32[128]{0:T(128)} broadcast(%constant.418.clone.21), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
+  %add.1053 = f32[128]{0:T(128)} add(%div.1020, %broadcast.1077), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.917 = f32[1,128]{1,0:T(1,128)} bitcast(%add.1053), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.218 = f32[1,128]{1,0:T(1,128)} rsqrt(%bitcast.917), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %div.1019 = f32[1,128]{1,0:T(1,128)} divide(%rsqrt.218, %bitcast.917), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
   %constant.426.clone.9 = f32[]{:T(128)} constant(-0.5)
   %eval_jaxpr.58 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.426.clone.9), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %mul.2337 = f32[1,128]{1,0:T(1,128)} multiply(%div.1019, %eval_jaxpr.58), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2336 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.899, %mul.2337), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %mul.2335 = f32[1,128]{1,0:T(1,128)} multiply(%div.1019, %eval_jaxpr.58), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2334 = f32[1,128]{1,0:T(1,128)} multiply(%bitcast.918, %mul.2335), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
   %constant.427.clone.5 = f32[]{:T(128)} constant(0.0009765625)
-  %mul.2338 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.427.clone.5), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %mul.2335 = f32[1,128]{1,0:T(1,128)} multiply(%mul.2336, %mul.2338), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  ROOT %bitcast.897 = f32[128]{0:T(128)S(1)} bitcast(%mul.2335), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %mul.2336 = f32[1,128]{1,0:T(1,128)} broadcast(%constant.427.clone.5), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %mul.2333 = f32[1,128]{1,0:T(1,128)} multiply(%mul.2334, %mul.2336), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  ROOT %bitcast.916 = f32[128]{0:T(128)S(1)} bitcast(%mul.2333), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
 }
 
-%region_23.27 (dot_general.209: bf16[], dot_general.210: bf16[]) -> bf16[] {
-  %dot_general.209 = bf16[]{:T(256)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general"}
-  %dot_general.210 = bf16[]{:T(256)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general"}
-  ROOT %add.418 = bf16[]{:T(256)} add(%dot_general.209, %dot_general.210), metadata={op_name="add.70"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+%fused_computation.201.clone.1 (param_0.1783: bf16[1,128,2048], param_1.1875: bf16[1,128,2048], param_2.1427: f32[128], param_3.944: f32[128], param_4.554: bf16[2048,1,128], param_5.482: bf16[2048]) -> bf16[1,128,2048] {
+  %param_0.1783 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %convert.490 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1783)
+  %param_4.554 = bf16[2048,1,128]{0,2,1:T(8,128)(2,1)S(1)} parameter(4)
+  %convert.488 = f32[2048,1,128]{0,2,1:T(8,128)} convert(%param_4.554)
+  %param_5.482 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(5)
+  %dot_general.601 = bf16[2048,1,128]{0,2,1:T(8,128)(2,1)} broadcast(%param_5.482), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.489 = f32[2048,1,128]{0,2,1:T(8,128)} convert(%dot_general.601)
+  %dot_general.600 = f32[2048,1,128]{0,2,1:T(8,128)} multiply(%convert.488, %convert.489), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["2048","1","128"],"tuple_shapes":[],"layout":{"minor_to_major":["0","2","1"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  %convert_element_type.1417 = f32[2048,1,128]{0,2,1:T(8,128)} convert(%dot_general.600), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
+  %bitcast.919 = f32[1,128,2048]{2,1,0:T(8,128)} bitcast(%convert_element_type.1417), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
+  %param_3.944 = f32[128]{0:T(128)S(1)} parameter(3)
+  %mul.2340 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_3.944), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2338 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%bitcast.919, %mul.2340), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %param_1.1875 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert_element_type.1416 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_1.1875), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_2.1427 = f32[128]{0:T(128)S(1)} parameter(2)
+  %mul.2339 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_2.1427), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %mul.2337 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1416, %mul.2339), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %add_any.222 = f32[1,128,2048]{2,1,0:T(8,128)} add(%mul.2338, %mul.2337), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}
+  %convert_element_type.1415 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%add_any.222), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
+  %convert.491 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1415)
+  %add_any.221 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.490, %convert.491), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
+  ROOT %convert.492 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add_any.221)
 }
 
-%fused_computation.237.clone.1 (param_0.1774: bf16[1,128,2048], param_1.1870: f32[128], param_2.1423: bf16[1,128,2048], param_3.940: bf16[1,128,2048], param_4.558: f32[128], param_5.488: bf16[2048]) -> (bf16[2048], bf16[1,128,2048]) {
-  %param_0.1774 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.487 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_0.1774)
-  %param_2.1423 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %convert_element_type.1409 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_2.1423), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1870 = f32[128]{0:T(128)S(1)} parameter(1)
-  %mul.2340 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_1.1870), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2339 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1409, %mul.2340), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1408 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%mul.2339), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.488 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1408)
-  %multiply.470 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.487, %convert.488), metadata={op_name="multiply.352"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.489 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%multiply.470)
-  %constant.429.clone.9 = bf16[]{:T(256)} constant(0)
-  %reduce.268 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} reduce(%convert.489, %constant.429.clone.9), dimensions={0,1}, to_apply=%region_23.27, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}
-  %param_3.940 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %convert.491 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%param_3.940)
-  %param_5.488 = bf16[2048]{0:T(1024)(128)(2,1)S(1)} parameter(5)
-  %dot_general.448.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} broadcast(%param_5.488), dimensions={2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.490 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.448.clone.3)
-  %dot_general.364.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert.487, %convert.490), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert_element_type.1090.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%dot_general.364.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
-  %mul.1572.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1090.clone.3, %mul.2340), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %param_4.558 = f32[128]{0:T(128)S(1)} parameter(4)
-  %mul.1591.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} broadcast(%param_4.558), dimensions={1}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %mul.1571.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} multiply(%convert_element_type.1409, %mul.1591.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %add_any.171.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%mul.1572.clone.3, %mul.1571.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}
-  %convert_element_type.1088.clone.3 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)} convert(%add_any.171.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
-  %convert.492 = f32[1,128,2048]{2,1,0:T(8,128)} convert(%convert_element_type.1088.clone.3)
-  %add_any.169.clone.3 = f32[1,128,2048]{2,1,0:T(8,128)} add(%convert.491, %convert.492), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","2048"],"tuple_shapes":[],"layout":{"minor_to_major":["2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false]}}}
-  %convert.493 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} convert(%add_any.169.clone.3)
-  ROOT %tuple.227 = (bf16[2048]{0:T(1024)(128)(2,1)S(1)}, bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)}) tuple(%reduce.268, %convert.493)
+%fused_computation.220.clone.clone.clone.1 (param_0.1785: bf16[1,128,2048]) -> bf16[128,2048,1] {
+  %param_0.1785 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.921 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%param_0.1785)
 }
 
-%fused_computation.218.clone.clone.clone.1 (param_0.1776: bf16[1,128,2048]) -> bf16[128,2048,1] {
-  %param_0.1776 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.901 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} bitcast(%param_0.1776)
+%fused_computation.101.clone.clone.clone.1 (param_0.1784: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
+  %param_0.1784 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.920 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1784), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.101.clone.clone.clone.1 (param_0.1775: bf16[1,16,128,2048]) -> bf16[16,128,2048] {
-  %param_0.1775 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)} parameter(0)
-  ROOT %bitcast.900 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} bitcast(%param_0.1775), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+%region_19.22 (dot_general.192: f32[], dot_general.193: f32[]) -> f32[] {
+  %dot_general.192 = f32[]{:T(128)} parameter(0), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general"}
+  %dot_general.193 = f32[]{:T(128)} parameter(1), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general"}
+  ROOT %add.417 = f32[]{:T(128)} add(%dot_general.192, %dot_general.193), metadata={op_name="add.47"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%region_19.22 (dot_general.206: f32[], dot_general.207: f32[]) -> f32[] {
-  %dot_general.206 = f32[]{:T(128)} parameter(0), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general"}
-  %dot_general.207 = f32[]{:T(128)} parameter(1), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general"}
-  ROOT %add.417 = f32[]{:T(128)} add(%dot_general.206, %dot_general.207), metadata={op_name="add.47"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-}
-
-%fused_computation.185.clone.1 (param_0.1777: bf16[16,128,128], param_1.1871: bf16[1,16,128,2048], param_2.1424: bf16[1,128,2048]) -> (f32[16,128], bf16[128,16,128]) {
-  %param_0.1777 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.903 = bf16[1,16,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1777), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/broadcast_in_dim" stack_frame_id=0}
-  %convert.343 = f32[1,16,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.903), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/convert" stack_frame_id=0}
-  %param_2.1424 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %fusion.216.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_2.1424), kind=kLoop, calls=%fused_computation.218.clone.clone.clone.1
-  %param_1.1871 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)} parameter(1)
-  %fusion.110.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_1.1871), kind=kLoop, calls=%fused_computation.101.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convolution.66.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} convolution(%fusion.216.clone.3, %fusion.110.clone.3), window={size=16 pad=15_15 rhs_reversal=1}, dim_labels=bf0_0oi->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
-  %bitcast.902 = bf16[1,16,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%convolution.66.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/transpose" stack_frame_id=0}
-  %convert.342 = f32[1,16,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.902), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/convert.1" stack_frame_id=0}
-  %multiply.471 = f32[1,16,128,128]{3,2,1,0:T(8,128)} multiply(%convert.343, %convert.342), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/multiply" stack_frame_id=0}
+%fused_computation.185.clone.1 (param_0.1786: bf16[16,128,128], param_1.1876: bf16[1,16,128,2048], param_2.1428: bf16[1,128,2048]) -> (f32[16,128], bf16[128,16,128]) {
+  %param_0.1786 = bf16[16,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %bitcast.923 = bf16[1,16,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1786), metadata={op_name="vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/pallas_call/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_fwd_segmented_residuals/splash_mha_fwd_segmented_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.344 = f32[1,16,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.923), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/convert" stack_frame_id=0}
+  %param_2.1428 = bf16[1,128,2048]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %fusion.221.clone.3 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} fusion(%param_2.1428), kind=kLoop, calls=%fused_computation.220.clone.clone.clone.1
+  %param_1.1876 = bf16[1,16,128,2048]{3,2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %fusion.110.clone.3 = bf16[16,128,2048]{2,1,0:T(8,128)(2,1)} fusion(%param_1.1876), kind=kLoop, calls=%fused_computation.101.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convolution.66.clone.3 = bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)} convolution(%fusion.221.clone.3, %fusion.110.clone.3), window={size=16 pad=15_15 rhs_reversal=1}, dim_labels=bf0_0oi->b0f, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
+  %bitcast.922 = bf16[1,16,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%convolution.66.clone.3), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/transpose" stack_frame_id=0}
+  %convert.343 = f32[1,16,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.922), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/convert.1" stack_frame_id=0}
+  %multiply.472 = f32[1,16,128,128]{3,2,1,0:T(8,128)} multiply(%convert.344, %convert.343), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/multiply" stack_frame_id=0}
   %constant.416.clone.24 = f32[]{:T(128)} constant(0)
-  %dot_general.610 = f32[16,128]{1,0:T(8,128)S(1)} reduce(%multiply.471, %constant.416.clone.24), dimensions={0,3}, to_apply=%region_19.22, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general" stack_frame_id=0}
-  ROOT %tuple.228 = (f32[16,128]{1,0:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) tuple(%dot_general.610, %convolution.66.clone.3)
+  %dot_general.602 = f32[16,128]{1,0:T(8,128)S(1)} reduce(%multiply.472, %constant.416.clone.24), dimensions={0,3}, to_apply=%region_19.22, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/hsd,hsd->hs/dot_general" stack_frame_id=0}
+  ROOT %tuple.225 = (f32[16,128]{1,0:T(8,128)S(1)}, bf16[128,16,128]{2,0,1:T(8,128)(2,1)S(1)}) tuple(%dot_general.602, %convolution.66.clone.3)
 }
 
-%fused_computation.260.clone.1 (param_0.1801: bf16[8,128,128], param_1.1888: bf16[128,128]) -> bf16[1,128,8,128] {
-  %param_0.1801 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
-  %bitcast.923 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1801), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
-  %convert.494 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.923)
-  %param_1.1888 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %broadcast.1081 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_1.1888), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.495 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.1081)
-  %mul.2362 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.494, %convert.495), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.496 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.2362)
-  ROOT %bitcast.922 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convert.496), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+%fused_computation.261.clone.1 (param_0.1810: bf16[8,128,128], param_1.1893: bf16[128,128]) -> bf16[1,128,8,128] {
+  %param_0.1810 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  %bitcast.943 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_0.1810), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.493 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.943)
+  %param_1.1893 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %broadcast.1082 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_1.1893), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.494 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.1082)
+  %mul.2362 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.493, %convert.494), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.495 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.2362)
+  ROOT %bitcast.942 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} bitcast(%convert.495), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
 }
 
-%fused_computation.495.clone.1 (param_0.1802: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
-  %param_0.1802 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %slice.79 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1802), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/split" stack_frame_id=0}
-  %slice.52.clone.3 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1802), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/split" stack_frame_id=0}
-  %convert.497 = f32[1,128,8,64]{3,1,2,0:T(8,128)} convert(%slice.52.clone.3)
-  %neg.100.clone.3 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.497), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.498 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.100.clone.3)
-  ROOT %tuple.234 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%slice.79, %convert.498)
+%fused_computation.496.clone.1 (param_0.1811: bf16[1,128,8,128]) -> (bf16[1,128,8,64], bf16[1,128,8,64]) {
+  %param_0.1811 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %slice.79 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} slice(%param_0.1811), slice={[0:1], [0:128], [0:8], [64:128]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/split" stack_frame_id=0}
+  %slice.52.clone.3 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)} slice(%param_0.1811), slice={[0:1], [0:128], [0:8], [0:64]}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/split" stack_frame_id=0}
+  %convert.496 = f32[1,128,8,64]{3,1,2,0:T(8,128)} convert(%slice.52.clone.3)
+  %neg.100.clone.3 = f32[1,128,8,64]{3,1,2,0:T(8,128)} negate(%convert.496), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/neg" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","64"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.497 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%neg.100.clone.3)
+  ROOT %tuple.231 = (bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}, bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%slice.79, %convert.497)
 }
 
-%region_25.29 (dot_general.213: bf16[], dot_general.214: bf16[]) -> bf16[] {
-  %dot_general.213 = bf16[]{:T(256)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general"}
-  %dot_general.214 = bf16[]{:T(256)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general"}
-  ROOT %add.420 = bf16[]{:T(256)} add(%dot_general.213, %dot_general.214), metadata={op_name="add.72"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+%region_25.29 (dot_general.199: bf16[], dot_general.200: bf16[]) -> bf16[] {
+  %dot_general.199 = bf16[]{:T(256)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general"}
+  %dot_general.200 = bf16[]{:T(256)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general"}
+  ROOT %add.420 = bf16[]{:T(256)} add(%dot_general.199, %dot_general.200), metadata={op_name="add.72"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.261.clone.1 (param_0.1803: f32[128,8], param_1.1889: bf16[1,128,8,128], param_2.1437: bf16[128,128], param_3.948: bf16[8,128,128], param_4.564: bf16[1,128,8,64], param_5.491: bf16[1,128,8,64]) -> (bf16[128], bf16[1,128,8,128]) {
-  %param_5.491 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
-  %constant.1086.clone.3 = bf16[]{:T(256)} constant(-inf)
-  %pad.61.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_5.491, %constant.1086.clone.3), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/concatenate" stack_frame_id=0}
-  %convert.499 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.61.clone.3)
-  %param_4.564 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(4)
-  %pad.60.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_4.564, %constant.1086.clone.3), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/concatenate" stack_frame_id=0}
-  %convert.500 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.60.clone.3)
-  %maximum.49.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.499, %convert.500), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_3.948 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
-  %bitcast.653.clone.3 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_3.948), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
-  %convert.501 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.653.clone.3)
-  %param_2.1437 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %broadcast.979.clone.3 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_2.1437), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert.502 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.979.clone.3)
-  %mul.1994.clone.3 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.501, %convert.502), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.503 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.1994.clone.3)
-  %bitcast.652.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%convert.503), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %convert.504 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%bitcast.652.clone.3)
-  %add_any.197.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%maximum.49.clone.3, %convert.504), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %param_1.1889 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.350 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_1.1889), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_0.1803 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
-  %mul.2364 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_0.1803), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2363 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.350, %mul.2364), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %convert_element_type.1420 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2363), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convert.505 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1420)
-  %multiply.475 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%add_any.197.clone.3, %convert.505), metadata={op_name="multiply.355"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert.506 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%multiply.475)
-  %constant.429.clone.11 = bf16[]{:T(256)} constant(0)
-  %reduce.271 = bf16[128]{0:T(256)(128)(2,1)S(1)} reduce(%convert.506, %constant.429.clone.11), dimensions={0,1,2}, to_apply=%region_25.29, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.507 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%add_any.197.clone.3)
-  ROOT %tuple.235 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%reduce.271, %convert.507)
+%fused_computation.262.clone.1 (param_0.1812: f32[128,8], param_1.1894: bf16[1,128,8,128], param_2.1441: bf16[128,128], param_3.952: bf16[8,128,128], param_4.560: bf16[1,128,8,64], param_5.485: bf16[1,128,8,64]) -> (bf16[128], bf16[1,128,8,128]) {
+  %param_5.485 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(5)
+  %constant.1087.clone.3 = bf16[]{:T(256)} constant(-inf)
+  %pad.61.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_5.485, %constant.1087.clone.3), padding=0_0x0_0x0_0x0_64, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/concatenate" stack_frame_id=0}
+  %convert.498 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.61.clone.3)
+  %param_4.560 = bf16[1,128,8,64]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(4)
+  %pad.60.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} pad(%param_4.560, %constant.1087.clone.3), padding=0_0x0_0x0_0x64_0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/concatenate" stack_frame_id=0}
+  %convert.499 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%pad.60.clone.3)
+  %maximum.49.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)} maximum(%convert.498, %convert.499), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/concatenate" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_3.952 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(3)
+  %bitcast.668.clone.3 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} bitcast(%param_3.952), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/shard_map/vmap(static_sparsity_splash)/jit(_splash_attention)/splash_mha_dkv_segmented_no_residuals/splash_mha_dkv_segmented_no_residuals/broadcast_in_dim" stack_frame_id=0}
+  %convert.500 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%bitcast.668.clone.3)
+  %param_2.1441 = bf16[128,128]{1,0:T(8,128)(2,1)S(1)} parameter(2)
+  %broadcast.980.clone.3 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} broadcast(%param_2.1441), dimensions={2,3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert.501 = f32[1,8,128,128]{3,2,1,0:T(8,128)} convert(%broadcast.980.clone.3)
+  %mul.1994.clone.3 = f32[1,8,128,128]{3,2,1,0:T(8,128)} multiply(%convert.500, %convert.501), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","8","128","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","2","1","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.502 = bf16[1,8,128,128]{3,2,1,0:T(8,128)(2,1)} convert(%mul.1994.clone.3)
+  %bitcast.667.clone.3 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} bitcast(%convert.502), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %convert.503 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%bitcast.667.clone.3)
+  %add_any.206.clone.3 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%maximum.49.clone.3, %convert.503), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %param_1.1894 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.351 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_1.1894), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_0.1812 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
+  %mul.2364 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_0.1812), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2363 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.351, %mul.2364), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %convert_element_type.1428 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%mul.2363), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convert.504 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%convert_element_type.1428)
+  %multiply.476 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%add_any.206.clone.3, %convert.504), metadata={op_name="multiply.355"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert.505 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%multiply.476)
+  %constant.429.clone.10 = bf16[]{:T(256)} constant(0)
+  %reduce.269 = bf16[128]{0:T(256)(128)(2,1)S(1)} reduce(%convert.505, %constant.429.clone.10), dimensions={0,1,2}, to_apply=%region_25.29, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.506 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} convert(%add_any.206.clone.3)
+  ROOT %tuple.232 = (bf16[128]{0:T(256)(128)(2,1)S(1)}, bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)}) tuple(%reduce.269, %convert.506)
 }
 
 %region_20.24 (reduce_sum.228: f32[], reduce_sum.232: f32[]) -> f32[] {
@@ -1923,78 +1911,90 @@ StackFrames
   ROOT %reduce_sum.233 = f32[]{:T(128)} add(%reduce_sum.228, %reduce_sum.232), metadata={op_name="checkpoint/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.200.clone.1 (param_0.1804: bf16[1,128,8,128], param_1.1890: bf16[1,128,8,128], param_2.1438: bf16[128]) -> f32[128,8] {
-  %param_0.1804 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.351 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_0.1804), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1890 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert.508 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_1.1890)
-  %param_2.1438 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
-  %dot_general.622 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1438), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.509 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.622)
-  %dot_general.621 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.508, %convert.509), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert_element_type.1421 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.621), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
-  %mul.2365 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.351, %convert_element_type.1421), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+%fused_computation.200.clone.1 (param_0.1813: bf16[1,128,8,128], param_1.1895: bf16[1,128,8,128], param_2.1442: bf16[128]) -> f32[128,8] {
+  %param_0.1813 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.352 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_0.1813), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1895 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert.507 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_1.1895)
+  %param_2.1442 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(2)
+  %dot_general.614 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_2.1442), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.508 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.614)
+  %dot_general.613 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.507, %convert.508), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert_element_type.1429 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.613), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
+  %mul.2365 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.352, %convert_element_type.1429), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
   %constant.416.clone.26 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.272 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%mul.2365, %constant.416.clone.26), dimensions={0,3}, to_apply=%region_20.24, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/reduce_sum" stack_frame_id=0}
+  ROOT %reduce.270 = f32[128,8]{0,1:T(8,128)S(1)} reduce(%mul.2365, %constant.416.clone.26), dimensions={0,3}, to_apply=%region_20.24, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.297.clone.1 (param_0.1805: f32[128,8], param_1.1891: f32[128,8]) -> f32[128,8] {
-  %param_0.1805 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
-  %bitcast.925 = f32[1,128,8]{1,2,0:T(8,128)} bitcast(%param_0.1805), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/reduce_sum" stack_frame_id=0}
-  %param_1.1891 = f32[128,8]{0,1:T(8,128)S(1)} parameter(1)
+%fused_computation.298.clone.1 (param_0.1814: f32[128,8], param_1.1896: f32[128,8]) -> f32[128,8] {
+  %param_0.1814 = f32[128,8]{0,1:T(8,128)S(1)} parameter(0)
+  %bitcast.945 = f32[1,128,8]{1,2,0:T(8,128)} bitcast(%param_0.1814), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/reduce_sum" stack_frame_id=0}
+  %param_1.1896 = f32[128,8]{0,1:T(8,128)S(1)} parameter(1)
   %constant.419.clone.15 = f32[]{:T(128)} constant(0.0078125)
-  %broadcast.1083 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.419.clone.15), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
-  %div.1025 = f32[128,8]{0,1:T(8,128)} multiply(%param_1.1891, %broadcast.1083), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %broadcast.1084 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.419.clone.15), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr" stack_frame_id=0}
+  %div.1025 = f32[128,8]{0,1:T(8,128)} multiply(%param_1.1896, %broadcast.1084), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
   %constant.418.clone.23 = f32[]{:T(128)} constant(1e-06)
-  %broadcast.1082 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.418.clone.23), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %add.1056 = f32[128,8]{0,1:T(8,128)} add(%div.1025, %broadcast.1082), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %bitcast.926 = f32[1,128,8]{1,2,0:T(8,128)} bitcast(%add.1056), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
-  %rsqrt.220 = f32[1,128,8]{1,2,0:T(8,128)} rsqrt(%bitcast.926), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
-  %div.1024 = f32[1,128,8]{1,2,0:T(8,128)} divide(%rsqrt.220, %bitcast.926), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
+  %broadcast.1083 = f32[128,8]{0,1:T(8,128)} broadcast(%constant.418.clone.23), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %add.1056 = f32[128,8]{0,1:T(8,128)} add(%div.1025, %broadcast.1083), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %bitcast.946 = f32[1,128,8]{1,2,0:T(8,128)} bitcast(%add.1056), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/add" stack_frame_id=0}
+  %rsqrt.220 = f32[1,128,8]{1,2,0:T(8,128)} rsqrt(%bitcast.946), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/rsqrt" stack_frame_id=0}
+  %div.1024 = f32[1,128,8]{1,2,0:T(8,128)} divide(%rsqrt.220, %bitcast.946), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/div" stack_frame_id=0}
   %constant.426.clone.11 = f32[]{:T(128)} constant(-0.5)
   %mul.2370 = f32[1,128,8]{1,2,0:T(8,128)} broadcast(%constant.426.clone.11), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
   %mul.2368 = f32[1,128,8]{1,2,0:T(8,128)} multiply(%div.1024, %mul.2370), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2367 = f32[1,128,8]{1,2,0:T(8,128)} multiply(%bitcast.925, %mul.2368), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %mul.2367 = f32[1,128,8]{1,2,0:T(8,128)} multiply(%bitcast.945, %mul.2368), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
   %constant.428.clone.6 = f32[]{:T(128)} constant(0.015625)
   %mul.2369 = f32[1,128,8]{1,2,0:T(8,128)} broadcast(%constant.428.clone.6), dimensions={}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
   %mul.2366 = f32[1,128,8]{1,2,0:T(8,128)} multiply(%mul.2367, %mul.2369), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  ROOT %bitcast.924 = f32[128,8]{0,1:T(8,128)S(1)} bitcast(%mul.2366), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  ROOT %bitcast.944 = f32[128,8]{0,1:T(8,128)S(1)} bitcast(%mul.2366), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
 }
 
-%fused_computation.249.clone.1.clone.1 (param_0.1815: bf16[1,128,8,128], param_1.1899: f32[128,8], param_2.1446: f32[128,8], param_3.953: bf16[1,128,8,128], param_4.568: bf16[128]) -> bf16[128,8,128] {
-  %param_3.953 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(3)
-  %convert.436 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_3.953)
-  %param_4.568 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(4)
-  %dot_general.630 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_4.568), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
-  %convert.437 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.630)
-  %dot_general.629 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.436, %convert.437), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
-  %convert_element_type.1429 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.629), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
-  %param_2.1446 = f32[128,8]{0,1:T(8,128)S(1)} parameter(2)
-  %mul.2387 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_2.1446), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
-  %mul.2385 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert_element_type.1429, %mul.2387), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %param_0.1815 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %convert.354 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_0.1815), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %param_1.1899 = f32[128,8]{0,1:T(8,128)S(1)} parameter(1)
-  %mul.2386 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1899), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %mul.2384 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.354, %mul.2386), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
-  %add_any.215 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.2385, %mul.2384), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}
-  %convert_element_type.1428 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add_any.215), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
-  ROOT %bitcast.934 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%convert_element_type.1428)
+%fused_computation.250.clone.1.clone.1 (param_0.1824: bf16[1,128,8,128], param_1.1904: f32[128,8], param_2.1450: f32[128,8], param_3.957: bf16[1,128,8,128], param_4.564: bf16[128]) -> bf16[128,8,128] {
+  %param_3.957 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(3)
+  %convert.437 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_3.957)
+  %param_4.564 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(4)
+  %dot_general.622 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} broadcast(%param_4.564), dimensions={3}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/...k,k->...k/dot_general" stack_frame_id=0}
+  %convert.438 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.622)
+  %dot_general.621 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.437, %convert.438), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/...k,k->...k/dot_general" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"float_type_correction_info":{"original_type":"BF16","original_shape":{"element_type":"BF16","dimensions":["1","128","8","128"],"tuple_shapes":[],"layout":{"minor_to_major":["3","1","2","0"],"tiles":[{"dimensions":["8","128"]},{"dimensions":["2","1"]}],"element_size_in_bits":"0","memory_space":"0","dim_level_types":[],"index_primitive_type":"PRIMITIVE_TYPE_INVALID","pointer_primitive_type":"PRIMITIVE_TYPE_INVALID","dim_unique":[],"dim_ordered":[],"dynamic_shape_metadata_prefix_bytes":"0","tail_padding_alignment_in_elements":"1","split_configs":[]},"is_dynamic_dimension":[false,false,false,false]}}}
+  %convert_element_type.1437 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%dot_general.621), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
+  %param_2.1450 = f32[128,8]{0,1:T(8,128)S(1)} parameter(2)
+  %mul.2387 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_2.1450), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/mul" stack_frame_id=0}
+  %mul.2385 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert_element_type.1437, %mul.2387), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %param_0.1824 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %convert.355 = f32[1,128,8,128]{3,1,2,0:T(8,128)} convert(%param_0.1824), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %param_1.1904 = f32[128,8]{0,1:T(8,128)S(1)} parameter(1)
+  %mul.2386 = f32[1,128,8,128]{3,1,2,0:T(8,128)} broadcast(%param_1.1904), dimensions={1,2}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %mul.2384 = f32[1,128,8,128]{3,1,2,0:T(8,128)} multiply(%convert.355, %mul.2386), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/mul" stack_frame_id=0}
+  %add_any.226 = f32[1,128,8,128]{3,1,2,0:T(8,128)} add(%mul.2385, %mul.2384), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/add_any" stack_frame_id=0}
+  %convert_element_type.1436 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)} convert(%add_any.226), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/convert_element_type" stack_frame_id=0}
+  ROOT %bitcast.954 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%convert_element_type.1436)
 }
 
-%fused_computation.118.clone.clone.clone.1 (param_0.1814: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
-  %param_0.1814 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  ROOT %bitcast.933 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1814), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+%fused_computation.118.clone.clone.clone.1 (param_0.1823: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
+  %param_0.1823 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.953 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} bitcast(%param_0.1823), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.158.clone.1 (param_0.1816: bf16[1,2048,8,128], param_1.1900: bf16[1,128,8,128], param_2.1447: f32[128,8], param_3.954: f32[128,8], param_4.569: bf16[1,128,8,128], param_5.494: bf16[128]) -> bf16[128,2048] {
-  %param_1.1900 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
-  %param_2.1447 = f32[128,8]{0,1:T(8,128)S(1)} parameter(2)
-  %param_3.954 = f32[128,8]{0,1:T(8,128)S(1)} parameter(3)
-  %param_4.569 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(4)
-  %param_5.494 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(5)
-  %fusion.472 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_1.1900, %param_2.1447, %param_3.954, %param_4.569, %param_5.494), kind=kLoop, calls=%fused_computation.249.clone.1.clone.1
-  %param_0.1816 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.471 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1816), kind=kLoop, calls=%fused_computation.118.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
-  %convolution.145 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.472, %fusion.471), window={size=8}, dim_labels=b0f_o0i->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
-  ROOT %bitcast.935 = bf16[128,2048]{1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.145), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
+%fused_computation.157.clone.1 (param_0.1825: bf16[1,2048,8,128], param_1.1905: bf16[1,128,8,128], param_2.1451: f32[128,8], param_3.958: f32[128,8], param_4.565: bf16[1,128,8,128], param_5.488: bf16[128]) -> bf16[128,2048] {
+  %param_1.1905 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(1)
+  %param_2.1451 = f32[128,8]{0,1:T(8,128)S(1)} parameter(2)
+  %param_3.958 = f32[128,8]{0,1:T(8,128)S(1)} parameter(3)
+  %param_4.565 = bf16[1,128,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(4)
+  %param_5.488 = bf16[128]{0:T(256)(128)(2,1)S(1)} parameter(5)
+  %fusion.479 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} fusion(%param_1.1905, %param_2.1451, %param_3.958, %param_4.565, %param_5.488), kind=kLoop, calls=%fused_computation.250.clone.1.clone.1
+  %param_0.1825 = bf16[1,2048,8,128]{1,3,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.478 = bf16[2048,8,128]{0,2,1:T(8,128)(2,1)} fusion(%param_0.1825), kind=kLoop, calls=%fused_computation.118.clone.clone.clone.1, frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+  %convolution.145 = bf16[128,2048,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.479, %fusion.478), window={size=8}, dim_labels=b0f_o0i->bf0, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
+  ROOT %bitcast.955 = bf16[128,2048]{1,0:T(8,128)(2,1)S(1)} bitcast(%convolution.145), metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/dot_general" stack_frame_id=0}
+}
+
+%fused_computation.258.clone.1 (param_0.1827: bf16[8,128,128]) -> bf16[128,8,128] {
+  %param_0.1827 = bf16[8,128,128]{2,1,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.957 = bf16[128,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1827)
+}
+
+%fused_computation.114.clone.clone.clone.clone.clone.1 (param_0.1826: bf16[1,2048,8,128]) -> bf16[2048,8,128] {
+  %param_0.1826 = bf16[1,2048,8,128]{3,1,2,0:T(8,128)(2,1)S(1)} parameter(0)
+  ROOT %bitcast.956 = bf16[2048,8,128]{2,0,1:T(8,128)(2,1)} bitcast(%param_0.1826), frontend_attributes={is_spmd_generated="true"}, metadata={op_name="jit(train_step)/transpose(jvp())/while/body/eval_jaxpr/checkpoint/rematted_computation/convert_element_type" stack_frame_id=0}
+}
+

--- a/tests/utils/sharding_info/qwen3-0.6b/tpu7x-16/slice_1/rule_default/input_shardings.json
+++ b/tests/utils/sharding_info/qwen3-0.6b/tpu7x-16/slice_1/rule_default/input_shardings.json
@@ -1,18 +1,6 @@
 {
   "Activation Sharding Dump": [
     {
-      "qwen3/inputs: bfloat16[192,2048,1024]": {
-        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
-        "PartitionSpec": "P('fsdp', None, None)"
-      }
-    },
-    {
-      "Unknown: bfloat16[192,2048,1024]": {
-        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
-        "PartitionSpec": "P('fsdp', None, None)"
-      }
-    },
-    {
       "attentions/inputs_q: bfloat16[192,2048,1024]": {
         "logic_axes": "('activation_batch_attn', 'activation_input_length_attn', 'activation_embed_attn')",
         "PartitionSpec": "P('fsdp', None, None)"


### PR DESCRIPTION
## Description

This PR fixes the numerical accuracy drift (KL divergence failure) in Qwen3 model when running in `ShardMode.AUTO`. It strictly restores XLA arithmetic fusions and floating-point precision without breaking the recently added `ShardMode.EXPLICIT` feature.

[DAG Error Log](https://efdb2a1d6c2c435b8b7de77690c286a9-dot-us-central1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_checkpoint_conversion/grid?search=maxtext_e2e_tpu_checkpoint_conversion&dag_run_id=manual__2026-08-31T00%3A58%3A38.434413%2B00%3A00&task_id=qwen3-30b.to-mt-v5p-8.run_model.wait_for_workload_completion&tab=logs)

## Root Cause

A recent PR replaced native logical constraints with MaxText's `maybe_shard_with_logical` to support explicit physical layouts. However, this wrapper actively emits `jax.lax.with_sharding_constraint` even when the model runs in `AUTO` mode.

These hard constraints silently disrupted optimal XLA compiler fusions (such as combining GEMM, Add, and RMSNorm ops). By breaking these fusions, it altered the mathematical order of parallel reductions. Across 48+ layers in FP32 format, this numerical drift accumulated and caused the output logits to drift, pushing the E2E test KL divergence (~0.07) beyond the safe 0.03 threshold.


## Solution

Conditionally gate the initialization of explicit targets (`out_sharding`, `mlp_intermediate_sharding`) and the `maybe_shard_with_logical` wrapper behind an `if config.shard_mode == ShardMode.EXPLICIT:` check in `qwen3.py`.

In `AUTO` mode, these calls now cleanly fall back to No-Op lambdas. This limits the layout constraints entirely to EXPLICIT users, allowing AUTO mode to safely restore full XLA fusions and pristine precision.

# Tests

Run `tests.utils.forward_pass_logit_checker` with Qwen3-30b: https://cloudlogging.app.goo.gl/8SmHTMpi2CRNckAh6

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
