### PR TITLE
Write final checkpoint before close() tears down

### DIFF
--- a/src/maxtext/training_engine/checkpointing.py
+++ b/src/maxtext/training_engine/checkpointing.py
@@ -14,6 +14,7 @@
 
 """Checkpointing utilities for MaxText training engine."""
 
+from collections.abc import Mapping
 import dataclasses
 from typing import Any, List
 
@@ -33,6 +34,9 @@ class CheckpointState:
   optimizer: nnx.optimizer.Optimizer | None = None
   accumulated_metrics: List[abstract_engine.MetricsBuffer] | None = None
   accumulated_grads: Any = None
+  # How many micro-batches of `step` are folded into `accumulated_grads`. 0 for a complete
+  # step, whose gradients have already been applied and discarded.
+  micro_step_count: int = 0
 
 
 class CheckpointManager:
@@ -71,12 +75,67 @@ class CheckpointManager:
     if self._checkpoint_manager:
       self._checkpoint_manager.wait_until_finished()
 
+  def get_saved_micro_step_count(self, step: int) -> int:
+    """Returns how far into `step` the checkpoint already on disk got.
+
+    Args:
+      step: The step whose saved checkpoint should be inspected.
+
+    Returns:
+      0 if that checkpoint covers a complete step, otherwise the number of micro-batches
+      accumulated into it.
+    """
+    if self._checkpoint_manager is None:
+      return 0
+    try:
+      metadata = self._checkpoint_manager.metadata(step)
+    except Exception as e:  # pylint: disable=broad-except
+      logging.warning("Could not read metadata for step %d, treating it as complete: %s", step, e)
+      return 0
+    custom_metadata = getattr(metadata, "custom_metadata", None)
+    if not isinstance(custom_metadata, Mapping):
+      return 0
+    saved = custom_metadata.get("micro_step_count", 0)
+    return saved if isinstance(saved, int) else 0
+
+  def _supersedes_saved_checkpoint(self, step: int, micro_step_count: int) -> bool:
+    """Returns whether a new checkpoint is more complete than the one saved at `step`.
+
+    A complete step is never superseded: once the optimizer update for `step` has been
+    checkpointed there is nothing more to record for it. A partial one is superseded by a
+    complete step, and by a partial one that got further through the same step.
+
+    Args:
+      step: The step both checkpoints belong to.
+      micro_step_count: The new checkpoint's progress through `step`.
+
+    Returns:
+      Whether the new checkpoint should replace the saved one.
+    """
+    saved_micro_step_count = self.get_saved_micro_step_count(step)
+    if saved_micro_step_count == 0:
+      return False
+    return micro_step_count == 0 or micro_step_count > saved_micro_step_count
+
+  def _delete_saved_step(self, step: int) -> None:
+    """Deletes the checkpoint at `step` to make room for a more complete one.
+
+    Orbax refuses to write a step that already exists, so superseding one means removing it
+    first. An async save for this step may still be in flight, so drain before deleting.
+
+    Args:
+      step: The step to delete.
+    """
+    logging.info("Deleting intra-step checkpoint at step %d so a more complete one can replace it.", step)
+    self._checkpoint_manager.wait_until_finished()
+    self._checkpoint_manager.delete(step)
+
   def save_checkpoint(
       self,
       step: int,
       checkpoint_state: CheckpointState,
       custom_metadata: Any = None,
-      force_ckpt_save: bool = False,
+      **kwargs,
   ) -> bool:
     """Saves the params for the given step along with optional intra-step state.
 
@@ -85,7 +144,6 @@ class CheckpointManager:
       checkpoint_state: CheckpointState object containing model, optimizer, and
         optional intra_step_state.
       custom_metadata: Custom metadata to save with the checkpoint.
-      force_ckpt_save: Whether to force save the checkpoint.
 
     Returns:
       Whether the checkpoint was saved.
@@ -94,13 +152,25 @@ class CheckpointManager:
       logging.info("Checkpointing is disabled, skipping save.")
       return False
 
-    # Check if the checkpoint already exists at the current step.
-    if not force_ckpt_save and self.get_latest_step() == step:
-      logging.info(
-          "Checkpoint already saved at step %d, skipping save.",
-          step,
-      )
-      return False
+    # Record micro_step_count on every checkpoint, complete or not, so that a later save at the same step
+    # can tell whether it supersedes what is already on disk.
+    custom_metadata = dict(custom_metadata) if custom_metadata else {}
+    custom_metadata["micro_step_count"] = checkpoint_state.micro_step_count
+
+    # A checkpoint already exists at this step. Skip, unless this one is more complete --
+    # the case that matters is a step resumed from an intra-step checkpoint and then run to
+    # completion, whose finished state would otherwise never reach disk.
+    if self.get_latest_step() == step:
+      if not self._supersedes_saved_checkpoint(step, checkpoint_state.micro_step_count):
+        logging.info(
+            "Checkpoint already saved at step %d, skipping save.",
+            step,
+        )
+        return False
+      self._delete_saved_step(step)
+      # Orbax's save-interval policy declines a step it has already saved, so the
+      # replacement has to be forced through.
+      kwargs["force"] = True
 
     params = nnx.state(checkpoint_state.model)
     jax.block_until_ready(params)
@@ -145,7 +215,7 @@ class CheckpointManager:
         step=step,
         args=ocp.args.Composite(**save_args),
         custom_metadata=custom_metadata,
-        force=force_ckpt_save,
+        **kwargs,
     )
 
   def restore_checkpoint(

--- a/src/maxtext/training_engine/maxtext_engine.py
+++ b/src/maxtext/training_engine/maxtext_engine.py
@@ -20,7 +20,7 @@ the MaxRL AbstractTrainer interface without running an outer loop.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 import dataclasses
 import os
 from typing import Any
@@ -351,6 +351,9 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     self._state: Any = None
     self._accumulated_grads: Any = None
     self._micro_step_count = 0
+    # Set when this run resumed from an intra-step checkpoint, cleared once the step it
+    # resumed into completes and its finished state has been checkpointed.
+    self._resumed_mid_step = False
     self._cached_losses: list[abstract_engine.WeightedMetric | jax.Array] = []
     # `create_training_optimizer` returns a raw optax GradientTransformation. `TrainStateNNX.apply_gradients`
     # calls `optimizer.update(model, grads)`, which is the nnx.Optimizer signature, and
@@ -882,6 +885,14 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     self._accumulated_grads = None
     self._micro_step_count = 0
     self._train_step += 1
+
+    if self._resumed_mid_step:
+      # This is the step the run resumed into, and it just finished. The checkpoint on disk
+      # for it is still the partial one. Orbax's save-interval policy will not save this step
+      # again.
+      self._resumed_mid_step = False
+      self.save_checkpoint(metadata={"step": self.train_step}, force=True)
+
     return self.train_step
 
   def eval_step(self, payload: abstract_engine.TrainerPayload, **kwargs: Any) -> None:
@@ -918,21 +929,25 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     # Drain all inflight computations and log pending metrics before checkpointing.
     self._throttler.wait_for_all()
 
-    step = kwargs.get("step", self.train_step)
-    force_ckpt_save = kwargs.get("force", False)
+    step = kwargs.pop("step", None)
+    if step is None and isinstance(metadata, Mapping):
+      step = metadata.get("step")
+    if step is None:
+      # checkpoint for incomplete train step is saved for self.train_step+1
+      # because update() is not called yet to increment train_step;
+      # checkpoint for completed step is saved for self.train_step because update() increments train_step
+      step = self.train_step + 1 if self._micro_step_count > 0 else self.train_step
 
-    custom_metadata = {}
     if self._micro_step_count > 0:
       logging.info(
           "Saving intra-step checkpoint at step %d (micro_step_count=%d).",
           step,
           self._micro_step_count,
       )
-      force_ckpt_save = True
-      custom_metadata["micro_step_count"] = self._micro_step_count
     else:
       logging.info("Saving checkpoint at step %d.", step)
 
+    custom_metadata = {}
     if metadata:
       # Metadata from Orchestrator
       custom_metadata["additional_metadata"] = metadata
@@ -946,9 +961,12 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
             # a list, and restore_checkpoint iterates it back into the recorder's buffer.
             accumulated_metrics=self._metrics_recorder.get_metrics_history(clear_cache=False),
             accumulated_grads=self._accumulated_grads,
+            # Recorded by the CheckpointManager into custom_metadata, so that a later save
+            # at this same step can tell it supersedes this one.
+            micro_step_count=self._micro_step_count,
         ),
         custom_metadata=custom_metadata,
-        force_ckpt_save=force_ckpt_save,
+        **kwargs,
     )
     if ckpt_saved:
       logging.info("Checkpoint saved at step %d.", step)
@@ -977,7 +995,6 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
       return None
 
     logging.info("Checkpoint restored from step %d.", restored_step)
-    self.train_step = restored_step
 
     if restored_checkpoint_state.accumulated_metrics:
       buffers = []
@@ -1004,15 +1021,35 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
       self._metrics_recorder._metrics_buffer = buffers
 
     restored_additional_metadata = None
+    # Checkpoint with no metadata says nothing about how far into its step it
+    # got, and must not inherit the count from whatever this engine was doing before.
+    self._micro_step_count = 0
     if restored_metadata:
       self._micro_step_count = restored_metadata.get("micro_step_count", 0)
       restored_additional_metadata = restored_metadata.get("additional_metadata", None)
 
-    # Restore intra-step state if it exists.
-    if restored_checkpoint_state.accumulated_grads:
+    if self._micro_step_count > 0:
+      logging.info(
+          "Restored intra-step checkpoint at step %d (micro_step_count=%d).",
+          restored_step,
+          self._micro_step_count,
+      )
+      # update() will increment the step after applying the accumulated gradients
+      self.train_step = restored_step - 1
+      # The checkpoint at `restored_step` holds a partially accumulated step. Once that step
+      # completes, `update` replaces it with the finished state.
+      self._resumed_mid_step = True
+    else:
+      self.train_step = restored_step
+      self._resumed_mid_step = False
+
+    # Restore intra-step state if it exists. Gated on the count because for a complete step
+    # `restored_checkpoint_state.accumulated_grads` is just the value this engine passed in
+    # above, which the branch above has already discarded.
+    if self._micro_step_count > 0 and restored_checkpoint_state.accumulated_grads:
       self._accumulated_grads = restored_checkpoint_state.accumulated_grads
 
-      if self._micro_step_count > 0 and self._metrics_recorder._metrics_buffer:  # pylint: disable=protected-access
+      if self._metrics_recorder._metrics_buffer:  # pylint: disable=protected-access
         active_buf = self._metrics_recorder.get_step_metrics(restored_step)
         if active_buf and "loss" in active_buf.weighted_metrics:
           wm = active_buf.weighted_metrics["loss"]
@@ -1149,9 +1186,10 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     """
     if staging_transport == "raiden":
       try:
