### PR TITLE
[Maxtext][vLLM] Normalize MRoPE position shapes for vLLM

### DIFF
--- a/src/maxtext/integration/vllm/hybrid_cache_utils.py
+++ b/src/maxtext/integration/vllm/hybrid_cache_utils.py
@@ -17,21 +17,29 @@
 import math
 from typing import Any
 
+import jax.numpy as jnp
+
 
 def normalize_vllm_input_positions(input_positions: Any):
-  """Converts vLLM's flattened position layout to MaxText decode layout.
+  """Converts vLLM's position layout to MaxText decode/prefill layout.
 
-  vLLM supplies ordinary positions as ``(num_tokens,)`` and MRoPE positions
-  as ``(3, num_tokens)``. MaxText treats flattened decode tokens as a batch
-  with a singleton sequence dimension, so it expects ``(num_tokens, 1)`` or
-  ``(num_tokens, 1, 3)``, respectively.
+  vLLM supplies ordinary positions as ``(num_tokens,)``, decode MRoPE positions
+  as ``(3, num_tokens)``, and batched MRoPE positions as ``(3, batch, seq)``.
+  MaxText treats flattened decode tokens as a batch with a singleton sequence dimension,
+  expecting ``(num_tokens, 1)`` or ``(num_tokens, 1, 3)``, and batched MRoPE as
+  ``(batch, seq, 3)``.
   """
+  if input_positions is None:
+    return None
   if input_positions.ndim == 1:
     return input_positions.reshape((-1, 1))
   if input_positions.ndim == 2 and input_positions.shape[0] == 3:
     return input_positions.T[:, None, :]
+  if input_positions.ndim == 3 and input_positions.shape[0] == 3:
+    return jnp.transpose(input_positions, (1, 2, 0))
   raise ValueError(
-      "vLLM input positions must have shape (num_tokens,) or (3, num_tokens); " f"got {input_positions.shape}."
+      "vLLM input positions must have shape (num_tokens,), (3, num_tokens), or (3, batch, seq); "
+      f"got {input_positions.shape}."
   )
 
 

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -1913,6 +1913,10 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(RotaryEmbedding):
     if self.head_dim != inputs.shape[3]:
       raise ValueError("The head dim of the rotary position embedding must match the hidden dimension of the inputs.")
 
+    # Normalize trailing singleton: (batch, seq, 1) -> (batch, seq)
+    if position.ndim == 3 and position.shape[-1] == 1:
+      position = jnp.squeeze(position, axis=-1)
+
     # Handle both 2D (text-only) and 3D (multimodal) position IDs
     if position.ndim == 2:
       # Text-only: expand (batch, seq) -> (batch, seq, 3) with same positions


### PR DESCRIPTION
# Description


- integration/vllm/hybrid_cache_utils.py: Support None input positions and transpose 3D batched MRoPE layouts from (3, batch, seq) to (batch, seq, 3).
- layers/embeddings.py: Squeeze trailing singleton dimensions (batch, seq, 1) to (batch, seq) in Qwen3OmniMoeThinkerTextRotaryEmbedding.

# Tests

E2E test for post_train/train_rl 10 step smoke tests passed:

E2E train_rl test with vllm native HF layout, [logs](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22mlperf-v5p%22%0Aresource.labels.pod_name:%22q35rl-m2-1788232322-%22%0Aresource.labels.container_name:%22jax-tpu%22%0Aseverity%3E%3DDEFAULT;cursorTimestamp=2026-09-01T03:58:36.556358466Z;customDuration=today?e=13803378&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
