### PR TITLE
Onboard Qwen3.5 and Qwen3-Next to explicit sharding and ZeRO-1 gradient accumulation

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4342,6 +4342,8 @@ class MaxTextConfig(
           "qwen3",
           "qwen3_moe",
           "qwen3_custom_moe",
+          "qwen3_5",
+          "qwen3_next",
           "gemma",
           "gemma2",
           "gemma3",
@@ -4356,6 +4358,27 @@ class MaxTextConfig(
             "'explicit' sharding is not supported with `use_multimodal`; the vision and audio encoders "
             "have not been onboarded to explicit sharding yet."
         )
+      # Both hybrid decoders share the same GatedDeltaNet sublayers, so the same gaps.
+      if self.decoder_block in (DecoderBlockType.QWEN3_5, DecoderBlockType.QWEN3_NEXT):
+        decoder_name = self.decoder_block.value
+        if not self.sparse_matmul:
+          raise ValueError(
+              f"'explicit' sharding with the '{decoder_name}' decoder requires `sparse_matmul=True`; the dense "
+              "matmul MoE path has not been onboarded to explicit sharding yet."
+          )
+        gdn_context_parallel_size = (
+            self.ici_context_parallelism
+            * self.dcn_context_parallelism
+            * self.ici_context_usp_ulysses_parallelism
+            * self.dcn_context_usp_ulysses_parallelism
+        )
+        if gdn_context_parallel_size > 1:
+          raise ValueError(
+              f"'explicit' sharding with the '{decoder_name}' decoder does not support context parallelism yet. The "
+              "GatedDeltaNet short convolution left-pads the sequence by `gdn_conv_kernel_dim - 1` and slices "
+              "the result back, which explicit sharding cannot express on a sharded sequence axis. Use "
+              "`shard_mode=auto` when `ici_context_parallelism` or `ici_context_usp_ulysses_parallelism` is set."
+          )
     if self.context_sharding not in ("context", "expert"):
       raise ValueError(f"Assigned context_sharding f{self.context_sharding} is not supported.")
     if self.ulysses_context_sharding != "context_usp_ulysses":

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -524,6 +524,7 @@ class Attention(nnx.Module):
           epsilon=self.config.normalization_layer_epsilon,
           dtype=self.config.dtype,
           weight_dtype=self.config.weight_dtype,
+          shard_mode=self.config.shard_mode,
           rngs=self.rngs,
       )
       self.key_norm = Qwen3NextRMSNorm(
@@ -531,6 +532,7 @@ class Attention(nnx.Module):
           epsilon=self.config.normalization_layer_epsilon,
           dtype=self.config.dtype,
           weight_dtype=self.config.weight_dtype,
+          shard_mode=self.config.shard_mode,
           rngs=self.rngs,
       )
     else:

--- a/src/maxtext/layers/normalizations.py
+++ b/src/maxtext/layers/normalizations.py
@@ -174,8 +174,11 @@ def Qwen3NextRMSNorm(
           epsilon=epsilon,
           dtype=dtype,
           weight_dtype=weight_dtype,
+          shard_mode=shard_mode if shard_mode is not None else ShardMode.AUTO,
+          kernel_axes=kernel_axes if kernel_axes is not None else (),
           scale_init=linen_initializers.zeros,
           scale_offset=1.0,
+          parameter_memory_host_offload=bool(parameter_memory_host_offload),
           rngs=rngs,
       )
   )
@@ -196,7 +199,16 @@ class Qwen3NextRMSNormGated(nnx.Module):
     weight_dtype: The datatype of the internal RMSNorm scale.
   """
 
-  def __init__(self, num_features: int, epsilon: float, dtype: DType, weight_dtype: DType, *, rngs: nnx.Rngs):
+  def __init__(
+      self,
+      num_features: int,
+      epsilon: float,
+      dtype: DType,
+      weight_dtype: DType,
+      shard_mode: ShardMode = ShardMode.AUTO,
+      *,
+      rngs: nnx.Rngs,
+  ):
     self.num_features = num_features
     self.epsilon = epsilon
     self.dtype = dtype
@@ -207,12 +219,13 @@ class Qwen3NextRMSNormGated(nnx.Module):
             epsilon=self.epsilon,
             dtype=dtype,
             weight_dtype=weight_dtype,
+            shard_mode=shard_mode,
             scale_init=nnx.initializers.ones,
             rngs=rngs,
         )
     )
 
-  def __call__(self, hidden_states: Array, gate: Array) -> Array:
+  def __call__(self, hidden_states: Array, gate: Array, out_sharding: NamedSharding | None = None) -> Array:
     """
     Applies RMSNorm and then a SiLU gate.
 
@@ -220,11 +233,13 @@ class Qwen3NextRMSNormGated(nnx.Module):
       hidden_states: The input array to be normalized (o). Shape: (..., F)
       gate: The gating array for the activation (z). Shape: (..., F)
             where F is num_features.
