### PR TITLE
Track tunix API changes in the MaxText training engine

### DIFF
--- a/src/maxtext/training_engine/maxtext_engine.py
+++ b/src/maxtext/training_engine/maxtext_engine.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from absl import logging
 from flax import nnx
+from flax import struct
 from flax.traverse_util import flatten_dict
 from flax.traverse_util import unflatten_dict
 import jax
@@ -145,7 +146,13 @@ _UNCOMPARABLE_STRUCTURE_HINT = (
 )
 
 
-@dataclasses.dataclass(kw_only=True)
+# Frozen to match tunix's `TrainerPayload`, which is a
+# `flax.struct.dataclass(frozen=True, kw_only=True)`. Python refuses to derive a
+# non-frozen dataclass from a frozen one, so a plain `dataclasses.dataclass`
+# here fails at import time with "cannot inherit non-frozen dataclass from a
+# frozen one". `struct.dataclass` also keeps the subclass registered as a
+# pytree, so it can still cross a `jit` boundary.
+@struct.dataclass(frozen=True, kw_only=True)
 class RouterReplayTrainerPayload(abstract_engine.TrainerPayload):
   """A TrainerPayload extension carrying forced router-replay expert decisions.
 
@@ -1237,12 +1244,10 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
       # optimization (fewer stale holds) depends on.
       num_chunks = max(1, int(os.environ.get("RAIDEN_WEIGHT_SYNC_CHUNKS", "1")))
       if self._raiden_syncs is None:
-        # Under Pathways (JAX_PLATFORMS=proxy + JAX_BACKEND_TARGET set, same
-        # detection tunix's K8sJaxContext.initialize() uses), trainer params
-        # are proxy-backed and Raiden can't bind them in place -- host_stage
-        # pulls them to client host memory first. Direct-TPU trainers skip
-        # that extra copy since their params already live on TPU.
-        is_pathways = bool("proxy" in os.environ.get("JAX_PLATFORMS", "") and os.environ.get("JAX_BACKEND_TARGET"))
+        # Proxy-backed (Pathways) params used to need `host_stage=True` to pull
+        # them into client host memory before binding. The synchronizer now
+        # detects the proxy runtime itself and binds them via the Raiden FFI
+        # without the host round-trip, and no longer accepts the argument.
         # worker_index must be unique per chunk (it seeds WorkUnitId's
         # job_replica_id) -- otherwise every chunk's work unit collides under
         # the same id in the handler's registry and only one survives
@@ -1252,7 +1257,6 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
                 job_name="trainer",
                 worker_index=jax.process_index() if num_chunks == 1 else (jax.process_index() * num_chunks + i + 1),
                 auto_h2d=False,
-                host_stage=is_pathways,
                 parallelism=4,
             )
             for i in range(num_chunks)
@@ -1295,7 +1299,9 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     if self._raiden_syncs:
       for sync in self._raiden_syncs:
         logging.vlog(1, "Trainer Raiden metrics: %s", sync.metrics())
-        sync.release_host_arrays()
+        # `release_host_arrays()` used to drop the staged references here. The
+        # synchronizer now clears them itself at the start of the next bind, so
+        # there is nothing to release between rounds and the method is gone.
     return True
 
   def close(self) -> None:


### PR DESCRIPTION
# Description

Three compat fixes, all needed to import and run `MaxTextTrainingEngine` against current tunix. Each one is an unconditional break today.

1. Freeze `RouterReplayTrainerPayload`.

Tunix declares `TrainerPayload` as
`@flax.struct.dataclass(frozen=True, kw_only=True)` (tunix/experimental/common/datatypes.py). Python refuses to derive a non-frozen dataclass from a frozen one, so importing maxtext_engine raises at class-creation time:

    TypeError: cannot inherit non-frozen dataclass from a frozen one

Match the base: `struct.dataclass` rather than `dataclasses.dataclass`, so the subclass is frozen too and stays registered as a pytree, which it has to be to cross the `jit` boundary in the engine's step functions.

tests/post_training/unit/router_replay_engine_test.py passes unchanged (7 tests), so nothing was relying on mutating a payload after construction.

2. Drop the `host_stage=` kwarg to `RaidenSynchronizer`.

It no longer exists, so constructing the synchronizer fails outright:

    TypeError: RaidenSynchronizer.__init__() got an unexpected keyword
    argument 'host_stage'

The kwarg used to pull proxy-backed (Pathways) params into client host memory before binding. The synchronizer now detects the proxy runtime itself and binds via the Raiden FFI without the host round-trip, so the `is_pathways` probe that fed it is dead too and goes with it.

3. Drop the `release_host_arrays()` call in `release_weight_sync`.

Same rewrite removed the method:

    AttributeError: 'RaidenSynchronizer' object has no attribute
    'release_host_arrays'

The synchronizer clears its staged references at the start of the next bind, so there is nothing left to release between rounds.

# Tests

Verified end to end on v5p-8 (4 chips) with the tunix `math_gsm8k_dist` GRPO demo, Qwen3-0.6B, Raiden weight sync between the MaxText trainer and a vLLM rollout. Source and destination checksums match across the sync: 310 tensors, 596049920 elements, grand total 13217973.204956055.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
