### PR TITLE
Fix AttributeError on missing use_sft in grain data processing

### DIFF
--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -732,11 +732,11 @@ def vision_sft_preprocessing_pipeline(
 
 def _get_pipeline_fn(config):
   """Returns the appropriate preprocessing pipeline function based on config."""
-  if config.use_sft and config.use_multimodal:
+  if getattr(config, "use_sft", False) and getattr(config, "use_multimodal", False):
     return vision_sft_preprocessing_pipeline
-  if config.use_dpo:
+  if getattr(config, "use_dpo", False):
     return dpo_preprocessing_pipeline
-  if config.use_sft:
+  if getattr(config, "use_sft", False):
     return sft_preprocessing_pipeline
   return pretrain_preprocessing_pipeline
 
@@ -831,8 +831,8 @@ def make_grain_train_iterator(
       "grain_worker_count": config.grain_worker_count,
       "grain_per_worker_buffer_size": config.grain_per_worker_buffer_size,
   }
-  if config.use_sft and config.use_multimodal:
-    preprocessing_fn_kwargs["image_column"] = config.train_image_column
+  if getattr(config, "use_sft", False) and getattr(config, "use_multimodal", False):
+    preprocessing_fn_kwargs["image_column"] = getattr(config, "train_image_column", None)
 
   preprocessing_fn = functools.partial(
       pipeline_fn,
@@ -977,8 +977,8 @@ def make_grain_eval_iterator(
       "grain_worker_count": config.grain_worker_count_eval,
       "grain_per_worker_buffer_size": config.grain_per_worker_buffer_size_eval,
   }
-  if config.use_sft and config.use_multimodal:
-    eval_preprocessing_fn_kwargs["image_column"] = config.eval_image_column
+  if getattr(config, "use_sft", False) and getattr(config, "use_multimodal", False):
+    eval_preprocessing_fn_kwargs["image_column"] = getattr(config, "eval_image_column", None)
 
   preprocessing_fn = functools.partial(
       pipeline_fn,

--- a/tests/unit/mmap_data_processing_test.py
+++ b/tests/unit/mmap_data_processing_test.py
@@ -1906,6 +1906,8 @@ class GrainMmapNpyEvalConfigTest(TestCase):
         tokenize_eval_data=False,
         colocated_python_data_input=False,
         generate_padding_batch_eval=False,
+        use_sft=False,
+        use_multimodal=False,
     )
 
   @staticmethod


### PR DESCRIPTION
## Description
Fixes an `AttributeError: 'types.SimpleNamespace' object has no attribute 'use_sft'` in `make_grain_eval_iterator` caused by a collision between PR #4754 and PR #4625.

- In `src/maxtext/input_pipeline/grain_data_processing.py`, safely check `use_sft`, `use_dpo`, and `use_multimodal` with `getattr(config, ..., False)` in `_get_pipeline_fn`, `make_grain_train_iterator`, and `make_grain_eval_iterator`.
- In `tests/unit/mmap_data_processing_test.py`, define `use_sft=False` and `use_multimodal=False` in `GrainMmapNpyEvalConfigTest._config`.

## Tests
- `pytest tests/unit/mmap_data_processing_test.py -k "GrainMmapNpyEvalConfigTest"` passes.
- All 161 tests in `tests/unit/mmap_data_processing_test.py` pass.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).