### PR TITLE
Register LazyTensor with the Orbax v1 leaf-handler registry

### DIFF
--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -50,6 +50,7 @@ Example Usage:
 """
 
 import argparse
+import dataclasses
 from functools import partial
 import json
 import os
@@ -76,6 +77,10 @@ from maxtext.utils import max_logging, max_utils, maxtext_utils
 from maxtext.utils.globals import HF_IDS
 import numpy as np
 from orbax.checkpoint import type_handlers
+from orbax.checkpoint import v1 as ocp_v1
+from orbax.checkpoint.experimental.v1._src.handlers import pytree_handler
+from orbax.checkpoint.experimental.v1._src.serialization import numpy_leaf_handler
+from orbax.checkpoint.experimental.v1._src.serialization import registry as leaf_handler_registry
 from safetensors import safe_open
 
 try:
@@ -295,6 +300,51 @@ class LazyTensorHandler(type_handlers.NumpyHandler):
 # Register LazyTensor with the custom handler.
 # It's safe to register this globally even if eager loading is used.
 type_handlers.register_type_handler(LazyTensor, LazyTensorHandler(), override=True)
+
+
+class LazyTensorLeafHandler(numpy_leaf_handler.NumpyLeafHandler):
+  """Orbax v1 leaf handler for LazyTensor.
+
+  The v0 registration above cannot serve the v1 save path. A v1 ``PyTreeHandler``
+  resolves leaves through a per-instance ``LeafHandlerRegistry`` and *derives* its
+  v0 registry from itself, so the compatibility bridge only runs v1 -> v0; a v0
+  global registration is unreachable from v1.
+
+  Like its v0 counterpart this masquerades as the standard numpy handler --
+  ``secondary_typestrs`` below writes ``np.ndarray`` as the leaf's typestr -- so
+  the checkpoint is indistinguishable from one a plain ``NumpyLeafHandler``
+  produced and restores in a standard MaxText instance.
+  """
+
+  async def serialize(self, params, serialization_context):
+    # MATERIALIZE: trigger the lazy load (__array__) explicitly before saving.
+    # This ensures the parent NumpyLeafHandler receives real np.ndarrays.
+    params = [dataclasses.replace(param, value=np.asarray(param.value)) for param in params]
+    return await super().serialize(params, serialization_context)
+
+
+class LazyTensorPyTreeHandler(pytree_handler.PyTreeHandler):
+  """``PyTreeHandler`` whose leaf registry additionally accepts ``LazyTensor``."""
+
+  def __init__(self, **kwargs):
+    if "leaf_handler_registry" not in kwargs:
+      registry = leaf_handler_registry.StandardLeafHandlerRegistry()
+      registry.add(
+          LazyTensor,
+          numpy_leaf_handler.NumpyShapeDtype,
+          LazyTensorLeafHandler,
+          override=True,
+          secondary_typestrs=["np.ndarray"],
+      )
+      kwargs["leaf_handler_registry"] = registry
+    super().__init__(**kwargs)
+
+
+def build_lazy_tensor_checkpointables_registry():
+  """Registry that saves MaxText's "items" checkpointable with LazyTensor support."""
+  registry = ocp_v1.handlers.local_registry(include_global_registry=True)
+  registry.add(LazyTensorPyTreeHandler, checkpointable_name="items")
+  return registry
 
 
 def get_maxtext_model_info(config):
@@ -1093,6 +1143,7 @@ def main(
       config.checkpoint_storage_use_ocdbt,
       config.checkpoint_storage_use_zarr3,
       config=config,
+      checkpointables_registry=build_lazy_tensor_checkpointables_registry(),
   )
 
   print_ram_usage("Program Ends")

--- a/src/maxtext/checkpoint_conversion/utils/utils.py
+++ b/src/maxtext/checkpoint_conversion/utils/utils.py
@@ -53,6 +53,7 @@ from maxtext.common.gcloud_stub import gcs_storage
 from maxtext.checkpoint_conversion.utils.tensor_handling import nesting_depth, stacked_axes
 from maxtext.utils import max_logging
 import orbax.checkpoint as ocp
+from orbax.checkpoint import v1 as ocp_v1
 
 _storage = gcs_storage()
 Client = _storage.Client