+      out_sharding: Optional layout for the normalized states, honoured only
+        under `ShardMode.EXPLICIT`.
 
     Returns:
       The normalized and gated output array. Shape: (..., F)
     """
-    normalized_states = self.rms_norm(hidden_states)
+    normalized_states = self.rms_norm(hidden_states, out_sharding=out_sharding)
 
     # Gated Activation using SiLU (Sigmoid-weighted Linear Unit)
     gated_states = normalized_states * jax.nn.silu(gate.astype(jnp.float32))

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -40,6 +40,7 @@ from maxtext.utils.sharding import (
     get_logical_axis_rules,
     logical_to_mesh_axes,
     maybe_shard_with_logical,
+    maybe_shard_with_name,
     remove_incompatible_mesh_axes_from_partition_spec,
 )
 from maxtext.layers import attentions
@@ -549,6 +550,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         weight_dtype=cfg.weight_dtype,
         kernel_axes=("embed_attn", "gdn_head"),
         matmul_precision=cfg.matmul_precision,
+        shard_mode=cfg.shard_mode,
         rngs=rngs,
     )
     self.in_proj_ba = DenseGeneral(
@@ -558,6 +560,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         weight_dtype=cfg.weight_dtype,
         kernel_axes=("embed_attn", "gdn_head"),
         matmul_precision=cfg.matmul_precision,
+        shard_mode=cfg.shard_mode,
         rngs=rngs,
     )
 
@@ -588,6 +591,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         epsilon=cfg.normalization_layer_epsilon,
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
+        shard_mode=cfg.shard_mode,
         rngs=rngs,
     )
     self.out_proj = DenseGeneral(
@@ -597,7 +601,43 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         weight_dtype=cfg.weight_dtype,
         kernel_axes=("gdn_head", "embed_attn"),
         matmul_precision=cfg.matmul_precision,
+        shard_mode=cfg.shard_mode,
         rngs=rngs,
+    )
+
+  def _explicit_activation_shardings(self, batch: int):
+    """Physical layouts for the GatedDeltaNet activations under explicit sharding.
+
+    Explicit sharding cannot infer a layout across the reshapes, the head repeat or the
+    shard_map boundary in `__call__`, so every intermediate is pinned to the logical
+    axes the auto path already asks GSPMD for.
+
+    Returns:
+      `(flat, head, state)` shardings for `(B, S, H*D)`, `(B, S, H, D)` and
+      `(B, H, D_k, D_v)` shaped activations, all `None` under `ShardMode.AUTO`.
+    """
+    if self.config.shard_mode != ShardMode.EXPLICIT or self.mesh is None:
+      return None, None, None
+
+    logical_rules = get_logical_axis_rules()
+    # Same sequence axis the shard_map specs below use: replicated unless a
+    # context axis carries it.
+    cp_len = LENGTH if gdn_context_axes(self.config) else None
+
+    def _sharding(logical_axes):
+      pspec = logical_to_mesh_axes(logical_axes, mesh=self.mesh, rules=logical_rules)
+      # Training microbatches can be smaller than the physical batch partition.
+      # Only dim 0 is inspected, so the trailing sizes are placeholders.
+      shape = (batch,) + (1,) * (len(logical_axes) - 1)
+      pspec = remove_incompatible_mesh_axes_from_partition_spec(
+          pspec, shape, self.mesh, dims=(0,), allow_remove_axes=True
+      )
+      return jax.sharding.NamedSharding(self.mesh, pspec)
+
+    return (
+        _sharding((KV_BATCH, cp_len, KV_HEAD)),
+        _sharding((KV_BATCH, cp_len, KV_HEAD, None)),
+        _sharding((KV_BATCH, KV_HEAD, None, None)),
     )
 
   def __call__(
@@ -607,11 +647,13 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       kv_cache=None,
       decoder_segment_ids: None | Array = None,
       attention_metadata=None,
+      out_sharding: jax.sharding.NamedSharding | None = None,
       **kwargs,
   ) -> tuple[Array, Any | None]:
     # hidden_states: (B, S, E)
     cfg = self.config
     batch, seq_len, _ = hidden_states.shape
+    flat_sharding, head_sharding, state_sharding = self._explicit_activation_shardings(batch)
 
     active_cache = kv_cache if kv_cache is not None else self.cache
 
@@ -630,9 +672,9 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     # STEP A: Input Projections
     # =========================================================================
     # qkvz: (B, S, 2 * K_dim + 2 * V_dim)
-    qkvz = self.in_proj_qkvz(hidden_states)
+    qkvz = self.in_proj_qkvz(hidden_states, out_sharding=flat_sharding)
     # ba: (B, S, 2 * H_v)
-    ba = self.in_proj_ba(hidden_states)
+    ba = self.in_proj_ba(hidden_states, out_sharding=flat_sharding)
 
     # =========================================================================
     # QKVZ and BA Reshaping and Splitting (shared by both paths)
@@ -645,7 +687,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         2 * self.head_k_dim + 2 * self.head_v_dim * self.v_heads_per_k_head,
     )
     # mixed_qkvz: (B, S, H_k, 2*D_k + 2*D_v*V_per_K)
-    mixed_qkvz = qkvz.reshape(new_shape_qkvz)
+    mixed_qkvz = jnp.reshape(qkvz, new_shape_qkvz, out_sharding=head_sharding)
     if self.mesh is not None:
       logical_rules = get_logical_axis_rules()
       # LENGTH, not None. This with_sharding_constraint told XLA to gather the
@@ -665,7 +707,14 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
           allow_remove_axes=True,
       )
       qkvz_sharding = jax.sharding.NamedSharding(self.mesh, qkvz_pspec)
-      mixed_qkvz = jax.lax.with_sharding_constraint(mixed_qkvz, qkvz_sharding)
+      # Under ShardMode.EXPLICIT `with_sharding_constraint` is an assertion rather than
+      # a hint and rejects any layout it has to change, so reshard through the helper.
+      mixed_qkvz = maybe_shard_with_name(
+          mixed_qkvz,
+          qkvz_sharding,
+          shard_mode=cfg.shard_mode,
+          debug_sharding=cfg.debug_sharding,
+      )
 
     split_indices_qkvz = [
         self.head_k_dim,  # D_k
@@ -679,9 +728,9 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     query, key, value_raw, z_raw = jnp.split(mixed_qkvz, split_indices_qkvz, axis=3)
 
     # value: (B, S, H_v, D_v)
-    value = value_raw.reshape(batch, seq_len, self.num_v_heads, self.head_v_dim)
+    value = jnp.reshape(value_raw, (batch, seq_len, self.num_v_heads, self.head_v_dim), out_sharding=head_sharding)
     # z: (B, S, H_v, D_v)
-    z = z_raw.reshape(batch, seq_len, self.num_v_heads, self.head_v_dim)
+    z = jnp.reshape(z_raw, (batch, seq_len, self.num_v_heads, self.head_v_dim), out_sharding=head_sharding)
 
     # BA Reshaping and Splitting
     new_shape_ba = (
@@ -691,7 +740,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         2 * self.v_heads_per_k_head,
     )
     # mixed_ba: (B, S, H_k, 2 * V_per_K)
-    mixed_ba = ba.reshape(new_shape_ba)
+    mixed_ba = jnp.reshape(ba, new_shape_ba, out_sharding=head_sharding)
 
     split_indices_ba = [self.v_heads_per_k_head]
     # b_raw: (B, S, H_k, V_per_K)
@@ -699,9 +748,9 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     b_raw, a_raw = jnp.split(mixed_ba, split_indices_ba, axis=3)
 
     # b: (B, S, H_v)
-    b = b_raw.reshape(batch, seq_len, self.num_v_heads)
+    b = jnp.reshape(b_raw, (batch, seq_len, self.num_v_heads), out_sharding=flat_sharding)
     # a: (B, S, H_v)
-    a = a_raw.reshape(batch, seq_len, self.num_v_heads)
+    a = jnp.reshape(a_raw, (batch, seq_len, self.num_v_heads), out_sharding=flat_sharding)
 
     if use_paged_state:
       # =========================================================================
@@ -807,11 +856,11 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
 
     # Flatten head dimensions for concatenation before conv
     # q: (B, S, K_dim)
-    q = query.reshape(batch, seq_len, -1)
+    q = jnp.reshape(query, (batch, seq_len, -1), out_sharding=flat_sharding)
     # k: (B, S, K_dim)
-    k = key.reshape(batch, seq_len, -1)
+    k = jnp.reshape(key, (batch, seq_len, -1), out_sharding=flat_sharding)
     # v: (B, S, V_dim)
-    v = value.reshape(batch, seq_len, -1)
+    v = jnp.reshape(value, (batch, seq_len, -1), out_sharding=flat_sharding)
 
     # =========================================================================
     # STEP B: 1D Convolution
@@ -862,7 +911,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       conv_input = jnp.pad(qkv, ((0, 0), (conv_kernel_size - 1, 0), (0, 0)))
 
     # Perform the convolution.
-    conv_out = self.conv1d(conv_input)
+    conv_out = self.conv1d(conv_input, out_sharding=flat_sharding)
     # Slice the output to match the original input sequence length.
     conv_out = conv_out[:, -seq_len:, :]
     qkv_conv = jax.nn.silu(conv_out.astype(jnp.float32)).astype(cfg.dtype)
@@ -871,17 +920,25 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
 
     # Reshape for multi-head processing
     # query shape: (B, S, H_k, D_k)
-    query = q_conv.reshape(batch, seq_len, self.num_k_heads, self.head_k_dim)
+    query = jnp.reshape(q_conv, (batch, seq_len, self.num_k_heads, self.head_k_dim), out_sharding=head_sharding)
     # key shape: (B, S, H_k, D_k)
-    key = k_conv.reshape(batch, seq_len, self.num_k_heads, self.head_k_dim)
+    key = jnp.reshape(k_conv, (batch, seq_len, self.num_k_heads, self.head_k_dim), out_sharding=head_sharding)
     # value shape: (B, S, H_v, D_v)
-    value = v_conv.reshape(batch, seq_len, self.num_v_heads, self.head_v_dim)
+    value = jnp.reshape(v_conv, (batch, seq_len, self.num_v_heads, self.head_v_dim), out_sharding=head_sharding)
 
     # =========================================================================
     # STEP C: Gated Delta Rule Recurrence
     # =========================================================================
     A_log = jnp.asarray(self.A_log[...], dtype=cfg.dtype)
     dt_bias = jnp.asarray(self.dt_bias[...], dtype=cfg.dtype)
+    if cfg.shard_mode == ShardMode.EXPLICIT:
+      # Both are stored replicated but broadcast against (B, S, H_v) activations whose
+      # head axis is sharded, and explicit sharding requires broadcast operands to
+      # agree -- the same fix `_align_scale_with_normalized_axis` applies to the norm
+      # scales.
+      head_spec = jax.sharding.PartitionSpec(jax.typeof(a).sharding.spec[-1])
+      A_log = jax.sharding.reshard(A_log, head_spec)
+      dt_bias = jax.sharding.reshard(dt_bias, head_spec)
     # beta shape: (B, S, H_v)
     beta = jax.nn.sigmoid(b)
     # g shape: (B, S, H_v)
@@ -897,9 +954,9 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     if self.num_v_heads > self.num_k_heads and self.num_v_heads % self.num_k_heads == 0:
       repeats = self.num_v_heads // self.num_k_heads
       # query shape after repeat: (B, S, H_v, D_k)
-      query = jnp.repeat(query, repeats, axis=2)
+      query = jnp.repeat(query, repeats, axis=2, out_sharding=head_sharding)
       # key shape after repeat: (B, S, H_v, D_k)
-      key = jnp.repeat(key, repeats, axis=2)
+      key = jnp.repeat(key, repeats, axis=2, out_sharding=head_sharding)
 
     if seq_len == 1 and model_mode == MODEL_MODE_AUTOREGRESSIVE:
       core_attn_out, next_recurrent_state = jax_ar_gated_delta_rule(
@@ -917,7 +974,11 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       recurrent_state_arg = (
           recurrent_state
           if recurrent_state is not None
-          else jnp.zeros((batch, self.num_v_heads, self.head_k_dim, self.head_v_dim), dtype=cfg.dtype)
+          else jnp.zeros(
+              (batch, self.num_v_heads, self.head_k_dim, self.head_v_dim),
+              dtype=cfg.dtype,
+              out_sharding=state_sharding,
+          )
       )
       # LENGTH, not None. The sequence axis was hardcoded to replicated, so
       # ici_context_parallelism could never shard the GDN sequence while still
@@ -953,6 +1014,17 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
           dims=(0,),
           allow_remove_axes=True,
       )
+
+      if cfg.shard_mode == ShardMode.EXPLICIT:
+        # shard_map manualises the mesh axes it is given and will not insert a reshard
+        # for an operand whose layout differs from `in_specs`, so hand it arrays that
+        # already match.
+        query = jax.sharding.reshard(query, qkv_pspec)
+        key = jax.sharding.reshard(key, qkv_pspec)
+        value = jax.sharding.reshard(value, qkv_pspec)
+        g = jax.sharding.reshard(g, g_beta_pspec)
+        beta = jax.sharding.reshard(beta, g_beta_pspec)
+        recurrent_state_arg = jax.sharding.reshard(recurrent_state_arg, state_pspec)
 
       @functools.partial(
           jax.shard_map,
@@ -1026,14 +1098,14 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     # The normalization and gating is applied per-head on the value dimension.
 
     # Apply the norm and gate. Output shape: (B, S, H_v, D_v)
-    gated_output_reshaped = self.norm(core_attn_out, z)
+    gated_output_reshaped = self.norm(core_attn_out, z, out_sharding=head_sharding)
 
     # Reshape back to a single feature dimension for the final projection.
     # Shape from (B, S, H_v, D_v) -> (B, S, value_dim)
-    gated_output = gated_output_reshaped.reshape(batch, seq_len, -1)
+    gated_output = jnp.reshape(gated_output_reshaped, (batch, seq_len, -1), out_sharding=flat_sharding)
 
     # Final output shape: (B, S, E)
-    output = self.out_proj(gated_output)
+    output = self.out_proj(gated_output, out_sharding=out_sharding)
 
     return output, active_cache
 
@@ -1138,6 +1210,7 @@ class Qwen3NextFullAttention(nnx.Module):
       model_mode: str,
       kv_cache: None | jnp.ndarray = None,
       attention_metadata: None | dict[str, Any] = None,
+      out_sharding: jax.sharding.NamedSharding | None = None,
   ):
     attention_output, kv_cache = self.attention(
         inputs_q=inputs,
@@ -1148,6 +1221,7 @@ class Qwen3NextFullAttention(nnx.Module):
         model_mode=model_mode,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
+        out_sharding=out_sharding,
     )
     return attention_output, kv_cache
 
@@ -1225,6 +1299,8 @@ class Qwen3NextSparseMoeBlock(nnx.Module):
       hidden_states: Array,
       deterministic: bool,
       forced_routed_experts: jnp.ndarray | None = None,
+      intermediate_sharding: jax.sharding.NamedSharding | None = None,
+      out_sharding: jax.sharding.NamedSharding | None = None,
   ) -> tuple[Array, Array | None]:
     """
     Applies the sparse MoE block to the input hidden states.
