### PR TITLE
Add RL sequence-packing and vLLM block-size knobs

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -115,6 +115,7 @@ num_batches: 4
 # and/or async sampling and training.
 train_micro_batch_size: -1
 rollout_micro_batch_size: -1
+max_seq_token_per_tpu: 0  # > 0 packs sequences into rows of this many tokens for training; 0 = one padded row per sequence
 # Keep `num_test_batches` low so that evaluation runs quickly. It can be
 # increased to a max. of 330 (if batch size is 4).
 num_test_batches: 5  # 200
@@ -176,6 +177,7 @@ enable_dp_attention: false
 # Performance tuning for samplers
 max_num_batched_tokens: null
 max_num_seqs: null
+vllm_block_size: null  # KV-cache page size; null lets the backend choose
 # If true, enables asynchronous scheduling in vLLM for faster generation
 async_scheduling: true
 # stop generation when any of these strings is generated

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2727,6 +2727,11 @@ class VLLM(BaseModel):
   async_scheduling: bool = Field(False, description="Enable asynchronous scheduling in vLLM.")
   max_num_batched_tokens: Optional[int] = Field(None, description="Max number of batched tokens in vLLM.")
   max_num_seqs: Optional[int] = Field(None, description="Max number of sequences in vLLM.")
+  vllm_block_size: Optional[int] = Field(
+      None,
+      gt=0,
+      description="KV-cache block (page) size for vLLM. None lets the backend pick it from the engine shape.",
+  )
   stop_strings: Optional[list[str]] = Field(None, description="List of stop strings for vLLM decoding.")
   vllm_additional_config: dict[str, Any] = Field(default_factory=dict, description="Additional vLLM config options.")
   vllm_hf_overrides: dict[str, Any] = Field(
@@ -2858,6 +2863,15 @@ class RLDataset(BaseModel):
   train_fraction: float = Field(1.0, gt=0.0, le=1.0, description="Fraction of the dataset to be used for training.")
   train_micro_batch_size: int = Field(-1, description="Micro batch size for training.")
   rollout_micro_batch_size: int = Field(-1, description="Micro batch size for rollout.")
+  max_seq_token_per_tpu: int = Field(
+      0,
+      ge=0,
+      description=(
+          "Token budget per packed training row (Tunix `max_seq_token_per_tpu`). When > 0, rollout sequences are packed "
+          "into rows of this many tokens for the actor/reference passes instead of one padded row per sequence; a maximal "
+          "sequence (max_prefill_predict_length + generation length) must fit in one row. 0 disables packing."
+      ),
+  )
   dataset_processor_path: str = Field(
       "",
       description=(
@@ -5164,6 +5178,16 @@ class RLConfig(
     model_name = getattr(self, "model_name", None)
     if model_name is None:
       raise ValueError("model_name is not set. Please pass model_name in your command.")
+
+    # With sequence packing on, a maximal sequence (prompt cap + generation
+    # cap = max_target_length) must fit in one packed row. Tunix checks this
+    # too, but only in the learner, after the models are already on the
+    # accelerators; fail here, before any of that work.
+    if 0 < self.max_seq_token_per_tpu < self.max_target_length:
+      raise ValueError(
+          f"max_seq_token_per_tpu ({self.max_seq_token_per_tpu}) must be at least "
+          f"max_target_length ({self.max_target_length}) when sequence packing is enabled."
+      )
 
     # Set tokenizer_path based on model_name if not explicitly provided.
     tokenizer_path = getattr(self, "tokenizer_path", None)

--- a/src/maxtext/integration/tunix/tunix_adapter.py
+++ b/src/maxtext/integration/tunix/tunix_adapter.py
@@ -109,10 +109,18 @@ class TunixMaxTextAdapter(nnx.Module):
       decoder_segment_ids: Optional[Array] = None,
       output_hidden_states: bool = False,  # ignored
       forced_routed_experts: Optional[Array] = None,
+      segment_ids: Optional[Array] = None,
   ) -> Tuple[Array, None]:
     """Forward compatible with Tunix Trainers default loss.
     Returns logits, None.
+
+    `segment_ids` is the name Tunix uses for packed-sequence segment ids: it
+    forwards them only to models whose call signature has a parameter of that
+    exact name. They are MaxText's `decoder_segment_ids`; when both are given,
+    `segment_ids` wins so packed rows keep per-sequence attention isolation.
     """
+    if segment_ids is not None:
+      decoder_segment_ids = segment_ids
     if decoder_segment_ids is None and self._pad_id is not None:
       decoder_segment_ids = (input_tokens != self._pad_id).astype(jnp.int32)
     logits = self.base(

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -437,6 +437,18 @@ def create_rl_components(  # pylint: disable=too-many-positional-arguments
 
   rl_rollout_engine = functools.partial(MaxTextVllmRollout, maxtext_config=trainer_config)
 
+  rollout_vllm_kwargs = {
+      "hf_overrides": trainer_config.vllm_hf_overrides,
+      "enable_expert_parallel": sampler_config.enable_expert_parallel,
+      "enable_prefix_caching": rollout_prefix_caching_enabled(trainer_config),
+      # Ensures vLLM model initializes with correct dtype (not float32 default)
+      "dtype": trainer_config.weight_dtype.value,
+  }
+  if trainer_config.vllm_block_size is not None:
+    # Pin the KV-cache page size; left unset, the backend derives it from the
+    # engine shape, so unrelated engine changes can move it.
+    rollout_vllm_kwargs["block_size"] = trainer_config.vllm_block_size
+
   cluster_config = rl_cluster_lib.ClusterConfig(
       role_to_mesh={
           rl_cluster_lib.Role.ACTOR: actor_mesh,
@@ -457,6 +469,7 @@ def create_rl_components(  # pylint: disable=too-many-positional-arguments
           mini_batch_size=trainer_config.batch_size,
           train_micro_batch_size=train_micro_batch_size,
           rollout_micro_batch_size=rollout_micro_batch_size,
+          max_seq_token_per_tpu=trainer_config.max_seq_token_per_tpu or None,
           metrics_logging_options=metrics_logging_options,
           profiler_options=profiler_options,
           checkpoint_root_directory=checkpoint_dir,
@@ -485,13 +498,7 @@ def create_rl_components(  # pylint: disable=too-many-positional-arguments
           rollout_vllm_async_scheduling=trainer_config.async_scheduling,
           rollout_vllm_server_mode=trainer_config.rl.use_agentic_rollout,
           rollout_vllm_reshard_chunk_size=trainer_config.rl.reshard_chunk_size,
-          rollout_vllm_kwargs={
-              "hf_overrides": trainer_config.vllm_hf_overrides,
-              "enable_expert_parallel": sampler_config.enable_expert_parallel,
-              "enable_prefix_caching": rollout_prefix_caching_enabled(trainer_config),
-              # Ensures vLLM model initializes with correct dtype (not float32 default)
-              "dtype": trainer_config.weight_dtype.value,
-          },
+          rollout_vllm_kwargs=rollout_vllm_kwargs,
           rollout_vllm_sampling_kwargs={
               "stop": trainer_config.stop_strings,
               "detokenize": trainer_config.stop_strings is not None,

--- a/tests/post_training/unit/train_rl_test.py
+++ b/tests/post_training/unit/train_rl_test.py
@@ -53,6 +53,25 @@ class TrainRLTest(unittest.TestCase):
     self.assertFalse(config.enable_mhc_lite)
     self.assertFalse(config.enable_prefix_caching)
 
+  def test_rl_config_packing_and_block_size_defaults(self):
+    """Packing is off and the vLLM page size is backend-chosen unless set."""
+    config = types.RLConfig(model_name="gemma4-26b")
+
+    self.assertEqual(config.max_seq_token_per_tpu, 0)
+    self.assertIsNone(config.vllm_block_size)
+
+    config = types.RLConfig(model_name="gemma4-26b", max_seq_token_per_tpu=12288, vllm_block_size=128)
+    self.assertEqual(config.max_seq_token_per_tpu, 12288)
+    self.assertEqual(config.vllm_block_size, 128)
+
+  def test_rl_config_packing_budget_must_fit_a_maximal_sequence(self):
+    """A packed row must hold prompt cap + generation cap (= max_target_length)."""
+    with self.assertRaisesRegex(ValueError, "max_seq_token_per_tpu"):
+      types.RLConfig(model_name="gemma4-26b", max_target_length=4096, max_seq_token_per_tpu=2048)
+
+    config = types.RLConfig(model_name="gemma4-26b", max_target_length=4096, max_seq_token_per_tpu=4096)
+    self.assertEqual(config.max_seq_token_per_tpu, 4096)
+
   @pytest.mark.cpu_only
   def test_rollout_prefix_caching_respects_config_for_attention_model(self):
     config = SimpleNamespace(

--- a/tests/post_training/unit/tunix_adapter_test.py
+++ b/tests/post_training/unit/tunix_adapter_test.py
@@ -14,6 +14,7 @@
 
 """Tests for TunixMaxTextAdapter segment_ids synthesis (CPU-only)."""
 
+import inspect
 import unittest
 from types import SimpleNamespace
 from unittest import mock
@@ -22,6 +23,8 @@ import pytest
 
 import jax.numpy as jnp
 import numpy as np
+
+from tunix.rl import common as tunix_common
 
 from maxtext.integration.tunix import tunix_adapter as tunix_adapter_module
 from maxtext.integration.tunix.tunix_adapter import TunixMaxTextAdapter
@@ -115,6 +118,43 @@ class TunixAdapterSegmentIdsTest(unittest.TestCase):
     adapter(input_tokens, positions, None, None, decoder_segment_ids=explicit_seg)
 
     np.testing.assert_array_equal(np.asarray(self.base.captured["decoder_segment_ids"]), np.asarray(explicit_seg))
+
+  def test_segment_ids_alias_maps_to_decoder_segment_ids(self):
+    """Tunix passes packed segment ids under the name `segment_ids`; the
+    adapter must forward them as MaxText's `decoder_segment_ids` instead of
+    synthesizing a pad mask."""
+    adapter = TunixMaxTextAdapter(base_model=self.base, pad_id=99)
+
+    input_tokens = jnp.array([[10, 11, 12, 20, 21]], dtype=jnp.int32)
+    positions = jnp.array([[0, 1, 2, 0, 1]], dtype=jnp.int32)
+    packed_seg = jnp.array([[1, 1, 1, 2, 2]], dtype=jnp.int32)
+
+    adapter(input_tokens, positions, None, None, segment_ids=packed_seg)
+
+    np.testing.assert_array_equal(np.asarray(self.base.captured["decoder_segment_ids"]), np.asarray(packed_seg))
+
+  def test_segment_ids_is_named_so_the_tunix_gate_passes(self):
+    """Tunix forwards packed segment ids only when the model's call signature
+    names `segment_ids` (tunix.rl.common.model_call_contains). Pin the name
+    itself, not just the plumbing: the gate also accepts a `**kwargs`, so a
+    later refactor could keep the forwarding tests green while every packed
+    row silently reverts to whole-row attention."""
+    params = inspect.signature(TunixMaxTextAdapter.__call__).parameters
+    self.assertIn("segment_ids", params)
+    adapter = TunixMaxTextAdapter(base_model=self.base, pad_id=99)
+    self.assertTrue(tunix_common.model_call_contains(adapter, "segment_ids"))
+
+  def test_segment_ids_alias_takes_precedence_over_decoder_segment_ids(self):
+    adapter = TunixMaxTextAdapter(base_model=self.base, pad_id=99)
+
+    input_tokens = jnp.array([[10, 11, 12, 20, 21]], dtype=jnp.int32)
+    positions = jnp.array([[0, 1, 2, 0, 1]], dtype=jnp.int32)
+    packed_seg = jnp.array([[1, 1, 1, 2, 2]], dtype=jnp.int32)
+    other_seg = jnp.array([[7, 7, 7, 7, 7]], dtype=jnp.int32)
+
+    adapter(input_tokens, positions, None, None, decoder_segment_ids=other_seg, segment_ids=packed_seg)
+
+    np.testing.assert_array_equal(np.asarray(self.base.captured["decoder_segment_ids"]), np.asarray(packed_seg))
 
   def test_forwards_forced_routed_experts(self):
     """The stub captures the kwarg but nothing asserted on it, so deleting the


### PR DESCRIPTION
# Description

Tunix packs RL training sequences into fixed-token rows when its training config carries `max_seq_token_per_tpu`, and it forwards the packed segment ids to the model only when the model's call signature has a parameter literally named `segment_ids`. MaxText exposed neither, so packing could not be turned on from an RL config: the CLI rejected the key (not in `RLConfig`), and the adapter would never have received the packed ids.

This PR adds:

- `max_seq_token_per_tpu` to `RLConfig` (default `0` = unpacked, one padded row per sequence, i.e. today's behavior), plumbed into `RLTrainingConfig`. When set, a maximal sequence (`max_prefill_predict_length` + generation length) must fit in one row; Tunix validates this at startup.
- A `segment_ids` parameter on `TunixMaxTextAdapter.__call__`, mapped to MaxText's `decoder_segment_ids`, so packed rows keep per-sequence attention isolation. Without it the adapter falls back to synthesizing a pad mask and packed sequences would attend to each other.
- `vllm_block_size` to `RLConfig` (default `None`, backend-chosen as today). tpu_inference derives the KV-cache page size from the engine shape, so unrelated engine changes (`max_model_len`, TP/DP layout) silently move it; pinning it keeps generation comparable across such experiments. It is forwarded through `rollout_vllm_kwargs` only when set.

Measured on a Qwen3-0.6B GRPO run on TPU v7x (2048 sequences/step, 12288-token rows, prompts ~150 tokens, completions ~4400 tokens): packing cut `actor_train_time` from 15.2 s to 6.7 s per step, with rewards and completion lengths unchanged. Both defaults leave existing configs untouched.

**Note on the adapter change:** the `segment_ids` parameter takes effect on every Tunix batch, not only packed ones. Once the gate passes, Tunix sends its non-pad mask as `segment_ids` on unpacked batches too, so the adapter's own pad-id fallback no longer fires on that path and pad-mask authority moves from the adapter's `pad_id` to Tunix's. Both derive from the tokenizer pad id today, so values are unchanged; "defaults leave existing configs untouched" applies to the config knobs, not to this.

# Tests

- `tests/post_training/unit/tunix_adapter_test.py`: `segment_ids` is forwarded as `decoder_segment_ids`, and takes precedence when both are given.
- `tests/post_training/unit/train_rl_test.py`: `RLConfig` defaults and explicit values for both knobs.

```
python -m pytest tests/post_training/unit/tunix_adapter_test.py tests/post_training/unit/train_rl_test.py
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

