### PR TITLE
Training engine: reject LoRA, emit perplexity, always compute grad norm

### DIFF
--- a/src/maxtext/training_engine/maxtext_engine.py
+++ b/src/maxtext/training_engine/maxtext_engine.py
@@ -298,6 +298,8 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
       TypeError: If training_config is not a pyconfig.HyperParameters instance.
       ValueError: If training_config.model_name is not specified or empty, or if `wrap_with_tunix_adapter`
         is requested without `tokenizer_pad_id` or without a `mesh`.
+      NotImplementedError: If `training_config.lora.enable_lora` is True. This engine has no LoRA
+        path and would otherwise full-finetune the base model while the config claims LoRA.
     """
     if not isinstance(training_config, pyconfig.HyperParameters):
       raise TypeError(
@@ -311,6 +313,13 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
         )
       if mesh is None:
         raise ValueError("wrap_with_tunix_adapter=True requires a mesh; the adapter is built under it.")
+
+    # This engine has no LoRA path
+    if getattr(getattr(training_config, "lora", None), "enable_lora", False):
+      raise NotImplementedError(
+          "MaxTextTrainingEngine does not support LoRA, but lora.enable_lora=True was set. "
+          "This engine trains all parameters, set lora.enable_lora=False to train with this engine."
+      )
     self._config = training_config
     self._mesh = mesh
     self._init_rng = jax.random.PRNGKey(training_config.init_weights_seed)
@@ -357,8 +366,8 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     self._cached_losses: list[abstract_engine.WeightedMetric | jax.Array] = []
     # `create_training_optimizer` returns a raw optax GradientTransformation. `TrainStateNNX.apply_gradients`
     # calls `optimizer.update(model, grads)`, which is the nnx.Optimizer signature, and
-    # `checkpointing.CheckpointState` expects an nnx.Optimizer too, so wrap it here. This engine is only
-    # driven via tunix's GRPO+Raiden integration, which never enables LoRA, so `wrt` is always `nnx.Param`.
+    # `checkpointing.CheckpointState` expects an nnx.Optimizer too, so wrap it here. `wrt=nnx.Param`
+    # covers every parameter, which is correct only because LoRA is rejected above.
     self._learning_rate_schedule, tx = train_utils.create_training_optimizer(self._config, self._model)
     self._optimizer = nnx.Optimizer(self._model, tx, wrt=nnx.Param)
     self._train_step: int = 0
@@ -568,12 +577,13 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
             lambda g: g / micro_step_count,
             accumulated_grads,
         )
+      grad_norm = max_utils.l2norm_pytree(grads)
       if self._config.gradient_clipping_threshold > 0:
         grads = maxtext_utils.apply_gradient_clipping(grads, None, self._config.gradient_clipping_threshold)
+
       local_state = nnx.merge(self._state_graphdef, state_pure, copy=True)
       if hasattr(local_state, "apply_gradients"):
         if self._config.skip_step_on_spikes:
-          grad_norm = max_utils.l2norm_pytree(grads)
           local_state.apply_gradients(grads, loss=mean_loss, grad_norm=grad_norm)
           opt_obj = getattr(local_state, "optimizer", self._optimizer)
           if opt_obj is not None:

--- a/src/maxtext/training_engine/metrics.py
+++ b/src/maxtext/training_engine/metrics.py
@@ -32,6 +32,7 @@ import numpy as np
 _METRICS_TO_LOG = [
     "learning_rate",
     "loss",
+    "perplexity",
     "total_weights",
     "gradient_norm",
     "step_skipped",
@@ -271,6 +272,9 @@ class MetricsLogger:
       if isinstance(host_val, (np.ndarray, jax.Array)):
         host_val = host_val.item() if host_val.size == 1 else float(np.mean(host_val))
       processed[name] = host_val
+
+    if "loss" in processed:
+      processed["perplexity"] = float(np.exp(np.asarray(processed["loss"], dtype=np.float64)))
     return processed
 
   def cleanup(self) -> None:

--- a/tests/post_training/unit/maxtext_engine_test.py
+++ b/tests/post_training/unit/maxtext_engine_test.py
@@ -27,6 +27,7 @@ import jax.numpy as jnp
 from maxtext.configs import pyconfig
 from maxtext.training_engine import abstract_engine
 from maxtext.training_engine import maxtext_engine
+from maxtext.training_engine import metrics as metrics_module
 from maxtext.utils import maxtext_utils
 from tests.utils.test_helpers import get_test_config_path
 import numpy as np
@@ -1104,6 +1105,53 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     self.assertIn("metric_b", metrics.scalar_metrics)
     self.assertAlmostEqual(float(metrics.weighted_metrics["loss"].compute().item()), 6.0, places=4)
     self.assertAlmostEqual(float(metrics.weighted_metrics["metric_a"].compute().item()), 4.0, places=4)
+
+  def _weighted_loss_fn(self, model, *_args, **_kwargs):
+    """Loss whose gradient wrt the dummy model's weights is exactly [2.0, 2.0].
+
+    `unreduced_sum` is 8 * sum(w) = 24.0 over a denominator of 4.0, so the reported loss
+    is 6.0 and each gradient element is 8.0 * compute_scale() = 2.0.
+    """
+    return abstract_engine.WeightedMetric(unreduced_sum=jnp.sum(model.weights[...]) * 8.0, denominator=jnp.array(4.0))
+
+  def test_enable_lora_is_rejected_instead_of_silently_full_finetuning(self):
+    """This engine has no LoRA path, so the flag must fail loudly."""
+    self.assertFalse(self.mock_config.lora.enable_lora, "the default config must not enable LoRA")
+    maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+    self.mock_from_pretrained.assert_called_once()
+    self.mock_from_pretrained.reset_mock()
+
+    lora_config = self.setup_config(lora={"enable_lora": True, "lora_rank": 8, "lora_alpha": 16.0})
+    with self.assertRaisesRegex(NotImplementedError, "does not support LoRA"):
+      maxtext_engine.MaxTextTrainingEngine(lora_config)
+    self.mock_from_pretrained.assert_not_called()
+
+  def test_gradient_norm_is_recorded_every_step(self):
+    cfg = self.setup_config(gradient_clipping_threshold=0.0, grad_dtype="bfloat16")
+    self.assertFalse(cfg.skip_step_on_spikes, "this test covers the default, spike-detection-off path")
+
+    t = maxtext_engine.MaxTextTrainingEngine(cfg)
+    t.with_loss_fn(self._weighted_loss_fn)
+    t.fwd_bwd(DummyPayload())
+    t.update()
+
+    buffer = t.get_metrics(clear_cache=True)
+    self.assertIn("gradient_norm", buffer.scalar_metrics)
+    grad_norm = buffer.scalar_metrics["gradient_norm"]
+    np.testing.assert_allclose(np.asarray(grad_norm), [np.sqrt(8.0)], rtol=1e-3)
+    self.assertNotIn("step_skipped", buffer.scalar_metrics)
+
+  def test_perplexity_is_emitted_alongside_the_loss(self):
+    t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+    t.with_loss_fn(self._weighted_loss_fn)
+    t.fwd_bwd(DummyPayload())
+    t.update()
+
+    processed = metrics_module.MetricsLogger(self.mock_config).process_metrics(t.get_metrics(clear_cache=True))
+
+    self.assertAlmostEqual(processed["loss"], 6.0, places=4)
+    self.assertIn("perplexity", processed)
+    self.assertAlmostEqual(processed["perplexity"], float(np.exp(6.0)), places=3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
This PR bridges three gaps between MaxTextTrainingEngine and the Tunix PeftTrainer:

1. `lora.enable_lora=True` was silently accepted. The engine differentiates and updates with respect to `nnx.Param` -- every parameter -- where PeftTrainer narrows to `nnx.LoRAParam`. A "LoRA" run therefore full-finetuned the base model, wrote full-size checkpoints, and reported success.

2. Perplexity was never emitted. PeftTrainer logs `exp(loss)` alongside the loss on every step. 

3. The gradient norm existed only on the `skip_step_on_spikes` path, which defaults off, so a default run reported no gradient norm at all.

# Tests
CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
