### PR TITLE
Support 2D transposed shape alignment in model_creation_utils

### DIFF
--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -180,6 +180,9 @@ def _align_checkpoint_to_model_shapes(ckpt_arr, model_arr, logical_axes=None):
         "If the checkpoint was saved with scan_layers=True (stacked layers), convert it to "
         "unscanned format before loading with vLLM (vllm.yml sets scan_layers=False)."
     )
+  if len(ckpt_shape) == 2 and ckpt_shape == model_shape[::-1]:
+    return jax.device_put(jnp.transpose(ckpt_arr), model_arr.sharding)
+
   axes = _normalize_logical_axes(logical_axes)
   if axes is None or len(axes) != len(model_shape):
     axes = (None,) * len(model_shape)

--- a/tests/unit/model_creation_utils_test.py
+++ b/tests/unit/model_creation_utils_test.py
@@ -195,6 +195,27 @@ class TestAlignCheckpointToModelShapes(unittest.TestCase):
     out = _align_checkpoint_to_model_shapes(ckpt, model, ("a", "b"))
     np.testing.assert_array_equal(np.asarray(out), np.asarray(ckpt))
 
+  def test_transposed_2d_shapes_align_correctly(self):
+    """Transposed 2D arrays must transpose to align ckpt (2, 3) to model (3, 2)."""
+    ckpt = jnp.arange(6, dtype=jnp.float32).reshape(2, 3)
+    model = jnp.zeros((3, 2), dtype=jnp.float32)
+    out = _align_checkpoint_to_model_shapes(ckpt, model, ("moe_layers", "expert"))
+    out_np = np.asarray(out)
+    self.assertEqual(out_np.shape, (3, 2))
+    np.testing.assert_array_equal(out_np, np.asarray(ckpt.T))
+
+  def test_transposed_2d_shapes_with_sharded_model(self):
+    """Transposed 2D arrays should align and assume the model array's sharding."""
+    mesh = jax.sharding.Mesh(jax.local_devices()[:1], ("x",))
+    sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec("x", None))
+    ckpt = jnp.arange(6, dtype=jnp.float32).reshape(2, 3)
+    model = jax.device_put(jnp.zeros((3, 2), dtype=jnp.float32), sharding)
+    out = _align_checkpoint_to_model_shapes(ckpt, model, ("moe_layers", "expert"))
+    out_np = np.asarray(out)
+    self.assertEqual(out_np.shape, (3, 2))
+    self.assertEqual(out.sharding, sharding)
+    np.testing.assert_array_equal(out_np, np.asarray(ckpt.T))
+
   def test_kv_heads_repeat_layout(self):
     """KV-head axis must use jnp.repeat: [h0, h0, h1, h1], NOT [h0, h1, h0, h1]."""
     # Distinguishable per-head values so the layout assertion is unambiguous.


### PR DESCRIPTION
When restoring scanned MoE checkpoints (such as DeepSeek V3), router gate bias (e.g. MoEBiasVar) may be stored on disk with shape (num_experts, num_moe_layers) due to converter scan-axis stacking, whereas Flax NNX defines the parameter as (num_moe_layers, num_experts).

Handle 2D transposed dimensions in _align_checkpoint_to_model_shapes() by transposing the checkpoint array to match target model shapes.


FIXES: b/553744097


# Tests
blaze test //third_party/py/maxtext/tests/unit:model_creation_utils_test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
