### PR TITLE
Clip gradients with the norm the engine already computed

### DIFF
--- a/src/maxtext/training_engine/maxtext_engine.py
+++ b/src/maxtext/training_engine/maxtext_engine.py
@@ -1007,6 +1007,39 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
     acc_grads = jax.tree.map(jnp.add, acc_grads, micro_grads)
     return loss_out.primary_loss, loss_out.aux_metrics, new_rest, acc_grads, acc_denom + denominator
 
+  def _clip_by_grad_norm(self, grads, grad_norm):
+    """Clips `grads` to the configured threshold, reusing the norm already computed.
+
+    `optax.clip_by_global_norm` -- which `maxtext_utils.apply_gradient_clipping` wraps --
+    recomputes `global_norm(grads)` internally, so the caller's `grad_norm` one line above
+    made it a second full pass over every gradient plus a second cross-replica reduction of
+    a scalar. The scale below is optax's exactly (`1` when under the threshold, else
+    `threshold / norm`), applied to the norm the caller already has.
+
+    Reusing it is also the more accurate of the two, and this is a numerical change rather
+    than only a saving. The caller's norm is computed in float32 for the reason stated at
+    its call site -- a sum of squares over bf16 overflows on production-size models --
+    while optax's runs in the gradients' own dtype, so under `grad_dtype=bfloat16` the
+    engine was guarding its reported norm and then clipping with an unguarded one. At the
+    default `grad_dtype=float32` the two are the same number and nothing changes.
+
+    The division is guarded the way the denominator above it is: `jnp.where` evaluates both
+    branches, so an all-zero gradient tree would otherwise divide by zero on the branch it
+    then discards -- harmless in the result, but it raises under `debug_nans` and pollutes
+    the cotangent if anything ever differentiates through here.
+
+    The fp8 path stays with optax: `apply_gradient_clipping` holds
+    `OVERWRITE_WITH_GRADIENT` out of both the norm and the scaling, and that carve-out is
+    not worth reproducing for the saving.
+    """
+    threshold = self._config.gradient_clipping_threshold
+    if maxtext_utils.OVERWRITE_WITH_GRADIENT in grads:
+      return maxtext_utils.apply_gradient_clipping(grads, None, threshold)
+    under = grad_norm < threshold
+    safe_norm = jnp.where(under, 1.0, grad_norm)
+    scale = jnp.where(under, 1.0, threshold / safe_norm)
+    return jax.tree.map(lambda g: g * scale.astype(g.dtype), grads)
+
   def _update_kernel(self, state_pure, accumulated_grads, accumulated_denominator, mean_loss):
     """Applies accumulated gradients to update the NNX model state.
 
@@ -1048,7 +1081,7 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
       # overflows on production-size models.
       grad_norm = max_utils.l2norm_pytree(jax.tree.map(lambda g: g.astype(jnp.float32), grads))
       if self._config.gradient_clipping_threshold > 0:
-        grads = maxtext_utils.apply_gradient_clipping(grads, None, self._config.gradient_clipping_threshold)
+        grads = self._clip_by_grad_norm(grads, grad_norm)
       local_state = nnx.merge(self._state_graphdef, state_pure, copy=True)
       if hasattr(local_state, "apply_gradients"):
         if self._config.skip_step_on_spikes:

--- a/tests/post_training/unit/maxtext_engine_test.py
+++ b/tests/post_training/unit/maxtext_engine_test.py
@@ -1349,6 +1349,43 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     self.assertIn("perplexity", processed)
     self.assertAlmostEqual(processed["perplexity"], float(np.exp(6.0)), places=3)
 
+  def _grads_scaled(self, scale):
+    return {"a": jnp.array([3.0, 4.0]) * scale, "b": jnp.array([[1.0, 2.0]]) * scale}
+
+  def test_clip_by_grad_norm_matches_optax(self):
+    """The hand-rolled scale is `optax.clip_by_global_norm`'s, on the norm already in hand.
+
+    Both sides of the threshold, because the scale is a `where` and only one branch is
+    exercised by a given gradient tree.
+    """
+    t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+    for scale, case in ((100.0, "above the threshold"), (1e-3, "below the threshold")):
+      with self.subTest(case):
+        grads = self._grads_scaled(scale)
+        threshold = t._config.gradient_clipping_threshold
+        expected, _ = optax.clip_by_global_norm(threshold).update(grads, None, None)
+        got = t._clip_by_grad_norm(grads, maxtext_engine.max_utils.l2norm_pytree(grads))
+        jax.tree.map(lambda e, g: np.testing.assert_allclose(e, g, rtol=1e-6), expected, got)
+
+  def test_clip_by_grad_norm_does_not_divide_by_zero(self):
+    """An all-zero gradient tree has to survive the `threshold / norm` branch it discards.
+
+    Compared against the analytic answer rather than optax, because optax is the side that
+    fails here: `clip_by_global_norm` divides by the norm unguarded and leans on
+    `lax.select` to drop the result, so the value is right but a NaN is computed to get
+    there and `debug_nans` stops on it. Reusing the caller's norm is what makes guarding it
+    possible, so this is a hazard the change removes rather than one it has to avoid
+    introducing.
+    """
+    t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+    grads = self._grads_scaled(0.0)
+    with jax.debug_nans(True):
+      got = t._clip_by_grad_norm(grads, maxtext_engine.max_utils.l2norm_pytree(grads))
+    jax.tree.map(lambda g: np.testing.assert_array_equal(g, jnp.zeros_like(g)), got)
+
+    with self.assertRaises(FloatingPointError), jax.debug_nans(True):
+      optax.clip_by_global_norm(t._config.gradient_clipping_threshold).update(grads, None, None)
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Split out of #5138, which was a deferral change and had no business carrying this.

### What

`_update_kernel` computes `grad_norm` for reporting, then one line later calls
`maxtext_utils.apply_gradient_clipping`, whose `optax.clip_by_global_norm` computes
`global_norm(grads)` again. This clips with the norm already in hand instead. The scale is
optax's exactly: `1` under the threshold, `threshold / norm` over it.

### This is a numerical change, not only a saving

The engine's norm is computed in float32 -- deliberately, because a sum of squares over
bf16 overflows on production-size models -- while optax's runs in the gradients' own dtype.
So under `grad_dtype=bfloat16` the engine has been reporting a guarded norm and clipping
with an unguarded one, and it now clips with the guarded one.

**At the default `grad_dtype=float32` the two are the same number and nothing changes.**
Only configs that set `grad_dtype: bfloat16` see different clipped gradients, and for those
the new behaviour is the correct one. That divergence is the reason this is a separate PR:
it should be reviewed on its own terms rather than approved as part of a deferral change.

### Division-by-zero

Addresses the review left on #5138. Having the norm in hand is what makes the division
guardable, so the guard comes for free here:

```python
under = grad_norm < threshold
safe_norm = jnp.where(under, 1.0, grad_norm)
scale = jnp.where(under, 1.0, threshold / safe_norm)
```

This is the same idiom the accumulated-denominator division 10 lines above already uses.

Worth noting the direction: **optax is the side that fails this.** `clip_by_global_norm`
divides by the norm unguarded and leans on `lax.select` to discard the result, so on an
all-zero gradient tree the value is right but a NaN is computed to get there, and
`JAX_DEBUG_NANS` stops on it. So this removes a hazard MaxText has today rather than
avoiding one it would have introduced. `test_clip_by_grad_norm_does_not_divide_by_zero`
asserts both halves of that.

### fp8

Unchanged, still routed to optax: `apply_gradient_clipping` holds `OVERWRITE_WITH_GRADIENT`
out of both the norm and the scaling, and reproducing that carve-out is not worth the
saving.

### Tests

`tests/post_training/unit/maxtext_engine_test.py` -- 52 passed on CPU.

- `test_clip_by_grad_norm_matches_optax` -- both sides of the threshold, against optax
- `test_clip_by_grad_norm_does_not_divide_by_zero` -- all-zero tree under `jax.debug_nans`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable. <!-- Unit tests only: 52 passed on CPU. No e2e run, and the honest reason is that this change is invisible to one at the default `grad_dtype=float32` -- the two norms are the same number. A convergence run under `grad_dtype: bfloat16` is the test that would actually distinguish the old behaviour from the new, and I have not done one. -->
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