@@ -1232,6 +1308,10 @@ class Qwen3NextSparseMoeBlock(nnx.Module):
     Args:
       hidden_states: The input array from the previous layer. Shape: (batch, seq, embed_dim)
       deterministic: If True, disables dropout.
+      intermediate_sharding: Optional layout for the shared expert's intermediate
+        activation, honoured only under `ShardMode.EXPLICIT`.
+      out_sharding: Optional layout for the block output, honoured only under
+        `ShardMode.EXPLICIT`.
 
     Returns:
       A tuple containing:
@@ -1239,15 +1319,23 @@ class Qwen3NextSparseMoeBlock(nnx.Module):
         - The load balancing loss from the routed experts, if applicable during training.
     """
     # 1. Apply the routed experts block.
-    routed_output, load_balance_loss, _ = self.routed_experts(hidden_states, forced_routed_experts=forced_routed_experts)
+    routed_output, load_balance_loss, _ = self.routed_experts(
+        hidden_states, out_sharding=out_sharding, forced_routed_experts=forced_routed_experts
+    )
 
     if not self.use_shared_expert:
       return routed_output, load_balance_loss
 
     # 2. Apply the shared expert.
-    shared_expert_output = self.shared_expert(hidden_states, deterministic=deterministic)
+    shared_expert_output = self.shared_expert(
+        hidden_states,
+        deterministic=deterministic,
+        intermediate_sharding=intermediate_sharding,
+        out_sharding=out_sharding,
+    )
 
-    # 3. Apply the gate for the shared expert.
+    # 3. Apply the gate for the shared expert. The output is (batch, seq, 1), so it
+    # carries no feature axis to pin and takes the default layout.
     shared_gate_output = self.shared_expert_gate(hidden_states)
 
     # 4. Combine the outputs.
@@ -1356,6 +1444,20 @@ class Qwen3NextScannableBlock(nnx.Module):
       )
     else:
       self.global_layer = None
+
+    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    # Same convention as Qwen3NextDecoderLayer: pin the carry under ShardMode.EXPLICIT,
+    # and leave the AUTO path free of sharding constraints so XLA keeps its fusions.
+    if cfg.shard_mode == ShardMode.EXPLICIT:
+      self._maybe_shard_with_logical = functools.partial(
+          maybe_shard_with_logical,
+          mesh=mesh,
+          shard_mode=cfg.shard_mode,
+          debug_sharding=cfg.debug_sharding,
+          extra_stack_level=1,
+      )
+    else:
+      self._maybe_shard_with_logical = lambda inputs, *args, **kwargs: inputs
 
   def _run_layer(self, layer, y, layer_kwargs, kv_cache=None):
     """Invokes one Qwen3NextDecoderLayer, returning (output, updated_kv_cache)."""
@@ -1479,7 +1581,7 @@ class Qwen3NextScannableBlock(nnx.Module):
     """
     cfg = self.config
     inputs = carry
