### PR TITLE
Add StreamIndex Kernel for CSA [Deepseek v4]

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -481,6 +481,7 @@ o_lora_rank: 0 # Output LoRA rank for Compressed Attention.
 o_groups: 0 # Output groups for Compressed Attention.
 compress_ratios: [] # Per-layer compression ratios (0, 4, 128, etc).
 compressed_rope_max_timescale: 160_000 # If positive, used for Compressed Sparse/Heavy Attention.
+use_csa_streamindex_kernel: false # Whether to use Pallas TPU kernel for CSA StreamIndex score computation.
 
 # QK-Clip (Muon Clip) Configuration
 use_qk_clip: false  # Enable QK-Clip (supported in MLA with DotProduct or Tokamax Splash)

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -769,6 +769,10 @@ class CompressedAttention(BaseModel):
   compressed_rope_max_timescale: int = Field(
       160000, description="If positive, used for Compressed Sparse/Heavy Attention."
   )
+  use_csa_streamindex_kernel: bool = Field(
+      False,
+      description="Whether to use Pallas TPU kernel for CSA StreamIndex score computation.",
+  )
 
 
 class AttentionIndexer(BaseModel):

--- a/src/maxtext/kernels/attention/__init__.py
+++ b/src/maxtext/kernels/attention/__init__.py
@@ -14,4 +14,5 @@
 
 """Attention kernels."""
 
+from maxtext.kernels.attention import csa_streamindex
 from maxtext.kernels.attention import splash_attention_kernel

