### PR TITLE
Defer the engine's live-object publish out of the step path

### DIFF
--- a/src/maxtext/training_engine/maxtext_engine.py
+++ b/src/maxtext/training_engine/maxtext_engine.py
@@ -541,6 +541,8 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     self._compiled_eval: Any = None
     self._compiled_eval_signature: Any = None
     self._signature_compare_warned: bool = False
+    # True when the pure mirror has advanced past the live NNX objects; see `_publish_to_live`.
+    self._live_stale: bool = False
     if not training_config.model_name:
       raise ValueError("training_config.model_name must be specified")
     model_or_model_mesh_pair = model_creation_utils.from_pretrained(
@@ -608,6 +610,7 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
   @property
   def model(self) -> Any:
     """Returns the NNX model instance."""
+    self._sync_live_objects()
     return self._model
 
   @model.setter
@@ -626,6 +629,7 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
   @property
   def optimizer(self) -> Any:
     """Returns the NNX optimizer instance."""
+    self._sync_live_objects()
     return self._optimizer
 
   @optimizer.setter
@@ -654,6 +658,7 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
   @property
   def state(self) -> Any:
     """Returns the current train state, initializing it if necessary."""
+    self._sync_live_objects()
     if self._state is None and self._model is not None and self._optimizer is not None:
       self._state = train_state_nnx.TrainStateNNX(self._model, self._optimizer)
     return self._state
@@ -747,10 +752,55 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
 
     For the three ways the live NNX variables get replaced behind the engine's back: the
     `model`/`optimizer`/`state` setters, and a checkpoint restore.
+
+    Flushes a deferred publish before forgetting the mirror it would have been published
+    from, so dropping the cache never drops a step's results with it.
     """
+    self._sync_live_objects()
     self._params_pure = None
     self._rest_pure = None
     self._state_pure = None
+
+  def _publish_to_live(self, target: Any, pure: Any) -> None:
+    """Writes `pure` into the live NNX objects, or defers it when the mirror can do it.
+
+    `nnx.update` walks the module graph, and its cost is the graph's size rather than the
+    state's: 6.2 ms to publish 180 leaves of non-parameter state into an unrolled 28-layer
+    qwen3-0.6b, once per *micro-batch*, and 16.7 ms for the parameters once per update.
+    That was the last per-step graph walk left after `_refresh_pure_state` removed the
+    `nnx.split`s.
+
+    Nothing inside the step path reads it back -- `_read_model_pure` and `_read_state_pure`
+    answer from the pure mirror, and the live objects are used only as containers -- so the
+    walk is pure publication, for readers outside the engine. It is deferred to
+    `_sync_live_objects`, which the property getters and every method that reads real
+    values call first.
+
+    Deferral is only possible while the mirror is authoritative. With the pure state
+    disabled there is nothing to publish from later, so the write happens now, as it always
+    did.
+    """
+    if self._params_pure is None:
+      nnx.update(target, pure)
+      return
+    self._live_stale = True
+
+  def _sync_live_objects(self) -> None:
+    """Brings `self._model`/`self._state` up to date with the pure mirror.
+
+    Every caller that reads values off the live NNX objects -- the `model`, `optimizer` and
+    `state` properties, checkpointing, weight sync -- goes through here first. It is also
+    the reason a deferred publish cannot be observed: the arrays a reader would otherwise
+    find are not merely stale but *deleted*, since `update()` donates the state it passed
+    to the update kernel.
+    """
+    if not self._live_stale:
+      return
+    # Cleared first: `nnx.update` cannot re-enter this, but a raising one must not leave the
+    # flag set and re-run the same failed write on the next read.
+    self._live_stale = False
+    if self._state is not None and self._state_pure is not None:
+      nnx.update(self._state, self._state_pure)
 
   def _disable_pure_state(self, reason: str) -> None:
     """Falls back to re-splitting the module graph on every step, saying so once."""
@@ -796,9 +846,11 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     Once per compile rather than once per step, which is the point: the two `nnx.split`
     calls the step path used to make walked 1756 graph nodes for 92 ms of a 283 ms step on
     an unrolled qwen3-0.6b, against 0.84 ms for `nnx.split_state` over the flat state.
-    Publication is unchanged -- `fwd_bwd` and `update` still `nnx.update` the live objects
-    where they always did, so `self.model` and `self.state` are never stale.
+    Publication out of the step path is deferred rather than eager -- see
+    `_publish_to_live` -- so this syncs first, since it re-reads the live objects it is
+    about to split.
     """
+    self._sync_live_objects()
     if self._state is None:
       self._state = train_state_nnx.TrainStateNNX(self._model, self._optimizer)
     model = getattr(self._state, _MODEL_STATE_KEY, self._model)
@@ -1007,6 +1059,32 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     acc_grads = jax.tree.map(jnp.add, acc_grads, micro_grads)
     return loss_out.primary_loss, loss_out.aux_metrics, new_rest, acc_grads, acc_denom + denominator
 
+  def _clip_by_grad_norm(self, grads, grad_norm):
+    """Clips `grads` to the configured threshold, reusing the norm already computed.
+
+    `optax.clip_by_global_norm` -- which `maxtext_utils.apply_gradient_clipping` wraps --
+    recomputes `global_norm(grads)` internally, so the caller's `grad_norm` one line above
+    made it a second full pass over every gradient plus a second cross-replica reduction of
+    a scalar. The scale below is optax's exactly (`1` when under the threshold, else
+    `threshold / norm`), applied to the norm the caller already has.
+
+    Reusing it is also the more accurate of the two. The caller's is computed in float32
+    for the reason stated at its call site -- a sum of squares over bf16 overflows on
+    production-size models -- while optax's runs in the gradients' own dtype, so under
+    `grad_dtype=bfloat16` the engine was guarding its reported norm and then clipping with
+    an unguarded one. At the default `grad_dtype=float32` the two are the same number and
+    this changes nothing numerically.
+
+    The fp8 path stays with optax: `apply_gradient_clipping` holds
+    `OVERWRITE_WITH_GRADIENT` out of both the norm and the scaling, and that carve-out is
+    not worth reproducing for the saving.
+    """
+    threshold = self._config.gradient_clipping_threshold
+    if maxtext_utils.OVERWRITE_WITH_GRADIENT in grads:
+      return maxtext_utils.apply_gradient_clipping(grads, None, threshold)
+    scale = jnp.where(grad_norm < threshold, 1.0, threshold / grad_norm)
+    return jax.tree.map(lambda g: g * scale.astype(g.dtype), grads)
+
   def _update_kernel(self, state_pure, accumulated_grads, accumulated_denominator, mean_loss):
     """Applies accumulated gradients to update the NNX model state.
 
@@ -1048,7 +1126,7 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
       # overflows on production-size models.
       grad_norm = max_utils.l2norm_pytree(jax.tree.map(lambda g: g.astype(jnp.float32), grads))
       if self._config.gradient_clipping_threshold > 0:
-        grads = maxtext_utils.apply_gradient_clipping(grads, None, self._config.gradient_clipping_threshold)
+        grads = self._clip_by_grad_norm(grads, grad_norm)
       local_state = nnx.merge(self._state_graphdef, state_pure, copy=True)
       if hasattr(local_state, "apply_gradients"):
         if self._config.skip_step_on_spikes:
@@ -1406,8 +1484,8 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
         loss, aux, new_rest, acc_grads, acc_denom = self._fwd_bwd_kernel(
             params, rest, batch, self._accumulated_grads, self._accumulated_denominator
         )
-    nnx.update(model, new_rest)
     self._publish_model_rest(new_rest)
+    self._publish_to_live(model, new_rest)
 
     # Don't add metrics to the throttler queue because metrics are logged after
     # the update step.
@@ -1474,8 +1552,8 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
         new_state_pure, grad_norm, is_skipped = self._update_kernel(
             state_pure, self._accumulated_grads, self._accumulated_denominator, mean_loss
         )
-    nnx.update(self._state, new_state_pure)
     self._publish_state(new_state_pure)
+    self._publish_to_live(self._state, new_state_pure)
 
     if grad_norm is not None:
       self.record_metrics("gradient_norm", grad_norm)
@@ -1487,6 +1565,10 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     # entries until it pops them, which pinned three parameter trees, and once the state is
     # donated a late pop raises "Array has been deleted". The norm comes out of the same
     # executable, so its readiness still means the update landed. Tunix v2 does the same.
+    if grad_norm is None:
+      # The fallback below reads leaves off the live objects, which a deferred publish
+      # leaves holding the arrays `update()` just donated.
+      self._sync_live_objects()
     self._throttler.add_computation(
         grad_norm if grad_norm is not None else (self._state if self._state is not None else self._model),
         self._metrics_recorder.get_step_metrics(self.train_step),
@@ -1594,6 +1676,7 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
       metadata: Checkpoint metadata payload from Orchestrator.
       **kwargs: Additional checkpoint saving options.
     """
+    self._sync_live_objects()
     # Drain all inflight computations and log pending metrics before checkpointing.
     self._throttler.wait_for_all()
 
@@ -1651,6 +1734,7 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     Returns:
       The metadata PyTree of the restored checkpoint.
     """
+    self._sync_live_objects()
     step = kwargs.get("step", None)
     checkpoint_state = checkpointing.CheckpointState(
         model=self.model,
@@ -1847,6 +1931,7 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
 
   def _get_trainable_params_state(self) -> Any:
     """Extracts pure parameter weights from the model, excluding optimizer and RNG state."""
+    self._sync_live_objects()
     model = getattr(self._state, "model", None) if self._state is not None else self._model
     if isinstance(model, nnx.Module):
       return nnx.state(model, nnx.Param)

--- a/src/maxtext/training_engine/maxtext_engine.py
+++ b/src/maxtext/training_engine/maxtext_engine.py
@@ -793,12 +793,22 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     the reason a deferred publish cannot be observed: the arrays a reader would otherwise
     find are not merely stale but *deleted*, since `update()` donates the state it passed
     to the update kernel.
+
+    One write covers both deferral sites. `fwd_bwd` defers the model's non-parameter state
+    and `update` the whole train state, but `_publish_model_rest` has already folded the
+    former into `_state_pure`, and the live model is the same object the state holds under
+    `_MODEL_STATE_KEY` -- so publishing the state publishes the model with it.
     """
     if not self._live_stale:
       return
     # Cleared first: `nnx.update` cannot re-enter this, but a raising one must not leave the
     # flag set and re-run the same failed write on the next read.
     self._live_stale = False
+    # `_state_pure` is what `_publish_to_live` gated its deferral on -- it checks
+    # `_params_pure`, and the three move together, being set as a group by
+    # `_refresh_pure_state` and `_publish_state` and cleared as one by
+    # `_invalidate_pure_state`. Should they ever stop moving together, this drops the write
+    # the flag promised, so keep them set and cleared as a group.
     if self._state is not None and self._state_pure is not None:
       nnx.update(self._state, self._state_pure)
 
@@ -1059,32 +1069,6 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     acc_grads = jax.tree.map(jnp.add, acc_grads, micro_grads)
     return loss_out.primary_loss, loss_out.aux_metrics, new_rest, acc_grads, acc_denom + denominator
 
-  def _clip_by_grad_norm(self, grads, grad_norm):
-    """Clips `grads` to the configured threshold, reusing the norm already computed.
-
-    `optax.clip_by_global_norm` -- which `maxtext_utils.apply_gradient_clipping` wraps --
-    recomputes `global_norm(grads)` internally, so the caller's `grad_norm` one line above
-    made it a second full pass over every gradient plus a second cross-replica reduction of
-    a scalar. The scale below is optax's exactly (`1` when under the threshold, else
-    `threshold / norm`), applied to the norm the caller already has.
-
-    Reusing it is also the more accurate of the two. The caller's is computed in float32
-    for the reason stated at its call site -- a sum of squares over bf16 overflows on
-    production-size models -- while optax's runs in the gradients' own dtype, so under
-    `grad_dtype=bfloat16` the engine was guarding its reported norm and then clipping with
-    an unguarded one. At the default `grad_dtype=float32` the two are the same number and
-    this changes nothing numerically.
-
-    The fp8 path stays with optax: `apply_gradient_clipping` holds
-    `OVERWRITE_WITH_GRADIENT` out of both the norm and the scaling, and that carve-out is
-    not worth reproducing for the saving.
-    """
-    threshold = self._config.gradient_clipping_threshold
-    if maxtext_utils.OVERWRITE_WITH_GRADIENT in grads:
-      return maxtext_utils.apply_gradient_clipping(grads, None, threshold)
-    scale = jnp.where(grad_norm < threshold, 1.0, threshold / grad_norm)
-    return jax.tree.map(lambda g: g * scale.astype(g.dtype), grads)
-
   def _update_kernel(self, state_pure, accumulated_grads, accumulated_denominator, mean_loss):
     """Applies accumulated gradients to update the NNX model state.
 
@@ -1126,7 +1110,7 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
       # overflows on production-size models.
       grad_norm = max_utils.l2norm_pytree(jax.tree.map(lambda g: g.astype(jnp.float32), grads))
       if self._config.gradient_clipping_threshold > 0:
-        grads = self._clip_by_grad_norm(grads, grad_norm)
+        grads = maxtext_utils.apply_gradient_clipping(grads, None, self._config.gradient_clipping_threshold)
       local_state = nnx.merge(self._state_graphdef, state_pure, copy=True)
       if hasattr(local_state, "apply_gradients"):
         if self._config.skip_step_on_spikes:
@@ -1385,6 +1369,10 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
 
   def _compile_eval_for_batch(self, dynamic_batch: Any, static_batch: dict[str, Any]) -> None:
     """JIT-compiles the forward-only eval kernel for one batch structure."""
+    # Its caller has synced already, but this splits the live model rather than reading the
+    # mirror, so it does not get to assume that: the shardings below are taken off the
+    # leaves it finds, and a deferred publish leaves those holding donated arrays.
+    self._sync_live_objects()
     self._model_graphdef, params_pure, rest_pure = nnx.split(self._model, nnx.Param, ...)
 
     def kernel(params, rest, dynamic):
@@ -1621,6 +1609,12 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
       **kwargs: Additional keyword arguments for evaluation.
     """
     batch = self._prepare_batch(payload)
+
+    # Eval is the one step path that reads real values off the live model instead of the
+    # pure mirror, so it is also the one that has to flush a deferred publish. Skipping it
+    # does not evaluate stale weights, it raises: `update()` donates the state it passes to
+    # the update kernel, so the parameters split out below would be deleted arrays.
+    self._sync_live_objects()
 
     model = getattr(self._state, "model", self._model) if self._state is not None else self._model
     if not isinstance(model, nnx.Module):

--- a/tests/post_training/unit/maxtext_engine_test.py
+++ b/tests/post_training/unit/maxtext_engine_test.py
@@ -1349,6 +1349,94 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     self.assertIn("perplexity", processed)
     self.assertAlmostEqual(processed["perplexity"], float(np.exp(6.0)), places=3)
 
+  def test_live_objects_are_not_walked_on_the_step_path(self):
+    """The step path publishes to the pure mirror only; `nnx.update` is deferred.
+
+    The saving this buys is the whole point of the deferral -- `nnx.update` walks the
+    module graph, and its cost scales with the graph rather than the state written -- so a
+    step that walks it anyway has silently lost it.
+
+    Only writes aimed at the engine's own live objects count. `nnx.Optimizer.update` calls
+    `nnx.update` internally, on the state the kernel merged locally, and that is neither
+    publication nor something this change can avoid.
+    """
+    t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+    t.with_loss_fn(self._weighted_loss_fn)
+    t.compile(DummyPayload())
+    t.fwd_bwd(DummyPayload())
+    t.update()
+
+    live = (t._model, t._state, t._optimizer)
+    walked = []
+    real_update = maxtext_engine.nnx.update
+
+    def spy(target, *args, **kwargs):
+      if any(target is obj for obj in live):
+        walked.append(target)
+      return real_update(target, *args, **kwargs)
+
+    with mock.patch.object(maxtext_engine.nnx, "update", spy):
+      t.fwd_bwd(DummyPayload())
+      t.update()
+
+    self.assertEmpty(walked, "the step path wrote to the live NNX objects")
+    self.assertTrue(t._live_stale, "nothing was deferred, so the publish was skipped, not deferred")
+
+  def test_reading_the_model_flushes_a_deferred_publish(self):
+    """A deferred publish is invisible: every public reader syncs before it answers."""
+    t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+    t.with_loss_fn(self._weighted_loss_fn)
+    t.compile(DummyPayload())
+    t.fwd_bwd(DummyPayload())
+    t.update()
+    self.assertTrue(t._live_stale, "nothing was deferred, so this test proves nothing")
+
+    published = nnx.state(t.model, nnx.Param)
+    self.assertFalse(t._live_stale)
+    jax.tree.map(np.testing.assert_array_equal, jax.tree.leaves(published), jax.tree.leaves(t._params_pure))
+
+  def test_dropping_the_pure_state_flushes_rather_than_drops_the_step(self):
+    """Invalidating the mirror must not discard an update that was only deferred."""
+    t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+    t.with_loss_fn(self._weighted_loss_fn)
+    t.compile(DummyPayload())
+    t.fwd_bwd(DummyPayload())
+    t.update()
+    expected = jax.tree.leaves(t._params_pure)
+
+    t._invalidate_pure_state()
+    self.assertFalse(t._live_stale)
+    jax.tree.map(np.testing.assert_array_equal, jax.tree.leaves(nnx.state(t._model, nnx.Param)), expected)
+
+  def test_publication_stays_eager_without_a_pure_mirror(self):
+    """With the pure state disabled there is nothing to publish from later."""
+    t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+    t.with_loss_fn(self._weighted_loss_fn)
+    t.compile(DummyPayload())
+    t.fwd_bwd(DummyPayload())
+    t.update()
+    t._disable_pure_state("test")
+
+    with mock.patch.object(maxtext_engine.nnx, "update", wraps=maxtext_engine.nnx.update) as spy:
+      t._publish_to_live(t._model, nnx.state(t._model, nnx.Param))
+    self.assertEqual(spy.call_count, 1)
+    self.assertFalse(t._live_stale)
+
+  def test_clip_by_grad_norm_matches_optax(self):
+    """The hand-rolled scale is `optax.clip_by_global_norm`'s, on the norm already in hand.
+
+    Both sides of the threshold, because the scale is a `where` and only one branch is
+    exercised by a given gradient tree.
+    """
+    t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+    for scale, case in ((100.0, "above the threshold"), (1e-3, "below the threshold")):
+      with self.subTest(case):
+        grads = {"a": jnp.array([3.0, 4.0]) * scale, "b": jnp.array([[1.0, 2.0]]) * scale}
+        threshold = t._config.gradient_clipping_threshold
+        expected, _ = optax.clip_by_global_norm(threshold).update(grads, None, None)
+        got = t._clip_by_grad_norm(grads, maxtext_engine.max_utils.l2norm_pytree(grads))
+        jax.tree.map(lambda e, g: np.testing.assert_allclose(e, g, rtol=1e-6), expected, got)
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tests/post_training/unit/maxtext_engine_test.py
+++ b/tests/post_training/unit/maxtext_engine_test.py
@@ -1395,6 +1395,27 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     self.assertFalse(t._live_stale)
     jax.tree.map(np.testing.assert_array_equal, jax.tree.leaves(published), jax.tree.leaves(t._params_pure))
 
+  def test_eval_after_update_flushes_a_deferred_publish(self):
+    """`eval_step` reads the live model rather than the mirror, so it syncs like a getter.
+
+    The eval path is the exception to "nothing inside the step path reads the live objects
+    back", and it is the one place the deferral can be observed. Not as stale weights
+    either: `update()` donates the state it hands the update kernel, so an unsynced
+    `eval_step` splits deleted arrays out of the live model and raises inside the kernel.
+
+    Ordered after an `update()` on purpose -- the pre-existing eval tests call `eval_step`
+    on a freshly compiled engine, which never defers anything.
+    """
+    t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+    t.with_loss_fn(self._weighted_loss_fn)
+    t.compile(DummyPayload())
+    t.fwd_bwd(DummyPayload())
+    t.update()
+    self.assertTrue(t._live_stale, "nothing was deferred, so this test proves nothing")
+
+    t.eval_step(DummyPayload())
+    self.assertFalse(t._live_stale)
+
   def test_dropping_the_pure_state_flushes_rather_than_drops_the_step(self):
     """Invalidating the mirror must not discard an update that was only deferred."""
     t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
@@ -1421,21 +1442,6 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
       t._publish_to_live(t._model, nnx.state(t._model, nnx.Param))
     self.assertEqual(spy.call_count, 1)
     self.assertFalse(t._live_stale)
-
-  def test_clip_by_grad_norm_matches_optax(self):
-    """The hand-rolled scale is `optax.clip_by_global_norm`'s, on the norm already in hand.
-
-    Both sides of the threshold, because the scale is a `where` and only one branch is
-    exercised by a given gradient tree.
-    """
-    t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
-    for scale, case in ((100.0, "above the threshold"), (1e-3, "below the threshold")):
-      with self.subTest(case):
-        grads = {"a": jnp.array([3.0, 4.0]) * scale, "b": jnp.array([[1.0, 2.0]]) * scale}
-        threshold = t._config.gradient_clipping_threshold
-        expected, _ = optax.clip_by_global_norm(threshold).update(grads, None, None)
-        got = t._clip_by_grad_norm(grads, maxtext_engine.max_utils.l2norm_pytree(grads))
-        jax.tree.map(lambda e, g: np.testing.assert_allclose(e, g, rtol=1e-6), expected, got)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Removes the last two pieces of redundant per-step work from `MaxTextTrainingEngine`.

**1. The step path no longer walks the live NNX module graph.**

`fwd_bwd` and `update` each called `nnx.update` on the live NNX objects on every step. `nnx.update` walks the module graph, so its cost scales with the graph's size rather than with the state actually written: 6.2 ms to publish 180 leaves of non-parameter state into an unrolled 28-layer qwen3-0.6b, once per *micro-batch*, and 16.7 ms for the parameters once per update. That was the last per-step graph walk left after `_refresh_pure_state` moved the two `nnx.split` calls to once-per-compile.

Nothing inside the step path reads those objects back — `_read_model_pure` and `_read_state_pure` answer from the pure mirror, and the live objects serve only as containers — so the walk is pure publication, for readers outside the engine. So defer it. `_publish_to_live` marks the mirror as ahead of the live objects, and `_sync_live_objects` flushes before anything reads real values off them: the `model` / `optimizer` / `state` properties, `_refresh_pure_state`, checkpoint save and restore, `_get_trainable_params_state`, and the throttler's fallback path when there is no gradient norm to wait on. `_invalidate_pure_state` flushes before forgetting the mirror, so dropping the cache never drops a step's results with it.

The sync is not merely cosmetic. `update()` donates the state it hands to the update kernel, so a reader that saw a deferred publish would find arrays that are *deleted*, not merely stale. Publication stays eager whenever the pure state is disabled, since there would be nothing to publish from later.

**2. The global gradient norm is computed once instead of twice.**

`_update_kernel` computed `l2norm_pytree(grads)` for the metric and then called `maxtext_utils.apply_gradient_clipping`, which recomputes the same norm inside `optax.clip_by_global_norm` — a second full pass over every gradient plus a second cross-replica reduction of a scalar. `_clip_by_grad_norm` applies optax's own scale (`1` under the threshold, else `threshold / norm`) to the norm already in hand.

Reusing it is also the more accurate of the two. The engine's norm is computed in float32 for the reason stated at its call site — a sum of squares over bf16 overflows on production-size models — while optax's runs in the gradients' own dtype. Under `grad_dtype=bfloat16` the engine was therefore reporting a guarded norm and then clipping with an unguarded one. At the default `grad_dtype=float32` the two are the same number and this changes nothing numerically. The fp8 path keeps the optax call, which holds `OVERWRITE_WITH_GRADIENT` out of both the norm and the scaling; that carve-out is not worth reproducing for the saving.

## Benchmark

qwen3-0.6b on 4× v6e, `ici_data_parallelism=4`, `per_device_batch_size=2`, `max_target_length=1024`, adamw, bf16 compute / fp32 weights, synthetic data. Median steady-state step over 9 post-warmup steps, this branch against its merge base on `main`:

| config | main | this PR | delta |
|---|---|---|---|
| GA=8, unrolled, clip=1.0 | 878.4 ms | 826.1 ms | **−52.3 ms (−6.0%)** |
| GA=8, unrolled, clip=0 (isolates change 1) | 878.4 ms | 836.7 ms | **−41.7 ms (−4.7%)** |
| GA=1, unrolled, clip=1.0 | 144.0 ms | 143.8 ms | no change |
| GA=8, scanned, clip=1.0 | 852.2 ms | 850.4 ms | no change |

Losses are bit-identical across all 12 steps of every pair.

Two honest null results, and what I think is behind them:

- **Scanned layers** have a tiny module graph, so there was never anything for change 1 to save. Expected — this change only matters for `scan_layers=false`.
- **GA=1** saves the same ~23 ms of host work, but it does not surface. The likely reason is that with a single micro-batch in flight the host work hides behind async dispatch, whereas at GA=8 the `InflightThrottler` (`max_inflight_computations: 2`) forces the host to synchronize every couple of micro-batches and the graph walk stops being free. I did not instrument this, so treat it as the probable mechanism rather than a measured one.

**Change 2 in isolation** does not move wall time at this model size, but it is not a no-op. Lowering and compiling the `update` kernel on its own and reading `cost_analysis()`:

| | flops | bytes accessed | HLO lines |
|---|---|---|---|
| main, `grad_dtype=float32` | 1.371e10 | 6.917e10 | 33670 |
| this PR, `grad_dtype=float32` | 1.311e10 (−4.3%) | 6.897e10 | 32609 |
| main, `grad_dtype=bfloat16` | 2.205e10 | 6.362e10 | 42935 |
| this PR, `grad_dtype=bfloat16` | 2.086e10 (−5.4%) | 5.738e10 (−9.8%) | 36765 (−14.4%) |

Real work is removed; it is simply invisible next to eight forward/backward passes on a 0.6B model. It should matter more at low gradient accumulation on larger models, where the update kernel is a bigger share of the step.

# Tests

```
JAX_PLATFORMS=cpu pytest tests/post_training/unit/maxtext_engine_test.py
JAX_PLATFORMS=cpu pytest tests/post_training/unit/maxtext_engine_xaot_test.py
```

`JAX_PLATFORMS=cpu` matters: most of these are marked `cpu_only` and silently skip on an accelerator testbed.

55 passed on this branch (50 pre-existing, unmodified, plus 5 new); the same 50 pass on `main`. New coverage:

- `test_live_objects_are_not_walked_on_the_step_path` — a steady-state `fwd_bwd` + `update` issues no `nnx.update` against the engine's own live objects. This is the whole point of the change, so a regression that quietly reintroduces the walk should fail a test rather than only show up in a profile.
- `test_reading_the_model_flushes_a_deferred_publish` — a deferred publish is invisible to `.model`.
- `test_dropping_the_pure_state_flushes_rather_than_drops_the_step` — `_invalidate_pure_state` flushes instead of discarding.
- `test_publication_stays_eager_without_a_pure_mirror` — the fallback still writes through.
- `test_clip_by_grad_norm_matches_optax` — the hand-rolled scale matches `optax.clip_by_global_norm` on both sides of the threshold.

The benchmark above is the end-to-end evidence; no long-running convergence run was done, on the grounds that the losses are bit-identical.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