-        from tunix.experimental.worker import raiden_synchronizer  # pylint: disable=g-import-not-at-top,import-outside-toplevel
+        # pylint: disable=g-import-not-at-top,import-outside-toplevel
+        from tunix.experimental.weight_sync import raiden_synchronizer
       except ImportError:
-        logging.warning("tunix.experimental.worker.raiden_synchronizer not found; returning empty metadata.")
+        logging.warning("tunix.experimental.weight_sync.raiden_synchronizer not found; returning empty metadata.")
         return []
 
       # 1. Drain all in-flight TPU computations to ensure weights are fully updated
@@ -1251,12 +1289,18 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     return True
 
   def close(self) -> None:
-    """Closes the trainer and its associated resources."""
+    """Closes the trainer, writes buffered metrics and final checkpoint."""
     if self._raiden_syncs:
       for sync in self._raiden_syncs:
         if hasattr(sync, "close"):
           sync.close()
       self._raiden_syncs = None
-    self._throttler.cleanup()
-    self._metrics_recorder.cleanup()
+
+    self.save_checkpoint(metadata=None, force=True)
     self._checkpoint_manager.close()
+
+    # Write the metrics and cleanup metrics logger resources
+    self._throttler.cleanup()
+
+    # Cleanup metrics recorder resources after saving the checkpoint, ensuring all buffered metrics are saved properly
+    self._metrics_recorder.cleanup()

