### PR TITLE
[vLLM] Fix cache_heads and paged_kv_heads logical axis order in vllm.yml

### DIFF
--- a/src/maxtext/configs/inference/vllm.yml
+++ b/src/maxtext/configs/inference/vllm.yml
@@ -102,8 +102,8 @@ logical_axis_rules: [
                       # ==========================================
                       ['activation_prefill_kv_batch', ['data', 'attn_dp', 'attn_dp_expert']],
                       ['decode_batch', ['data', 'attn_dp', 'attn_dp_expert']],
-                      ['cache_heads', ['expert', 'model']],
-                      ['paged_kv_heads', ['expert', 'model']],
+                      ['cache_heads', ['model', 'expert']],
+                      ['paged_kv_heads', ['model', 'expert']],
                       ['cache_batch_prefill', []],
                       ['cache_batch', []],
                       ['cache_heads_none', []],


### PR DESCRIPTION
# Description

In `src/maxtext/configs/inference/vllm.yml`:
- `activation_kv_heads` is ordered as `['model', 'expert']`.
- However, `cache_heads` and `paged_kv_heads` had the inverted order `['expert', 'model']`.
When serving models with expert parallelism enabled via vLLM integration:
- This inverted axis order causes SPMD layout mismatches across `model` and `expert` axes between attention activations and cache tensors.
- Aligning `cache_heads` and `paged_kv_heads` to `['model', 'expert']` prevents unexpected axis transpose operations.

Related Bug: b/549307194

# Tests

- Verified with Qwen-3.5-397B on TPU v7x-8 alongside `tpu-inference`.
- Confirmed that unnecessary cache axis-transpose communications are eliminated.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
