### PR TITLE
fix pyink

### DIFF
--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -624,9 +624,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     cp_len = LENGTH if gdn_context_axes(self.config) else None
 
     def _sharding(logical_axes):
-      pspec = logical_to_mesh_axes(
-          logical_axes, mesh=self.mesh, rules=logical_rules
-      )
+      pspec = logical_to_mesh_axes(logical_axes, mesh=self.mesh, rules=logical_rules)
       # Training microbatches can be smaller than the physical batch partition.
       # Only dim 0 is inspected, so the trailing sizes are placeholders.
       shape = (batch,) + (1,) * (len(logical_axes) - 1)
@@ -654,9 +652,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     # hidden_states: (B, S, E)
     cfg = self.config
     batch, seq_len, _ = hidden_states.shape
-    flat_sharding, head_sharding, state_sharding = (
-        self._explicit_activation_shardings(batch)
-    )
+    flat_sharding, head_sharding, state_sharding = self._explicit_activation_shardings(batch)
 
     active_cache = kv_cache if kv_cache is not None else self.cache
 
@@ -759,13 +755,9 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     b_raw, a_raw = jnp.split(mixed_ba, split_indices_ba, axis=3)
 
     # b: (B, S, H_v)
-    b = jnp.reshape(
-        b_raw, (batch, seq_len, self.num_v_heads), out_sharding=flat_sharding
-    )
+    b = jnp.reshape(b_raw, (batch, seq_len, self.num_v_heads), out_sharding=flat_sharding)
     # a: (B, S, H_v)
-    a = jnp.reshape(
-        a_raw, (batch, seq_len, self.num_v_heads), out_sharding=flat_sharding
-    )
+    a = jnp.reshape(a_raw, (batch, seq_len, self.num_v_heads), out_sharding=flat_sharding)
 
     if use_paged_state:
       # =========================================================================
@@ -1051,9 +1043,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         value = jax.sharding.reshard(value, qkv_pspec)
         g = jax.sharding.reshard(g, g_beta_pspec)
         beta = jax.sharding.reshard(beta, g_beta_pspec)
