### PR TITLE
Fix RL Training - vLLM sampler TypeError

### DIFF
--- a/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
@@ -450,7 +450,7 @@ class MaxTextVllmSampler(VllmSampler):
       scan_axis: int = 1,
       layer_pattern_length: Optional[int] = None,
   ):
-    super().__init__(tokenizer=tokenizer, config=config, converter=converter)
+    super().__init__(tokenizer=tokenizer, config=config)
     self._converter = converter
     self.converter = converter
     self._direct_maxtext_sync = direct_maxtext_sync


### PR DESCRIPTION
## Description

This PR resolves critical failures in RL training pipelines. It restores a previously dropped fix for the `MaxTextVllmSampler` initialization.

[DAG Error Log](https://cloudlogging.app.goo.gl/MNk3Zay6bMCH3kGL9)

## Root Cause

- **RL Rollout `TypeError`**: Commit `4521fc5` accidentally overwrote the fix applied in `5bf4b88` due to a stale branch merge. It reintroduced the invalid `converter=converter` kwarg into the base `tunix` `VllmSampler.__init__`, triggering an immediate `TypeError` during RL graph initialization.


## Solution

**Rollout Logic**: Removed the invalid `converter` argument from `super().__init__` in `MaxTextVllmSampler`, restoring the logic without breaking the newly added Qwen3.5 routing.

# Tests

Llama3.1-70b RL: https://cloudlogging.app.goo.gl/i7cbeR8hzSyt38s36

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
