### PR TITLE
vLLM adapter: index kv_caches through layer_name_to_kvcache_index

### DIFF
--- a/src/maxtext/integration/vllm/hybrid_cache_utils.py
+++ b/src/maxtext/integration/vllm/hybrid_cache_utils.py
@@ -61,3 +61,97 @@ def build_qwen_gdn_cache_layout(cfg: Any, torch_module: Any):
       for shape, dtype in zip(shapes, dtypes, strict=True)
   )
   return shapes, dtypes, page_size_bytes
+
+
+_LAYER_NAME_PREFIX = "layer."
+
+
+def resolve_layer_kv_cache_indices(layer_name_to_kvcache_index: Any, num_kv_caches: int) -> list[int] | None:
+  """Maps decoder layer index -> physical index into vLLM's ``kv_caches`` list.
+
+  tpu-inference allocates one physical cache per unique slot and reports which
+  cache each layer uses through ``layer_name_to_kvcache_index`` (JAX-side layer
+  names are ``layer.{i}``). The physical list is *not* guaranteed to be in layer
+  order: hybrid models group the Mamba/GDN caches ahead of the attention caches,
+  KV-sharing layers redirect to another layer's cache, and the legacy aliased
+  layout backs several layers with one cache. MaxText decoders index the list
+  positionally (``kv_caches[lyr]``), so the adapter uses this mapping to present
+  them a layer-ordered view.
+
+  Args:
+    layer_name_to_kvcache_index: ``{layer_name: physical_index}``, or the
+      ``tuple(dict.items())`` form tpu-inference passes as a static jit
+      argument. ``None``/empty means "no mapping": callers fall back to
+      positional indexing, matching the native tpu-inference models.
+    num_kv_caches: Length of the physical ``kv_caches`` list, for validation.
+
+  Returns:
+    ``physical_indices`` with ``physical_indices[lyr]`` the position of layer
+    ``lyr``'s cache in ``kv_caches``, or ``None`` when no mapping was given.
+
+  Raises:
+    ValueError: If the ``layer.{i}`` entries do not cover a contiguous
+      ``0..n-1`` range, or an index falls outside ``kv_caches``.
+  """
+  if not layer_name_to_kvcache_index:
+    return None
+  if not isinstance(layer_name_to_kvcache_index, dict):
+    layer_name_to_kvcache_index = dict(layer_name_to_kvcache_index)
+
+  by_layer: dict[int, int] = {}
+  for name, physical_index in layer_name_to_kvcache_index.items():
+    # Other entries (e.g. a per-layer auxiliary cache suffix) are not decoder
+    # layers and are left to the model that declared them.
+    if not name.startswith(_LAYER_NAME_PREFIX):
+      continue
+    suffix = name[len(_LAYER_NAME_PREFIX) :]
+    if not suffix.isdigit():
+      continue
+    by_layer[int(suffix)] = int(physical_index)
+
+  if not by_layer:
+    return None
+
+  num_layers = max(by_layer) + 1
+  missing = sorted(set(range(num_layers)) - set(by_layer))
+  if missing:
+    raise ValueError(
+        f"layer_name_to_kvcache_index is missing decoder layers {missing} (expected layer.0..layer.{num_layers - 1})."
+    )
+
+  physical_indices = [by_layer[lyr] for lyr in range(num_layers)]
+  out_of_range = [idx for idx in physical_indices if not 0 <= idx < num_kv_caches]
+  if out_of_range:
+    raise ValueError(
+        f"layer_name_to_kvcache_index points outside the kv_caches list (len={num_kv_caches}): {sorted(set(out_of_range))}."
+    )
+  return physical_indices
+
+
+def gather_layer_kv_caches(kv_caches: list[Any], physical_indices: list[int] | None) -> list[Any]:
+  """Returns ``kv_caches`` re-ordered so that entry ``lyr`` is layer ``lyr``'s cache.
+
+  A no-op (same list object) when ``physical_indices`` is ``None``. This is
+  pure Python list indexing on traced values, so it adds no XLA ops.
+  """
+  if physical_indices is None:
+    return kv_caches
+  return [kv_caches[idx] for idx in physical_indices]
+
+
+def scatter_layer_kv_caches(
+    kv_caches: list[Any], layer_kv_caches: list[Any], physical_indices: list[int] | None
+) -> list[Any]:
+  """Writes layer-ordered updated caches back into the physical ``kv_caches`` layout.
+
+  The returned list has the same length and order as the physical list the
+  runner handed us, which is what its donation / out_shardings expect. Physical
+  caches no decoder layer maps to are passed through unchanged. If several
+  layers share one physical cache, the highest-numbered layer's update wins.
+  """
+  if physical_indices is None:
+    return layer_kv_caches
+  updated = list(kv_caches)
+  for lyr, idx in enumerate(physical_indices):
+    updated[idx] = layer_kv_caches[lyr]
+  return updated

