### PR TITLE
Share one CUSTOM_REMAT_TENSORS list between MaxTextConfig and RLConfig

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -143,6 +143,43 @@ class RematLocation(str, Enum):
   OFFLOAD = "offload"
 
 
+# Tensors that ``remat_policy: custom`` can pin to device or offload to host.
+#
+# Every name here must have a matching ``checkpoint_name(...)`` call in the model
+# code; a name with no matching call is silently inert. Kept as one constant
+# because two separate ``model_post_init`` hooks consume it -- MaxTextConfig's and
+# RLConfig's -- and the two hardcoded copies had drifted: RLConfig's was missing
+# "kv_proj", so under RL a ``remat_policy: custom`` run with ``kv_proj: device``
+# silently rematerialised the unified KV projection instead of keeping it.
+#
+# ``engram`` is deliberately absent: it is declared as a RematLocation field on
+# RematAndOffload, but no ``checkpoint_name(..., "engram")`` exists in the tree,
+# so listing it here would promise control the model code cannot honour.
+CUSTOM_REMAT_TENSORS: tuple[str, ...] = (
+    "decoder_layer_input",
+    "indexer_cutoff_threshold",
+    "context",
+    "mlpwi",
+    "moe_mlpwi_0",
+    "moe_mlpwi_1",
+    "moe_mlpwo",
+    "mlpwi_0",
+    "mlpwi_1",
+    "mlpwo",
+    "query_proj",
+    "key_proj",
+    "value_proj",
+    "kv_proj",
+    "query_wa_proj",
+    "kv_wa_proj",
+    "mla_kv",
+    "mla_q",
+    "qkv_proj",
+    "attention_out",
+    "out_proj",
+)
+
+
 class OptimizerType(str, Enum):
   """Supported optimizer algorithms."""
 