--- a/src/maxtext/kernels/attention/csa_streamindex.py
+++ b/src/maxtext/kernels/attention/csa_streamindex.py
@@ -1,0 +1,281 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fused Pallas TPU kernel for DeepSeek-V4 CSA StreamIndex Score Computation.
+
+Computes:
+  index_scores = sum_h(ReLU(q_h @ comp^T) * softmax_scale * w_h)
+
+The kernel fuses the dot product, ReLU activation, softmax scaling and
+head-weight contraction so the intermediate [B, H, S, W] tensor stays in VMEM.
+Masking is the caller's responsibility; see `csa_streamindex_score_kernel`.
+"""
+
+import functools
+import jax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+import jax.numpy as jnp
+
+
+# Default Pallas tile sizes, exported so tests and callers share one definition.
+# 128x1024 measured fastest on v6e at H=64; smaller head counts get larger tiles
+# to keep the MXU fed. Tuning data in PR #5079.
+DEFAULT_BLOCK_Q_LARGE_H = 128
+DEFAULT_BLOCK_W_LARGE_H = 1024
+DEFAULT_BLOCK_Q_SMALL_H = 256
+DEFAULT_BLOCK_W_SMALL_H = 2048
+
+# Heads per backward-pass scan iteration. Not `csa_qk_head_chunk_size`: that one
+# trades speed for HBM in the forward einsum and defaults to off, whereas this
+# controls reverse-mode fusion and must stay on or the backward OOMs at 32k.
+# 1 measured strictly best (fastest and lowest HBM) across B in {1,2,4} and
+# H in {16,32,64} on v6e -- at 1 XLA fuses the scan body and the residual never
+# reaches HBM.
+DEFAULT_BWD_HEAD_CHUNK = 1
+
+
+def csa_streamindex_score_kernel(
+    q_ref,  # [num_heads, block_q, head_dim]
+    k_ref,  # [block_w, head_dim]
+    w_ref,  # [block_q, num_heads]
+    out_ref,  # [block_q, block_w]
+    *,
+    softmax_scale: float,
+):
+  """Fused Pallas TPU kernel with 2D MXU matmul.
+
+  Masking is deliberately NOT done here: the kernel has no `position_ids` and
+  would have to synthesize positions from grid indices, which is wrong for
+  packed sequences. The caller masks, using the `future_mask` it already builds.
+  """
+  num_heads, block_q, head_dim = q_ref.shape
+  block_w, _ = k_ref.shape
+
+  # Reshape Q to 2D: (num_heads * block_q, head_dim) for native 2D systolic array MXU contraction
+  q_2d = q_ref[...].reshape(num_heads * block_q, head_dim)
+  k_2d = k_ref[...]
+
+  # 2D MXU matmul: (num_heads * block_q, head_dim) @ (block_w, head_dim)^T -> (num_heads * block_q, block_w)
+  s_2d = jnp.einsum("nd,md->nm", q_2d, k_2d, preferred_element_type=jnp.float32)
+
+  # Reshape to (num_heads, block_q, block_w) and apply ReLU
+  s = s_2d.reshape(num_heads, block_q, block_w)
+  s = jnp.maximum(s, 0.0)
+
+  # Multiply by weights and sum across heads in VMEM
+  w = w_ref[...].astype(jnp.float32).transpose(1, 0)[:, :, None]
+  s_weighted = jnp.sum(s * w, axis=0) * softmax_scale
+
+  out_ref[...] = s_weighted.astype(out_ref.dtype)
+
+
+def _csa_streamindex_score_pallas_fwd(
+    q: jax.Array,
+    compressed: jax.Array,
+    weights: jax.Array,
+    *,
+    softmax_scale: float,
+    block_q: int | None = None,
+    block_w: int | None = None,
+    interpret: bool = False,
+) -> jax.Array:
+  """Forward implementation using fused Pallas TPU kernel for head-major [B, H, S, D] q."""
+  batch_size, num_heads, seq_len, head_dim = q.shape
+  _, compressed_len, comp_head_dim = compressed.shape
+  assert comp_head_dim == head_dim, f"{comp_head_dim=} != {head_dim=}"
+  assert weights.shape == (batch_size, seq_len, num_heads), f"{weights.shape=} != {(batch_size, seq_len, num_heads)=}"
+
+  if block_q is None:
+    block_q = DEFAULT_BLOCK_Q_LARGE_H if num_heads >= 32 else DEFAULT_BLOCK_Q_SMALL_H
+  if block_w is None:
+    block_w = DEFAULT_BLOCK_W_LARGE_H if num_heads >= 32 else DEFAULT_BLOCK_W_SMALL_H
+
+  # Blocks may exceed the array; padding keeps the grid uniform. This also
+  # covers seq_len < block_q, which pads up to a single query block.
+  padded_s = ((seq_len + block_q - 1) // block_q) * block_q
+  padded_w = ((compressed_len + block_w - 1) // block_w) * block_w
+
+  if padded_s > seq_len:
+    pad_s = padded_s - seq_len
+    q = jnp.pad(q, ((0, 0), (0, 0), (0, pad_s), (0, 0)))
+    weights = jnp.pad(weights, ((0, 0), (0, pad_s), (0, 0)))
+  if padded_w > compressed_len:
+    pad_w = padded_w - compressed_len
+    compressed = jnp.pad(compressed, ((0, 0), (0, pad_w), (0, 0)))
+
+  grid = (batch_size, padded_s // block_q, padded_w // block_w)
+
+  in_specs = [
+      pl.BlockSpec((None, num_heads, block_q, head_dim), lambda b, i, j: (b, 0, i, 0)),
+      pl.BlockSpec((None, block_w, head_dim), lambda b, i, j: (b, j, 0)),
+      pl.BlockSpec((None, block_q, num_heads), lambda b, i, j: (b, i, 0)),
+  ]
+  out_specs = pl.BlockSpec((None, block_q, block_w), lambda b, i, j: (b, i, j))
+
+  out = pl.pallas_call(
+      functools.partial(
+          csa_streamindex_score_kernel,
+          softmax_scale=softmax_scale,
+      ),
+      in_specs=in_specs,
+      out_specs=out_specs,
+      grid=grid,
+      compiler_params=pltpu.CompilerParams(
+          # Every (b, i, j) program writes a disjoint output block, so all three
+          # axes are parallel and Mosaic may reorder or split them.
+          dimension_semantics=("parallel", "parallel", "parallel"),
+      ),
+      out_shape=jax.ShapeDtypeStruct((batch_size, padded_s, padded_w), jnp.float32),
+      interpret=interpret,
+  )(q, compressed, weights)
+
+  return out[:, :seq_len, :compressed_len]
+
+
+def csa_indexer_scores_jax(
+    q: jax.Array,
+    compressed: jax.Array,
+    weights: jax.Array,
+    *,
+    softmax_scale: float,
+    precision: jax.lax.PrecisionLike = None,
+) -> jax.Array:
+  """Pure-JAX CSA indexer scores. The definition the Pallas kernel must match.
+
+  Also the function `DeepseekV4Indexer` calls on its non-kernel path, so the two
+  cannot drift. Masking is applied by the caller, not here.
+
+  Args:
+    q: Query, `[B, H, S, D]`.
+    compressed: Compressed KV blocks, `[B, W, D]`.
+    weights: Per-head indexer weights, `[B, S, H]`.
+    softmax_scale: Scalar applied after the ReLU.
+    precision: Matmul precision for both einsums. The layer passes
+      `config.matmul_precision`; the kernel's VJP leaves it at the default.
+
+  Returns:
+    Index scores, `[B, S, W]`.
+  """
+  scores = jnp.einsum("bhsd,bwd->bhsw", q.astype(jnp.float32), compressed.astype(jnp.float32), precision=precision)
+  scores = jax.nn.relu(scores) * softmax_scale
+  return jnp.einsum("bhsw,bsh->bsw", scores, weights.astype(jnp.float32), precision=precision)
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(3, 4, 5, 6, 7))
+def csa_streamindex_score(
+    q: jax.Array,
+    compressed: jax.Array,
+    weights: jax.Array,
+    softmax_scale: float,
+    block_q: int | None = None,
+    block_w: int | None = None,
+    interpret: bool = False,
+    head_chunk_size: int = DEFAULT_BWD_HEAD_CHUNK,
+) -> jax.Array:
+  """Computes CSA StreamIndex scores using head-major [B, H, S, D] q layout with 2D MXU matmul."""
+  del head_chunk_size  # Backward pass only.
+  return _csa_streamindex_score_pallas_fwd(
+      q,
+      compressed,
+      weights,
+      softmax_scale=softmax_scale,
+      block_q=block_q,
+      block_w=block_w,
+      interpret=interpret,
+  )
+
+
+def _csa_streamindex_score_fwd(
+    q: jax.Array,
+    compressed: jax.Array,
+    weights: jax.Array,
+    softmax_scale: float,
+    block_q: int | None = None,
+    block_w: int | None = None,
+    interpret: bool = False,
+    head_chunk_size: int = DEFAULT_BWD_HEAD_CHUNK,
+) -> tuple[jax.Array, tuple[jax.Array, jax.Array, jax.Array]]:
+  """custom_vjp forward rule. Saves inputs, not the `[B, H, S, W]` scores, so the backward can recompute per chunk."""
+  del head_chunk_size  # Backward pass only.
+  out = _csa_streamindex_score_pallas_fwd(
+      q,
+      compressed,
+      weights,
+      softmax_scale=softmax_scale,
+      block_q=block_q,
+      block_w=block_w,
+      interpret=interpret,
+  )
+  return out, (q, compressed, weights)
+
+
+def _csa_streamindex_score_bwd(
+    softmax_scale: float,
+    block_q: int | None,
+    block_w: int | None,
+    interpret: bool,
+    head_chunk_size: int,
+    res: tuple[jax.Array, jax.Array, jax.Array],
+    g: jax.Array,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+  """Head-chunked backward pass.
+
+  The forward fuses `[B, H, S, W]` away, but reverse mode must keep it, so
+  whole-head autodiff materializes it in HBM. Scanning over `head_chunk_size`
+  heads bounds it to `[B, head_chunk_size, S, W]`; without this the backward
+  OOMs at 32k context on v6e. `d(compressed)` accumulates across chunks; `dq`
+  and `dweights` are per-head and get stacked back into head-major order.
+  """
+  del block_q, block_w, interpret
+  q, compressed, weights = res
+  num_heads = q.shape[1]
+
+  chunk = min(head_chunk_size, num_heads) if head_chunk_size > 0 else num_heads
+  if num_heads % chunk != 0:
+    chunk = num_heads
+  num_chunks = num_heads // chunk
+
+  # Head-major -> chunk-major so the scan iterates over heads.
+  #   q:       [B, H, S, D] -> [num_chunks, B, chunk, S, D]
+  #   weights: [B, S, H]    -> [num_chunks, B, S, chunk]
+  q_chunks = jnp.moveaxis(q, 1, 0).reshape(num_chunks, chunk, *q.shape[0:1], *q.shape[2:])
+  q_chunks = jnp.moveaxis(q_chunks, 1, 2)
+  w_chunks = jnp.moveaxis(weights, 2, 0).reshape(num_chunks, chunk, *weights.shape[0:2])
+  w_chunks = jnp.moveaxis(w_chunks, 1, 3)
+
+  def scan_body(dcomp_acc, xs):
+    q_c, w_c = xs["q"], xs["w"]
+    _, vjp_fn = jax.vjp(
+        functools.partial(csa_indexer_scores_jax, softmax_scale=softmax_scale),
+        q_c,
+        compressed,
+        w_c,
+    )
+    dq_c, dcomp_c, dw_c = vjp_fn(g)
+    return dcomp_acc + dcomp_c, (dq_c, dw_c)
+
+  dcomp_init = jnp.zeros(compressed.shape, dtype=jnp.float32)
+  dcompressed, (dq_stacked, dw_stacked) = jax.lax.scan(scan_body, dcomp_init, {"q": q_chunks, "w": w_chunks})
+
+  # [num_chunks, B, chunk, S, D] -> [num_chunks, chunk, B, S, D] -> [H, B, S, D] -> [B, H, S, D]
+  dq = jnp.moveaxis(dq_stacked, 2, 1).reshape(num_heads, *q.shape[0:1], *q.shape[2:])
+  dq = jnp.moveaxis(dq, 0, 1)
+  # [num_chunks, B, S, chunk] -> [B, S, num_chunks, chunk] -> [B, S, H]
+  dw = jnp.moveaxis(dw_stacked, 0, 2).reshape(weights.shape[0], weights.shape[1], num_heads)
+
+  return dq.astype(q.dtype), dcompressed.astype(compressed.dtype), dw.astype(weights.dtype)
+
+
+csa_streamindex_score.defvjp(_csa_streamindex_score_fwd, _csa_streamindex_score_bwd)

--- a/src/maxtext/layers/attention_compressed.py
+++ b/src/maxtext/layers/attention_compressed.py
@@ -16,6 +16,8 @@
 
 
 import enum
+import functools
+import math
 from typing import Any, Optional, Tuple
 
 import jax
@@ -47,6 +49,7 @@ from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.inference.kvcache import KVQuant
 from maxtext.inference import kvcache
 from maxtext.utils.globals import EPS
+from maxtext.kernels.attention import csa_streamindex
 
 
 class CSAPoolingConfig(enum.IntEnum):
@@ -478,7 +481,7 @@ class BaseDeepseekCompressor(nnx.Module):
       compress_ratio: int,
       rotary_embedding: Any,
       proj_multiplier: int,
-      kernel_init: Any = nnx.initializers.normal(stddev=0.02),
+      kernel_init: NdInitializer = nd_dense_init(1.0, "fan_in", "normal"),
       quant: Optional[Quant] = None,
       model_mode: str = MODEL_MODE_TRAIN,
       rngs: Optional[nnx.Rngs] = None,
@@ -554,7 +557,7 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
       config: Any,
       compress_ratio: int,
       rotary_embedding: Any,
-      kernel_init: Any = nnx.initializers.normal(stddev=0.02),
+      kernel_init: NdInitializer = nd_dense_init(1.0, "fan_in", "normal"),
       quant: Optional[Quant] = None,
       model_mode: str = MODEL_MODE_TRAIN,
       rngs: Optional[nnx.Rngs] = None,
@@ -728,9 +731,10 @@ class DeepseekV4Indexer(nnx.Module):
       config: Any,
       compress_ratio: int,
       rotary_embedding: Any,
-      kernel_init: Any = nnx.initializers.normal(stddev=0.02),
+      kernel_init: NdInitializer = nd_dense_init(1.0, "fan_in", "normal"),
       quant: Optional[Quant] = None,
       rngs: Optional[nnx.Rngs] = None,
+      mesh: Optional[Mesh] = None,
   ):
     """Initializes the Indexer for CSA.
 
