### PR TITLE
Fix RLConfig mesh initialization to prevent NoneType AttributeError

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4935,4 +4935,32 @@ class RLConfig(
       self.tensors_on_device = [t for t in tensors if getattr(self, t) == "device"]
       self.tensors_to_offload = [t for t in tensors if getattr(self, t) == "offload"]
 
+    def get_parallelism_map(prefix: str) -> dict[str, int]:
+      return {
+          "diloco": getattr(self, f"{prefix}_diloco_parallelism"),
+          "data": getattr(self, f"{prefix}_data_parallelism"),
+          "stage": getattr(self, f"{prefix}_pipeline_parallelism"),
+          "fsdp": getattr(self, f"{prefix}_fsdp_parallelism"),
+          "fsdp_transpose": getattr(self, f"{prefix}_fsdp_transpose_parallelism"),
+          "sequence": getattr(self, f"{prefix}_sequence_parallelism"),
+          "context": getattr(self, f"{prefix}_context_parallelism"),
+          "context_usp_ulysses": getattr(self, f"{prefix}_context_usp_ulysses_parallelism"),
+          "context_autoregressive": getattr(self, f"{prefix}_context_autoregressive_parallelism"),
+          "tensor": getattr(self, f"{prefix}_tensor_parallelism"),
+          "tensor_sequence": getattr(self, f"{prefix}_tensor_sequence_parallelism"),
+          "model": getattr(self, f"{prefix}_tensor_parallelism"),
+          "expert": getattr(self, f"{prefix}_expert_parallelism"),
+          "autoregressive": getattr(self, f"{prefix}_autoregressive_parallelism"),
+          "attn_dp": 1,
+          "attn_dp_expert": 1,
+          "dcp": 1,
+          "pcp": 1,
+      }
+
+    ici_map = get_parallelism_map("ici")
+    self.ici_parallelism = [ici_map[axis] for axis in self.mesh_axes]
+
+    dcn_map = get_parallelism_map("dcn")
+    self.dcn_parallelism = [dcn_map[axis] for axis in self.mesh_axes]
+
     return self


### PR DESCRIPTION
## Description

Fix `RLConfig` mesh initialization to prevent `AttributeError: 'NoneType' object has no attribute 'copy'` during device mesh creation.

[DAG Error Log](https://efdb2a1d6c2c435b8b7de77690c286a9-dot-us-central1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_post_training/grid?search=maxtext_e2e_tpu_post_training&tab=logs&dag_run_id=manual__2026-08-31T06%3A01%3A37%2B00%3A00&task_id=llama3_1-70b.rl-llama3_1-70b.rl-v5p-128.run_model.wait_for_workload_completion)

## Root Cause

Commit `9de4fba1` removed the duplicate mesh axis parallelism setup from `create_device_mesh`, expecting Config objects to derive this from `mesh_axes` upfront. However, `RLConfig` is uncoupled from `MaxTextConfig` and lacked this derivation, leaving `ici_parallelism` and `dcn_parallelism` as `None`, which crashed the execution.

## Solution

Add the missing mesh parallelism derivations (`ici_map` and `dcn_map` construction) into `RLConfig.set_derived_values_and_validate()`, bringing it to parity with `MaxTextConfig`.

# Tests

RL:

Gemma3-4b: https://cloudlogging.app.goo.gl/5jfR11f2apBjZJik9
Gemma4-26b: https://cloudlogging.app.goo.gl/ZJeavBPQfDayVDE27
Qwen3-30b: https://cloudlogging.app.goo.gl/oZ9NanGcTwpnUPLfA
Llama3.1-70b: https://cloudlogging.app.goo.gl/wwKReUTgA3V6GnEc8
GPT-OSS-20b: https://cloudlogging.app.goo.gl/9r5ePozTRmcQbd5v6

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
