### PR TITLE
Trace the engine's eval kernel under the mesh and the axis rules

### DIFF
--- a/src/maxtext/training_engine/maxtext_engine.py
+++ b/src/maxtext/training_engine/maxtext_engine.py
@@ -1554,9 +1554,13 @@ class MaxTextTrainingEngine(abstract_engine.AbstractTrainingEngine):
       signature = _batch_signature(dynamic_batch, static_batch)
       if self._compiled_eval is None or self._needs_recompile(signature, self._compiled_eval_signature):
         self._compile_eval_for_batch(dynamic_batch, static_batch)
-      loss, aux = self._compiled_eval(params, rest, dynamic_batch)
+      # Around the call, as `fwd_bwd` and `update` do: `jax.jit` is lazy, so this is where
+      # the eval kernel is traced and where the mesh and the axis rules have to be live.
+      with self._sharding_ctx():
+        loss, aux = self._compiled_eval(params, rest, dynamic_batch)
     else:
-      loss, aux = self._eval_kernel(params, rest, batch)
+      with self._sharding_ctx():
+        loss, aux = self._eval_kernel(params, rest, batch)
 
     # No metrics attached: eval metrics are buffered by `_eval_metrics_recorder` and written
     # in EVAL mode when `eval_context` exits.

--- a/tests/post_training/unit/maxtext_engine_test.py
+++ b/tests/post_training/unit/maxtext_engine_test.py
@@ -1117,6 +1117,42 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     # The recorder is drained, so a later pass cannot re-write this one's numbers.
     self.assertEmpty(t._eval_metrics_recorder.get_metrics_history(clear_cache=False))
 
+  def test_eval_step_traces_under_the_mesh_and_axis_rules(self):
+    """The eval kernel is traced under the same context every training kernel gets.
+
+    `fwd_bwd` and `update` wrap their kernel calls in `_sharding_ctx`; eval was the one step
+    path that did not. Under `shard_mode=auto` that only costs partitioning quality, so it
+    goes unnoticed, but the MaxText layers call `jax.sharding.reshard(x, P(...))` and a bare
+    `PartitionSpec` with no mesh in context is an error rather than a no-op under explicit
+    axis types -- there, an eval kernel traced outside the context raises instead of running.
+
+    Both branches: `compile()` picks which of the two eval paths a run takes, and they were
+    missing the context independently.
+    """
+    for compiled in (False, True):
+      with self.subTest(compiled=compiled):
+        seen = {}
+
+        def loss_fn(model, *_args, _seen=seen, **_kwargs):
+          # Read from inside the kernel, which is the only place that matters: `jax.jit` is
+          # lazy, so a context entered around the compile call and not the kernel call would
+          # still leave the trace bare.
+          _seen["mesh"] = jax.sharding.get_abstract_mesh()
+          _seen["rules"] = maxtext_engine.nn_partitioning.get_axis_rules()
+          return (
+              abstract_engine.WeightedMetric(unreduced_sum=jnp.sum(model.weights.value), denominator=jnp.array(1.0)),
+              {},
+          )
+
+        t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+        t.with_loss_fn(loss_fn)
+        if compiled:
+          t.compile(DummyPayload())
+        t.eval_step(DummyPayload())
+
+        self.assertFalse(seen["mesh"].empty, "the eval kernel was traced with no mesh in context")
+        self.assertTrue(seen["rules"], "the eval kernel was traced with an empty logical axis rule set")
+
   def test_get_metrics_returns_one_buffer_and_a_sentinel_when_empty(self):
     """`get_metrics` returns a single buffer, matching both ABCs.
 

--- a/tests/post_training/unit/maxtext_engine_test.py
+++ b/tests/post_training/unit/maxtext_engine_test.py
@@ -1117,6 +1117,28 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     # The recorder is drained, so a later pass cannot re-write this one's numbers.
     self.assertEmpty(t._eval_metrics_recorder.get_metrics_history(clear_cache=False))
 
+  def _sharding_ctx_seen_by_eval(self, compiled: bool) -> dict[str, Any]:
+    """Runs one `eval_step` and reports the context its kernel was actually traced under."""
+    seen = {}
+
+    def loss_fn(model, *_args, **_kwargs):
+      # Read from inside the kernel, which is the only place that matters: `jax.jit` is lazy,
+      # so a context entered around the compile call and not the kernel call would still
+      # leave the trace bare.
+      seen["mesh"] = jax.sharding.get_abstract_mesh()
+      seen["rules"] = maxtext_engine.nn_partitioning.get_axis_rules()
+      return (
+          abstract_engine.WeightedMetric(unreduced_sum=jnp.sum(model.weights.value), denominator=jnp.array(1.0)),
+          {},
+      )
+
+    t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
+    t.with_loss_fn(loss_fn)
+    if compiled:
+      t.compile(DummyPayload())
+    t.eval_step(DummyPayload())
+    return seen
+
   def test_eval_step_traces_under_the_mesh_and_axis_rules(self):
     """The eval kernel is traced under the same context every training kernel gets.
 