@@ -3874,29 +3911,7 @@ class MaxTextConfig(
 
     # G. CALCULATE/SET OTHER DERIVED VALUES, E.G. PIPELINE CONFIG
     if self.remat_policy == "custom":
-      tensors = [
-          "decoder_layer_input",
-          "indexer_cutoff_threshold",
-          "context",
-          "mlpwi",
-          "moe_mlpwi_0",
-          "moe_mlpwi_1",
-          "moe_mlpwo",
-          "mlpwi_0",
-          "mlpwi_1",
-          "mlpwo",
-          "query_proj",
-          "key_proj",
-          "value_proj",
-          "kv_proj",
-          "query_wa_proj",
-          "kv_wa_proj",
-          "mla_kv",
-          "mla_q",
-          "qkv_proj",
-          "attention_out",
-          "out_proj",
-      ]
+      tensors = CUSTOM_REMAT_TENSORS
       self.tensors_on_device = [t for t in tensors if getattr(self, t) == "device"]
       self.tensors_to_offload = [t for t in tensors if getattr(self, t) == "offload"]
 
@@ -5154,28 +5169,7 @@ class RLConfig(
     self.steps = getattr(self, "train_steps", getattr(self, "num_batches", 10))
 
     if self.remat_policy == "custom":
-      tensors = [
-          "decoder_layer_input",
-          "indexer_cutoff_threshold",
-          "context",
-          "mlpwi",
-          "moe_mlpwi_0",
-          "moe_mlpwi_1",
-          "moe_mlpwo",
-          "mlpwi_0",
-          "mlpwi_1",
-          "mlpwo",
-          "query_proj",
-          "key_proj",
-          "value_proj",
-          "query_wa_proj",
-          "kv_wa_proj",
-          "mla_kv",
-          "mla_q",
-          "qkv_proj",
-          "attention_out",
-          "out_proj",
-      ]
+      tensors = CUSTOM_REMAT_TENSORS
       self.tensors_on_device = [t for t in tensors if getattr(self, t) == "device"]
       self.tensors_to_offload = [t for t in tensors if getattr(self, t) == "offload"]
 

--- a/tests/unit/configs_test.py
+++ b/tests/unit/configs_test.py
@@ -22,6 +22,7 @@ errors like "Extra inputs are not permitted."
 """
 
 import os
+import ast
 import functools
 from copy import deepcopy
 
@@ -72,6 +73,23 @@ def load_and_merge_yamls(yaml_path: str) -> dict:
   return data if data is not None else {}
 
 
+def normalize_config_dict(config_dict: dict) -> dict:
+  """Aligns a merged YAML dict with the Pydantic model before validation.
+
+  Drops the base_config pointer, renames num_epochs, and turns the YAML string
+  "none" into a real None.
+  """
+  config_dict = dict(config_dict)
+  if "base_config" in config_dict:
+    del config_dict["base_config"]
+  if "num_epochs" in config_dict:
+    config_dict["num_epoch"] = config_dict.pop("num_epochs")
+  for key, value in config_dict.items():
+    if isinstance(value, str) and value.lower() == "none":
+      config_dict[key] = None
+  return config_dict
+
+
 def run_config_validation(config_file_path: str):
   """
   Core validation logic: loads, merges, and validates a single config file.
@@ -82,13 +100,7 @@ def run_config_validation(config_file_path: str):
     config_dict = load_and_merge_yamls(config_file_path)
 
     # Pre-process dictionary to align with Pydantic model before validation.
-    if "base_config" in config_dict:
-      del config_dict["base_config"]
-    if "num_epochs" in config_dict:
-      config_dict["num_epoch"] = config_dict.pop("num_epochs")
-    for key, value in config_dict.items():
-      if isinstance(value, str) and value.lower() == "none":
-        config_dict[key] = None
+    config_dict = normalize_config_dict(config_dict)
 
     # Step 2: Attempt to instantiate the Pydantic model.
     # This is where validation happens. If there are extra fields,
@@ -300,3 +312,109 @@ INFERENCE_CONFIGS = [
 @pytest.mark.parametrize("config_file", INFERENCE_CONFIGS)
 def test_inference_configs(config_file):
   run_config_validation(config_file)
+
+
+# --- Test Group 10: remat_policy "custom" tensor selection ---
+
+# Fields declared as RematLocation but with no matching checkpoint_name(...) call
+# anywhere in the model code, so remat_policy: custom cannot actually act on them.
+# Listing one in CUSTOM_REMAT_TENSORS would promise control the model code cannot
+# honour, so they are excluded on purpose and this set records why. Either the
+# layer gains a checkpoint_name or the field should go.
+NON_SELECTABLE_REMAT_FIELDS = frozenset({"engram"})
+
+# Selectable, but only on a config that also enables the feature that owns them,
+# so the parity test below cannot set them on a stock base.yml. Excluded from that
+# test only -- the declared-fields test still covers them.
+GATED_REMAT_FIELDS = frozenset({"indexer_cutoff_threshold"})  # needs use_indexer=True, hence MLA
+
+MAXTEXT_SRC_DIR = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext")
+
+
+def declared_remat_fields() -> set[str]:
+  """Every config field whose type is RematLocation."""
+  return {
+      name
+      for name, field in pydantic_types.MaxTextConfig.model_fields.items()
+      if field.annotation is pydantic_types.RematLocation
+  }
+
+
+def checkpoint_names_in_tree() -> set[str]:
+  """Literal names passed to checkpoint_name(...) anywhere under src/maxtext.
+
+  Parsed with ast rather than a regex for two reasons: calls nest, as in
+  checkpoint_name(checkpoint_name(x, "mlpwi_0"), "moe_mlpwi_0"), and a textual
+  scan also matches checkpoint_name( written inside a comment or docstring --
+  including the one in configs/types.py explaining which names are absent, which
+  would make this check vacuously pass for exactly the names it should catch.
+  """
+  names = set()
+  for dirpath, _, filenames in os.walk(MAXTEXT_SRC_DIR):
+    for filename in filenames:
+      if not filename.endswith(".py"):
+        continue
+      with open(os.path.join(dirpath, filename), "rt", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=filename)
+      for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+          continue
+        func = node.func
+        called = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if called != "checkpoint_name":
+          continue
+        # checkpoint_name(x, "name") or checkpoint_name(x, name="name").
+        argument = next((kw.value for kw in node.keywords if kw.arg == "name"), None)
+        if argument is None and len(node.args) > 1:
+          argument = node.args[1]
+        if isinstance(argument, ast.Constant) and isinstance(argument.value, str):
+          names.add(argument.value)
+  return names
+
+
+def test_custom_remat_tensors_match_declared_fields():
+  """The selectable list must track the declared fields, minus the inert ones."""
+  selectable = set(pydantic_types.CUSTOM_REMAT_TENSORS)
+  assert len(pydantic_types.CUSTOM_REMAT_TENSORS) == len(selectable), "duplicate name in CUSTOM_REMAT_TENSORS"
+  assert not (selectable & NON_SELECTABLE_REMAT_FIELDS), (
+      "CUSTOM_REMAT_TENSORS lists a field that has no checkpoint_name: "
+      f"{sorted(selectable & NON_SELECTABLE_REMAT_FIELDS)}"
+  )
+  assert selectable == declared_remat_fields() - NON_SELECTABLE_REMAT_FIELDS
+
+
+def test_custom_remat_tensors_have_checkpoint_names():
+  """A name with no checkpoint_name call is silently inert; catch that here."""
+  missing = sorted(set(pydantic_types.CUSTOM_REMAT_TENSORS) - checkpoint_names_in_tree())
+  assert not missing, f"CUSTOM_REMAT_TENSORS names with no checkpoint_name(...) in the tree: {missing}"
+
+
+@pytest.mark.parametrize("location", ["device", "offload"])
+def test_custom_remat_parity_between_maxtext_and_rl(location):
+  """MaxTextConfig and RLConfig must honour the same tensors under remat_policy: custom.
+
+  These lists were written out twice and drifted: RLConfig's was missing
+  "kv_proj", so under RL a custom policy with kv_proj: device validated cleanly
+  and was then dropped with no warning.
+  """
+  attribute = "tensors_on_device" if location == "device" else "tensors_to_offload"
+  selectable = set(pydantic_types.CUSTOM_REMAT_TENSORS) - GATED_REMAT_FIELDS
+
+  overrides = {"remat_policy": "custom", **{name: location for name in selectable}}
+
+  def config_dict_with_overrides(*path_parts):
+    config_dict = normalize_config_dict(deepcopy(load_and_merge_yamls(os.path.join(CONFIGS_DIR, *path_parts))))
+    config_dict.update(overrides)
+    return config_dict
+
+  maxtext_config = pydantic_types.MaxTextConfig(**config_dict_with_overrides("base.yml"))
+  rl_config = pydantic_types.RLConfig(**config_dict_with_overrides("post_train", "rl.yml"))
+
+  maxtext_honoured = set(getattr(maxtext_config, attribute))
+  rl_honoured = set(getattr(rl_config, attribute))
+
+  assert maxtext_honoured == rl_honoured, (
+      f"only MaxTextConfig honours: {sorted(maxtext_honoured - rl_honoured)}; "
+      f"only RLConfig honours: {sorted(rl_honoured - maxtext_honoured)}"
+  )
+  assert maxtext_honoured == selectable


### PR DESCRIPTION
`remat_policy: custom` filters the tensors the user pinned against a hardcoded
name list. That list is written twice -- once in MaxTextConfig.model_post_init
and once in RLConfig.model_post_init -- and the two copies have drifted:
RLConfig's is missing "kv_proj".

Both classes inherit the same RematAndOffload field set, so under RL a config
with `kv_proj: device` validates cleanly, is then dropped from
tensors_on_device, and the unified KV projection is silently rematerialised
instead of kept. There is no warning; the only symptom is extra recompute.

Collapse both onto one module-level constant. MaxTextConfig's existing order is
preserved exactly, so the non-RL path is unchanged.

Three tests are added to tests/unit/configs_test.py:

  - the constant matches the declared RematLocation fields, minus the one
    documented as non-selectable;
  - every name in it has a real checkpoint_name() call in the model code;
  - MaxTextConfig and RLConfig honour the same set, for device and offload
    (parametrized, so 4 test cases in total).

Controls that were run, not just asserted:

  - Reverting only the two call sites, keeping the constant, turns the parity
    test red with `only MaxTextConfig honours: ['kv_proj']` for both device and
    offload. So the test detects the behavioural drift, not the refactor.
  - Injecting "engram" into the constant turns both guard tests red.
  - The pre-existing 76 tests pass before and after, with the same single
    pre-existing pydantic serializer warning on rl.yml.

A small extraction rides along: the dict normalisation inside
run_config_validation is lifted into normalize_config_dict() so the new tests
run the same preprocessing as the existing 76 rather than a second copy of it.

checkpoint_names_in_tree() parses with ast rather than a regex. This is not
stylistic -- a textual scan also matches `checkpoint_name(` written inside a
comment, including the new comment in types.py that names "engram" as the
excluded case, which made the check vacuously pass for exactly the name it
exists to catch. That was caught by the negative control above.

Two related problems are deliberately left alone, called out in comments rather
than fixed here, since both need a decision from their owners:

  - `engram` is a declared RematLocation field with no checkpoint_name()
    anywhere in src/maxtext. Measured on this base: 97 checkpoint_name call
    sites, 90 with a literal name, 22 distinct names; the 7 non-literal sites
    are 6 `residual_checkpoint_name` in the splash-attention kernels and one
    string concatenation in linears.py that yields mlpwi / mlpwi_0 / mlpwi_1,
    all three of which appear as literals elsewhere. `engram` appears in none
    of them. Listing it would promise control the model code cannot honour, so
    it is excluded and the reason is recorded in the test. Either the layer
    needs a checkpoint_name or the field should be removed.

  - configs/pyconfig_deprecated.py:510, validate_and_assign_remat_tensors, holds
    a third and older copy of the same list: 15 names, missing attention_out,
    indexer_cutoff_threshold, kv_proj, mla_kv, mla_q and qkv_proj. Pointing it
    at the constant is mechanically safe -- adding
    `from maxtext.configs import types` there imports cleanly in both orders,
    checked -- but it is not a no-op: it would make those six names newly
    selectable on that path, which is a behaviour change to a deprecated config
    system and belongs in its own change with its own owner.

One test-only exclusion worth flagging for review: `indexer_cutoff_threshold`
is in the constant but skipped by the parity test, because setting it requires
use_indexer=True, which in turn requires attention_type='mla', a nonzero
q_lora_rank and a compatible attention kernel. Bolting a whole MLA model spec
onto a list-parity test would make it break for unrelated reasons. It is still
covered by the declared-fields test.
