### PR TITLE
Forward tpu-inference MoE kernel knobs and surface MoE padding

### DIFF
--- a/src/dependencies/extra_deps/post_train_github_deps.txt
+++ b/src/dependencies/extra_deps/post_train_github_deps.txt
@@ -1,3 +1,3 @@
 google-tunix @ https://github.com/google/tunix/archive/c4ec573d29e4c3a3955b348256d464b119c8a6d1.zip
-tpu-inference @ https://github.com/vllm-project/tpu-inference/archive/7ecc401e6faefe3f793f3e4a8e6e2dbc49eca868.zip
-vllm @ git+https://github.com/vllm-project/vllm@0ba2aa35a81dcc3246b26291368b53fa2389c7d7
+tpu-inference @ https://github.com/vllm-project/tpu-inference/archive/b67ae5f8f234fd559cf4b376840e7bb9ae6d3275.zip
+vllm @ git+https://github.com/vllm-project/vllm@d626108b1841888ec90aced33367149a6bbc7e4b

--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -128,6 +128,23 @@ def generate_maxtext_config(vllm_config: VllmConfig) -> pyconfig.HyperParameters
       f"num_lanes={num_lanes}, tp={tp}, attn_dp={attn_dp}, ep={ep}, moe_mlp_tp_size={moe_mlp_tp_size}"
   )
 