--- a/tests/post_training/unit/maxtext_engine_test.py
+++ b/tests/post_training/unit/maxtext_engine_test.py
@@ -112,6 +112,20 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     overrides.update(kwargs)
     return pyconfig.initialize([None, get_test_config_path()], **overrides)
 
+  def _mock_orbax_manager(self, engine, latest_step=None):
+    """Installs a mock Orbax manager and returns it."""
+    mock_orbax_mgr = mock.MagicMock()
+    mock_orbax_mgr.latest_step.return_value = latest_step
+    mock_orbax_mgr.save.return_value = True
+    engine._checkpoint_manager._checkpoint_manager = mock_orbax_mgr
+    return mock_orbax_mgr
+
+  def _mock_saved_micro_step_count(self, mock_orbax_mgr, micro_step_count):
+    """Makes the mocked Orbax manager report how far into its step a saved checkpoint got."""
+    saved_metadata = mock.MagicMock()
+    saved_metadata.custom_metadata = {"micro_step_count": micro_step_count}
+    mock_orbax_mgr.metadata.return_value = saved_metadata
+
   def test_raises_type_error_for_non_pyconfig(self):
     invalid_config = abstract_engine.TrainingConfig()
     with self.assertRaises(TypeError):
@@ -165,10 +179,7 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     mock_config = self.setup_config(enable_checkpointing=True)
 
     t = maxtext_engine.MaxTextTrainingEngine(mock_config)