-    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
 
     layer_kwargs = {
         "decoder_segment_ids": decoder_segment_ids,
@@ -1541,6 +1643,26 @@ class Qwen3NextDecoderLayer(nnx.Module):
     self.quant = quant
     cfg = self.config
     self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    self.mlp_activation_axis_names = ("activation_batch", "activation_norm_length", "activation_mlp")
+
+    # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore these and let GSPMD infer the layout.
+    if cfg.shard_mode == ShardMode.EXPLICIT:
+      self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
+      self.mlp_intermediate_sharding = create_sharding(
+          mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules()
+      )
+      self._maybe_shard_with_logical = functools.partial(
+          maybe_shard_with_logical,
+          mesh=mesh,
+          shard_mode=cfg.shard_mode,
+          debug_sharding=cfg.debug_sharding,
+          extra_stack_level=1,
+      )
+    else:
+      self.out_sharding = None
+      self.mlp_intermediate_sharding = None
+      self._maybe_shard_with_logical = lambda inputs, *args, **kwargs: inputs
 
     # First LayerNorm, applied before the attention block.
     self.input_layernorm = Qwen3NextRMSNorm(
@@ -1548,6 +1670,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
         epsilon=cfg.normalization_layer_epsilon,
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
+        shard_mode=cfg.shard_mode,
         rngs=rngs,
     )
 
@@ -1581,6 +1704,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
         epsilon=cfg.normalization_layer_epsilon,
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
+        shard_mode=cfg.shard_mode,
         rngs=rngs,
     )
 
@@ -1602,11 +1726,12 @@ class Qwen3NextDecoderLayer(nnx.Module):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):
       inputs = inputs[0]
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     residual = inputs
 
     # First LayerNorm, applied before the attention block.