@@ -1238,6 +1239,7 @@ def save_weights_to_checkpoint(
     use_ocdbt: bool,
     use_zarr3: bool,
     config=None,
+    checkpointables_registry: ocp_v1.handlers.CheckpointableHandlerRegistry | None = None,
 ):
   """Saves model weights to a MaxText-compatible checkpoint with optional sharding.
 
@@ -1254,6 +1256,10 @@ def save_weights_to_checkpoint(
           (OCDBT) format for improved metadata handling.
       use_zarr3: If True, uses the Zarr3 storage format for the underlying array data.
       config: Optional config to save along with checkpoint metadata.
+      checkpointables_registry: Optional Orbax v1 handler registry, for converters whose
+          weight pytrees hold leaf types Orbax does not know natively. Only matters when
+          device_count is 1; above that shard_jax_weights has already materialized every
+          leaf into a sharded jax.Array.
   """
   mem_info = psutil.Process()
   logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
@@ -1281,6 +1287,7 @@ def save_weights_to_checkpoint(
       save_interval_steps,
       use_ocdbt=use_ocdbt,
       use_zarr3=use_zarr3,
+      checkpointables_registry=checkpointables_registry,
   )
   if checkpoint_manager is None:
     raise RuntimeError("Failed to create Orbax checkpoint manager.")