@@ -1131,25 +1153,7 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     """
     for compiled in (False, True):
       with self.subTest(compiled=compiled):
-        seen = {}
-
-        def loss_fn(model, *_args, _seen=seen, **_kwargs):
-          # Read from inside the kernel, which is the only place that matters: `jax.jit` is
-          # lazy, so a context entered around the compile call and not the kernel call would
-          # still leave the trace bare.
-          _seen["mesh"] = jax.sharding.get_abstract_mesh()
-          _seen["rules"] = maxtext_engine.nn_partitioning.get_axis_rules()
-          return (
-              abstract_engine.WeightedMetric(unreduced_sum=jnp.sum(model.weights.value), denominator=jnp.array(1.0)),
-              {},
-          )
-
-        t = maxtext_engine.MaxTextTrainingEngine(self.mock_config)
-        t.with_loss_fn(loss_fn)
-        if compiled:
-          t.compile(DummyPayload())
-        t.eval_step(DummyPayload())
-
+        seen = self._sharding_ctx_seen_by_eval(compiled)
         self.assertFalse(seen["mesh"].empty, "the eval kernel was traced with no mesh in context")
         self.assertTrue(seen["rules"], "the eval kernel was traced with an empty logical axis rule set")
 


### PR DESCRIPTION
# Description

`fwd_bwd` and `update` wrap their kernel calls in `_sharding_ctx()` — the engine's
`with jax.set_mesh(self._mesh), nn_partitioning.axis_rules(config.logical_axis_rules)`.
`eval_step` was the one step path that did not, so the eval kernel was traced with **no mesh
in context and an empty logical axis rule set**.

Under `shard_mode=auto` that only costs partitioning quality — every
`maybe_shard_with_logical` becomes a no-op and XLA guesses — which is why it went unnoticed.
Under explicit axis types it is fatal. The MaxText layers call `jax.sharding.reshard(x, P(...))`
(e.g. `models/qwen3.py:940`), and a bare `PartitionSpec` outside a mesh context is an error
rather than a no-op:

```
ValueError: Using PartitionSpec when you are not under a mesh context is not allowed.
Please pass a NamedSharding instance or enter into a mesh context via `jax.set_mesh`. Got P(None,)
```

So `eval_step` does not merely evaluate with bad partitioning under `shard_mode=explicit` —
it raises on the first call.

The context is entered around the **call**, not around `_compile_eval_for_batch`, because
`jax.jit` is lazy: tracing happens at the call. That is the pattern `fwd_bwd` and `update`
already follow, and `_sharding_ctx`'s own docstring spells it out.

Pre-existing; not introduced by any open PR. Independent of #5138 and #5143 — no file overlap
in the source hunk beyond the same method, and this branch is cut from `main`.

# Tests

**Unit** — `tests/post_training/unit/maxtext_engine_test.py`:
`test_eval_step_traces_under_the_mesh_and_axis_rules` reads `jax.sharding.get_abstract_mesh()`
and `nn_partitioning.get_axis_rules()` from *inside* the loss fn, covering both eval branches
(`compile()`d and eager) via subTest. Verified red on `main` — both subtests fail with
`AssertionError: True is not false : the eval kernel was traced with no mesh in context` — and
green with the fix. Full file: **51 passed**.

```
JAX_PLATFORMS=cpu python -m pytest tests/post_training/unit/maxtext_engine_test.py -q
```
(the `JAX_PLATFORMS=cpu` matters — the suite silently skips without it)

**End-to-end** — qwen3.5-35b-a3b on a v7-8 (8 devices), `ep=8`, ring-of-experts + ragged-sort,
GA=8, bf16, seq 1024, adamw, 23 steps, then 4 `eval_step` calls:

| `shard_mode` | before | after |
|---|---|---|
| `explicit` | `eval_step` raises `ValueError` on the first call | 4 steps OK, **139.9 ms** median |
| `auto` | 4 steps OK, 1327.4 ms median | 4 steps OK, 1327.4 ms median |

Training step time and peak HBM are unchanged (4185.3 ms / 61.40 G explicit, 4043.8 ms /
61.39 G auto) — this only touches the eval path. The 9.5x explicit-vs-auto eval gap is the
point of the fix: with the rules live, the eval kernel gets the partitioning the training
kernels already had.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
