### PR TITLE
fix(checkpointing): use Orbax v1 load in standalone checkpointer rest…

### DIFF
--- a/src/maxtext/utils/standalone_checkpointer.py
+++ b/src/maxtext/utils/standalone_checkpointer.py
@@ -31,6 +31,7 @@ import jax
 from jax import numpy as jnp
 from maxtext.configs import pyconfig
 from maxtext.common import checkpointing
+from maxtext.common import emergency_checkpointing
 from maxtext.common import train_state_nnx
 from maxtext.models import models
 from maxtext.trainers.pre_train.train import get_first_step
@@ -43,6 +44,13 @@ from maxtext.utils.model_creation_utils import from_config
 import numpy as np
 
 Transformer = models.transformer_as_linen
+
+
+def _as_abstract_leaf(leaf):
+  """Shape/dtype/sharding stand-in for a concrete leaf, as an Orbax restore target."""
+  if isinstance(leaf, jax.Array):
+    return jax.ShapeDtypeStruct(leaf.shape, leaf.dtype, sharding=leaf.sharding)
+  return leaf
 
 
 def checkpoint_loop(config, state=None):
@@ -152,9 +160,15 @@ def checkpoint_loop(config, state=None):
             os.system("sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'")
 
           restore_start = datetime.datetime.now()
-          restored_state = checkpoint_manager.restore(int(step))
-          if restored_state:
-            restored_state = restored_state.get("items", restored_state)
+          # Restore against the saved sharding, else the timing below is not a real restore.
+          abstract_state = jax.tree_util.tree_map(_as_abstract_leaf, state_to_save)
+          if isinstance(
+              checkpoint_manager,
+              (checkpointing.EmergencyCheckpointManager, checkpointing.EmergencyReplicatorCheckpointManager),
+          ):
+            restored_state = emergency_checkpointing.restore(checkpoint_manager, int(step), abstract_state)
+          else:
+            restored_state = checkpoint_manager.load_checkpointables(int(step), {"items": abstract_state})["items"]
           jax.block_until_ready(restored_state)
           restore_end = datetime.datetime.now()
           if jax.process_index() == 0:

--- a/tests/unit/mmap_data_processing_test.py
+++ b/tests/unit/mmap_data_processing_test.py
@@ -1904,6 +1904,8 @@ class GrainMmapNpyEvalConfigTest(TestCase):
         grain_data_source_max_workers=1,
         eval_data_columns=("text",),
         tokenize_eval_data=False,
+        use_sft=False,
+        use_multimodal=False,
         colocated_python_data_input=False,
         generate_padding_batch_eval=False,
     )

--- a/tests/unit/standalone_checkpointer_nnx_test.py
+++ b/tests/unit/standalone_checkpointer_nnx_test.py
@@ -119,7 +119,7 @@ class CheckpointLoopTest(unittest.TestCase):
     config = self._create_mock_config(start_from_checkpoint=False)
     mock_state = mock.MagicMock()
     mock_ckpt_mgr = mock.MagicMock()
-    mock_ckpt_mgr.restore.return_value = {"items": mock_state}
+    mock_ckpt_mgr.load_checkpointables.return_value = {"items": mock_state}
 
     with (
         mock.patch("maxtext.utils.standalone_checkpointer.from_config"),
@@ -144,14 +144,14 @@ class CheckpointLoopTest(unittest.TestCase):
     mock_setup.assert_called_once()
     mock_sleep.assert_called_once()
     mock_system.assert_called_once_with("sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'")
-    mock_ckpt_mgr.restore.assert_called_once_with(1)
+    mock_ckpt_mgr.load_checkpointables.assert_called_once_with(1, {"items": mock_state})
 
   def test_checkpoint_loop_start_from_checkpoint(self):
     """Tests initializing state from an existing checkpoint."""
     config = self._create_mock_config(start_from_checkpoint=True)
     mock_state = mock.MagicMock()
     mock_ckpt_mgr = mock.MagicMock()
-    mock_ckpt_mgr.restore.return_value = {"items": mock_state}
+    mock_ckpt_mgr.load_checkpointables.return_value = {"items": mock_state}
 
     with (
         mock.patch("maxtext.utils.standalone_checkpointer.from_config"),
@@ -183,7 +183,7 @@ class CheckpointLoopTest(unittest.TestCase):
     config = self._create_mock_config(start_from_checkpoint=True)
     mock_state = mock.MagicMock()
     mock_ckpt_mgr = mock.MagicMock()
-    mock_ckpt_mgr.restore.return_value = {"items": mock_state}
+    mock_ckpt_mgr.load_checkpointables.return_value = {"items": mock_state}
 
     with (
         mock.patch("maxtext.utils.standalone_checkpointer.from_config"),
@@ -216,7 +216,7 @@ class CheckpointLoopTest(unittest.TestCase):
     mock_state = mock.MagicMock()
     mock_state.to_pure_dict.return_value = {"params": {}}
     mock_ckpt_mgr = mock.MagicMock()
-    mock_ckpt_mgr.restore.return_value = {"items": mock_state}
+    mock_ckpt_mgr.load_checkpointables.return_value = {"items": mock_state}
 
     with (
         mock.patch("maxtext.utils.maxtext_utils.get_mesh_from_config"),


### PR DESCRIPTION
…ore loop

The restore-in-loop benchmark path still called the Orbax v0 `CheckpointManager.restore(step)` API. Since the v1 migration in c41b2ae3a, `checkpointing.create_orbax_checkpoint_manager` returns an `ocp.training.Checkpointer`, which has no `restore` method, so `standalone_checkpointer_enable_restore_in_loop` (default true) raised:

  AttributeError: 'Checkpointer' object has no attribute 'restore'

Switch to the symmetric v1 call, `load_checkpointables(step, {"items": ...})`, matching the "items" checkpointable that `save_checkpoint` writes. The abstract target is derived from the state just saved so the restore reproduces the on-disk sharding; without it the v1 loader takes a convenience path that would make the benchmark's restore timing unrepresentative.




*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Fixes tests/integration/standalone_dl_ckpt_test.py::Standalone_DL_CKPT::test_standalone_checkpointer

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