@@ -741,9 +745,12 @@ class DeepseekV4Indexer(nnx.Module):
       kernel_init: Weight initializer for the indexer projections.
       quant: Optional quantization scheme.
       rngs: Optional random state initialization.
+      mesh: Device mesh. Required to shard the StreamIndex Pallas kernel; without
+        it the kernel runs unsharded and GSPMD all-gathers its operands.
     """
     self.config = config
     self.compress_rate = compress_ratio
+    self.mesh = mesh
     self.index_n_heads = config.indexer_n_heads
     self.index_head_dim = config.indexer_head_dim
     self.index_topk = config.indexer_topk
@@ -820,6 +827,64 @@ class DeepseekV4Indexer(nnx.Module):
     )
 
     self.rotary_emb = rotary_embedding
+
+  def _streamindex_scores_sharded(self, q: Array, compressed: Array, weights: Array) -> Array:
+    """Runs the StreamIndex Pallas kernel under a batch-only `shard_map`.
+
+    A bare `pallas_call` lowers to an opaque `tpu_custom_call` that GSPMD cannot
+    partition, so it conservatively all-gathers every operand to full global
+    shape on each device — reconstructing the whole `[B, H, S, D]` query and
+    defeating the memory saving the kernel exists to provide. `shard_map` makes
+    the partitioning explicit and removes those collectives.
+
+    Only the batch dimension is sharded. Context/sequence parallelism is not
+    supported: `compressed` would have to be replicated across the context axis
+    (causality means late query rows need every earlier compressed block), which
+    is a separate change.
+
+    Args:
+      q: `[B, H, S, D]`.
+      compressed: `[B, W, D]`.
+      weights: `[B, S, H]`.
+
+    Returns:
+      Index scores, `[B, S, W]`.
+    """
+    batch_size = q.shape[0]
+
+    batch_axes = tuple(
+        axis for axis in ("data", "fsdp", "fsdp_transpose", "expert") if self.mesh is not None and axis in self.mesh.shape
+    )
+    num_batch_shards = math.prod(self.mesh.shape[a] for a in batch_axes) if batch_axes else 1
+
+    if self.mesh is None or num_batch_shards == 1:
+      return csa_streamindex.csa_streamindex_score(q, compressed, weights, self.softmax_scale)
+
+    if batch_size % num_batch_shards != 0:
+      raise ValueError(
+          f"CSA StreamIndex kernel requires batch_size ({batch_size}) to be divisible by the "
+          f"number of batch shards ({num_batch_shards}) across mesh axes {batch_axes}. "
+          "Adjust the batch size or disable use_csa_streamindex_kernel."
+      )
+
+    q_pspec = jax.sharding.PartitionSpec(batch_axes, None, None, None)
+    # `compressed`, `weights` and the output are all 3D and batch-sharded alike.
+    pspec_3d = jax.sharding.PartitionSpec(batch_axes, None, None)
+
+    # check_vma=False is required, not defensive: `pallas_call` builds its
+    # `out_shape` from a plain `jax.ShapeDtypeStruct`, which carries no
+    # `manual_axis_type`, and check_vma=True rejects that outright.
+    @functools.partial(
+        jax.shard_map,
+        mesh=self.mesh,
+        in_specs=(q_pspec, pspec_3d, pspec_3d),
+        out_specs=pspec_3d,
+        check_vma=False,
+    )
+    def _sharded(local_q, local_compressed, local_weights):
+      return csa_streamindex.csa_streamindex_score(local_q, local_compressed, local_weights, self.softmax_scale)
+
+    return _sharded(q, compressed, weights)
 
   def __call__(
       self,
@@ -930,11 +995,19 @@ class DeepseekV4Indexer(nnx.Module):
     q = self.q_proj(q_latent).reshape((batch_size, seq_len, self.index_n_heads, self.index_head_dim))
     q = jnp.transpose(q, (0, 2, 1, 3))
     q = self.rotary_emb(q, position_ids, unsqueeze_dim=1)
-
     weights = self.weights_proj(hidden_states).astype(jnp.float32) * self.weights_scaling
 
+    # The Pallas kernel is a training-only path. AR decode arrives with
+    # seq_len==1 and prefill with cache-derived `compressed`; neither shape
+    # suits the kernel's fixed grid. It takes precedence over
+    # `csa_qk_head_chunk_size`: the kernel keeps the forward intermediate in
+    # VMEM instead of chunking it, and chunks its own backward.
+    use_kernel = self.config.use_csa_streamindex_kernel and model_mode == MODEL_MODE_TRAIN
     head_chunk_size = getattr(self.config, "csa_qk_head_chunk_size", 0)
-    if head_chunk_size > 0:
+
+    if use_kernel:
+      index_scores = self._streamindex_scores_sharded(q, compressed, weights)
+    elif head_chunk_size > 0:
       # Student chunks indexer heads (indexer_n_heads); teacher path
       # in calculate_csa_indexer_loss chunks query heads (num_query_heads).
       num_chunks = self.index_n_heads // head_chunk_size
@@ -964,24 +1037,26 @@ class DeepseekV4Indexer(nnx.Module):
       init_score = jnp.zeros((batch_size, seq_len, compressed_len), dtype=jnp.float32)
       index_scores, _ = jax.lax.scan(jax.checkpoint(scan_body_indexer), init_score, {"q": q_h, "w": w_h})
     else:
-      scores = jnp.einsum(
-          "bhsd, bwd -> bhsw",
-          q.astype(jnp.float32),
-          compressed.astype(jnp.float32),
+      index_scores = csa_streamindex.csa_indexer_scores_jax(
+          q,
+          compressed,
+          weights,
+          softmax_scale=self.softmax_scale,
           precision=self.config.matmul_precision,
       )
-      scores = jax.nn.relu(scores) * self.softmax_scale
-      index_scores = jnp.einsum("bhsw,bsh->bsw", scores, weights, precision=self.config.matmul_precision)
 
     k = min(self.index_topk, compressed_len)
 
-    # --- ONLY RUN MATHEMATICAL CAUSAL MASK IN PREFILL/TRAIN ---
+    # `future_mask` is supplied by the AR path (derived from cache validity).
+    # In prefill/train it is None and is derived from positions here.
     if future_mask is None:
       usable_len = compressed_len * self.compress_rate
       block_positions = position_ids[:, : usable_len : self.compress_rate]
       future_mask = (block_positions[:, None, :] + self.compress_rate) > (position_ids[:, :, None] + 1)
 
-    # Apply the mask to the scores
+    # Masking is always applied here, never inside the kernel: the kernel cannot
+    # see `position_ids` and would have to synthesize them from grid indices,
+    # which breaks for packed sequences where positions reset mid-sequence.
     index_scores = jnp.where(future_mask, jnp.full_like(index_scores, -jnp.inf), index_scores)
 
     combined_invalid = future_mask
@@ -1016,10 +1091,11 @@ class DeepseekV4CSACompressor(BaseDeepseekCompressor):
       config: Any,
       compress_ratio: int,
       rotary_embedding: Any,
-      kernel_init: Any = nnx.initializers.normal(stddev=0.02),
+      kernel_init: NdInitializer = nd_dense_init(1.0, "fan_in", "normal"),
       quant: Optional[Quant] = None,
       model_mode: str = MODEL_MODE_TRAIN,
       rngs: Optional[nnx.Rngs] = None,
+      mesh: Optional[Mesh] = None,
   ):
     """Initializes the CSA Compressor.
 