-    hidden_states = self.input_layernorm(inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self.input_layernorm(inputs, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Conditionally apply either the Linear Attention or Full Attention block.
     if isinstance(self.attention, Qwen3NextFullAttention):
@@ -1618,6 +1743,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
           model_mode,
           kv_cache=kv_cache,  # pyrefly: ignore[bad-argument-type]
           attention_metadata=attention_metadata,
+          out_sharding=self.out_sharding,
       )
     else:
       attention_output, new_kv_cache = cast(Qwen3NextGatedDeltaNet, self.attention)(
@@ -1626,21 +1752,28 @@ class Qwen3NextDecoderLayer(nnx.Module):
           kv_cache=kv_cache,
           decoder_segment_ids=decoder_segment_ids,
           attention_metadata=attention_metadata,
+          out_sharding=self.out_sharding,
       )
 
     # First residual connection after attention
+    attention_output = self._maybe_shard_with_logical(attention_output, self.activation_axis_names)
     hidden_states = residual + attention_output
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Prepare for the MoE block by capturing the new residual
     residual = hidden_states
 
     # Second LayerNorm, applied before the MoE block.
-    hidden_states = self.post_attention_layernorm(hidden_states)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self.post_attention_layernorm(hidden_states, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Instantiate and call our `Qwen3NextSparseMoeBlock`.
-    mlp_output, load_balance_loss = self.mlp(hidden_states, deterministic=deterministic)
+    mlp_output, load_balance_loss = self.mlp(
+        hidden_states,
+        deterministic=deterministic,
+        intermediate_sharding=self.mlp_intermediate_sharding,
+        out_sharding=self.out_sharding,
+    )
 
     # We sow the load balancing loss so it can be collected and added to the total loss
     # during training.
@@ -1648,8 +1781,9 @@ class Qwen3NextDecoderLayer(nnx.Module):
       self.moe_lb_loss = nnx.Intermediate(load_balance_loss)
 
     # Final residual connection (after the MoE block)
+    mlp_output = self._maybe_shard_with_logical(mlp_output, self.activation_axis_names)
     layer_output = residual + mlp_output
-    layer_output = nn.with_logical_constraint(
+    layer_output = self._maybe_shard_with_logical(
         layer_output,
         self.activation_axis_names,
     )

--- a/src/maxtext/models/qwen3_5.py
+++ b/src/maxtext/models/qwen3_5.py
@@ -16,20 +16,21 @@
 # pylint: disable=arguments-differ
 # pylint: disable=no-name-in-module
 
+import functools
 from typing import Any, cast
 
 from jax.sharding import Mesh
 import jax.numpy as jnp
 
-from flax import linen as nn
 from flax import nnx
 
-from maxtext.common.common_types import Config, Array
+from maxtext.common.common_types import Config, Array, ShardMode
 from maxtext.layers import initializers as max_initializers
 from maxtext.layers import nnx_wrappers
 from maxtext.layers.normalizations import Qwen3NextRMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.utils import max_utils
+from maxtext.utils.sharding import create_sharding, get_logical_axis_rules, maybe_shard_with_logical
 
 from maxtext.models.qwen3 import (
     Qwen3NextGatedDeltaNet,
@@ -138,6 +139,26 @@ class Qwen3_5DecoderLayer(nnx.Module):
     self.quant = quant
     cfg = self.config
     self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    self.mlp_activation_axis_names = ("activation_batch", "activation_norm_length", "activation_mlp")
+
+    # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore these and let GSPMD infer the layout.
+    if cfg.shard_mode == ShardMode.EXPLICIT:
+      self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
+      self.mlp_intermediate_sharding = create_sharding(
+          mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules()
+      )
+      self._maybe_shard_with_logical = functools.partial(
+          maybe_shard_with_logical,
+          mesh=mesh,
+          shard_mode=cfg.shard_mode,
+          debug_sharding=cfg.debug_sharding,
+          extra_stack_level=1,
+      )
+    else:
+      self.out_sharding = None
+      self.mlp_intermediate_sharding = None
+      self._maybe_shard_with_logical = lambda inputs, *args, **kwargs: inputs
 
     # First LayerNorm, applied before the attention block.
     self.input_layernorm = Qwen3NextRMSNorm(
@@ -145,6 +166,7 @@ class Qwen3_5DecoderLayer(nnx.Module):
         epsilon=cfg.normalization_layer_epsilon,
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
+        shard_mode=cfg.shard_mode,
         rngs=rngs,
     )
 
@@ -174,6 +196,7 @@ class Qwen3_5DecoderLayer(nnx.Module):
         epsilon=cfg.normalization_layer_epsilon,
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
+        shard_mode=cfg.shard_mode,
         rngs=rngs,
     )
 
@@ -196,11 +219,12 @@ class Qwen3_5DecoderLayer(nnx.Module):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):
       inputs = inputs[0]
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     residual = inputs
 
     # First LayerNorm, applied before the attention block.
-    hidden_states = self.input_layernorm(inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self.input_layernorm(inputs, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Conditionally apply either the Linear Attention or Full Attention block.
     if isinstance(self.attention, Qwen3_5FullAttention):
@@ -212,6 +236,7 @@ class Qwen3_5DecoderLayer(nnx.Module):
           model_mode,
           kv_cache=kv_cache,
           attention_metadata=attention_metadata,
+          out_sharding=self.out_sharding,
       )
     else:
       attention_output, new_kv_cache = cast(Qwen3_5GatedDeltaNet, self.attention)(
@@ -220,24 +245,28 @@ class Qwen3_5DecoderLayer(nnx.Module):
           kv_cache=kv_cache,
           decoder_segment_ids=decoder_segment_ids,
           attention_metadata=attention_metadata,
+          out_sharding=self.out_sharding,
       )
 
     # First residual connection after attention
+    attention_output = self._maybe_shard_with_logical(attention_output, self.activation_axis_names)
     hidden_states = residual + attention_output
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Prepare for the MoE block by capturing the new residual
     residual = hidden_states
 
     # Second LayerNorm, applied before the MoE block.
-    hidden_states = self.post_attention_layernorm(hidden_states)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self.post_attention_layernorm(hidden_states, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Instantiate and call our `Qwen3_5SparseMoEBlock`.
     mlp_output, load_balance_loss = self.mlp(
         hidden_states,
         deterministic=deterministic,
         forced_routed_experts=forced_routed_experts,
+        intermediate_sharding=self.mlp_intermediate_sharding,
+        out_sharding=self.out_sharding,
     )
 
     # We sow the load balancing loss so it can be collected and added to the total loss
@@ -246,8 +275,9 @@ class Qwen3_5DecoderLayer(nnx.Module):
       self.sow(nnx.Intermediate, "moe_lb_loss", load_balance_loss)
 
     # Final residual connection (after the MoE block)
+    mlp_output = self._maybe_shard_with_logical(mlp_output, self.activation_axis_names)
     layer_output = residual + mlp_output
-    layer_output = nn.with_logical_constraint(
+    layer_output = self._maybe_shard_with_logical(
         layer_output,
         self.activation_axis_names,
     )

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -195,6 +195,65 @@ class TrainTests(unittest.TestCase):
       rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
   ]
 
+  # Four layers is one whole `inhomogeneous_layer_cycle_interval`, so both the
+  # gated-delta-net and the full-attention layer run. head_dim has to stay at 256
+  # because `mrope_section` sums to head_dim * partial_rotary_factor / 2.
+  _qwen3_5_overrides = [
+      "model_name=qwen3.5-35b-a3b",
+      "override_model_config=True",
+      "base_num_decoder_layers=4",
+      "base_emb_dim=256",
+      "base_mlp_dim=256",
+      "base_moe_mlp_dim=256",
+      "base_num_query_heads=8",
+      "base_num_kv_heads=8",
+      "head_dim=256",
+      "num_experts=8",
+      "num_experts_per_tok=2",
+      "gdn_num_key_heads=4",
+      "gdn_num_value_heads=8",
+      "gdn_key_head_dim=64",
+      "gdn_value_head_dim=64",
+      "vocab_size=2048",
+      "max_target_length=256",
+      # RoutedMoE.dense_matmul is not onboarded to explicit sharding yet.
+      "sparse_matmul=True",
+      "megablox=True",
+      # The Qwen3.5 model configs default to a HuggingFace tokenizer that is not
+      # vendored in the repo; use the checked-in tiktoken asset instead.
+      "tokenizer_type=tiktoken",
+      rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+  ]
+
+  # Same sublayers as Qwen3.5, wired together by Qwen3NextScannableBlock rather than a
+  # Python loop. No MRoPE, so head_dim is free.
+  _qwen3_next_overrides = [
+      "model_name=qwen3-next-80b-a3b",
+      "override_model_config=True",
+      "base_num_decoder_layers=4",
+      "base_emb_dim=256",
+      "base_mlp_dim=256",
+      "base_moe_mlp_dim=256",
+      "base_num_query_heads=8",
+      "base_num_kv_heads=8",
+      "head_dim=128",
+      "num_experts=8",
+      "num_experts_per_tok=2",
+      "gdn_num_key_heads=4",
+      "gdn_num_value_heads=8",
+      "gdn_key_head_dim=64",
+      "gdn_value_head_dim=64",
+      "vocab_size=2048",
+      "max_target_length=256",
+      "sparse_matmul=True",
+      "megablox=True",
+  ]
+
+  _QWEN3_HYBRID_MODELS = {
+      "qwen3_5": _qwen3_5_overrides,
+      "qwen3_next": _qwen3_next_overrides,
+  }
+
   CONFIGS = {
       "base": [  # short test for train.py with TFDS c4
           None,
@@ -747,8 +806,8 @@ class TrainTests(unittest.TestCase):
     ]
     train_main(zero1_ga)
 
-  def _qwen3_losses(self, run_name, extra_args):
-    """Trains a tiny Qwen3 model for a few steps and returns its per-step losses."""
+  def _losses(self, run_name, model_overrides, extra_args):
+    """Trains a tiny model for a few steps and returns its per-step losses."""
     with tempfile.TemporaryDirectory() as tmp_dir:
       metrics_file = os.path.join(tmp_dir, "metrics.txt")
       train_main(
@@ -764,11 +823,15 @@ class TrainTests(unittest.TestCase):
               "enable_checkpointing=False",
               "enable_goodput_recording=False",
           ]
-          + self._qwen3_overrides
+          + list(model_overrides)
           + list(extra_args)
       )
       with open(metrics_file, "rt", encoding="utf8") as f:
         return [json.loads(line)["learning/loss"] for line in f if line.strip()]
+
+  def _qwen3_losses(self, run_name, extra_args):
+    """Trains a tiny Qwen3 model for a few steps and returns its per-step losses."""
+    return self._losses(run_name, self._qwen3_overrides, extra_args)
 
   @pytest.mark.integration_test
   @pytest.mark.tpu_only
@@ -834,26 +897,7 @@ class TrainTests(unittest.TestCase):
 
   def _mistral_losses(self, run_name, extra_args):
     """Trains a tiny Mistral/Mixtral model for a few steps and returns its per-step losses."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-      metrics_file = os.path.join(tmp_dir, "metrics.txt")
-      train_main(
-          [
-              None,
-              get_test_config_path(),
-              f"base_output_directory={self._base_output_directory}",
-              f"dataset_path={self.dataset_path}",
-              f"run_name={run_name}",
-              f"metrics_file={metrics_file}",
-              "dataset_type=synthetic",
-              "steps=3",
-              "enable_checkpointing=False",
-              "enable_goodput_recording=False",
-          ]
-          + self._mistral_overrides
-          + list(extra_args)
-      )
-      with open(metrics_file, "rt", encoding="utf8") as f:
-        return [json.loads(line)["learning/loss"] for line in f if line.strip()]
+    return self._losses(run_name, self._mistral_overrides, extra_args)
 
   @pytest.mark.integration_test
   @pytest.mark.tpu_only
@@ -920,29 +964,6 @@ class TrainTests(unittest.TestCase):
         self.assertTrue(baseline, "baseline run produced no metrics")
         # ZeRO-1 reassociates the gradient all-reduce, so allow a little float slack.
         np.testing.assert_allclose(sharded, baseline, rtol=1e-4, atol=0.0)
-
-  def _losses(self, run_name, model_overrides, extra_args):
-    """Trains a tiny model for a few steps and returns its per-step losses."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-      metrics_file = os.path.join(tmp_dir, "metrics.txt")
-      train_main(
-          [
-              None,
-              get_test_config_path(),
-              f"base_output_directory={self._base_output_directory}",
-              f"dataset_path={self.dataset_path}",
-              f"run_name={run_name}",
-              f"metrics_file={metrics_file}",
-              "dataset_type=synthetic",
-              "steps=3",
-              "enable_checkpointing=False",
-              "enable_goodput_recording=False",
-          ]
-          + list(model_overrides)
-          + list(extra_args)
-      )
-      with open(metrics_file, "rt", encoding="utf8") as f:
-        return [json.loads(line)["learning/loss"] for line in f if line.strip()]
 
   @pytest.mark.integration_test
   @pytest.mark.tpu_only
@@ -1015,6 +1036,78 @@ class TrainTests(unittest.TestCase):
         )
         print(f"[{case}] auto + GA losses: {baseline}", flush=True)
         print(f"[{case}] explicit + ZeRO-1 + GA losses: {sharded}", flush=True)
+        self.assertTrue(baseline, "baseline run produced no metrics")
+        # ZeRO-1 reassociates the gradient all-reduce, so allow a little float slack.
+        np.testing.assert_allclose(sharded, baseline, rtol=1e-4, atol=0.0)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  def test_tpu_qwen3_hybrid_explicit_sharding_matches_auto(self):
+    """Explicit sharding only changes how layouts are expressed, so the losses must not move.
+
+    The two decoders share every sublayer, so each is paired with the parallelism that
+    stresses a different half of it: expert parallelism shards the MoE dispatch, and
+    tensor parallelism shards the gated-delta-net head axis, which is the one the layer
+    has to carry by hand across its reshapes, its head repeat and the `jax.shard_map`
+    boundary. Qwen3-Next takes the latter because it also nests two `jax.lax.scan`s,
+    whose carry layout has to stay invariant across iterations.
+    """
+    parallelism = {
+        "qwen3_5": ["ici_fsdp_parallelism=1", "ici_expert_parallelism=-1"],
+        # The gated-delta-net weights stay replicated under tensor parallelism, which is
+        # a large fraction of a model this small, so relax the unsharded-parameter check.
+        "qwen3_next": ["ici_fsdp_parallelism=1", "ici_tensor_parallelism=-1", "sharding_tolerance=0.5"],
+    }
+    for decoder_block, model_overrides in self._QWEN3_HYBRID_MODELS.items():
+      with self.subTest(decoder_block=decoder_block):
+        args = parallelism[decoder_block]
+        auto_losses = self._losses(f"{decoder_block}_auto", model_overrides, args + ["shard_mode=auto"])
+        explicit_losses = self._losses(f"{decoder_block}_explicit", model_overrides, args + ["shard_mode=explicit"])
+        print(f"[{decoder_block}] auto losses: {auto_losses}", flush=True)
+        print(f"[{decoder_block}] explicit losses: {explicit_losses}", flush=True)
+        self.assertTrue(auto_losses, "auto run produced no metrics")
+        # `activation_batch` carries the expert axis, so pinning it reassociates the
+        # backward reductions: the forward pass is bit-for-bit and the drift only appears
+        # once gradients flow. Over 20 steps it stays below 4e-5 relative and changes
+        # sign, i.e. it is float noise rather than the two runs pulling apart.
+        np.testing.assert_allclose(explicit_losses, auto_losses, rtol=1e-4, atol=0.0)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  # TODO(b/517509898): Skip ZeRo-1 compiler Segfault on TPU7x SparseCore platforms
+  @pytest.mark.skip_on_tpu7x
+  def test_tpu_qwen3_hybrid_zero1_gradient_accumulation(self):
+    """ZeRO-1 only shards the optimizer state, so it must not change the loss trajectory.
+
+    Under explicit sharding this routes the accumulated gradients through the
+    `reduced`/`unreduced` PartitionSpec labels applied in
+    `maxtext.utils.gradient_accumulation`, and casts the parameters to bf16 before the
+    accumulation scan so the all-gather happens once in low precision rather than once
+    per microbatch.
+    """
+    zero1_ga = [
+        "remat_policy=minimal",
+        "per_device_batch_size=2",
+        "ici_data_parallelism=-1",
+        "dcn_data_parallelism=1",
+        "ici_fsdp_parallelism=1",
+        "dcn_fsdp_parallelism=1",
+        "gradient_accumulation_steps=8",
+    ]
+    for decoder_block, model_overrides in self._QWEN3_HYBRID_MODELS.items():
+      with self.subTest(decoder_block=decoder_block):
+        baseline = self._losses(
+            f"{decoder_block}_ga",
+            model_overrides,
+            zero1_ga + ["shard_mode=auto", "shard_optimizer_over_data=False"],
+        )
+        sharded = self._losses(
+            f"{decoder_block}_ga_zero1",
+            model_overrides,
+            zero1_ga + ["shard_mode=explicit", "shard_optimizer_over_data=True"],
+        )
+        print(f"[{decoder_block}] auto + GA losses: {baseline}", flush=True)
+        print(f"[{decoder_block}] explicit + ZeRO-1 + GA losses: {sharded}", flush=True)
         self.assertTrue(baseline, "baseline run produced no metrics")
         # ZeRO-1 reassociates the gradient all-reduce, so allow a little float slack.
         np.testing.assert_allclose(sharded, baseline, rtol=1e-4, atol=0.0)

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -240,7 +240,7 @@ class PyconfigTest(unittest.TestCase):
 
   def test_explicit_sharding_qwen3_decoder_support(self):
     """The Qwen3 decoders that have been onboarded to explicit sharding are accepted."""
-    for decoder_block in ("qwen3", "qwen3_moe", "qwen3_custom_moe"):
+    for decoder_block in ("qwen3", "qwen3_moe", "qwen3_custom_moe", "qwen3_5", "qwen3_next"):
       with self.subTest(decoder_block=decoder_block):
         config = pyconfig.initialize(
             [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
@@ -250,18 +250,7 @@ class PyconfigTest(unittest.TestCase):
         )
         self.assertEqual(config.decoder_block.value, decoder_block)
 
-    # Qwen3-Next and Qwen3.5 use gated-delta-net linear attention, and the
-    # Qwen3-VL/Omni encoders are multimodal; neither is onboarded yet.
-    for decoder_block in ("qwen3_next", "qwen3_5"):
-      with self.subTest(decoder_block=decoder_block):
-        with self.assertRaisesRegex(Exception, "not supported with 'explicit' sharding"):
-          pyconfig.initialize(
-              [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
-              skip_jax_distributed_system=True,
-              shard_mode="explicit",
-              decoder_block=decoder_block,
-          )
-
+    # The Qwen3-VL/Omni encoders are multimodal and are not onboarded yet.
     with self.assertRaisesRegex(Exception, "not supported with `use_multimodal`"):
       pyconfig.initialize(
           [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
@@ -272,6 +261,29 @@ class PyconfigTest(unittest.TestCase):
           use_multimodal=True,
           scan_layers=False,  # Required by the Qwen3-VL deepstack path; unrelated to sharding.
       )
+
+  def test_explicit_sharding_gated_delta_net_unsupported_combinations(self):
+    """The hybrid Qwen3 decoders reject the combinations they have not been onboarded to."""
+    for decoder_block in ("qwen3_5", "qwen3_next"):
+
+      def initialize(decoder_block=decoder_block, **kwargs):
+        return pyconfig.initialize(
+            [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+            skip_jax_distributed_system=True,
+            shard_mode="explicit",
+            decoder_block=decoder_block,
+            **kwargs,
+        )
+
+      with self.subTest(decoder_block=decoder_block):
+        with self.assertRaisesRegex(Exception, "requires `sparse_matmul=True`"):
+          initialize(sparse_matmul=False, megablox=False)
+
+        with self.assertRaisesRegex(Exception, "does not support context parallelism"):
+          initialize(ici_context_parallelism=2)
+
+        with self.assertRaisesRegex(Exception, "does not support context parallelism"):
+          initialize(ici_context_usp_ulysses_parallelism=2)
 
   def test_explicit_sharding_mistral_decoder_support(self):
     """The Mistral-family decoders that have been onboarded to explicit sharding are accepted."""

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -1140,6 +1140,128 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
+  def test_qwen3_next_explicit_sharding(self):
+    """AOT test for qwen3-next under explicit sharding, at FSDP 32 x expert 8.
+
+    `Qwen3NextScannableBlock` nests two `jax.lax.scan`s, whose carry layout has to stay
+    invariant across iterations; that only holds if the decoder layer returns the
+    layout it was handed.
+    """
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_qwen3_next_explicit_sharding.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-512",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3-next-80b-a3b",
+            "per_device_batch_size=1.0",
+            "max_target_length=1024",
+            "ici_fsdp_parallelism=32",
+            "ici_expert_parallelism=8",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "use_tokamax_splash=True",
+            "shard_mode=explicit",
+        )
+    )
+
+  def test_qwen3_next_explicit_sharding_zero1(self):
+    """AOT test for qwen3-next under explicit sharding with ZeRO-1 and gradient accumulation."""
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_qwen3_next_explicit_sharding_zero1.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-256",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3-next-80b-a3b",
+            "override_model_config=True",
+            "base_num_decoder_layers=4",
+            "per_device_batch_size=1.0",
+            "max_target_length=1024",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "use_tokamax_splash=True",
+            "shard_mode=explicit",
+            "ici_data_parallelism=-1",
+            "ici_fsdp_parallelism=1",
+            "gradient_accumulation_steps=4",
+            "shard_optimizer_over_data=True",
+        )
+    )
+
+  def test_qwen3_5_explicit_sharding(self):
+    """AOT test for qwen3-5 under explicit sharding, at FSDP 32 x expert 8.
+
+    Explicit sharding type-checks every operation's layout instead of letting GSPMD
+    infer one, so a missing `out_sharding` fails the trace here rather than silently
+    costing a collective at a scale a real test cannot reach.
+    """
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_qwen3_5_explicit_sharding.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-512",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3.5-397b-a17b",
+            "per_device_batch_size=1.0",
+            "max_target_length=1024",
+            "ici_fsdp_parallelism=32",
+            "ici_expert_parallelism=8",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "use_tokamax_splash=True",
+            "shard_mode=explicit",
+            # Qwen3.5 defaults to a HuggingFace tokenizer that is not vendored.
+            "tokenizer_type=tiktoken",
+            f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+        )
+    )
+
+  def test_qwen3_5_explicit_sharding_zero1(self):
+    """AOT test for qwen3-5 under explicit sharding with ZeRO-1 and gradient accumulation.
+
+    ZeRO-1 shards the optimizer moments over "data", so the parameters are all-gathered
+    in bf16 once before the accumulation scan rather than once per microbatch; that
+    reshard only type-checks if the decoder pins its activation layouts. Four layers is
+    one full `inhomogeneous_layer_cycle_interval`, which covers both attention variants
+    while staying small enough to hold data-parallel replicas of the parameters.
+    """
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_qwen3_5_explicit_sharding_zero1.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-256",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3.5-35b-a3b",
+            "override_model_config=True",
+            "base_num_decoder_layers=4",
+            "per_device_batch_size=1.0",
+            "max_target_length=1024",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "use_tokamax_splash=True",
+            "shard_mode=explicit",
+            "ici_data_parallelism=-1",
+            "ici_fsdp_parallelism=1",
+            "gradient_accumulation_steps=4",
+            "shard_optimizer_over_data=True",
+            "tokenizer_type=tiktoken",
+            f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+        )
+    )
+
   def test_serialization_and_deserialization_formats(self):
     """Tests that our custom binary save/load functions work securely and legacy fallback triggers warning."""
 