--- a/src/maxtext/common/checkpoint_context.py
+++ b/src/maxtext/common/checkpoint_context.py
@@ -94,6 +94,7 @@ def build_context(
     colocated_python_checkpointing: bool = False,
     partial_load: bool = False,
     checkpoint_layout: ocp.options.CheckpointLayout | None = None,
+    checkpointables_registry: ocp.handlers.CheckpointableHandlerRegistry | None = None,
 ) -> ocp.Context:
   """Builds an Orbax v1 ``Context`` from MaxText checkpoint flags.
 
@@ -119,6 +120,10 @@ def build_context(
       equivalent of v0 ``partial_restore=True``).
     checkpoint_layout: On-disk layout (``ORBAX`` or ``SAFETENSORS``) for
       loading.
+    checkpointables_registry: Handler registry deciding which
+      ``CheckpointableHandler`` serves each named checkpointable. Callers whose
+      pytrees hold leaf types Orbax does not know natively pass a registry
+      carrying a handler for them; ``None`` leaves the global registry in place.
 
   Returns:
     A configured, unfrozen ``ocp_v1.Context``.
@@ -171,5 +176,8 @@ def build_context(
 
   if checkpoint_layout is not None:
     ctx.checkpoint_layout = checkpoint_layout
+
+  if checkpointables_registry is not None:
+    ctx.checkpointables.registry = checkpointables_registry
 
   return ctx

--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -375,6 +375,7 @@ def create_orbax_checkpoint_manager(
     todelete_subdir: str | None = None,
     todelete_full_path: str | None = None,
     ocdbt_target_data_file_size_bytes: int | None = None,
+    checkpointables_registry: ocp.handlers.CheckpointableHandlerRegistry | None = None,
 ):
   """Returns an Orbax v1 training ``Checkpointer``, or None if checkpointing is disabled."""
   if not enable_checkpointing:
@@ -411,6 +412,7 @@ def create_orbax_checkpoint_manager(
       todelete_full_path=todelete_full_path,
       todelete_subdir=todelete_subdir,
       partial_load=True,
+      checkpointables_registry=checkpointables_registry,
   )
 
   manager = ocp.training.Checkpointer(


### PR DESCRIPTION
## What

Registers the converter's `LazyTensor` leaf type with the Orbax **v1** leaf-handler
registry, so HF→MaxText checkpoint conversion works again at
`--simulated_cpu_devices_count=1`.

Fixes #5106.

## Why

`checkpoint_conversion/to_maxtext.py:297` registers `LazyTensor` through the Orbax
**v0** API (`type_handlers.register_type_handler`). Since c41b2ae3a *("Refactor
MaxText's checkpointing system to primarily use the Orbax v1 API",  2026-09-01)* the
save path runs through `ocp.training.Checkpointer.save_checkpointables`, which
resolves handlers against the **v1** registry only.

The two registries are disjoint, and the compatibility bridge runs **one way**: a v1
`PyTreeHandler` builds a per-instance `StandardLeafHandlerRegistry` and *derives* its
v0 registry from itself. So a v0 global registration is structurally unreachable from
a v1 save. Conversion dies with `NoEntryError`.

The error names the *checkpointable* (`"items"` / `TrainState`), never the leaf type,
which is why this is easy to misdiagnose — the real failure is one leaf deeper.

c41b2ae3a touched zero files under `checkpoint_conversion/`, which is why this
regressed silently.

## Scope — measured, not inferred

The failure requires `simulated_cpu_devices_count=1`. At 2+, `shard_jax_weights`
materializes every leaf at `checkpoint_conversion/utils/utils.py:1194-1196` before the
tree ever reaches Orbax. Same tree, same model, same `lazy_load_tensors=True`, one flag
apart:

| `simulated_cpu_devices_count` | result on `main` |
|---|---|
| 1 | `NoEntryError` at `save_checkpointables` |
| 16 (the default) | rc=0, conversion succeeds |

**This is also why CI is green.**
`tests/integration/checkpoint_conversion_test.py::test_qwen3_30b_a3b_roundtrip_conversion`
is a real round-trip test collected by the `tpu-integration` and `gpu-integration`
flavors — but it never passes `--simulated_cpu_devices_count`, so it always runs at 16,
the one setting that cannot fail. Not "nobody runs it"; it runs constantly, at the safe
setting.

## How

Purely additive — 4 files, +68 −0. The existing v0 registration at `:297` is left in
place; removing it is orthogonal.

- `LazyTensorLeafHandler(NumpyLeafHandler)` — materializes via `np.asarray` in
  `serialize`, then defers to the numpy handler.
- `LazyTensorPyTreeHandler(PyTreeHandler)` — injects a per-instance
  `StandardLeafHandlerRegistry` carrying that handler. (`registry.add` takes a *type*,
  not an instance, hence the subclass.)
- `build_lazy_tensor_checkpointables_registry()` — a `local_registry` with
  `include_global_registry=True`, bound to checkpointable name `"items"`.
- Threaded through `checkpoint_context.build_context` /
  `checkpointing.create_orbax_checkpoint_manager` /
  `checkpoint_conversion/utils/utils.save_weights_to_checkpoint` as an optional
  `checkpointables_registry` kwarg, default `None` — no behavior change for any
  existing caller.

### The load-bearing detail: `secondary_typestrs=["np.ndarray"]`

Without it, the checkpoint records the *custom handler's* typestr, and a standard v0
restore then fails with `Unknown type: "...LazyTensorLeafHandler"`. The "fix" would
silently write **unloadable checkpoints** — strictly worse than the loud failure it
replaces. An earlier prototype did exactly that, and it was caught only because the
validator restores through the v0 `PyTreeCheckpointer` rather than just checking that
the save returned 0.

Reviewers: this is the line to scrutinize.

## Testing

CPU logits diff against the `transformers` reference at reduced dimensions
(hidden 256, 8 layers, vocab 512), every parameter randomized — default init leaves
RMSNorm scales at 0, which hides a wrong norm mapping. Run on a tree carrying the
patch, not a monkeypatch, at `simulated_cpu_devices_count=1`:

| arm | rc | max\|diff\| | cosine | argmax agreement |
|---|---|---|---|---|
| `lazy_load_tensors=True`, `scan_layers=False` | 0 | 1.66893e-06 | 1.00000000 | 100% |
| `lazy_load_tensors=True`, `scan_layers=True` | 0 | 1.57952e-06 | 1.00000000 | 100% |
| `lazy_load_tensors=False` (eager reference) | 0 | 1.66893e-06 | 1.00000000 | 100% |

Both lazy arms fail with `NoEntryError` without this patch; the eager arm is the
unchanged reference. Lazy now matches eager to the digit.

Both `scan_layers` settings are exercised because they are different code paths and
`scan_layers=True` is what training consumes.

The harness is sensitive to real corruption, not just to crashes: a same-shape
`gate_proj`↔`up_proj` swap in the same converter scores cosine **0.729** / argmax 18.8%.
Shape and name assertions cannot see that swap; only a value diff can.

## Notes

Two imports reach into `_src`
(`orbax...experimental.v1._src.serialization.numpy_leaf_handler` and
`..._src.serialization.registry`). If there is a public path for these I'd rather use
it — happy to switch.