-    mock_orbax_mgr = mock.MagicMock()
-    mock_orbax_mgr.latest_step.return_value = None
-    mock_orbax_mgr.save.return_value = True
-    t._checkpoint_manager._checkpoint_manager = mock_orbax_mgr
+    mock_orbax_mgr = self._mock_orbax_manager(t)
 
     dummy_metadata = mock.MagicMock()
     t.save_checkpoint(metadata=dummy_metadata)
@@ -176,7 +187,7 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     # Verify orbax save was called
     mock_orbax_mgr.save.assert_called_once()
     call_kwargs = mock_orbax_mgr.save.call_args.kwargs
-    self.assertNotIn("micro_step_count", call_kwargs["custom_metadata"])
+    self.assertEqual(call_kwargs["custom_metadata"]["micro_step_count"], 0)
     self.assertEqual(call_kwargs["custom_metadata"]["additional_metadata"], dummy_metadata)
     args_dict = (
         dict(call_kwargs["args"].items())
@@ -191,28 +202,114 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     mock_config = self.setup_config(enable_checkpointing=True)
 
     t = maxtext_engine.MaxTextTrainingEngine(mock_config)
-    mock_orbax_mgr = mock.MagicMock()
-    mock_orbax_mgr.latest_step.return_value = 10
-    t._checkpoint_manager._checkpoint_manager = mock_orbax_mgr
-    t.train_step = 10
+    mock_orbax_mgr = self._mock_orbax_manager(t, latest_step=10)
 
-    t.save_checkpoint(metadata={"key": "val"})
+    t.save_checkpoint(metadata={"step": 10})
+    mock_orbax_mgr.save.assert_not_called()
+    mock_orbax_mgr.delete.assert_not_called()
+
+  def test_save_checkpoint_overwrites_intra_step_checkpoint_at_same_step(self):
+    t = maxtext_engine.MaxTextTrainingEngine(self.setup_config(enable_checkpointing=True))
+    mock_orbax_mgr = self._mock_orbax_manager(t, latest_step=10)
+    self._mock_saved_micro_step_count(mock_orbax_mgr, 2)
+
+    # The step that intra-step checkpoint belongs to has since run to completion.
+    t.train_step = 10
+    t._micro_step_count = 0
+
+    t.save_checkpoint(metadata=None)
+
+    mock_orbax_mgr.wait_until_finished.assert_called()
+    mock_orbax_mgr.delete.assert_called_once_with(10)
+    mock_orbax_mgr.save.assert_called_once()
+    call_kwargs = mock_orbax_mgr.save.call_args.kwargs
+    self.assertEqual(call_kwargs["step"], 10)
+    # Orbax's save-interval policy would otherwise decline a step it has already saved.
+    self.assertTrue(call_kwargs["force"])
+    self.assertEqual(call_kwargs["custom_metadata"]["micro_step_count"], 0)
+
+  def test_save_checkpoint_overwrites_less_complete_intra_step_checkpoint(self):
+    t = maxtext_engine.MaxTextTrainingEngine(self.setup_config(enable_checkpointing=True))
+    mock_orbax_mgr = self._mock_orbax_manager(t, latest_step=10)
+    self._mock_saved_micro_step_count(mock_orbax_mgr, 1)
+
+    t.train_step = 9
+    t._micro_step_count = 3
+    t._accumulated_grads = {"params": {"w": jnp.array([0.5, 0.5])}}
+
+    t.save_checkpoint(metadata=None)
+
+    mock_orbax_mgr.delete.assert_called_once_with(10)
+    self.assertEqual(mock_orbax_mgr.save.call_args.kwargs["custom_metadata"]["micro_step_count"], 3)
+
+  def test_save_checkpoint_never_overwrites_a_complete_step(self):
+    t = maxtext_engine.MaxTextTrainingEngine(self.setup_config(enable_checkpointing=True))
+    mock_orbax_mgr = self._mock_orbax_manager(t, latest_step=10)
+    self._mock_saved_micro_step_count(mock_orbax_mgr, 0)
+
+    t.train_step = 10
+    t._micro_step_count = 0
+
+    t.save_checkpoint(metadata=None)
+
+    mock_orbax_mgr.save.assert_not_called()
+    mock_orbax_mgr.delete.assert_not_called()
+
+  def test_update_supersedes_intra_step_checkpoint_it_resumed_from(self):
+    t = maxtext_engine.MaxTextTrainingEngine(self.setup_config(enable_checkpointing=True))
+    t.with_loss_fn(
+        lambda *args, **kwargs: (
+            abstract_engine.WeightedMetric(unreduced_sum=jnp.array(0.5), denominator=jnp.array(1.0)),
+            {},
+        )
+    )
+    mock_orbax_mgr = self._mock_orbax_manager(t, latest_step=5)
+    self._mock_saved_micro_step_count(mock_orbax_mgr, 2)
+
+    # State as `restore_checkpoint` leaves it after loading an intra-step checkpoint at 5.
+    t.train_step = 4
+    t._resumed_mid_step = True
+
+    payload = DummyPayload(token_ids=jnp.ones((2, 2)), token_mask=jnp.ones((2, 2)))
+    t.compile(payload)
+    t.fwd_bwd(payload)
+    self.assertEqual(t.update(), 5)
+
+    # The completed step must land on disk now, not a checkpoint period later.
+    mock_orbax_mgr.delete.assert_called_once_with(5)
+    call_kwargs = mock_orbax_mgr.save.call_args.kwargs
+    self.assertEqual(call_kwargs["step"], 5)
+    self.assertEqual(call_kwargs["custom_metadata"]["micro_step_count"], 0)
+    self.assertFalse(t._resumed_mid_step)
+
+  def test_update_does_not_checkpoint_when_not_resumed_mid_step(self):
+    t = maxtext_engine.MaxTextTrainingEngine(self.setup_config(enable_checkpointing=True))
+    t.with_loss_fn(
+        lambda *args, **kwargs: (
+            abstract_engine.WeightedMetric(unreduced_sum=jnp.array(0.5), denominator=jnp.array(1.0)),
+            {},
+        )
+    )
+    mock_orbax_mgr = self._mock_orbax_manager(t)
+
+    payload = DummyPayload(token_ids=jnp.ones((2, 2)), token_mask=jnp.ones((2, 2)))
+    t.compile(payload)
+    t.fwd_bwd(payload)
+    t.update()
+
     mock_orbax_mgr.save.assert_not_called()
 
   def test_save_checkpoint_drains_inflight_throttler(self):
     mock_config = self.setup_config(enable_checkpointing=True)
     t = maxtext_engine.MaxTextTrainingEngine(mock_config)
-    mock_orbax_mgr = mock.MagicMock()
-    mock_orbax_mgr.latest_step.return_value = None
-    mock_orbax_mgr.save.return_value = True
-    t._checkpoint_manager._checkpoint_manager = mock_orbax_mgr
+    mock_orbax_mgr = self._mock_orbax_manager(t)
 
     # Add a dummy item to the throttler queue.
     dummy_computation = jnp.array(1.0)
     t._throttler.add_computation(computation=dummy_computation, metrics=None)
     self.assertEqual(t._throttler._inflight_queue.qsize(), 1)
 
-    t.save_checkpoint(metadata={"test": "val"})
+    t.save_checkpoint(metadata={"step": 10})
 
     # Checkpoint should be saved and throttler queue should be drained.
     mock_orbax_mgr.save.assert_called_once()
@@ -221,12 +318,10 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
   def test_save_checkpoint_called_after_fwd_bwd_before_update(self):
     mock_config = self.setup_config(enable_checkpointing=True)
     t = maxtext_engine.MaxTextTrainingEngine(mock_config)
-    mock_orbax_mgr = mock.MagicMock()
-    mock_orbax_mgr.latest_step.return_value = None
-    mock_orbax_mgr.save.return_value = True
-    t._checkpoint_manager._checkpoint_manager = mock_orbax_mgr
+    mock_orbax_mgr = self._mock_orbax_manager(t)
 
     t._micro_step_count = 1
+    t.train_step = 10
     t._accumulated_grads = {"params": {"w": jnp.array([0.5, 0.5])}}
 
     dummy_metadata = mock.MagicMock()
@@ -246,13 +341,37 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     self.assertIn("accumulated_metrics", args_dict)
     self.assertIn("accumulated_grads", args_dict)
 
+  def test_close_writes_final_checkpoint(self):
+    t = maxtext_engine.MaxTextTrainingEngine(self.setup_config(enable_checkpointing=True))
+    mock_orbax_mgr = self._mock_orbax_manager(t, latest_step=3)
+    t.train_step = 4
+    t._micro_step_count = 0
+
+    t.close()
+
+    call_kwargs = mock_orbax_mgr.save.call_args.kwargs
+    self.assertEqual(call_kwargs["step"], 4)
+    self.assertTrue(call_kwargs["force"])
+
+  def test_close_saves_an_incomplete_step(self):
+    t = maxtext_engine.MaxTextTrainingEngine(self.setup_config(enable_checkpointing=True))
+    mock_orbax_mgr = self._mock_orbax_manager(t, latest_step=4)
+    mock_logger = mock.MagicMock()
+    t._throttler._metrics_logger = mock_logger
+    t.train_step = 4
+    t.record_metrics("loss", jnp.array(1.5))
+    t._micro_step_count = 2
+    t._accumulated_grads = {"params": {"w": jnp.array([0.5, 0.5])}}
+
+    t.close()
+
+    self.assertEqual(mock_orbax_mgr.save.call_args.kwargs["step"], 5)
+
   def test_restore_checkpoint_no_checkpoint_returns_defaults(self):
     mock_config = self.setup_config(enable_checkpointing=True)
 
     t = maxtext_engine.MaxTextTrainingEngine(mock_config)
-    mock_orbax_mgr = mock.MagicMock()
-    mock_orbax_mgr.latest_step.return_value = None
-    t._checkpoint_manager._checkpoint_manager = mock_orbax_mgr
+    _ = self._mock_orbax_manager(t)
 
     restored_metadata = t.restore_checkpoint()
     self.assertIsNone(restored_metadata)
@@ -260,8 +379,7 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
   def test_restore_checkpoint_restores_ckpt_metadata(self):
     mock_config = self.setup_config(enable_checkpointing=True)
     t = maxtext_engine.MaxTextTrainingEngine(mock_config)
-    mock_orbax_mgr = mock.MagicMock()
-    mock_orbax_mgr.latest_step.return_value = 10
+    mock_orbax_mgr = self._mock_orbax_manager(t, latest_step=10)
 
     # Mock metadata with item_metadata and custom_metadata attributes
     dummy_metadata = mock.MagicMock()
@@ -288,8 +406,7 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
   def test_restore_intra_step_checkpoint(self):
     mock_config = self.setup_config(enable_checkpointing=True)
     t = maxtext_engine.MaxTextTrainingEngine(mock_config)
-    mock_orbax_mgr = mock.MagicMock()
-    mock_orbax_mgr.latest_step.return_value = 5
+    mock_orbax_mgr = self._mock_orbax_manager(t, latest_step=5)
 
     # Mock metadata with item_metadata and custom_metadata attributes
     dummy_metadata = mock.MagicMock()
@@ -320,6 +437,8 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
 
     _ = t.restore_checkpoint(step=5)
     self.assertEqual(t._micro_step_count, 2)
+    # Flags the partial checkpoint at step 5 for replacement once that step completes.
+    self.assertTrue(t._resumed_mid_step)
     self.assertEqual(t._accumulated_grads, dummy_grads)
     self.assertEqual(len(t._cached_losses), 2)
     self.assertTrue(isinstance(t._cached_losses[0], abstract_engine.WeightedMetric))


### PR DESCRIPTION
# Description

This PR ensures that the training engine saves its final state (either a completed step or a partial intra-step state) during a graceful shutdown before resources like the checkpoint manager and metrics loggers are torn down. Additionally, it improves the lifecycle and supersession of intra-step checkpoints, ensuring that partial checkpoints are correctly overwritten when a step makes further progress or fully completes.

## Detailed Changes
1. Final Checkpoint on Shutdown:
* Modified `MaxTextTrainingEngine.close()` to force-save a final checkpoint before tearing down the _checkpoint_manager, _throttler, and _metrics_recorder.
* Properly handles step indexing on exit: if there are accumulated gradients (_micro_step_count > 0), it saves at train_step + 1 (since update() hasn't incremented it yet). Otherwise, it saves at the completed train_step.

2. Intra-step Checkpoint Supersession:
* Added `micro_step_count` to CheckpointState and saves it into Orbax's custom_metadata to track how many micro-batches are folded into accumulated_grads.
* Introduced `_supersedes_saved_checkpoint` to evaluate if a new checkpoint is more complete than one already on disk for the same step.
* Because Orbax refuses to overwrite an existing step directory, the CheckpointManager now explicitly deletes the older, less-complete checkpoint using `_delete_saved_step` before force-saving the more complete one.
* A complete step (micro_step_count = 0) always supersedes a partial one, and a partial one supersedes another partial one if it has processed more micro-steps.

3. Mid-step Resume Handling (maxtext_engine.py):
* Added a `_resumed_mid_step` flag. When `restore_checkpoint` detects it is loading a partial step (micro_step_count > 0), it sets self.train_step = restored_step - 1 and flags `_resumed_mid_step = True`.
* When `update()` is called and the step finally finishes, if `_resumed_mid_step` is True, it forces a checkpoint save (force=True). This ensures the completed state reaches the disk instead of being skipped by Orbax's standard save-interval policy.

4. Raiden synchronizer import path: 
* `prepare_weight_sync` imported `raiden_synchronizer` from `tunix.experimental.worker`; the module lives in `tunix.experimental.weight_sync`, and the `worker` package does not contain it. Every Raiden weight-sync attempt therefore took the `ImportError` branch and returned empty metadata. 

# Tests

```
pytest tests/post_training/unit/maxtext_engine_test.py
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