### PR DESCRIPTION
# Description

Onboards the `qwen3_5` and `qwen3_next` decoder blocks to `shard_mode=explicit`, and
adds ZeRO-1 + efficient gradient accumulation coverage on top of them.

The two are the hybrid members of the Qwen3 family: both interleave GatedDeltaNet
linear attention with a full-attention layer every
`inhomogeneous_layer_cycle_interval` layers, on top of a fully-MoE block with a shared
expert. Qwen3.5 subclasses the Qwen3-Next sublayers outright, so almost all of the work
is shared. Two commits:

1. **`Onboard Qwen3.5 to explicit sharding and ZeRO-1 gradient accumulation`** — the
   shared sublayers plus `Qwen3_5DecoderLayer`.
2. **`Onboard Qwen3-Next to explicit sharding`** — `Qwen3NextDecoderLayer` and
   `Qwen3NextScannableBlock`, which is the only structural difference between the two.

## The decoder layers

`Qwen3_5DecoderLayer`, `Qwen3NextDecoderLayer` and `Qwen3NextScannableBlock` all still
expressed their activation layouts with `nn.with_logical_constraint`, so
`shard_mode=explicit` rejected both blocks at config validation time. They now use the
same pattern the Qwen3, Qwen2 and DeepSeek layers already use: cache the physical
`NamedSharding`s in `__init__`, pin every sublayer output through
`maybe_shard_with_logical`, and thread `out_sharding` / `intermediate_sharding` into
the norms, both attention variants and the MoE block. Under `ShardMode.AUTO` the
callees ignore those arguments and the constraints become no-ops, matching the pattern
`cdfade207` established for Qwen3 so XLA keeps the fusions it picks today.