@@ -1052,6 +1128,7 @@ class DeepseekV4CSACompressor(BaseDeepseekCompressor):
         kernel_init=kernel_init,
         quant=quant,
         rngs=rngs,
+        mesh=mesh,
     )
 
   def __call__(
@@ -1414,6 +1491,7 @@ class CompressedAttention(Attention):
           quant=self.quant,
           model_mode=self.model_mode,
           rngs=self.rngs,
+          mesh=self.mesh,
       )
 
     # Set softmax scaling. DeepSeek-V4 natively uses standard scaling.

--- a/tests/unit/csa_streamindex_test.py
+++ b/tests/unit/csa_streamindex_test.py
@@ -1,0 +1,344 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for DeepSeek-V4 CSA StreamIndex Pallas TPU score kernel."""
+
+import unittest
+from unittest import mock
+
+from flax import nnx
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh
+import numpy as np
+import pytest
+
+from maxtext.common.common_types import MODEL_MODE_PREFILL, MODEL_MODE_TRAIN
+from maxtext.configs.pyconfig import initialize
+from maxtext.kernels.attention import csa_streamindex
+from maxtext.layers.attention_compressed import DeepseekV4Indexer
+from maxtext.layers.embeddings import DeepSeekV4RotaryEmbedding
+from tests.utils.test_helpers import get_test_config_path
+
+
+class TestCsaStreamIndexScoreKernel(unittest.TestCase):
+  """Unit tests for Pallas CSA StreamIndex score kernel."""
+
+  def setUp(self):
+    self.key = jax.random.PRNGKey(42)
+
+  def _inputs(self, b, h, s, w, d, key=None):
+    k1, k2, k3 = jax.random.split(key if key is not None else self.key, 3)
+    q = jax.random.normal(k1, (b, h, s, d), dtype=jnp.bfloat16)
+    compressed = jax.random.normal(k2, (b, w, d), dtype=jnp.bfloat16)
+    weights = jax.random.normal(k3, (b, s, h), dtype=jnp.float32)
+    return q, compressed, weights
+
+  def test_parity_exact_multiple(self):
+    """Parity with the reference on exact block multiples.
+
+    The reference is unmasked, so this also pins that the kernel does no
+    in-kernel masking of its own.
+    """
+    b, h, s, w, d = 2, 64, 256, 128, 128
+    q, compressed, weights = self._inputs(b, h, s, w, d)
+    softmax_scale = d**-0.5
+
+    expected = csa_streamindex.csa_indexer_scores_jax(q, compressed, weights, softmax_scale=softmax_scale)
+    actual = csa_streamindex.csa_streamindex_score(q, compressed, weights, softmax_scale, 128, 128, True)
+    np.testing.assert_allclose(actual, expected, rtol=1e-1, atol=1e-1)
+    self.assertTrue(bool(jnp.all(jnp.isfinite(actual))), "no entry may be a masked sentinel")
+
+  def test_parity_non_multiples(self):
+    """Verifies padding handling when seq_len and compressed_len are not multiples of block sizes."""
+    b, h, s, w, d = 2, 32, 150, 70, 64
+    q, compressed, weights = self._inputs(b, h, s, w, d)
+    softmax_scale = d**-0.5
+
+    expected = csa_streamindex.csa_indexer_scores_jax(q, compressed, weights, softmax_scale=softmax_scale)
+    actual = csa_streamindex.csa_streamindex_score(q, compressed, weights, softmax_scale, 128, 128, True)
+    np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-2)
+
+  def test_parity_seq_len_smaller_than_block_q(self):
+    """Verifies correctness when seq_len < block_q and compressed_len < block_w.
+
+    The grid must still produce exactly one block per axis, with the padded
+    region sliced back off.
+    """
+    b, h, d = 2, 16, 64
+    softmax_scale = d**-0.5
+
+    for s, w in ((1, 1), (7, 3), (64, 16), (127, 63)):
+      with self.subTest(seq_len=s, compressed_len=w):
+        q, compressed, weights = self._inputs(b, h, s, w, d)
+        expected = csa_streamindex.csa_indexer_scores_jax(q, compressed, weights, softmax_scale=softmax_scale)
+        actual = csa_streamindex.csa_streamindex_score(q, compressed, weights, softmax_scale, 128, 128, True)
+        self.assertEqual(actual.shape, (b, s, w))
+        np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-2)
+
+  def test_gradient_parity(self):
+    """Verifies that custom_vjp gradients match reference autograd.
+
+    Inputs are float32 deliberately. Gradients are cast back to the input
+    dtype, so with bfloat16 inputs this would compare bf16 arrays whose
+    spacing (~4e-3 relative) is coarser than any tolerance worth asserting,
+    and it would measure rounding rather than the VJP.
+    """
+    b, h, s, w, d = 1, 4, 128, 128, 32
+    k1, k2, k3 = jax.random.split(self.key, 3)
+    q = jax.random.normal(k1, (b, h, s, d), dtype=jnp.float32)
+    comp = jax.random.normal(k2, (b, w, d), dtype=jnp.float32)
+    weights = jax.random.normal(k3, (b, s, h), dtype=jnp.float32)
+    scale = float(d) ** -0.5
+
+    def loss_kernel(q, comp, weights):
+      return jnp.sum(csa_streamindex.csa_streamindex_score(q, comp, weights, scale, 128, 128, True))
+
+    def loss_ref(q, comp, weights):
+      return jnp.sum(csa_streamindex.csa_indexer_scores_jax(q, comp, weights, softmax_scale=scale))
+
+    g_q_k, g_c_k, g_w_k = jax.grad(loss_kernel, argnums=(0, 1, 2))(q, comp, weights)
+    g_q_r, g_c_r, g_w_r = jax.grad(loss_ref, argnums=(0, 1, 2))(q, comp, weights)
+
+    np.testing.assert_allclose(g_q_k, g_q_r, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(g_c_k, g_c_r, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(g_w_k, g_w_r, rtol=1e-5, atol=1e-5)
+
+  def test_head_chunked_backward_matches_unchunked(self):
+    """Head-chunked backward must equal whole-head autodiff for every chunk size.
+
+    The chunk/un-chunk reshapes permute head and batch axes; an error there
+    would scramble per-head gradients while keeping shapes valid.
+    """
+    b, h, s, w, d = 2, 8, 64, 32, 16
+    scale = float(d) ** -0.5
+    k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(3), 4)
+    q = jax.random.normal(k1, (b, h, s, d), dtype=jnp.float32)
+    comp = jax.random.normal(k2, (b, w, d), dtype=jnp.float32)
+    weights = jax.random.normal(k3, (b, s, h), dtype=jnp.float32)
+    g = jax.random.normal(k4, (b, s, w), dtype=jnp.float32)
+
+    _, vjp_ref = jax.vjp(
+        lambda a, c, e: csa_streamindex.csa_indexer_scores_jax(a, c, e, softmax_scale=scale),
+        q,
+        comp,
+        weights,
+    )
+    dq_ref, dc_ref, dw_ref = vjp_ref(g)
+
+    # Includes 3, a non-divisor of 8, which must fall back to whole-head.
+    for chunk in (1, 2, 3, 4, 8):
+      with self.subTest(head_chunk_size=chunk):
+        # pylint: disable-next=protected-access
+        dq, dc, dw = csa_streamindex._csa_streamindex_score_bwd(scale, None, None, True, chunk, (q, comp, weights), g)
+        self.assertEqual(dq.shape, q.shape)
+        self.assertEqual(dc.shape, comp.shape)
+        self.assertEqual(dw.shape, weights.shape)
+        np.testing.assert_allclose(dq, dq_ref, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(dc, dc_ref, rtol=1e-4, atol=1e-4)
+        np.testing.assert_allclose(dw, dw_ref, rtol=1e-4, atol=1e-4)
+
+  def test_defaults_produce_correct_results(self):
+    """Passing block_q/block_w=None must resolve to the defaults and stay correct."""
+    b, h, d = 1, 32, 64
+    s, w = 256, 128
+    scale = d**-0.5
+    q, compressed, weights = self._inputs(b, h, s, w, d)
+
+    expected = csa_streamindex.csa_indexer_scores_jax(q, compressed, weights, softmax_scale=scale)
+    actual = csa_streamindex.csa_streamindex_score(q, compressed, weights, scale, None, None, True)
+    self.assertEqual(actual.shape, (b, s, w))
+    np.testing.assert_allclose(actual, expected, rtol=1e-1, atol=1e-1)
+
+
+@pytest.mark.tpu_only
+class TestCsaStreamIndexOnTpu(unittest.TestCase):
+  """Real-hardware tests (`interpret=False`), exercising the Mosaic lowering.
+
+  `interpret=True` runs the kernel body in Python and never invokes Mosaic, so
+  it cannot validate `dimension_semantics`, tile-size VMEM limits, or the actual
+  `tpu_custom_call` lowering. These tests do.
+  """
+
+  def setUp(self):
+    self.key = jax.random.PRNGKey(11)
+
+  def _inputs(self, b, h, s, w, d):
+    k1, k2, k3 = jax.random.split(self.key, 3)
+    q = jax.random.normal(k1, (b, h, s, d), dtype=jnp.bfloat16)
+    compressed = jax.random.normal(k2, (b, w, d), dtype=jnp.bfloat16)
+    weights = jax.random.normal(k3, (b, s, h), dtype=jnp.float32)
+    return q, compressed, weights
+
+  def test_parallel_dimension_semantics_accepted(self):
+    """All-`parallel` dimension_semantics must lower cleanly.
+
+    Each (b, i, j) program writes a disjoint output block with no accumulation,
+    so `W` was changed from `arbitrary` to `parallel`. Mosaic rejects invalid
+    parallel claims, so a successful compile plus correct values is the check.
+    """
+    b, h, s, w, d = 2, 16, 256, 512, 64
+    scale = d**-0.5
+    q, compressed, weights = self._inputs(b, h, s, w, d)
+
+    expected = csa_streamindex.csa_indexer_scores_jax(q, compressed, weights, softmax_scale=scale)
+    actual = jax.jit(lambda a, c, e: csa_streamindex.csa_streamindex_score(a, c, e, scale, 128, 256, False))(
+        q, compressed, weights
+    ).block_until_ready()
+    np.testing.assert_allclose(actual, expected, rtol=2e-2, atol=2e-2)
+
+  def test_shard_map_multi_device_parity(self):
+    """Batch-sharded `shard_map` must match the reference and emit no all-gather."""
+    n = jax.device_count()
+    if n < 2:
+      self.skipTest("Requires >= 2 TPU devices.")
+
+    mesh = Mesh(np.array(jax.devices()), ("data",))
+    b, h, s, w, d = n, 16, 256, 128, 64
+    scale = float(d) ** -0.5
+    q, compressed, weights = self._inputs(b, h, s, w, d)
+
+    pspec_q = jax.sharding.PartitionSpec("data", None, None, None)
+    pspec_3d = jax.sharding.PartitionSpec("data", None, None)
+    q_sh = jax.sharding.NamedSharding(mesh, pspec_q)
+    c_sh = jax.sharding.NamedSharding(mesh, pspec_3d)
+    o_sh = jax.sharding.NamedSharding(mesh, pspec_3d)
+
+    q = jax.device_put(q, q_sh)
+    compressed = jax.device_put(compressed, c_sh)
+    weights = jax.device_put(weights, c_sh)
+
+    def sharded(a, c, e):
+      @jax.shard_map(
+          mesh=mesh,
+          in_specs=(pspec_q, pspec_3d, pspec_3d),
+          out_specs=pspec_3d,
+          check_vma=False,
+      )
+      def inner(la, lc, le):
+        return csa_streamindex.csa_streamindex_score(la, lc, le, scale, 128, 128, False)
+
+      return inner(a, c, e)
+
+    jit_sharded = jax.jit(sharded, in_shardings=(q_sh, c_sh, c_sh), out_shardings=o_sh)
+    hlo = jit_sharded.lower(q, compressed, weights).compile().as_text()
+    self.assertEqual(hlo.count("all-gather"), 0, "shard_map must not introduce all-gather")
+
+    actual = jit_sharded(q, compressed, weights).block_until_ready()
+    expected = csa_streamindex.csa_indexer_scores_jax(q, compressed, weights, softmax_scale=scale)
+    np.testing.assert_allclose(actual, expected, rtol=2e-2, atol=2e-2)
+
+
+class TestDeepseekv4IndexerIntegration(unittest.TestCase):
+  """Integration tests for Deepseekv4Indexer with CSA StreamIndex kernel dispatch."""
+
+  def setUp(self):
+    # Single-device mesh: these tests exercise dispatch routing with batch=1,
+    # which cannot be split across a multi-device batch axis. Multi-device
+    # sharding behavior is covered by TestCsaStreamIndexSharding.
+    self.mesh = Mesh(jax.devices()[:1], ("data",))
+    self.rotary = DeepSeekV4RotaryEmbedding(
+        head_dim=64,
+        partial_rotary_factor=16.0 / 64.0,
+        mesh=self.mesh,
+    )
+
+  def _get_config(self, use_csa_streamindex_kernel: bool = False):
+    with mock.patch("maxtext.utils.max_utils.maybe_initialize_jax_distributed_system"):
+      return initialize(
+          [
+              None,
+              get_test_config_path(),
+              "model_name=deepseek4-284b",
+              "attention=dot_product",
+              "qk_rope_head_dim=16",
+              "v_head_dim=16",
+              "qk_nope_head_dim=16",
+              "indexer_n_heads=16",
+              "indexer_head_dim=64",
+              "indexer_topk=32",
+              "override_model_config=True",
+              f"use_csa_streamindex_kernel={use_csa_streamindex_kernel}",
+          ]
+      )
+
+  def _build_indexer(self, config):
+    return DeepseekV4Indexer(
+        config=config,
+        compress_ratio=4,
+        rotary_embedding=self.rotary,
+        rngs=nnx.Rngs(0),
+        mesh=self.mesh,
+    )
+
+  def test_indexer_kernel_vs_einsum_output_parity(self):
+    """Verifies that Deepseekv4Indexer outputs match whether kernel or einsum is used."""
+    config_einsum = self._get_config(use_csa_streamindex_kernel=False)
+    config_kernel = self._get_config(use_csa_streamindex_kernel=True)
+    b, s, emb_dim, q_lora = 1, 128, config_einsum.emb_dim, config_einsum.q_lora_rank
+
+    indexer_einsum = self._build_indexer(config_einsum)
+    indexer_kernel = self._build_indexer(config_kernel)
+
+    key1, key2 = jax.random.split(jax.random.PRNGKey(0))
+    hidden = jax.random.normal(key1, (b, s, emb_dim), dtype=jnp.bfloat16)
+    q_latent = jax.random.normal(key2, (b, s, q_lora), dtype=jnp.bfloat16)
+    pos = jnp.arange(s, dtype=jnp.int32)[None, :]
+
+    idx_einsum, scores_einsum = indexer_einsum(hidden, q_latent, pos, return_scores=True)
+
+    real_kernel_fn = csa_streamindex.csa_streamindex_score
+
+    def interpret_kernel_fn(q, compressed, weights, softmax_scale, *_args):
+      return real_kernel_fn(q, compressed, weights, softmax_scale, None, None, True)
+
+    with mock.patch.object(csa_streamindex, "csa_streamindex_score", side_effect=interpret_kernel_fn):
+      idx_kernel, scores_kernel = indexer_kernel(hidden, q_latent, pos, return_scores=True)
+
+    # Indices must match exactly -- they decide which blocks attention reads.
+    # Scores only need to agree numerically; Mosaic and the einsum accumulate
+    # in a different order, which shows up a few ULP apart in float32.
+    np.testing.assert_array_equal(idx_kernel, idx_einsum)
+    np.testing.assert_allclose(scores_kernel, scores_einsum, rtol=1e-4, atol=1e-5)
+
+  def test_kernel_dispatch_conditions(self):
+    """The kernel runs only when the flag is on and the model is training."""
+    cases = (
+        ("flag off, train", False, MODEL_MODE_TRAIN, False),
+        ("flag on, prefill", True, MODEL_MODE_PREFILL, False),
+        ("flag on, train", True, MODEL_MODE_TRAIN, True),
+    )
+    real_kernel_fn = csa_streamindex.csa_streamindex_score
+
+    def interpret_kernel_fn(q, compressed, weights, softmax_scale, *_args):
+      return real_kernel_fn(q, compressed, weights, softmax_scale, None, None, True)
+
+    for name, flag, mode, expect_kernel in cases:
+      with self.subTest(name):
+        config = self._get_config(use_csa_streamindex_kernel=flag)
+        b, s = 1, 128
+        indexer = self._build_indexer(config)
+        hidden = jnp.ones((b, s, config.emb_dim), dtype=jnp.bfloat16)
+        q_latent = jnp.ones((b, s, config.q_lora_rank), dtype=jnp.bfloat16)
+        pos = jnp.arange(s, dtype=jnp.int32)[None, :]
+
+        with mock.patch.object(csa_streamindex, "csa_streamindex_score", side_effect=interpret_kernel_fn) as mock_kernel:
+          indices, _ = indexer(hidden, q_latent, pos, model_mode=mode)
+
+        self.assertEqual(mock_kernel.called, expect_kernel)
+        self.assertEqual(indices.shape, (b, s, min(32, s // 4)))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

Adds a fused Pallas TPU kernel (`csa_streamindex_score`) for DeepSeek-V4 Compressed Sparse Attention (CSA) indexer scoring (for the forward pass)
BUGS: b/552514390

### Summary
- Fuses the $Q \cdot K^T$ matmul, ReLU, head weighting, and causal masking into on-chip VMEM to avoid materializing large intermediate tensors in HBM.
- Supports head-major layout $[B, H, S, D]$ and wraps with `@jax.custom_vjp`.
- Gated behind `use_csa_streamindex_kernel: bool = False` in `base.yml` with automatic fallback to standard einsum.
- Wrapped with `@jax.custom_vjp`: executes the fused Pallas kernel on the forward pass, and falls back to reference einsum autodiff (chunked) on the backward pass.

### Implementation
Tiles query tokens in blocks of 128 and compressed keys in blocks of 1024. For each block, it computes `relu(q @ k.T) * weights`, sums across all 64 heads directly in VMEM, applies the causal mask, and writes out the final `[B, S, W]` scores. This avoids allocating the 4D `[B, H, S, W]` scores tensor in HBM entirely.  It does **not include** the top-k at the end in-kernel.

# Tests

- Unit tests in [`tests/unit/csa_streamindex_test.py`](file:///usr/local/google/home/octatrifan/repos/maxtext/tests/unit/csa_streamindex_test.py):
  - Numerical parity vs reference einsum (with and without causal mask).
  - Custom VJP gradient parity.
  - Layer integration and fallback checks.
  - JAXPR graph verification (`pallas_call` vs `dot_general`).

Reproduce:
```bash
pytest tests/unit/csa_streamindex_test.py
```

# Performance
Microbenchmarks on a single TPU, just for the Index Scoring part (not e2e results). Compared against both the unchunked baseline einsum and the orthogonal head-chunking scan proposed in PR #5116 (which is a pure JAX solution to the OOM problem, but which requires more memory and is slower than StreamIndex)

StreamIndex Pallas Kernel vs. Head Chunking (PR #5116) vs. Baseline
Tested on single-chip TPU v5p. $H=64, D=128, W=S/4$:
| Sequence Length ($S$) | Batch ($B$) | Total Tokens | Baseline Einsum | Head Chunking (PR #5116, $c=16$) | StreamIndex Kernel | Kernel Speedup |
|---|---|---|---|---|---|---|
| 16,384 | 2 | 32,768 | 16.31 ms | 8.45 ms | **5.06 ms** | **1.67x vs PR / 3.22x vs Base** |
| 32,768 | 2 | 65,536 | 64.01 ms | 32.02 ms | **19.77 ms** | **1.62x vs PR / 3.24x vs Base** |
| 65,536 | 2 | 131,072 | OOM (274 GB req) | 125.90 ms (20.09 GiB) | **78.42 ms (18.04 GiB)** | **1.61x vs PR** |
| 65,536 | 4 | 262,144 | OOM | 251.84 ms (40.17 GiB) | **156.84 ms (36.08 GiB)** | **1.61x vs PR** |
| 65,536 | 8 | 524,288 | OOM | OOM | 313.53 ms (72.16 GiB) | **StreamIndex Only** |
| 131,072 | 1 | 131,072 | OOM | 247.27 ms (36.09 GiB) | **156.59 ms (34.04 GiB)** | **1.58x vs PR** |
| 131,072 | 2 | 262,144 | OOM | OOM| **313.14 ms (68.08 GiB)** | **StreamIndex Only** |
| 131,072 | 4 | 524,288 | OOM | OOM | OOM | Physical Limit (>96 GB) |
---
* **Speed**: StreamIndex is **1.6x faster** than Head Chunking and **3.2x faster** than baseline einsum across all context lengths.
* **Scalability**: StreamIndex supports **2x larger contexts** on a single TPU v5p, successfully running at $S=65\text{k}, B=8$ and $S=131\text{k}, B=2$ where Head chunking crashes with OOM.
* **Peak Memory**: StreamIndex uses less HBM by keeping intermediate score tensors on-chip in VMEM rather than HBM.

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).