-        recurrent_state_arg = jax.sharding.reshard(
-            recurrent_state_arg, state_pspec
-        )
+        recurrent_state_arg = jax.sharding.reshard(recurrent_state_arg, state_pspec)
 
       @functools.partial(
           jax.shard_map,
@@ -1127,15 +1117,11 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     # The normalization and gating is applied per-head on the value dimension.
 
     # Apply the norm and gate. Output shape: (B, S, H_v, D_v)
-    gated_output_reshaped = self.norm(
-        core_attn_out, z, out_sharding=head_sharding
-    )
+    gated_output_reshaped = self.norm(core_attn_out, z, out_sharding=head_sharding)
 
     # Reshape back to a single feature dimension for the final projection.
     # Shape from (B, S, H_v, D_v) -> (B, S, value_dim)
-    gated_output = jnp.reshape(
-        gated_output_reshaped, (batch, seq_len, -1), out_sharding=flat_sharding
-    )
+    gated_output = jnp.reshape(gated_output_reshaped, (batch, seq_len, -1), out_sharding=flat_sharding)
 
     # Final output shape: (B, S, E)
     output = self.out_proj(gated_output, out_sharding=out_sharding)
@@ -1692,9 +1678,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
     # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
     # ShardMode.AUTO the callees ignore these and let GSPMD infer the layout.
     if cfg.shard_mode == ShardMode.EXPLICIT:
-      self.out_sharding = create_sharding(
-          mesh, self.activation_axis_names, rules=get_logical_axis_rules()
-      )
+      self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
       self.mlp_intermediate_sharding = create_sharding(
           mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules()
       )
@@ -1777,15 +1761,11 @@ class Qwen3NextDecoderLayer(nnx.Module):
 
     # First LayerNorm, applied before the attention block.
     hidden_states = self.input_layernorm(inputs, out_sharding=self.out_sharding)
-    hidden_states = self._maybe_shard_with_logical(
-        hidden_states, self.activation_axis_names
-    )
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Conditionally apply either the Linear Attention or Full Attention block.
     if isinstance(self.attention, Qwen3NextFullAttention):
-      attention_output, new_kv_cache = cast(
-          Qwen3NextFullAttention, self.attention
-      )(
+      attention_output, new_kv_cache = cast(Qwen3NextFullAttention, self.attention)(
           hidden_states,
           decoder_segment_ids,
           decoder_positions,
@@ -1796,9 +1776,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
           out_sharding=self.out_sharding,
       )
     else:
-      attention_output, new_kv_cache = cast(
-          Qwen3NextGatedDeltaNet, self.attention
-      )(
+      attention_output, new_kv_cache = cast(Qwen3NextGatedDeltaNet, self.attention)(
           hidden_states,
           model_mode=model_mode,
           kv_cache=kv_cache,
@@ -1808,24 +1786,16 @@ class Qwen3NextDecoderLayer(nnx.Module):
       )
 
     # First residual connection after attention
-    attention_output = self._maybe_shard_with_logical(
-        attention_output, self.activation_axis_names
-    )
+    attention_output = self._maybe_shard_with_logical(attention_output, self.activation_axis_names)
     hidden_states = residual + attention_output
-    hidden_states = self._maybe_shard_with_logical(
-        hidden_states, self.activation_axis_names
-    )
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Prepare for the MoE block by capturing the new residual
     residual = hidden_states
 
     # Second LayerNorm, applied before the MoE block.
-    hidden_states = self.post_attention_layernorm(
-        hidden_states, out_sharding=self.out_sharding
-    )
-    hidden_states = self._maybe_shard_with_logical(
-        hidden_states, self.activation_axis_names
-    )
+    hidden_states = self.post_attention_layernorm(hidden_states, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Instantiate and call our `Qwen3NextSparseMoeBlock`.
     mlp_output, load_balance_loss = self.mlp(
@@ -1841,9 +1811,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
       self.moe_lb_loss = nnx.Intermediate(load_balance_loss)
 
     # Final residual connection (after the MoE block)
-    mlp_output = self._maybe_shard_with_logical(
-        mlp_output, self.activation_axis_names
-    )
+    mlp_output = self._maybe_shard_with_logical(mlp_output, self.activation_axis_names)
     layer_output = residual + mlp_output
     layer_output = self._maybe_shard_with_logical(
         layer_output,

--- a/src/maxtext/models/qwen3_5.py
+++ b/src/maxtext/models/qwen3_5.py
@@ -144,9 +144,7 @@ class Qwen3_5DecoderLayer(nnx.Module):
     # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
     # ShardMode.AUTO the callees ignore these and let GSPMD infer the layout.
     if cfg.shard_mode == ShardMode.EXPLICIT:
-      self.out_sharding = create_sharding(
-          mesh, self.activation_axis_names, rules=get_logical_axis_rules()
-      )
+      self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
       self.mlp_intermediate_sharding = create_sharding(
           mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules()
       )
@@ -226,15 +224,11 @@ class Qwen3_5DecoderLayer(nnx.Module):
 
     # First LayerNorm, applied before the attention block.
     hidden_states = self.input_layernorm(inputs, out_sharding=self.out_sharding)
-    hidden_states = self._maybe_shard_with_logical(
-        hidden_states, self.activation_axis_names
-    )
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Conditionally apply either the Linear Attention or Full Attention block.
     if isinstance(self.attention, Qwen3_5FullAttention):
-      attention_output, new_kv_cache = cast(
-          Qwen3_5FullAttention, self.attention
-      )(
+      attention_output, new_kv_cache = cast(Qwen3_5FullAttention, self.attention)(
           hidden_states,
           decoder_segment_ids,
           decoder_positions,
@@ -245,9 +239,7 @@ class Qwen3_5DecoderLayer(nnx.Module):
           out_sharding=self.out_sharding,
       )
     else:
-      attention_output, new_kv_cache = cast(
-          Qwen3_5GatedDeltaNet, self.attention
-      )(
+      attention_output, new_kv_cache = cast(Qwen3_5GatedDeltaNet, self.attention)(
           hidden_states,
           model_mode=model_mode,
           kv_cache=kv_cache,
@@ -257,24 +249,16 @@ class Qwen3_5DecoderLayer(nnx.Module):
       )
 
     # First residual connection after attention
-    attention_output = self._maybe_shard_with_logical(
-        attention_output, self.activation_axis_names
-    )
+    attention_output = self._maybe_shard_with_logical(attention_output, self.activation_axis_names)
     hidden_states = residual + attention_output
-    hidden_states = self._maybe_shard_with_logical(
-        hidden_states, self.activation_axis_names
-    )
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Prepare for the MoE block by capturing the new residual
     residual = hidden_states
 
     # Second LayerNorm, applied before the MoE block.
-    hidden_states = self.post_attention_layernorm(
-        hidden_states, out_sharding=self.out_sharding
-    )
-    hidden_states = self._maybe_shard_with_logical(
-        hidden_states, self.activation_axis_names
-    )
+    hidden_states = self.post_attention_layernorm(hidden_states, out_sharding=self.out_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # Instantiate and call our `Qwen3_5SparseMoEBlock`.
     mlp_output, load_balance_loss = self.mlp(
@@ -291,9 +275,7 @@ class Qwen3_5DecoderLayer(nnx.Module):
       self.sow(nnx.Intermediate, "moe_lb_loss", load_balance_loss)
 
     # Final residual connection (after the MoE block)
-    mlp_output = self._maybe_shard_with_logical(
-        mlp_output, self.activation_axis_names
-    )
+    mlp_output = self._maybe_shard_with_logical(mlp_output, self.activation_axis_names)
     layer_output = residual + mlp_output
     layer_output = self._maybe_shard_with_logical(
         layer_output,

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -1068,7 +1068,12 @@ class TrainTests(unittest.TestCase):
         # a large fraction of a model this small, so relax the unsharded-parameter check.
         "qwen3_next": [
             "ici_fsdp_parallelism=1",
-            "ici_tensor_parallelism=-1",
+            # `gdn_num_key_heads=4` caps how far the head axis can shard, so pin the
+            # degree rather than take the device count: `-1` resolves to 8 on tpu7x-8
+            # and the gated-delta-net reshapes then fail to divide. Whatever is left
+            # over goes to data parallelism, which both shard modes see alike.
+            "ici_tensor_parallelism=4",
+            "ici_data_parallelism=-1",
             "sharding_tolerance=0.5",
         ],
     }

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -855,8 +855,13 @@ class TrainTests(unittest.TestCase):
         print(f"[{decoder_block}] auto losses: {auto_losses}", flush=True)
         print(f"[{decoder_block}] explicit losses: {explicit_losses}", flush=True)
         self.assertTrue(auto_losses, "auto run produced no metrics")
-        # The two runs execute the same math, so they match bit-for-bit.
-        np.testing.assert_allclose(explicit_losses, auto_losses, rtol=1e-6, atol=0.0)
+        # The two runs execute the same math, but not necessarily in the same order: once
+        # tensor parallelism fully shards `heads` (8 heads on an 8-device mesh, as on
+        # tpu7x-8) the layout pinned under explicit sharding reassociates the backward
+        # reductions. The forward pass stays bit-for-bit and the drift only appears once
+        # gradients flow -- under 1e-5 relative at step 3, i.e. float noise rather than
+        # the two runs pulling apart.
+        np.testing.assert_allclose(explicit_losses, auto_losses, rtol=1e-4, atol=0.0)
 
   @pytest.mark.integration_test
   @pytest.mark.tpu_only

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -222,9 +222,7 @@ class TrainTests(unittest.TestCase):
       # The Qwen3.5 model configs default to a HuggingFace tokenizer that is not
       # vendored in the repo; use the checked-in tiktoken asset instead.
       "tokenizer_type=tiktoken",
-      (
-          rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}"
-      ),
+      (rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}"),
   ]
 
   # Same sublayers as Qwen3.5, wired together by Qwen3NextScannableBlock rather than a
@@ -1072,26 +1070,20 @@ class TrainTests(unittest.TestCase):
     for decoder_block, model_overrides in self._QWEN3_HYBRID_MODELS.items():
       with self.subTest(decoder_block=decoder_block):
         args = parallelism[decoder_block]
-        auto_losses = self._losses(
-            f"{decoder_block}_auto", model_overrides, args + ["shard_mode=auto"]
-        )
+        auto_losses = self._losses(f"{decoder_block}_auto", model_overrides, args + ["shard_mode=auto"])
         explicit_losses = self._losses(
             f"{decoder_block}_explicit",
             model_overrides,
             args + ["shard_mode=explicit"],
         )
         print(f"[{decoder_block}] auto losses: {auto_losses}", flush=True)
-        print(
-            f"[{decoder_block}] explicit losses: {explicit_losses}", flush=True
-        )
+        print(f"[{decoder_block}] explicit losses: {explicit_losses}", flush=True)
         self.assertTrue(auto_losses, "auto run produced no metrics")
         # `activation_batch` carries the expert axis, so pinning it reassociates the
         # backward reductions: the forward pass is bit-for-bit and the drift only appears
         # once gradients flow. Over 20 steps it stays below 4e-5 relative and changes
         # sign, i.e. it is float noise rather than the two runs pulling apart.
-        np.testing.assert_allclose(
-            explicit_losses, auto_losses, rtol=1e-4, atol=0.0
-        )
+        np.testing.assert_allclose(explicit_losses, auto_losses, rtol=1e-4, atol=0.0)
 
   @pytest.mark.integration_test
   @pytest.mark.tpu_only
@@ -1127,8 +1119,7 @@ class TrainTests(unittest.TestCase):
         sharded = self._losses(
             f"{decoder_block}_ga_zero1",
             model_overrides,
-            zero1_ga
-            + ["shard_mode=explicit", "shard_optimizer_over_data=True"],
+            zero1_ga + ["shard_mode=explicit", "shard_optimizer_over_data=True"],
         )
         print(f"[{decoder_block}] auto + GA losses: {baseline}", flush=True)
         print(

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -285,14 +285,10 @@ class PyconfigTest(unittest.TestCase):
         with self.assertRaisesRegex(Exception, "requires `sparse_matmul=True`"):
           initialize(sparse_matmul=False, megablox=False)
 
-        with self.assertRaisesRegex(
-            Exception, "does not support context parallelism"
-        ):
+        with self.assertRaisesRegex(Exception, "does not support context parallelism"):
           initialize(ici_context_parallelism=2)
 
-        with self.assertRaisesRegex(
-            Exception, "does not support context parallelism"
-        ):
+        with self.assertRaisesRegex(Exception, "does not support context parallelism"):
           initialize(ici_context_usp_ulysses_parallelism=2)
 
   def test_explicit_sharding_mistral_decoder_support(self):

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -1149,53 +1149,53 @@ class TrainCompile(parameterized.TestCase):
     the
     layout it was handed.
     """
-    compiled_trainstep_file = os.path.join(
-        gettempdir(), "test_qwen3_next_explicit_sharding.pickle"
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_qwen3_next_explicit_sharding.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-512",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3-next-80b-a3b",
+            "per_device_batch_size=1.0",
+            "max_target_length=1024",
+            "ici_fsdp_parallelism=32",
+            "ici_expert_parallelism=8",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "use_tokamax_splash=True",
+            "shard_mode=explicit",
+        )
     )
-    train_compile_main((
-        "",
-        get_test_config_path(),
-        f"compiled_trainstep_file={compiled_trainstep_file}",
-        "compile_topology=v5p-512",
-        "compile_topology_num_slices=1",
-        "model_name=qwen3-next-80b-a3b",
-        "per_device_batch_size=1.0",
-        "max_target_length=1024",
-        "ici_fsdp_parallelism=32",
-        "ici_expert_parallelism=8",
-        "sparse_matmul=True",
-        "megablox=True",
-        "attention=flash",
-        "use_tokamax_splash=True",
-        "shard_mode=explicit",
-    ))
 
   def test_qwen3_next_explicit_sharding_zero1(self):
     """AOT test for qwen3-next under explicit sharding with ZeRO-1 and gradient accumulation."""
-    compiled_trainstep_file = os.path.join(
-        gettempdir(), "test_qwen3_next_explicit_sharding_zero1.pickle"
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_qwen3_next_explicit_sharding_zero1.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-256",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3-next-80b-a3b",
+            "override_model_config=True",
+            "base_num_decoder_layers=4",
+            "per_device_batch_size=1.0",
+            "max_target_length=1024",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "use_tokamax_splash=True",
+            "shard_mode=explicit",
+            "ici_data_parallelism=-1",
+            "ici_fsdp_parallelism=1",
+            "gradient_accumulation_steps=4",
+            "shard_optimizer_over_data=True",
+        )
     )
-    train_compile_main((
-        "",
-        get_test_config_path(),
-        f"compiled_trainstep_file={compiled_trainstep_file}",
-        "compile_topology=v5p-256",
-        "compile_topology_num_slices=1",
-        "model_name=qwen3-next-80b-a3b",
-        "override_model_config=True",
-        "base_num_decoder_layers=4",
-        "per_device_batch_size=1.0",
-        "max_target_length=1024",
-        "sparse_matmul=True",
-        "megablox=True",
-        "attention=flash",
-        "use_tokamax_splash=True",
-        "shard_mode=explicit",
-        "ici_data_parallelism=-1",
-        "ici_fsdp_parallelism=1",
-        "gradient_accumulation_steps=4",
-        "shard_optimizer_over_data=True",
-    ))
 
   def test_qwen3_5_explicit_sharding(self):
     """AOT test for qwen3-5 under explicit sharding, at FSDP 32 x expert 8.
@@ -1206,31 +1206,29 @@ class TrainCompile(parameterized.TestCase):
     silently
     costing a collective at a scale a real test cannot reach.
     """
-    compiled_trainstep_file = os.path.join(
-        gettempdir(), "test_qwen3_5_explicit_sharding.pickle"
-    )
-    train_compile_main((
-        "",
-        get_test_config_path(),
-        f"compiled_trainstep_file={compiled_trainstep_file}",
-        "compile_topology=v5p-512",
-        "compile_topology_num_slices=1",
-        "model_name=qwen3.5-397b-a17b",
-        "per_device_batch_size=1.0",
-        "max_target_length=1024",
-        "ici_fsdp_parallelism=32",
-        "ici_expert_parallelism=8",
-        "sparse_matmul=True",
-        "megablox=True",
-        "attention=flash",
-        "use_tokamax_splash=True",
-        "shard_mode=explicit",
-        # Qwen3.5 defaults to a HuggingFace tokenizer that is not vendored.
-        "tokenizer_type=tiktoken",
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_qwen3_5_explicit_sharding.pickle")
+    train_compile_main(
         (
-            f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}"
-        ),
-    ))
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-512",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3.5-397b-a17b",
+            "per_device_batch_size=1.0",
+            "max_target_length=1024",
+            "ici_fsdp_parallelism=32",
+            "ici_expert_parallelism=8",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "use_tokamax_splash=True",
+            "shard_mode=explicit",
+            # Qwen3.5 defaults to a HuggingFace tokenizer that is not vendored.
+            "tokenizer_type=tiktoken",
+            (f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}"),
+        )
+    )
 
   def test_qwen3_5_explicit_sharding_zero1(self):
     """AOT test for qwen3-5 under explicit sharding with ZeRO-1 and gradient accumulation.
@@ -1245,34 +1243,32 @@ class TrainCompile(parameterized.TestCase):
     variants
     while staying small enough to hold data-parallel replicas of the parameters.
     """
-    compiled_trainstep_file = os.path.join(
-        gettempdir(), "test_qwen3_5_explicit_sharding_zero1.pickle"
-    )
-    train_compile_main((
-        "",
-        get_test_config_path(),
-        f"compiled_trainstep_file={compiled_trainstep_file}",
-        "compile_topology=v5p-256",
-        "compile_topology_num_slices=1",
-        "model_name=qwen3.5-35b-a3b",
-        "override_model_config=True",
-        "base_num_decoder_layers=4",
-        "per_device_batch_size=1.0",
-        "max_target_length=1024",
-        "sparse_matmul=True",
-        "megablox=True",
-        "attention=flash",
-        "use_tokamax_splash=True",
-        "shard_mode=explicit",
-        "ici_data_parallelism=-1",
-        "ici_fsdp_parallelism=1",
-        "gradient_accumulation_steps=4",
-        "shard_optimizer_over_data=True",
-        "tokenizer_type=tiktoken",
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_qwen3_5_explicit_sharding_zero1.pickle")
+    train_compile_main(
         (
-            f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}"
-        ),
-    ))
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-256",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3.5-35b-a3b",
+            "override_model_config=True",
+            "base_num_decoder_layers=4",
+            "per_device_batch_size=1.0",
+            "max_target_length=1024",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "use_tokamax_splash=True",
+            "shard_mode=explicit",
+            "ici_data_parallelism=-1",
+            "ici_fsdp_parallelism=1",
+            "gradient_accumulation_steps=4",
+            "shard_optimizer_over_data=True",
+            "tokenizer_type=tiktoken",
+            (f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}"),
+        )
+    )
 
   def test_serialization_and_deserialization_formats(self):
     """Tests that our custom binary save/load functions work securely and legacy fallback triggers warning."""


### PR DESCRIPTION
# Description

Fixes every failure on `main` that is attributable to recently merged Qwen
explicit-sharding work. Three commits.

**1. pyink formatting (Code Quality Check).** `pre-commit run pyink --all-files`
fails on `main`. Five files landed wrapped at 80 columns instead of the repo's
`--pyink-indentation=2 --line-length=122`:

- `src/maxtext/models/qwen3.py`
- `src/maxtext/models/qwen3_5.py`
- `tests/integration/train_tests.py`
- `tests/unit/pyconfig_test.py`
- `tests/unit/train_compile_test.py`

All five came in with #5119 (f452e7134). The Code Quality job runs pyink over all
files rather than only the diff, so this reddens the check on every unrelated PR.
The nightly at 13988fb8e (run 33932239729) is the first to include #5119 and it
reports exactly these five files. That commit is pyink's output verbatim.

**2. `test_tpu_qwen3_explicit_sharding_matches_auto` tolerance.** Fails on
`tpu7x-8`, passes on `v6e-4`, bit-identical across nightlies:

```
Not equal to tolerance rtol=1e-06, atol=0
ACTUAL  (explicit): [189.751099, 189.440186, 189.269714]
DESIRED (auto):     [189.751099, 189.442078, 189.269928]
Max relative difference: 9.99e-06
```

Only the dense `qwen3` subtest is affected -- the one that sets
`ici_tensor_parallelism=-1`, which resolves to the device count. With
`base_num_query_heads=8` that is 4-way TP on v6e (2 heads per shard) and 8-way on
tpu7x (1 head per shard). Step 1 matches bit-for-bit and the drift appears only
from step 2, so the backward reductions reassociate under the pinned layout while
the forward pass is unchanged. Loosened to `rtol=1e-4`, matching what the sibling
hybrid test already allows for the same effect.

**3. `test_tpu_qwen3_hybrid_explicit_sharding_matches_auto` divisibility.** Hard
failure on `tpu7x-8`, new with #5119:

```
ValueError: Sharding spec ('tensor',) implies that array axis 2 is partitioned
8 times, but does not evenly divide the dimension size 4.
Got shape: (96, 256, 4, 384)
```

Same root cause, different symptom: `ici_tensor_parallelism=-1` asks the head axis
to shard 8 ways while `gdn_num_key_heads=4`. It passes on v6e-4 only because 4
divides 4. Pinned the degree at 4 with the leftover devices going to data
parallelism, which both shard modes see alike.

# Tests

`pre-commit run pyink --all-files` and `mdformat --all-files` pass on this branch;
pyink fails on `main`. codespell, pylint, yamllint, actionlint and the
decoupled-requirements hook were already passing and still pass.

The qwen3-next fix was reproduced and verified locally by AOT-compiling that exact
config: with `ici_tensor_parallelism=-1` it raises the identical `ValueError` at
`v5p-16` (8 devices), and with the pinned degree it compiles clean at both
`v5p-8` and `v5p-16`. The tpu7x CI job on this PR is the end-to-end check for
both test changes.

## Not addressed here (not caused by this work)

For the record, the other failures on `main` at 13988fb8e were checked and are
unrelated:

- `tokamax_test.py::test_smoke_train_tokamax_v1_fp8_full_ep1` -- `NotImplementedError: subchannel_iters != 1 not supported yet in tgmm`, a tokamax limitation.
- `train_tests.py::test_moe_nanoo_fp8[_sparse_matmul]` -- GCS `412 PreconditionFailed` writing to `runner-maxtext-logs`, infrastructure.
- `sft_multimodal_gemma3_demo.ipynb` / `native_lora_demo.ipynb` -- `NOT_FOUND: "google/gemma-3-4b-it"` tokenizer, failing nightly for weeks.
- `checkpoint_resharding_test.py::test_checkpoint_resharding` -- tensorstore zarr3 `chunk_shape` mismatch. Not root-caused here, but no PR in this range touches checkpointing, orbax or tensorstore, and this shard has a history of orbax-flavoured breakage (e.g. `'Checkpointer' object has no attribute 'restore'` in run 33776554492, well before this work).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable. (AOT compile verification described above; tpu7x CI on this PR covers the rest.)
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files). (Not applicable.)