`Qwen3NextScannableBlock` is the part that is new relative to Qwen3.5, which runs one
cycle as a plain Python loop. Qwen3-Next puts its linear-attention layers inside
`nnx_scan.apply_scanned_layers` and its lone full-attention layer inside a
trip-count-one `jax.lax.scan`, and both scans require the carry's layout to be
invariant across iterations. That holds because the decoder layer now returns the
layout it was handed, so nothing extra is needed inside the scans themselves.

## The shared sublayers

- **`Qwen3NextGatedDeltaNet`** is the interesting one. Explicit sharding cannot infer a
  layout across its reshapes, its head repeat or the `jax.shard_map` boundary, so each
  intermediate is pinned to the logical axes the auto path already asks GSPMD for (a
  new `_explicit_activation_shardings` helper returns the flat / head / state layouts,
  all `None` under AUTO). `A_log` and `dt_bias` are stored replicated but broadcast
  against `(B, S, H_v)` activations whose head axis is sharded, so they are resharded
  onto the head axis first — the same fix `_align_scale_with_normalized_axis` applies
  to the norm scales. Finally, `shard_map` manualises the mesh axes it is given and
  will not insert a reshard for an operand whose layout differs from `in_specs`, so its
  six operands are resharded to match before the call. The existing
  `with_sharding_constraint` on `mixed_qkvz` is routed through `maybe_shard_with_name`,
  since under EXPLICIT `with_sharding_constraint` is an assertion rather than a hint
  and rejects any layout it would have to change.
- **`Qwen3NextRMSNorm`** was accepting `shard_mode`, `kernel_axes` and
  `parameter_memory_host_offload` and then silently dropping them on the floor; it now
  forwards them to the inner `RMSNorm`. No caller passes the latter two today, so that
  part is a no-op fix.
