### PR TITLE
Fix Multimodal SFT grain pipeline crashes (Tokenizer & IterDataset)

### DIFF
--- a/src/maxtext/configs/pyconfig.py
+++ b/src/maxtext/configs/pyconfig.py
@@ -310,7 +310,10 @@ def _prepare_for_pydantic(raw_keys: dict[str, Any], config_class: type[Any] = ty
 
     if key == "tokenizer_path" and new_value is None:
       try:
-        new_value = HF_IDS[raw_keys["model_name"]]
+        model_name = raw_keys.get("model_name", "default")
+        new_value = HF_IDS[model_name]
+        if model_name != "default":
+          pydantic_kwargs["_auto_hf_tokenizer"] = True
       except KeyError:
         new_value = os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers/tokenizer.llama2")
         max_logging.warning(
@@ -320,6 +323,9 @@ def _prepare_for_pydantic(raw_keys: dict[str, Any], config_class: type[Any] = ty
         )
 
     pydantic_kwargs[key] = new_value
+
+  if pydantic_kwargs.pop("_auto_hf_tokenizer", False):
+    pydantic_kwargs["tokenizer_type"] = "huggingface"
 
   return pydantic_kwargs
 

--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -721,9 +721,11 @@ def vision_sft_preprocessing_pipeline(
             keep_aux_fields=False,  # drop aux to match train shape
         )
     )
-  dataset = dataset.map(input_pipeline_utils.ShiftData(ignored_ids=[pad_id], axis=1))
 
-  dataset = dataset.to_iter_dataset()
+  if hasattr(dataset, "to_iter_dataset"):
+    dataset = dataset.to_iter_dataset()
+
+  dataset = dataset.map(input_pipeline_utils.ShiftData(ignored_ids=[pad_id], axis=1))
   dataset = data_processing_utils.apply_multiprocessing_and_prefetch(
       dataset, config, grain_worker_count, grain_per_worker_buffer_size
   )

--- a/tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_multimodal_sft.sh
+++ b/tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_multimodal_sft.sh
@@ -64,9 +64,9 @@ python -m maxtext.trainers.post_train.sft.train_sft_native "${MAXTEXT_CONFIGS_DI
     async_checkpointing=False \
     float32_qk_product=True \
     float32_logits=True \
-    dataset_type=hf \
-    hf_path=parquet \
-    hf_train_files=${DATASET_PATH}/hf/chartqa/train-* \
+    dataset_type=grain \
+    grain_file_type=parquet \
+    grain_train_files=${DATASET_PATH}/hf/chartqa/train-* \
     base_output_directory=${BASE_OUTPUT_DIRECTORY}/multimodal/sft \
     load_parameters_path=${MULTIMODAL_UNSCANNED_CKPT_PATH} \
     sharding_tolerance=0.05 \


### PR DESCRIPTION
## Description

When running Multimodal SFT workloads with `dataset_type=grain`, the pipeline fails with two consecutive issues:
1. A tokenizer crash (`NOT_FOUND`) because it attempts to pass a HuggingFace repo ID directly to the native SentencePiece library.
2. An `AttributeError: 'MapIterDataset' object has no attribute 'to_iter_dataset'` causing the data pipeline to break completely.

[DAG Error Log](https://cloudlogging.app.goo.gl/EsWAR2yiw2jUqF5dA)

## Root Cause

This PR addresses two upstream edge-cases exposed by the recent multimodal SFT grain migration:
1. **Tokenizer Config Mismatch:** In `pyconfig.py`, the auto-injected HuggingFace setup was getting silently erased because `tokenizer_type` was overwritten back to the `base.yml` default (`sentencepiece`) during the config dictionary iteration loop. 
2. **Redundant IterDataset Conversion:** In `grain_data_processing.py`, the `vision_sft_preprocessing_pipeline` explicitly calls `dataset = dataset.to_iter_dataset()`. However, upstream parquet loaders already construct `IterDataset` objects (e.g., `MapIterDataset`), which do not possess this method, triggering the `AttributeError`.

## Solution

- **`src/maxtext/configs/pyconfig.py`**: Defer the modification. Safely explicitly assign `pydantic_kwargs["tokenizer_type"] = "huggingface"` immediately *after*  the `base.yml` iteration loop finishes.
- **`src/maxtext/input_pipeline/grain_data_processing.py`**: Remove the `.to_iter_dataset()` call from `vision_sft_preprocessing_pipeline` since the upstream parquet / grain dataloader outputs are inherently iterable.


# Tests

Qwen3-vl-2b Multimodal SFT: https://paste.googleplex.com/6459973572362240

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