+  # The native tpu-inference model paths derive use_ep from
+  # parallel_config.enable_expert_parallel, but the mesh built by
+  # ShardingConfigManager.from_vllm_config takes expert parallelism only from
+  # additional_config's sharding_strategy. MaxText derives use_ep from the mesh, so
+  # --enable-expert-parallel alone leaves the experts unsharded here while the native
+  # implementation of the same model runs expert-parallel. Warn rather than fail, since
+  # the run is still correct, only sharded differently than the flag suggests.
+  expert_shard_degree = ep * sharding_config.attn_dp_expert_size
+  if vllm_config.parallel_config.enable_expert_parallel and expert_shard_degree == 1:
+    max_logging.warning(
+        "--enable-expert-parallel was requested but the mesh has no expert shards "
+        f"(expert={ep}, attn_dp_expert={sharding_config.attn_dp_expert_size}), so MaxText will shard the MoE over "
+        "the MLP dimension instead of the expert dimension. The vLLM flag does not reach the JAX mesh; set "
+        'expert_parallelism in the vLLM additional_config sharding_strategy, e.g. \'{"sharding": '
+        '{"sharding_strategy": {"expert_parallelism": <num_devices>}}}\', to actually shard experts.'
+    )
+
   # Replicate the number of KV heads if its less than the total degree of model parallelism
   if kv_tp_size % num_kv_heads == 0 and num_kv_heads < kv_tp_size:
     max_logging.log(
@@ -152,8 +169,15 @@ def generate_maxtext_config(vllm_config: VllmConfig) -> pyconfig.HyperParameters
     while (padded_hidden_size // moe_mlp_tp_size) < (2 * num_lanes):
       padded_hidden_size = next_power_of_two(padded_hidden_size + 1)
 
-    max_logging.log(
-        f"Padding moe_intermediate_size from {hidden_size} to {padded_hidden_size} to match MLP MoE requirements."
+    # This inflates every expert weight, so it is a real memory/FLOP cost rather than a
+    # cosmetic reshape: at moe_mlp_tp_size=4 a 512-wide MoE is padded to 1024 (2x the MoE
+    # weights), and at moe_mlp_tp_size=8 to 2048 (4x). Log it at WARNING so it is visible
+    # under vLLM's logging configuration, which does not surface absl INFO records.
+    max_logging.warning(
+        f"Padding moe_intermediate_size from {hidden_size} to {padded_hidden_size} to match MLP MoE requirements "
+        f"(moe_mlp_tp_size={moe_mlp_tp_size}, 2*num_lanes={2 * num_lanes}). This multiplies the MoE weights and "
+        f"MoE FLOPs by {padded_hidden_size / hidden_size:g}x. Consider sharding the MoE over the expert axis "
+        f"instead, by setting expert_parallelism in the vLLM additional_config sharding_strategy."
     )
     overrides["padded_base_moe_mlp_dim"] = padded_hidden_size
 

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -3290,6 +3290,7 @@ class RoutedMoE(nnx.Module):
       # pylint: disable=import-outside-toplevel
       # pytype: disable=import-error
       from tpu_inference.layers.common.fused_moe_gmm import fused_moe_func
+      from tpu_inference import envs as tpu_inference_envs
     except ImportError as e:
       raise ImportError("fused_moe_matmul requires the tpu-inference package.") from e
 
@@ -3333,6 +3334,18 @@ class RoutedMoE(nnx.Module):
         use_ep=use_ep,
         activation=activation,
         scoring_fn=scoring_fn,
+        # Forward the same environment-backed kernel knobs that tpu-inference passes on its
+        # own serving path (tpu_inference/layers/common/moe.py). Without these, env vars such
+        # as ONEHOT_MOE_PERMUTE_THRESHOLD and VLLM_MOE_CHUNK_SIZE are silently ignored when a
+        # MaxText model is served through vLLM, so the two paths run the same kernel with
+        # different configurations. In particular, ONEHOT_MOE_PERMUTE_THRESHOLD selects the
+        # one-hot permute path instead of the SparseCore ragged_gather_reduce kernel, which
+        # is what makes expert parallelism usable on TPU generations whose SparseCore has
+        # fewer SIMD lanes than the kernel requires (e.g. v5p).
+        enable_rs_kernel=tpu_inference_envs.ENABLE_RS_KERNEL,
+        use_gmm_fused_rs_kernel=tpu_inference_envs.USE_GMM_FUSED_RS_KERNEL,
+        onehot_moe_permute_threshold=tpu_inference_envs.ONEHOT_MOE_PERMUTE_THRESHOLD,
+        moe_chunk_size=tpu_inference_envs.VLLM_MOE_CHUNK_SIZE,
     )
 
     # Reshape output 2D [T, D] -> 3D [B, S, D]


### PR DESCRIPTION
# Description

Two fixes to the vLLM serving path for MoE models.

1. `RoutedMoE.fused_moe_matmul` calls tpu-inference's `fused_moe_func` without the
   environment-backed knobs that tpu-inference passes on its own serving path, so
   `ENABLE_RS_KERNEL`, `USE_GMM_FUSED_RS_KERNEL`, `ONEHOT_MOE_PERMUTE_THRESHOLD` and
   `VLLM_MOE_CHUNK_SIZE` are silently ignored when serving a MaxText model. Forward them.

   `ONEHOT_MOE_PERMUTE_THRESHOLD` matters beyond tuning: it picks the one-hot permute path
   over the SparseCore `ragged_gather_reduce` kernel, which doesn't fit v5p. Before this,
   any `expert_parallelism > 1` died on the first request with
   `AssertionError: num_row_partitions=16 must be <= num_simd_lanes=8`.

2. The adapter pads `moe_intermediate_size` to satisfy GMM_v2's tiling constraint, which
   inflates every expert weight (`moe_mlp_tp_size` always equals `--tensor-parallel-size`,
   so TP=4 pads 512->1024 and TP=8 pads 512->2048). It was logged at absl INFO, which vLLM's
   logging doesn't surface, so serving Qwen3.5-35B-A3B quietly used 2x the MoE weights with
   nothing in the logs. Log it at WARNING with the cost.

No behaviour change with no env vars set, and the padding logic itself is untouched.

# Tests

Qwen3.5-35B-A3B on v5p-8, bf16 (v5p has no fp8 MXU). Server:

```bash
export HF_HOME=... USE_MOE_EP_KERNEL=0 ATTN_BUCKETIZED_NUM_REQS=true \
  ATTN_CUSTOM_NUM_REQS_BUCKETS=4 ONEHOT_MOE_PERMUTE_THRESHOLD=32768 \
  VLLM_MOE_CHUNK_SIZE=256 SLICE_ROPE_CACHE=1 DP_SCHED_BATCH_PREFILL=false \
  NEW_MODEL_DESIGN=1 NUM_PRECOMPILE_WORKERS=8 SKIP_JAX_PRECOMPILE=1 \
  VLLM_ENABLE_V1_MULTIPROCESSING=0

vllm serve Qwen/Qwen3.5-35B-A3B \
  --max-model-len=65536 --max-num-batched-tokens=2048 --max-num-seqs=256 \
  --no-enable-prefix-caching --gpu-memory-utilization=0.9 --tensor-parallel-size=4 \
  --async-scheduling --port=8000 --language-model-only --enable-auto-tool-choice \
  --tool-call-parser=qwen3_coder --reasoning-parser=qwen3 \
  --default-chat-template-kwargs '{"enable_thinking": false}' \
  '--limit-mm-per-prompt={"image": 0, "video": 0}' \
  --hf-overrides '{"architectures": ["MaxTextForCausalLM"]}' \
  "--additional_config={\"sharding\": {\"sharding_strategy\": $SHARDING}, \"maxtext_config\": {\"model_name\": \"qwen3.5-35b-a3b\", \"load_parameters_path\": \"gs://maxtext-model-checkpoints/qwen3.5-35b-a3b/unscanned/0/items\", \"scan_layers\": false, \"weight_dtype\": \"bfloat16\", \"attention\": \"vllm_rpa\", \"enable_nnx\": true, \"pure_nnx_decoder\": true, \"allow_split_physical_axes\": true, \"use_multimodal\": false, \"prefuse_moe_weights\": true}}" \
  --block-size=256 --enable-chunked-prefill
```

with

```bash
# before
SHARDING='{"enable_dp_attention": true, "attn_dp_size": 2}'
# after  (crashed on first request before this PR)
SHARDING='{"enable_dp_attention": false, "tensor_parallelism": 1, "expert_parallelism": 4}'
```

Client, same for every run:

```bash
python tpu-inference/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py \
  --model Qwen/Qwen3.5-35B-A3B --model-path-or-id Qwen/Qwen3.5-35B-A3B \
  --trace-file gs://wenxindong-vm/rl/mlperf2026/agentic_benchmark/gbs1024_trace_file.jsonl \
  --global-prefix-len 6476 --num-groups 1 --concurrency 1 --group-size 8
```

240/240 turns in every run, identical output tokens (37,194), so wall clock is comparable.
Native vLLM (`MODEL_IMPL_TYPE=vllm`, same flags) included for reference.

| | before | after | native vLLM |
| --- | --- | --- | --- |
| weights/device | 33.92 GiB | 18.31 GiB | 16.95 GiB |
| wall clock | 1450.86 s | 1056.98 s | 877.64 s |
| tok/s/chip | 838.80 | 1151.31 | 1322.14 |
| output tok/s | 25.64 | 35.19 | 42.38 |
| TPOT avg | 282.74 ms | 160.73 ms | 184.82 ms |
| TPOT p99 | 1125.54 ms | 603.23 ms | 893.00 ms |
| turn-1 prefill | 112,390 ms | 144,246 ms | 99,449 ms |
| turns 2+ TTFT | 4,923 ms | 3,855 ms | 4,699 ms |

+37% tok/s/chip, and the gap to native goes from 1.58x to 1.15x. Decode is now ahead of
native; what's left is turn-1 prefill, since `tensor_parallelism=1` leaves the prefill GEMMs
unsharded. `TP=2 / EP=2` is also padding-free (18.12 GiB/device) and is the obvious follow-up
— it was equally unrunnable before this PR.

The padding warning on the before config, where previously nothing was logged:

```
WARNING:absl:Padding moe_intermediate_size from 512 to 1024 to match MLP MoE requirements
(moe_mlp_tp_size=4, 2*num_lanes=256). This multiplies the MoE weights and MoE FLOPs by 2x.
```

Note `--enable-expert-parallel` on the CLI doesn't affect the JAX mesh — tpu-inference reads
expert parallelism only from `additional_config`, which is why it's set there above.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