- **`Qwen3NextRMSNormGated`** had no way to take an `out_sharding`; it now accepts one
  and forwards it.
- **`Attention`** forwards `config.shard_mode` to the hybrid q/k norms.

`Qwen3NextGatedDeltaNet`, `Qwen3NextFullAttention` and `Qwen3NextSparseMoeBlock` all
gained an `out_sharding` keyword (plus `intermediate_sharding` on the MoE block).
Nothing inside the `jax.shard_map` body changed.

## Deliberate gaps

**Two new config guards** reject combinations that have not been onboarded. Both come
from the shared gated-delta-net path, so both apply to `qwen3_5` and `qwen3_next`:

- `sparse_matmul=False` — `RoutedMoE.dense_matmul` is still not onboarded to explicit
  sharding. This gap is shared with `qwen3_moe` and `kimi` and is left for a follow-up.
- context parallelism (`ici/dcn_context_parallelism`,
  `ici/dcn_context_usp_ulysses_parallelism`) — the gated-delta-net short convolution
  left-pads the sequence by `gdn_conv_kernel_dim - 1` and slices the result back, which
  explicit sharding cannot express on a sharded sequence axis. `shard_mode=auto` still
  works there.

The Qwen3-VL / Qwen3-Omni encoders remain unsupported; they are covered by the existing
`use_multimodal` guard.

## Known issue, not fixed here

`shard_mode=explicit` + `shard_optimizer_over_data=True` + `ici_expert_parallelism>1`
fails for **every** MoE model, not just the two here:

```
ShardingTypeError: add got incompatible shardings for broadcasting:
  ('expert', None, None), (('data', 'expert'), None, None)
```

`add_data_to_sharding` prepends `data` to the optimizer mu/nu spec while the gradients
keep the plain params spec. This reproduces on unmodified `main` with `mixtral-8x7b` at
DP2 x EP2 with ZeRO-1 and 4 accumulation steps (it passes under `shard_mode=auto`). The
ZeRO-1 coverage added here is therefore data-parallel only, which is the same coverage
every other onboarded MoE model has. A fix is left for a follow-up.

# Tests

All commands below were run on a v4-8 TPU VM.

**New AOT coverage** (`tests/unit/train_compile_test.py`), one pair per decoder:

- `test_qwen3_5_explicit_sharding` — `qwen3.5-397b-a17b` on `v5p-512`, FSDP 32 x expert
  8, `sparse_matmul`/`megablox`/flash/tokamax-splash.
- `test_qwen3_next_explicit_sharding` — `qwen3-next-80b-a3b` on `v5p-512`, same mesh.
- `test_qwen3_5_explicit_sharding_zero1` and `test_qwen3_next_explicit_sharding_zero1` —
  four-layer variants on `v5p-256`, DP 128, `gradient_accumulation_steps=4`,
  `shard_optimizer_over_data=True`.

These are the large-scale checks: explicit sharding type-checks every operation's
layout instead of letting GSPMD infer one, so a missing `out_sharding` fails the trace
here rather than silently costing a collective at a scale a real test cannot reach.
Four layers is one full `inhomogeneous_layer_cycle_interval`, so both attention
variants are still covered while the model stays small enough to hold data-parallel
replicas of the parameters.

```
$ pytest tests/unit/train_compile_test.py -k "qwen3_5 or qwen3_next" --durations=0
84.11s test_qwen3_5_explicit_sharding          69.10s test_qwen3_5   (existing)
79.57s test_qwen3_5_explicit_sharding_zero1    54.63s test_qwen3_next (existing)
57.16s test_qwen3_next_explicit_sharding
48.74s test_qwen3_next_explicit_sharding_zero1
6 passed in 403s
```

Each new case costs about what the AUTO sibling next to it already costs.

**New TPU integration coverage** (`tests/integration/train_tests.py`), parameterized
over both hybrid decoders rather than duplicated:

- `test_tpu_qwen3_hybrid_explicit_sharding_matches_auto` — explicit vs auto. Following
  the convention `test_tpu_qwen3_explicit_sharding_matches_auto` already uses, each
  decoder is paired with the one parallelism that stresses a different half of the
  shared layer rather than running the cross-product: Qwen3.5 under expert parallelism,
  which shards the MoE dispatch, and Qwen3-Next under tensor parallelism, which shards
  the gated-delta-net head axis — the one the layer has to carry by hand across its
  reshapes, its head repeat and the `shard_map` boundary.
- `test_tpu_qwen3_hybrid_zero1_gradient_accumulation` — explicit + ZeRO-1 + 8
  accumulation steps against the auto, non-ZeRO-1 baseline.

```
$ pytest tests/integration/train_tests.py -k qwen3_hybrid
2 passed, 4 subtests passed in 124s
```

Both run with `scan_layers` on, so the Qwen3-Next subtests exercise the nested scans.
Qwen3-Next was additionally spot-checked with `scan_layers=False` (the unscanned
`Qwen3NextDecoderLayer` path) under both shard modes.

The existing `_qwen3_losses` / `_mistral_losses` helpers were near-identical, so they
are now thin delegates over a shared `_losses(run_name, model_overrides, extra_args)`
rather than more copies being added.

**Numerical note.** Unlike mistral and qwen3, the hybrid decoders are **not**
bit-for-bit between explicit and auto. `activation_batch` carries the expert axis, so
pinning it reassociates the backward reductions rather than leaving the layout
untouched — the forward pass is bit-for-bit and the drift only appears once gradients
flow. Measured over 20 steps it stays below `3.1e-5` relative and changes sign, i.e. it
is float noise rather than the two runs pulling apart, so the parity assertions use
`rtol=1e-4`. For the same reason each decoder's AUTO path itself moves by up to
`2.8e-5` relative against `main` (its `with_logical_constraint` calls become AUTO
no-ops), which is the tradeoff `cdfade207` deliberately made for Qwen3 to restore XLA
fusion.

**New config-validation coverage** (`tests/unit/pyconfig_test.py`): `qwen3_5` and
`qwen3_next` moved into the accepted-decoder loop, and
`test_explicit_sharding_gated_delta_net_unsupported_combinations` covers the two new
guards for both decoders.

```
$ pytest tests/unit/pyconfig_test.py -k "explicit_sharding or zero1"
8 passed, 9 subtests passed in 10s
```

**Regressions checked:**

```
$ pytest tests/integration/train_tests.py \
    -k "qwen3_explicit or mistral_explicit or qwen3_zero1 or mistral_zero1 or gemma_zero1"
5 passed, 13 subtests passed in 199s

$ pytest tests/unit/qwen3_next_shared_expert_test.py tests/unit/qwen35_partial_mrope_test.py \
    tests/unit/router_replay_test.py tests/unit/sharding_test.py tests/unit/sharding_nnx_test.py \
    tests/unit/maxtext_utils_test.py tests/unit/param_mapping_test.py tests/unit/nnx_decoders_test.py \
    tests/unit/decoder_layer_model_mode_test.py
300 passed, 5 skipped, 5 subtests passed in 762s
```

- The three `attention_test.py` failures that show up when the CPU device count is
  raised above 1 are present unchanged on `main`.
- `tests/integration/hlo_diff_test.py` needs no reference-HLO regeneration: it covers
  deepseek3, llama3-8b and qwen3-1.7b, and no hunk in this PR is reachable from any of
  them (every `qwen3.py` change is inside a `Qwen3Next*` class, and the `attentions.py`
  change is inside the `is_qwen3_hybrid` branch).
- `pylint` reports 9.96/10 on the changed files, with all four remaining messages
  present unchanged on `main`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
