### PR TITLE
Remove fsdp_transpose from embed_attn.

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -309,7 +309,7 @@ logical_axis_rules: [
       ['gdn_head', ['fsdp_transpose', 'tensor', 'tensor_sequence', 'autoregressive']],
       ['embed', ['fsdp', 'fsdp_transpose', 'context', 'expert']],
       ['embed', ['fsdp', 'context', 'expert']],
-      ['embed_attn', ['fsdp', 'fsdp_transpose', 'context', 'expert']],
+      ['embed_attn', ['fsdp', 'context', 'expert']],
       ['norm', ['tensor']],
       ['layers', 'stage'],
       ['diloco', 'diloco'],


### PR DESCRIPTION
# Description

Remove fsdp_transpose from embed_attn rule. This causes a duplicate sharding
error in some cases where fsdp_transpose is already present in other sharding
rules.

# Tests

Running it on a v5p-256 for Qwen3.5-35B.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):

-   [X] I have performed a self-review of my code. For an optional AI review,
    add the `gemini-review` label.
-   [X] I have necessary comments in my code, particularly in hard-to-understand
    areas.
-   [X] I have run end-to-end tests tests and provided workload links above if
    applicable.
-   [X] I have made or will make corresponding changes to the doc if needed,
    including adding new documentation pages to the relevant Table of Contents
    (toctree directive) as explained in
    [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