--- a/src/maxtext/integration/vllm/hybrid_cache_utils.py
+++ b/src/maxtext/integration/vllm/hybrid_cache_utils.py
@@ -102,7 +102,7 @@ def resolve_layer_kv_cache_indices(layer_name_to_kvcache_index: Any, num_kv_cach
   for name, physical_index in layer_name_to_kvcache_index.items():
     # Other entries (e.g. a per-layer auxiliary cache suffix) are not decoder
     # layers and are left to the model that declared them.
-    if not name.startswith(_LAYER_NAME_PREFIX):
+    if not isinstance(name, str) or not name.startswith(_LAYER_NAME_PREFIX):
       continue
     suffix = name[len(_LAYER_NAME_PREFIX) :]
     if not suffix.isdigit():
@@ -151,6 +151,10 @@ def scatter_layer_kv_caches(
   """
   if physical_indices is None:
     return layer_kv_caches
+  if len(layer_kv_caches) != len(physical_indices):
+    raise ValueError(
+        f"Expected layer_kv_caches to have length {len(physical_indices)}, " f"but got {len(layer_kv_caches)}."
+    )
   updated = list(kv_caches)
   for lyr, idx in enumerate(physical_indices):
     updated[idx] = layer_kv_caches[lyr]

--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -243,6 +243,7 @@ class MaxTextForCausalLM(nnx.Module):
     """Dummy method to satisfy vLLM's internal cleanup logic."""
     return []
 
+  # pylint: disable=keyword-arg-before-vararg
   def __call__(
       self,
       kv_caches: list[jax.Array],
@@ -311,8 +312,12 @@ class MaxTextForCausalLM(nnx.Module):
     # Present the decoder a layer-ordered view of the physical cache list. With
     # the vLLM hybrid layout all Mamba/GDN caches precede the attention caches,
     # so kv_caches[lyr] would otherwise hand an attention layer a 3D conv state.
-    physical_indices = resolve_layer_kv_cache_indices(_layer_name_to_kvcache_index, len(kv_caches))
-    layer_kv_caches = gather_layer_kv_caches(kv_caches, physical_indices)
+    if kv_caches is not None:
+      physical_indices = resolve_layer_kv_cache_indices(_layer_name_to_kvcache_index, len(kv_caches))
+      layer_kv_caches = gather_layer_kv_caches(kv_caches, physical_indices)
+    else:
+      physical_indices = None
+      layer_kv_caches = None
 
     # MaxText decode treats vLLM's flattened tokens as a batch with seq_len=1.
     # MRoPE positions arrive channel-first and must also move their 3 channels
@@ -327,7 +332,10 @@ class MaxTextForCausalLM(nnx.Module):
       decoder_input_embeddings = None
       input_ids = jnp.expand_dims(input_ids, axis=1)
 
-    input_positions = normalize_vllm_input_positions(attention_metadata.input_positions)
+    positions = getattr(attention_metadata, "input_positions", None)
+    if positions is None:
+      positions = _input_positions
+    input_positions = normalize_vllm_input_positions(positions)
 
     with self.mesh, nn.logical_axis_rules(self.maxtext_config.logical_axis_rules):
       aux_hidden_states = []
@@ -348,7 +356,8 @@ class MaxTextForCausalLM(nnx.Module):
         hidden, layer_kv_caches = res
 
       # Hand the updated caches back in the runner's physical order.
-      kv_caches = scatter_layer_kv_caches(kv_caches, layer_kv_caches, physical_indices)
+      if kv_caches is not None:
+        kv_caches = scatter_layer_kv_caches(kv_caches, layer_kv_caches, physical_indices)
 
       # To be compatible with vLLM, we reshape to (batch * seq, dim).
       hidden = hidden.reshape((-1, hidden.shape[-1]))

--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -23,7 +23,13 @@ from jax.experimental.pallas import tpu as pltpu
 from jax.sharding import Mesh
 from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE
 from maxtext.configs import pyconfig
-from maxtext.integration.vllm.hybrid_cache_utils import build_qwen_gdn_cache_layout, normalize_vllm_input_positions
+from maxtext.integration.vllm.hybrid_cache_utils import (
+    build_qwen_gdn_cache_layout,
+    gather_layer_kv_caches,
+    normalize_vllm_input_positions,
+    resolve_layer_kv_cache_indices,
+    scatter_layer_kv_caches,
+)
 from maxtext.utils import lora_utils
 from maxtext.utils import max_logging
 from maxtext.utils import model_creation_utils
@@ -242,16 +248,33 @@ class MaxTextForCausalLM(nnx.Module):
       kv_caches: list[jax.Array],
       input_ids: jax.Array,
       attention_metadata: AttentionMetadata,
+      inputs_embeds: jax.Array | None = None,
+      _input_positions=None,
+      _layer_name_to_kvcache_index=None,
       *args,
       **kwargs,
   ) -> tuple[list[jax.Array], jax.Array, list[jax.Array], list[jax.Array] | None]:
     """Performs a forward pass through the causal language model.
 
+    The positional layout mirrors the tpu-inference runner's model call
+    (``kv_caches, input_ids, attention_metadata, inputs_embeds, input_positions,
+    layer_name_to_kvcache_index, lora_metadata, ...``), the same contract the
+    native JAX models such as Gemma4 consume.
+
     Args:
-      kv_caches: A list of JAX arrays representing the KV caches.
+      kv_caches: The physical KV caches allocated by tpu-inference, in the
+        runner's slot order. This is not necessarily layer order (see
+        ``_layer_name_to_kvcache_index``).
       input_ids: A JAX array of input token IDs.
       attention_metadata: Attention metadata for the decoding process.
-      *args: Variable length argument list.
+      inputs_embeds: Optional precomputed input embeddings.
+      _input_positions: Unused; positions are read from ``attention_metadata``.
+      _layer_name_to_kvcache_index: ``layer.{i} -> index into kv_caches``, as a
+        static tuple of pairs (or dict). MaxText decoders index caches by layer
+        (``kv_caches[lyr]``), so the list is re-ordered by this map before the
+        forward pass and scattered back afterwards. ``None`` keeps the
+        positional interpretation.
+      *args: Remaining positional runner arguments (unused).
       **kwargs: Arbitrary keyword arguments.
 
     Returns:
@@ -285,10 +308,15 @@ class MaxTextForCausalLM(nnx.Module):
         attention_metadata_picked = next(iter(attention_metadata.values()))
       attention_metadata = attention_metadata_picked
 
+    # Present the decoder a layer-ordered view of the physical cache list. With
+    # the vLLM hybrid layout all Mamba/GDN caches precede the attention caches,
+    # so kv_caches[lyr] would otherwise hand an attention layer a 3D conv state.
+    physical_indices = resolve_layer_kv_cache_indices(_layer_name_to_kvcache_index, len(kv_caches))
+    layer_kv_caches = gather_layer_kv_caches(kv_caches, physical_indices)
+
     # MaxText decode treats vLLM's flattened tokens as a batch with seq_len=1.
     # MRoPE positions arrive channel-first and must also move their 3 channels
     # to MaxText's trailing dimension.
-    inputs_embeds = args[0] if args else None
     if inputs_embeds is not None:
       decoder_input_embeddings = inputs_embeds[:, None, :].astype(self.maxtext_config.dtype)
       # tpu-inference passes input_ids=None with precomputed embeddings. The
@@ -308,16 +336,19 @@ class MaxTextForCausalLM(nnx.Module):
           decoder_input_tokens=input_ids,
           decoder_input_embeddings=decoder_input_embeddings,
           decoder_positions=input_positions,
-          kv_caches=kv_caches,
+          kv_caches=layer_kv_caches,
           attention_metadata=attention_metadata,
           model_mode=self.model_mode,
           **kwargs,
       )
 
       if isinstance(res, tuple) and len(res) == 3:
-        hidden, kv_caches, expert_indices = res
+        hidden, layer_kv_caches, expert_indices = res
       else:
-        hidden, kv_caches = res
+        hidden, layer_kv_caches = res
+
+      # Hand the updated caches back in the runner's physical order.
+      kv_caches = scatter_layer_kv_caches(kv_caches, layer_kv_caches, physical_indices)
 
       # To be compatible with vLLM, we reshape to (batch * seq, dim).
       hidden = hidden.reshape((-1, hidden.shape[-1]))

--- a/tests/post_training/unit/vllm_hybrid_cache_test.py
+++ b/tests/post_training/unit/vllm_hybrid_cache_test.py
@@ -153,7 +153,7 @@ class LayerOrderedKvCachesTest(unittest.TestCase):
 
   @pytest.mark.cpu_only
   def test_non_layer_entries_are_ignored(self):
-    index_map = {"layer.0": 0, "layer.1": 1, "layer.1.rope_cache": 2}
+    index_map = {"layer.0": 0, "layer.1": 1, "layer.1.rope_cache": 2, 42: 3}
 
     self.assertEqual(resolve_layer_kv_cache_indices(index_map, 3), [0, 1])
 
@@ -163,3 +163,8 @@ class LayerOrderedKvCachesTest(unittest.TestCase):
       resolve_layer_kv_cache_indices({"layer.0": 0, "layer.2": 1}, 2)
     with self.assertRaisesRegex(ValueError, "outside the kv_caches list"):
       resolve_layer_kv_cache_indices({"layer.0": 0, "layer.1": 5}, 2)
+
+  @pytest.mark.cpu_only
+  def test_scatter_rejects_length_mismatch(self):
+    with self.assertRaisesRegex(ValueError, "Expected layer_kv_caches to have length"):
+      scatter_layer_kv_caches(["c0", "c1"], ["c0'"], [0, 1])

--- a/tests/post_training/unit/vllm_hybrid_cache_test.py
+++ b/tests/post_training/unit/vllm_hybrid_cache_test.py
@@ -22,7 +22,13 @@ import numpy as np
 import pytest
 import torch
 
-from maxtext.integration.vllm.hybrid_cache_utils import build_qwen_gdn_cache_layout, normalize_vllm_input_positions
+from maxtext.integration.vllm.hybrid_cache_utils import (
+    build_qwen_gdn_cache_layout,
+    gather_layer_kv_caches,
+    normalize_vllm_input_positions,
+    resolve_layer_kv_cache_indices,
+    scatter_layer_kv_caches,
+)
 
 
 pytestmark = [pytest.mark.post_training]
@@ -91,3 +97,69 @@ class VllmInputPositionsTest(unittest.TestCase):
 
 if __name__ == "__main__":
   unittest.main()
+
+
+class LayerOrderedKvCachesTest(unittest.TestCase):
+  """Verify the physical-slot -> decoder-layer remapping of vLLM's kv_caches list."""
+
+  @pytest.mark.cpu_only
+  def test_type_grouped_hybrid_layout_is_remapped_to_layer_order(self):
+    # Qwen3.5-style 4-layer cycle: layers 0-2 are GDN, layer 3 is attention.
+    # tpu-inference's hybrid tensor layout groups caches by type, so the
+    # physical list is not in layer order; here the attention cache leads.
+    kv_caches = ["attn3", "mamba0", "mamba1", "mamba2"]
+    index_map = (("layer.0", 1), ("layer.1", 2), ("layer.2", 3), ("layer.3", 0))
+
+    physical_indices = resolve_layer_kv_cache_indices(index_map, len(kv_caches))
+    layer_view = gather_layer_kv_caches(kv_caches, physical_indices)
+
+    self.assertEqual(physical_indices, [1, 2, 3, 0])
+    self.assertEqual(layer_view, ["mamba0", "mamba1", "mamba2", "attn3"])
+
+  @pytest.mark.cpu_only
+  def test_scatter_restores_physical_order_and_passes_through_unmapped_slots(self):
+    kv_caches = ["attn3", "mamba0", "mamba1", "mamba2", "aux"]
+    physical_indices = [1, 2, 3, 0]
+    updated_layer_view = ["mamba0'", "mamba1'", "mamba2'", "attn3'"]
+
+    actual = scatter_layer_kv_caches(kv_caches, updated_layer_view, physical_indices)
+
+    self.assertEqual(actual, ["attn3'", "mamba0'", "mamba1'", "mamba2'", "aux"])
+    # The runner's list is not mutated in place.
+    self.assertEqual(kv_caches, ["attn3", "mamba0", "mamba1", "mamba2", "aux"])
+
+  @pytest.mark.cpu_only
+  def test_shared_physical_cache_is_visible_to_every_sharing_layer(self):
+    # KV-sharing: layer 2 redirects to layer 1's cache; only 2 physical caches.
+    kv_caches = ["c0", "c1"]
+    index_map = {"layer.0": 0, "layer.1": 1, "layer.2": 1}
+
+    physical_indices = resolve_layer_kv_cache_indices(index_map, len(kv_caches))
+    layer_view = gather_layer_kv_caches(kv_caches, physical_indices)
+    scattered = scatter_layer_kv_caches(kv_caches, ["c0'", "c1'", "c1''"], physical_indices)
+
+    self.assertEqual(layer_view, ["c0", "c1", "c1"])
+    # The highest-numbered sharing layer's update wins.
+    self.assertEqual(scattered, ["c0'", "c1''"])
+
+  @pytest.mark.cpu_only
+  def test_missing_map_keeps_positional_indexing(self):
+    kv_caches = ["c0", "c1"]
+
+    self.assertIsNone(resolve_layer_kv_cache_indices(None, 2))
+    self.assertIsNone(resolve_layer_kv_cache_indices((), 2))
+    self.assertIs(gather_layer_kv_caches(kv_caches, None), kv_caches)
+    self.assertEqual(scatter_layer_kv_caches(kv_caches, ["c0'", "c1'"], None), ["c0'", "c1'"])
+
+  @pytest.mark.cpu_only
+  def test_non_layer_entries_are_ignored(self):
+    index_map = {"layer.0": 0, "layer.1": 1, "layer.1.rope_cache": 2}
+
+    self.assertEqual(resolve_layer_kv_cache_indices(index_map, 3), [0, 1])
+
+  @pytest.mark.cpu_only
+  def test_rejects_gaps_and_out_of_range_indices(self):
+    with self.assertRaisesRegex(ValueError, r"missing decoder layers \[1\]"):
+      resolve_layer_kv_cache_indices({"layer.0": 0, "layer.2": 1}, 2)
+    with self.assertRaisesRegex(ValueError, "outside the kv_caches list"):
+      resolve_layer_kv_cache_indices({"layer.0": 0, "layer.1": 5}, 2)


### PR DESCRIPTION
# Description

This PR ensures MaxText's vLLM adapter correctly maps physical KV caches to decoder layers via `layer_name_to_kvcache_index`, rather than assuming physical slot order matches layer order.
### Related PRs & Context:
- **Supersedes / Continues**: https://github.com/AI-Hypercomputer/maxtext/pull/5113 (incorporates review feedback, pyink formatting, and pylint cleanups).
- **Upstream Workaround**: https://github.com/vllm-project/tpu-inference/pull/3512 (which worked around the issue by re-sorting slots in the cache manager).
- *(Related background on hybrid cache allocation: https://github.com/vllm-project/tpu-inference/pull/3515)*

### Background & Problem
`tpu-inference` allocates one physical KV cache per unique slot and reports which cache each layer uses via `layer_name_to_kvcache_index`, which the runner passes to every JAX model as a static positional argument (`kv_caches, input_ids, attention_metadata, inputs_embeds, input_positions, layer_name_to_kvcache_index, ...`). Native models (e.g. Gemma4) consume it directly; the MaxText adapter previously dropped the map into `*args` and let the decoder index the physical list positionally (`kv_caches[lyr]`).
That assumption broke with the vLLM hybrid tensor layout (tpu-inference #3481): all Mamba/GDN caches are allocated before the attention caches. Consequently, on Qwen3.5, an attention layer received a 3D recurrent conv state and the RPA `shard_map` failed with:

```test
ValueError: shard_map applied to '_ragged_paged_attention': in_specs[3] has length 5, but the passed args[3][0] has shape bfloat16[1028,3,8192], which has rank 3
```

While vllm-project/tpu-inference#3512 provided a temporary workaround by re-sorting slots in the cache manager, honoring `layer_name_to_kvcache_index` in MaxText is the principled solution. It also correctly handles cases that sorting cannot fix (e.g., KV-sharing layers where multiple layers redirect to the same physical cache, and lists shorter than the layer count).
### Changes in this PR:
1. **Model Signature**: `MaxTextForCausalLM.__call__` explicitly accepts `inputs_embeds`, `_input_positions`, and `_layer_name_to_kvcache_index` in positional alignment with the runner contract, with `# pylint: disable=keyword-arg-before-vararg`.
2. **Hybrid Cache Helpers** (`hybrid_cache_utils.py`):
   - `resolve_layer_kv_cache_indices`: Parses `layer.{i}` entries into per-layer physical indices with contiguity, string type, and range validation.
   - `gather_layer_kv_caches`: Builds the layer-ordered view the MaxText decoder expects.
   - `scatter_layer_kv_caches`: Validates length consistency and writes updated caches back into the runner's physical slot order (preserving runner donation and `out_shardings`).
3. **Zero XLA Overhead**: Gather and scatter are pure Python list indexings on traced values and introduce 0 XLA ops.

# Tests

- Ran unit tests covering the hybrid-cache reordering helpers, scatter restoration, KV cache sharing, non-string map keys, gap/out-of-range validation, and length mismatch detection
- End-to-End TPU Run (Qwen3.5 on vLLM Adapter), verified end-to-end decode using `MaxTextForCausalLM` on TPU with a `tpu-inference` build without the #3512 slot-sorting workaround (reproducing and verifying the root fix)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
