### PR TITLE
Onboard the Gemma 4 decoders to explicit sharding

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4359,6 +4359,8 @@ class MaxTextConfig(
           "gemma",
           "gemma2",
           "gemma3",
+          "gemma4",
+          "gemma4_small",
       }
       if self.decoder_block.value not in supported_decoders:
         raise ValueError(

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -803,8 +803,16 @@ class RoutedMoE(nnx.Module):
       rngs=None,
       input_ids=None,
       forced_routed_experts=None,
+      per_expert_scale=None,
   ):
-    """get topk."""
+    """get topk.
+
+    `per_expert_scale` (Gemma 4 only) is normally read off the module, but the
+    sparse path runs inside a `jax.shard_map` that cannot close over an array
+    living on explicit mesh axes, so it hands the value in instead.
+    """
+    if per_expert_scale is None and self.per_expert_scale is not None:
+      per_expert_scale = self.per_expert_scale[...]
     # shape of top_k_weights & top_k_indices:
     # (batch, sequence, num_experts_per_tok).
     valid_token_mask = None
@@ -872,10 +880,10 @@ class RoutedMoE(nnx.Module):
           weight_sum = jnp.where(weight_sum == 0, 1.0, weight_sum)
         top_k_weights /= weight_sum
 
-      if self.per_expert_scale is not None and not (
+      if per_expert_scale is not None and not (
           self.config.model_call_mode == "inference" and self.config.fuse_expert_scales
       ):
-        per_expert_scale_topk = jnp.take_along_axis(self.per_expert_scale.value[None, None, :], top_k_indices, axis=-1)
+        per_expert_scale_topk = jnp.take_along_axis(per_expert_scale[None, None, :], top_k_indices, axis=-1)
         top_k_weights = top_k_weights * per_expert_scale_topk.astype(top_k_weights.dtype)
 
     return top_k_weights, top_k_indices
@@ -994,13 +1002,21 @@ class RoutedMoE(nnx.Module):
       roll_to_expert_id=None,
       input_ids=None,
       forced_routed_experts=None,
+      per_expert_scale=None,
   ):
     """Permute tokens to group by expert to fit gmm call."""
     # reshape inputs (batch, sequence, emb) to (batch * sequence, emb)
     inputs_shape = inputs.shape
     bsz_times_seq_len = inputs_shape[0] * inputs_shape[1]
     inputs_2d = jnp.reshape(inputs, (bsz_times_seq_len, inputs_shape[2]))
-    weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs, input_ids, forced_routed_experts)
+    weights, selected_experts = self.get_topk(
+        gate_logits,
+        pre_bias_logits,
+        rngs,
+        input_ids,
+        forced_routed_experts,
+        per_expert_scale=per_expert_scale,
+    )
 
     lb_loss = None
     # Using pre_bias_logits ensures the router bias does not leak into the auxiliary loss gradient
@@ -1866,6 +1882,7 @@ class RoutedMoE(nnx.Module):
         rngs,
         input_ids=None,
         forced_routed_experts=None,
+        per_expert_scale=None,
     ):
       # The ring-of-experts strategy first duplicates the inputs to all
       # expert shards, and then routes within each shard.
@@ -1903,6 +1920,7 @@ class RoutedMoE(nnx.Module):
           rngs=rngs,
           input_ids=input_ids,
           forced_routed_experts=forced_routed_experts,
+          per_expert_scale=per_expert_scale,
       )
       return (
           x,
@@ -1932,6 +1950,7 @@ class RoutedMoE(nnx.Module):
         rngs,
         input_ids=None,
         forced_routed_experts=None,
+        per_expert_scale=None,
     ):
       local_sorted_indices = None
       all_shards_group_sizes = None
@@ -1953,6 +1972,7 @@ class RoutedMoE(nnx.Module):
           rngs,
           input_ids=input_ids,
           forced_routed_experts=forced_routed_experts,
+          per_expert_scale=per_expert_scale,
       )
 
       if num_ep > 1:
@@ -2041,6 +2061,7 @@ class RoutedMoE(nnx.Module):
         rngs,
         input_ids=None,
         forced_routed_experts=None,
+        per_expert_scale=None,
     ):
       """Performs both across device and within device token routing/sorting"""
       num_ep = self.get_expert_parallelism_size()
@@ -2056,6 +2077,7 @@ class RoutedMoE(nnx.Module):
             rngs,
             input_ids=input_ids,
             forced_routed_experts=forced_routed_experts,
+            per_expert_scale=per_expert_scale,
         )
       else:
         return ra2a_and_route(
@@ -2067,6 +2089,7 @@ class RoutedMoE(nnx.Module):
             rngs,
             input_ids=input_ids,
             forced_routed_experts=forced_routed_experts,
+            per_expert_scale=per_expert_scale,
         )
 
     def get_active_sharding_axes(pspec_dim_axes, tensor_dim_index):
@@ -2299,6 +2322,7 @@ class RoutedMoE(nnx.Module):
         rngs,
         embed_dim,
         forced_routed_experts=None,
+        per_expert_scale=None,
     ):
       """Overlap token all-gather and GMM computation along embedding dimension."""
       num_ep = self.get_expert_parallelism_size()
@@ -2319,6 +2343,7 @@ class RoutedMoE(nnx.Module):
           chunk_rngs_key,
           input_ids=sharded_input_ids,
           forced_routed_experts=forced_routed_experts,
+          per_expert_scale=per_expert_scale,
       )
 
       if self.config.mlp_bias:
@@ -2354,6 +2379,7 @@ class RoutedMoE(nnx.Module):
             chunk_rngs_key,
             input_ids=sharded_input_ids,
             forced_routed_experts=forced_routed_experts,
+            per_expert_scale=per_expert_scale,
         )
         return (next_x, next_ps0, next_ps1, chunk_idx + 1), None
 
@@ -2399,6 +2425,7 @@ class RoutedMoE(nnx.Module):
         sharded_input_ids,
         rngs,
         forced_routed_experts=None,
+        per_expert_scale=None,
     ):
       batch_size, sequence_length, embed_dim = x.shape
       if self.config.num_moe_emb_chunks > 0:
@@ -2415,6 +2442,7 @@ class RoutedMoE(nnx.Module):
             rngs,
             embed_dim,
             forced_routed_experts=forced_routed_experts,
+            per_expert_scale=per_expert_scale,
         )
       else:
         x, routing, route_metadata = route(
@@ -2424,6 +2452,7 @@ class RoutedMoE(nnx.Module):
             rngs,
             input_ids=sharded_input_ids,
             forced_routed_experts=forced_routed_experts,
+            per_expert_scale=per_expert_scale,
         )
         mask = jnp.arange(x.shape[0]) < valid_token_count(x, routing, route_metadata)
 
@@ -2515,6 +2544,11 @@ class RoutedMoE(nnx.Module):
 
       return output, routing.lb_loss, routing.bias_updates
 
+    # Gemma 4's per-expert router scale is consumed by get_topk, deep inside the
+    # shard_map below. A shard_map cannot close over an array that lives on explicit
+    # mesh axes, so it is threaded down as an argument instead of read off the module.
+    per_expert_scale = None if self.per_expert_scale is None else self.per_expert_scale[...]
+
     @functools.partial(
         jax.shard_map,
         mesh=self.mesh,
@@ -2534,6 +2568,8 @@ class RoutedMoE(nnx.Module):
             # with below); recomputing it would skip
             # maybe_replicate_incompatible_batch.
             gate_logits_pspec if forced_routed_experts is not None else None,
+            # Routing sees every expert, so the per-expert scale enters replicated.
+            P() if per_expert_scale is not None else None,
         ),
         out_specs=(
             output_pspec,
@@ -2555,6 +2591,7 @@ class RoutedMoE(nnx.Module):
         sharded_input_ids,
         rngs,
         forced_routed_experts=None,
+        per_expert_scale=None,
     ):
       # The expert weights (w0/w1/wo) are all-gathered over FSDP once at this
       # shard_map entry (implicitly, via the `embed_tensor_transpose` pspec which
@@ -2575,6 +2612,7 @@ class RoutedMoE(nnx.Module):
             sharded_input_ids,
             rngs,
             forced_routed_experts,
+            per_expert_scale,
         )
 
       # Chunked ring-of-experts pipeline: split the per-shard tokens along the
@@ -2610,6 +2648,7 @@ class RoutedMoE(nnx.Module):
             None if sharded_input_ids is None else sharded_input_ids[:, sl],
             rngs,
             None if forced_routed_experts is None else forced_routed_experts[:, sl, :],
+            per_expert_scale,
         )
         if self.config.moe_chunk_barrier:
           _prev = out_c
@@ -2674,6 +2713,10 @@ class RoutedMoE(nnx.Module):
       w1_bias = self._maybe_shard_with_pspec(w1_bias, w1_bias_pspec)
     if wo_bias is not None:
       wo_bias = self._maybe_shard_with_pspec(wo_bias, wo_bias_pspec)
+    if per_expert_scale is not None and self.config.shard_mode == ShardMode.EXPLICIT:
+      # shard_map will not insert a reshard for an operand whose layout disagrees with
+      # `in_specs`, and the scale is declared "exp" -> the expert axis.
+      per_expert_scale = self._maybe_shard_with_pspec(per_expert_scale, P())
 
     return sparse_matmul_route_and_compute(
         inputs,
@@ -2688,6 +2731,7 @@ class RoutedMoE(nnx.Module):
         input_ids,
         self.rngs,
         forced_routed_experts,
+        per_expert_scale,
     )
 
   def reshape_and_update_weights(self, weights, indices, safe_updates=False):

--- a/src/maxtext/layers/normalizations.py
+++ b/src/maxtext/layers/normalizations.py
@@ -31,15 +31,18 @@ from maxtext.utils import max_utils
 from maxtext.utils.sharding import truncate_out_sharding
 
 
-def _align_scale_with_normalized_axis(scale: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
-  """Reshards a 1-D norm scale to match the sharding of the axis it normalizes.
+def align_scale_with_normalized_axis(scale: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
+  """Reshards a 1-D per-feature scale to match the sharding of the axis it scales.
 
-  The scale is stored with the `kernel_axes` layout, which is picked for the
-  usual case of normalizing over the embedding axis (`norm` -> `tensor`). A
-  per-head QK norm instead normalizes over `head_dim`, which is unsharded while
-  the neighbouring `heads` axis is the one on `tensor`. Multiplying those
-  directly under `ShardMode.EXPLICIT` would place `tensor` on two axes of the
-  result, which JAX rejects, so align the scale with the activation instead.
+  A scale is stored with whatever layout its declared axes give it, which is
+  picked for the usual case of scaling the embedding axis (`norm` -> `tensor`).
+  A per-head QK norm instead normalizes over `head_dim`, which is unsharded
+  while the neighbouring `heads` axis is the one on `tensor`; Gemma 4's router
+  scale is declared `embed` (-> `fsdp`) but multiplies an activation whose last
+  axis is `activation_embed` (-> `tensor`). Multiplying either pair directly
+  under `ShardMode.EXPLICIT` puts one mesh axis on two axes of the result, or
+  two different axes on the same one, which JAX rejects -- so align the scale
+  with the activation instead.
 
   This is a no-op whenever the two already agree, which includes every
   auto-sharding-equivalent layout for the ordinary layer norms.
@@ -120,7 +123,7 @@ class RMSNorm(nnx.Module):
     scale = jnp.asarray(scale, self.dtype)
     effective_scale = scale + self.scale_offset
     if self.shard_mode == ShardMode.EXPLICIT:
-      effective_scale = _align_scale_with_normalized_axis(effective_scale, y)
+      effective_scale = align_scale_with_normalized_axis(effective_scale, y)
     return jnp.einsum("...k,k->...k", y, effective_scale, out_sharding=out_sharding)
 
 

--- a/src/maxtext/models/gemma4.py
+++ b/src/maxtext/models/gemma4.py
@@ -14,17 +14,18 @@
 
 """Specialized layers for Gemma 4."""
 
+import functools
+
 import jax
 from jax.experimental import xla_metadata
 from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh
 import jax.numpy as jnp
 
-from flax import linen as nn
 from flax import nnx
 from typing import Optional, Any
 
-from maxtext.common.common_types import Config, AttentionType, MODEL_MODE_PREFILL
+from maxtext.common.common_types import Config, AttentionType, MODEL_MODE_PREFILL, ShardMode
 from maxtext.layers import initializers
 from maxtext.layers import moe
 from maxtext.layers import nnx_scan, nnx_wrappers
@@ -33,10 +34,11 @@ from maxtext.layers.attentions import Attention
 from maxtext.layers.linears import MlpBlock
 
 import jax.sharding
-from maxtext.layers.normalizations import RMSNorm
+from maxtext.layers.normalizations import RMSNorm, align_scale_with_normalized_axis
 from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
+from maxtext.utils.sharding import create_sharding, get_logical_axis_rules, maybe_shard_with_logical
 
 
 GEMMA4_ATTENTION_PATTERN = (
@@ -88,6 +90,7 @@ class Gemma4MoE(nnx.Module):
         num_features=self.config.emb_dim,
         dtype=self.config.dtype,
         weight_dtype=self.config.weight_dtype,
+        shard_mode=self.config.shard_mode,
         kernel_axes=("norm",),
         rngs=self.rngs,
     )
@@ -95,6 +98,7 @@ class Gemma4MoE(nnx.Module):
         num_features=self.config.emb_dim,
         dtype=self.config.dtype,
         weight_dtype=self.config.weight_dtype,
+        shard_mode=self.config.shard_mode,
         kernel_axes=("norm",),
         rngs=self.rngs,
     )
@@ -102,6 +106,7 @@ class Gemma4MoE(nnx.Module):
         num_features=self.config.emb_dim,
         dtype=self.config.dtype,
         weight_dtype=self.config.weight_dtype,
+        shard_mode=self.config.shard_mode,
         kernel_axes=("norm",),
         rngs=self.rngs,
     )
@@ -110,6 +115,7 @@ class Gemma4MoE(nnx.Module):
         epsilon=self.config.normalization_layer_epsilon,
         dtype=jnp.float32 if self.config.float32_gate_logits else self.config.dtype,
         weight_dtype=self.config.weight_dtype,
+        shard_mode=self.config.shard_mode,
         kernel_axes=("norm",),
         with_scale=False,
         rngs=self.rngs,
@@ -126,17 +132,21 @@ class Gemma4MoE(nnx.Module):
     shared_experts = self.moe_block.shared_experts(
         inputs, intermediate_sharding=intermediate_sharding, out_sharding=out_sharding
     )
-    shared_experts = self.post_feedforward_layernorm_1(shared_experts)
+    shared_experts = self.post_feedforward_layernorm_1(shared_experts, out_sharding=out_sharding)
 
     # 1. Experts receive standard RMSNorm (with weight)
-    routed_inputs = self.pre_feedforward_layernorm_2(original_inputs)
+    routed_inputs = self.pre_feedforward_layernorm_2(original_inputs, out_sharding=out_sharding)
 
     # 2. Gate receives RMSNorm (without weight) * root_size * router_scale
     gate_dtype = jnp.float32 if self.config.float32_gate_logits else self.config.dtype
-    unscaled_norm = self.gate_norm(original_inputs)
+    unscaled_norm = self.gate_norm(original_inputs, out_sharding=out_sharding)
 
     root_size = self.config.emb_dim**-0.5
     router_scale = jnp.asarray(self.pre_forward_scale_2.value, gate_dtype)
+    if self.config.shard_mode == ShardMode.EXPLICIT:
+      # The router scale is declared "embed" but multiplies an activation whose last axis is
+      # "activation_embed", two different mesh axes under the default rules.
+      router_scale = align_scale_with_normalized_axis(router_scale, unscaled_norm)
     gate_inputs = unscaled_norm * root_size * router_scale
 
     # 3. Pass both to routed_moe
@@ -146,7 +156,7 @@ class Gemma4MoE(nnx.Module):
         out_sharding=out_sharding,
         forced_routed_experts=forced_routed_experts,
     )
-    routed_experts = self.post_feedforward_layernorm_2(routed_experts)
+    routed_experts = self.post_feedforward_layernorm_2(routed_experts, out_sharding=out_sharding)
 
     return routed_experts + shared_experts, load_balance_loss, moe_bias_updates
 
@@ -186,10 +196,29 @@ class Gemma4DecoderLayer(nnx.Module):
     batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
+    if model_mode == MODEL_MODE_PREFILL:
+      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
+    else:
+      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    self.mlp_activation_axis_names = self.activation_axis_names[:-1] + ("activation_mlp",)
+
+    # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore these and let GSPMD infer the layout.
+    self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
+    self.mlp_intermediate_sharding = create_sharding(mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules())
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
+
     self.pre_self_attention_norm = RMSNorm(
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         rngs=self.rngs,
     )
@@ -258,6 +287,7 @@ class Gemma4DecoderLayer(nnx.Module):
           num_features=config.emb_dim,
           dtype=config.dtype,
           weight_dtype=config.weight_dtype,
+          shard_mode=config.shard_mode,
           kernel_axes=("norm",),
           rngs=self.rngs,
       )
@@ -268,6 +298,7 @@ class Gemma4DecoderLayer(nnx.Module):
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         rngs=self.rngs,
     )
@@ -299,6 +330,7 @@ class Gemma4DecoderLayer(nnx.Module):
           num_features=config.emb_dim,
           dtype=config.dtype,
           weight_dtype=config.weight_dtype,
+          shard_mode=config.shard_mode,
           kernel_axes=("norm",),
           rngs=self.rngs,
       )
@@ -306,11 +338,6 @@ class Gemma4DecoderLayer(nnx.Module):
       self.post_ffw_norm = None
 
     self.layer_scalar = nnx.Param(jnp.ones((1,), dtype=config.weight_dtype), sharding=(None,))
-
-    if model_mode == MODEL_MODE_PREFILL:
-      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
-    else:
-      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
 
   def __call__(
       self,
@@ -337,11 +364,11 @@ class Gemma4DecoderLayer(nnx.Module):
       is_scan_carry = True
     elif isinstance(inputs, tuple):
       inputs = inputs[0]
-    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 
-    lnx = self.pre_self_attention_norm(inputs)
-    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+    lnx = self.pre_self_attention_norm(inputs, out_sharding=self.out_sharding)
+    lnx = self._maybe_shard_with_logical(lnx, self.activation_axis_names)
 
     # Gemma4 only applies bidirectional attention in sliding (local) layers,
     # not in full (global) attention layers.
@@ -357,39 +384,47 @@ class Gemma4DecoderLayer(nnx.Module):
         deterministic=deterministic,
         model_mode=model_mode,
         bidirectional_mask=bidirectional_mask,
+        out_sharding=self.out_sharding,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
     )
     if cfg.use_post_attn_norm:
-      attention_lnx = self.post_self_attention_norm(attention_lnx)
-    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
+      attention_lnx = self.post_self_attention_norm(attention_lnx, out_sharding=self.out_sharding)
+    attention_lnx = self._maybe_shard_with_logical(attention_lnx, self.activation_axis_names)
 
     attention_lnx += inputs
     residual = attention_lnx
-    attn_output = self.pre_ffw_norm(attention_lnx)
+    attn_output = self.pre_ffw_norm(attention_lnx, out_sharding=self.out_sharding)
 
     # MLP block.
     if getattr(self.config, "num_experts", 1) > 1:
       mlp_lnx, load_balance_loss, _ = self.mlp(
           attn_output,
           original_inputs=attention_lnx,
+          intermediate_sharding=self.mlp_intermediate_sharding,
+          out_sharding=self.out_sharding,
           forced_routed_experts=forced_routed_experts,
       )
       if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
         self.sow(nnx.Intermediate, "moe_lb_loss", load_balance_loss)
     else:
-      mlp_lnx = self.mlp(attn_output, deterministic=deterministic)
+      mlp_lnx = self.mlp(
+          attn_output,
+          deterministic=deterministic,
+          intermediate_sharding=self.mlp_intermediate_sharding,
+          out_sharding=self.out_sharding,
+      )
 
     if cfg.use_post_ffw_norm:
-      mlp_lnx = self.post_ffw_norm(mlp_lnx)
+      mlp_lnx = self.post_ffw_norm(mlp_lnx, out_sharding=self.out_sharding)
 
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+    mlp_lnx = self._maybe_shard_with_logical(mlp_lnx, self.activation_axis_names)
 
     next_layer_addition = mlp_lnx + residual
     layer_output = next_layer_addition
     layer_output = layer_output * jnp.asarray(self.layer_scalar.value, cfg.dtype)
 
-    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+    layer_output = self._maybe_shard_with_logical(layer_output, self.activation_axis_names)
 
     if getattr(cfg, "record_internal_nn_metrics", False):
       self.sow(nnx.Intermediate, "activation_mean", jnp.mean(layer_output))
@@ -459,6 +494,13 @@ class Gemma4ScannableBlock(nnx.Module):
     self.num_of_layers = num_of_layers
     self.remat_policy_fn = remat_policy_fn
     self.apply_internal_remat = apply_internal_remat
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
 
     pattern_length = len(GEMMA4_ATTENTION_PATTERN)
     if not 0 <= num_of_layers <= pattern_length:
@@ -667,7 +709,10 @@ class Gemma4ScannableBlock(nnx.Module):
       attention_metadata=None,
   ):
     cfg = self.config
-    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    # The per-layer constraints inside Gemma4DecoderLayer are model_mode aware; this
+    # block-level one deliberately is not, matching the axis names this code has always
+    # used so ShardMode.AUTO is unchanged.
+    inputs = self._maybe_shard_with_logical(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 
     # Arguments shared by every layer in the block. model_mode differentiates

--- a/src/maxtext/models/gemma4_small.py
+++ b/src/maxtext/models/gemma4_small.py
@@ -14,6 +14,8 @@
 
 """Specialized layers for Gemma 4 small (E2B and E4B)."""
 
+import functools
+
 import jax
 from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh
@@ -22,7 +24,7 @@ import jax.numpy as jnp
 from flax import linen as nn
 from flax import nnx
 
-from maxtext.common.common_types import Config, AttentionType, MODEL_MODE_PREFILL
+from maxtext.common.common_types import Config, AttentionType, MODEL_MODE_PREFILL, ShardMode
 from maxtext.layers import initializers
 from maxtext.layers import nnx_wrappers
 from maxtext.layers import quantizations
@@ -31,6 +33,7 @@ from maxtext.layers.linears import DenseGeneral, MlpBlock
 from maxtext.layers.normalizations import RMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.utils import max_utils
+from maxtext.utils.sharding import create_sharding, get_logical_axis_rules, maybe_shard_with_logical
 
 
 # E2B repeats 4 sliding + 1 global (period 5); E4B repeats 5 sliding + 1 global
@@ -186,9 +189,22 @@ class Gemma4SmallPLE(nnx.Module):
         epsilon=config.normalization_layer_epsilon,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         rngs=rngs,
     )
+
+    # Both halves of the per-layer input are built at `[B, S, L * D_ple]` and then split into
+    # `[B, S, L, D_ple]`, so the feature axis has to be replicated: a reshape cannot split a
+    # sharded axis, and the consumer -- the gate in Gemma4SmallDecoderLayer -- pins the same
+    # layout. In ShardMode.AUTO these are None and GSPMD infers the layout as before.
+    if config.shard_mode == ShardMode.EXPLICIT:
+      rules = get_logical_axis_rules()
+      self.flat_sharding = create_sharding(mesh, ("activation_batch", "activation_norm_length", None), rules=rules)
+      self.ple_sharding = create_sharding(mesh, ("activation_batch", "activation_norm_length", None, None), rules=rules)
+    else:
+      self.flat_sharding = None
+      self.ple_sharding = None
 
     # Plain Python floats — storing them as jnp arrays would let nnx promote
     # them to Variables, which then collide with the param tree on restore.
@@ -206,13 +222,13 @@ class Gemma4SmallPLE(nnx.Module):
     inv_sqrt2 = jnp.asarray(2.0**-0.5, cfg.dtype)
 
     embedding = jnp.asarray(self.embed_tokens_per_layer.value, cfg.dtype)
-    identity = embedding[input_ids.astype(jnp.int32)] * embed_scale
+    identity = embedding.at[input_ids.astype(jnp.int32)].get(out_sharding=self.flat_sharding) * embed_scale
     identity = identity.reshape(*input_ids.shape, self._num_layers, self._ple_dim)
 
-    context = self.per_layer_model_projection(inputs_embeds.astype(cfg.dtype))
+    context = self.per_layer_model_projection(inputs_embeds.astype(cfg.dtype), out_sharding=self.flat_sharding)
     context = context * proj_scale
     context = context.reshape(*inputs_embeds.shape[:-1], self._num_layers, self._ple_dim)
-    context = self.per_layer_projection_norm(context)
+    context = self.per_layer_projection_norm(context, out_sharding=self.ple_sharding)
 
     out = (identity + context) * inv_sqrt2
     return out.astype(cfg.dtype)
@@ -267,10 +283,33 @@ class Gemma4SmallDecoderLayer(nnx.Module):
     self.num_kv_heads = num_kv_heads
     self.head_dim = head_dim
 
+    if model_mode == MODEL_MODE_PREFILL:
+      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
+    else:
+      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    self.mlp_activation_axis_names = self.activation_axis_names[:-1] + ("activation_mlp",)
+
+    # Physical shardings used to pin sublayer outputs under ShardMode.EXPLICIT. In
+    # ShardMode.AUTO the callees ignore these and let GSPMD infer the layout.
+    self.out_sharding = create_sharding(mesh, self.activation_axis_names, rules=get_logical_axis_rules())
+    self.mlp_intermediate_sharding = create_sharding(mesh, self.mlp_activation_axis_names, rules=get_logical_axis_rules())
+    # The per-layer-input feature axis is left replicated: the gate is multiplied against a
+    # slice of the PLE tensor, whose feature axis falls out of a reshape and so carries no
+    # layout of its own. Pinning the gate here keeps the two operands in agreement.
+    self.ple_sharding = create_sharding(mesh, self.activation_axis_names[:-1] + (None,), rules=get_logical_axis_rules())
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
+        extra_stack_level=1,
+    )
+
     self.pre_self_attention_norm = RMSNorm(
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         rngs=rngs,
     )
@@ -278,6 +317,7 @@ class Gemma4SmallDecoderLayer(nnx.Module):
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         rngs=rngs,
     )
@@ -285,6 +325,7 @@ class Gemma4SmallDecoderLayer(nnx.Module):
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         rngs=rngs,
     )
@@ -292,6 +333,7 @@ class Gemma4SmallDecoderLayer(nnx.Module):
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         rngs=rngs,
     )
@@ -377,6 +419,7 @@ class Gemma4SmallDecoderLayer(nnx.Module):
           epsilon=config.normalization_layer_epsilon,
           dtype=config.dtype,
           weight_dtype=config.weight_dtype,
+          shard_mode=config.shard_mode,
           kernel_axes=("norm",),
           rngs=rngs,
       )
@@ -386,11 +429,6 @@ class Gemma4SmallDecoderLayer(nnx.Module):
       self.post_per_layer_input_norm = None
 
     self.layer_scalar = nnx.Param(jnp.ones((1,), dtype=config.weight_dtype), sharding=(None,))
-
-    if model_mode == MODEL_MODE_PREFILL:
-      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
-    else:
-      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
 
   def compute_shared_kv(self, inputs: jax.Array, decoder_positions: jax.Array) -> tuple[jax.Array, jax.Array]:
     """Returns the rotated, normed K / V for this (non-shared) layer.
@@ -402,7 +440,7 @@ class Gemma4SmallDecoderLayer(nnx.Module):
       raise ValueError("compute_shared_kv must not be called on a KV-shared layer.")
     if isinstance(inputs, tuple):
       inputs = inputs[0]
-    h = self.pre_self_attention_norm(inputs)
+    h = self.pre_self_attention_norm(inputs, out_sharding=self.out_sharding)
     return self.self_attention.compute_shared_kv(h, inputs_positions=decoder_positions)
 
   def __call__(
@@ -426,7 +464,7 @@ class Gemma4SmallDecoderLayer(nnx.Module):
 
     if isinstance(inputs, tuple):
       inputs = inputs[0]
-    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 
     # Bidirectional image-token mask is only meaningful in local-sliding
@@ -435,8 +473,8 @@ class Gemma4SmallDecoderLayer(nnx.Module):
       bidirectional_mask = None
 
     residual = inputs
-    h = self.pre_self_attention_norm(inputs)
-    h = nn.with_logical_constraint(h, self.activation_axis_names)
+    h = self.pre_self_attention_norm(inputs, out_sharding=self.out_sharding)
+    h = self._maybe_shard_with_logical(h, self.activation_axis_names)
 
     attn_out, kv_cache = self.self_attention(
         h,
@@ -446,34 +484,40 @@ class Gemma4SmallDecoderLayer(nnx.Module):
         deterministic=deterministic,
         model_mode=model_mode,
         bidirectional_mask=bidirectional_mask,
+        out_sharding=self.out_sharding,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,
         shared_key=shared_key,
         shared_value=shared_value,
     )
-    attn_out = self.post_self_attention_norm(attn_out)
-    attn_out = nn.with_logical_constraint(attn_out, self.activation_axis_names)
+    attn_out = self.post_self_attention_norm(attn_out, out_sharding=self.out_sharding)
+    attn_out = self._maybe_shard_with_logical(attn_out, self.activation_axis_names)
     h = residual + attn_out
 
     residual = h
-    mlp_in = self.pre_ffw_norm(h)
-    mlp_out = self.mlp(mlp_in, deterministic=deterministic)
-    mlp_out = self.post_ffw_norm(mlp_out)
-    mlp_out = nn.with_logical_constraint(mlp_out, self.activation_axis_names)
+    mlp_in = self.pre_ffw_norm(h, out_sharding=self.out_sharding)
+    mlp_out = self.mlp(
+        mlp_in,
+        deterministic=deterministic,
+        intermediate_sharding=self.mlp_intermediate_sharding,
+        out_sharding=self.out_sharding,
+    )
+    mlp_out = self.post_ffw_norm(mlp_out, out_sharding=self.out_sharding)
+    mlp_out = self._maybe_shard_with_logical(mlp_out, self.activation_axis_names)
     h = residual + mlp_out
 
     if self.per_layer_input_gate is not None and per_layer_input is not None:
       residual = h
-      gate = self.per_layer_input_gate(h)
+      gate = self.per_layer_input_gate(h, out_sharding=self.ple_sharding)
       gate = jax.nn.gelu(gate.astype(jnp.float32), approximate=True).astype(cfg.dtype)
       gated = gate * per_layer_input.astype(cfg.dtype)
-      proj = self.per_layer_projection(gated)
-      proj = self.post_per_layer_input_norm(proj)
-      proj = nn.with_logical_constraint(proj, self.activation_axis_names)
+      proj = self.per_layer_projection(gated, out_sharding=self.out_sharding)
+      proj = self.post_per_layer_input_norm(proj, out_sharding=self.out_sharding)
+      proj = self._maybe_shard_with_logical(proj, self.activation_axis_names)
       h = residual + proj
 
     h = h * jnp.asarray(self.layer_scalar.value, cfg.dtype)
-    h = nn.with_logical_constraint(h, self.activation_axis_names)
+    h = self._maybe_shard_with_logical(h, self.activation_axis_names)
 
     return h, kv_cache
 

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -953,7 +953,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     if cfg.shard_mode == ShardMode.EXPLICIT:
       # Both are stored replicated but broadcast against (B, S, H_v) activations whose
       # head axis is sharded, and explicit sharding requires broadcast operands to
-      # agree -- the same fix `_align_scale_with_normalized_axis` applies to the norm
+      # agree -- the same fix `align_scale_with_normalized_axis` applies to the norm
       # scales.
       head_spec = jax.sharding.PartitionSpec(jax.typeof(a).sharding.spec[-1])
       A_log = jax.sharding.reshard(A_log, head_spec)

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -54,6 +54,30 @@ _QWEN3_MODELS = {
     + _MOE_OVERRIDES,
 }
 
+# One tiny model per Gemma 4 decoder block that supports explicit sharding.
+_GEMMA4_MODELS = {
+    "gemma4": ["model_name=gemma4-31b"],
+    "gemma4_moe": [
+        "model_name=gemma4-26b",
+        # RoutedMoE.dense_matmul is not onboarded to explicit sharding yet (a gap it
+        # shares with mixtral and qwen3_moe), so exercise the sparse_matmul path.
+        "sparse_matmul=True",
+        "megablox=True",
+        "shared_experts=1",
+    ]
+    + _MOE_OVERRIDES,
+    "gemma4_small": [
+        "model_name=gemma4-e2b",
+        # E2B/E4B build their stack in a Python loop rather than a scan.
+        "scan_layers=False",
+        # Per-layer embeddings and KV sharing are what this block adds over gemma4.
+        # Six layers under the E2B period of five leaves layer 5 sharing K/V with layer 3.
+        "hidden_size_per_layer_input=64",
+        "vocab_size_per_layer_input=2048",
+        "num_kv_shared_layers=1",
+    ],
+}
+
 # One tiny model per Mistral-family decoder block that supports explicit sharding.
 _MISTRAL_MODELS = {
     "mistral": ["model_name=mistral-7b"],
@@ -147,6 +171,29 @@ class TrainTests(unittest.TestCase):
       "vocab_size=2048",
       "max_target_length=256",
       rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.mistral-v1')}",
+  ]
+
+  # Six layers is one whole period of the Gemma 4 sliding/global attention pattern, so both
+  # attention types run -- and for the scanned blocks it is one whole Gemma4ScannableBlock.
+  _gemma4_overrides = [
+      "override_model_config=True",
+      "base_num_decoder_layers=6",
+      "base_emb_dim=256",
+      "base_mlp_dim=512",
+      "base_num_query_heads=8",
+      "base_num_kv_heads=8",
+      "head_dim=128",
+      # Global layers carry their own head count and head dim; four kv heads keeps them
+      # divisible by a four-way tensor axis.
+      "global_num_kv_heads=4",
+      "global_head_dim=128",
+      "vocab_size=2048",
+      "max_target_length=256",
+      # The splash kernel cannot build a mask for a downscaled Gemma (its sliding window
+      # leaves empty blocks); dot product attention keeps the focus on sharding.
+      "attention=dot_product",
+      "tokenizer_type=sentencepiece",
+      rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer_gemma4.model')}",
   ]
 
   _qwen2_overrides = [
@@ -1203,6 +1250,91 @@ class TrainTests(unittest.TestCase):
             rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', tokenizer)}",
         ] + extra_args
         train_main(gemma_zero1_ga)
+
+  def _gemma4_losses(self, run_name, extra_args):
+    """Trains a tiny Gemma 4 model for a few steps and returns its per-step losses."""
+    return self._losses(run_name, self._gemma4_overrides, extra_args)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  def test_tpu_gemma4_explicit_sharding_matches_auto(self):
+    """Explicit sharding only changes how layouts are expressed, so the losses must not move.
+
+    Each decoder block is paired with the parallelism that stresses it most: tensor
+    parallelism shards the dense MLP intermediate and the attention heads the QK/V norms
+    sit next to, and expert parallelism shards the MoE dispatch.
+    """
+    parallelism = {
+        # The scanned gemma4 block should run under tensor parallelism too, but a four-way
+        # tensor axis makes the dot_product attention backward produce NaN gradients under
+        # explicit sharding. That is not new here -- gemma3-4b, which
+        # shares the scanned local/global block, reproduces it at the same sizes, and the
+        # splash kernel is unaffected -- so cover this block under FSDP and leave tensor
+        # parallelism to gemma4_small, which builds its stack without the scan.
+        "gemma4": ["ici_fsdp_parallelism=-1"],
+        "gemma4_moe": ["ici_fsdp_parallelism=1", "ici_expert_parallelism=-1"],
+        "gemma4_small": ["ici_fsdp_parallelism=1", "ici_tensor_parallelism=-1"],
+    }
+    for decoder_block, model_args in _GEMMA4_MODELS.items():
+      with self.subTest(decoder_block=decoder_block):
+        args = model_args + parallelism[decoder_block]
+        auto_losses = self._gemma4_losses(f"{decoder_block}_auto", args + ["shard_mode=auto"])
+        explicit_losses = self._gemma4_losses(f"{decoder_block}_explicit", args + ["shard_mode=explicit"])
+        print(f"[{decoder_block}] auto losses: {auto_losses}", flush=True)
+        print(f"[{decoder_block}] explicit losses: {explicit_losses}", flush=True)
+        self.assertTrue(auto_losses, "auto run produced no metrics")
+        # Step 0 is bit-for-bit for all three blocks: the forward pass computes the same
+        # numbers, explicit sharding only says where they live. The trajectory then drifts
+        # by a few parts in ten thousand, because pinning a layout GSPMD would have chosen
+        # differently reassociates the reductions underneath it and Gemma 4 runs its
+        # residual stream in bf16 with unscaled attention logits (query_pre_attn_scalar is
+        # 1.0), so a reassociated sum shows up sooner than it does for the other families.
+        # The same drift appears under pure data parallelism, where every reshard explicit
+        # sharding inserts is a no-op -- float noise, not the two runs disagreeing about
+        # the math. A genuinely wrong sharding does not land here: it either fails the
+        # shape check outright or moves the loss by percent.
+        np.testing.assert_allclose(explicit_losses, auto_losses, rtol=1e-3, atol=0.0)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  # TODO(b/517509898): Skip ZeRo-1 compiler Segfault on TPU7x SparseCore platforms
+  @pytest.mark.skip_on_tpu7x
+  def test_tpu_gemma4_zero1_gradient_accumulation(self):
+    """ZeRO-1 only shards the optimizer state, so it must not change the loss trajectory.
+
+    Under explicit sharding this routes the accumulated gradients through the
+    `reduced`/`unreduced` PartitionSpec labels applied in
+    `maxtext.utils.gradient_accumulation`, which the Gemma 4 layers have to keep intact
+    across the scan carry and, for the MoE block, across the router scale.
+    """
+    zero1_ga = [
+        "remat_policy=minimal",
+        "per_device_batch_size=2",
+        "ici_data_parallelism=-1",
+        "dcn_data_parallelism=1",
+        "ici_fsdp_parallelism=1",
+        "dcn_fsdp_parallelism=1",
+        "gradient_accumulation_steps=4",
+    ]
+    for decoder_block, model_args in _GEMMA4_MODELS.items():
+      with self.subTest(decoder_block=decoder_block):
+        args = model_args + zero1_ga
+        baseline = self._gemma4_losses(
+            f"{decoder_block}_ga",
+            args + ["shard_mode=auto", "shard_optimizer_over_data=False"],
+        )
+        sharded = self._gemma4_losses(
+            f"{decoder_block}_ga_zero1",
+            args + ["shard_mode=explicit", "shard_optimizer_over_data=True"],
+        )
+        print(f"[{decoder_block}] auto + GA losses: {baseline}", flush=True)
+        print(f"[{decoder_block}] explicit + ZeRO-1 + GA losses: {sharded}", flush=True)
+        self.assertTrue(baseline, "baseline run produced no metrics")
+        # Step 0 matches to the last bit or two; from there this compares two runs that
+        # differ in both shard mode and where the optimizer moments live, on top of the
+        # bf16 sensitivity described in the parity test above. gemma4_moe is the loosest
+        # at a few parts in a thousand by the third step.
+        np.testing.assert_allclose(sharded, baseline, rtol=5e-3, atol=0.0)
 
   @pytest.mark.integration_test
   @pytest.mark.gpu_only

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -291,6 +291,20 @@ class PyconfigTest(unittest.TestCase):
         with self.assertRaisesRegex(Exception, "does not support context parallelism"):
           initialize(ici_context_usp_ulysses_parallelism=2)
 
+  def test_explicit_sharding_gemma4_decoder_support(self):
+    """Both Gemma 4 decoders are accepted under explicit sharding."""
+    for decoder_block in ("gemma4", "gemma4_small"):
+      with self.subTest(decoder_block=decoder_block):
+        config = pyconfig.initialize(
+            [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+            skip_jax_distributed_system=True,
+            shard_mode="explicit",
+            decoder_block=decoder_block,
+            # gemma4_small builds its stack in a Python loop; gemma4 accepts either.
+            scan_layers=False,
+        )
+        self.assertEqual(config.decoder_block.value, decoder_block)
+
   def test_explicit_sharding_mistral_decoder_support(self):
     """The Mistral-family decoders that have been onboarded to explicit sharding are accepted."""
     for decoder_block in ("mistral", "mixtral"):

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -1361,6 +1361,91 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
+  def test_gemma4_dense_explicit_sharding(self):
+    """AOT test for gemma4-31b at full size under explicit sharding.
+
+    The dense Gemma 4 block scans five local-sliding layers and one global layer with a
+    wider head, so this checks that both attention variants and the surrounding norms
+    agree on a layout at a scale a test cannot run.
+    """
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_gemma4_dense_explicit_sharding.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-256",
+            "compile_topology_num_slices=1",
+            "model_name=gemma4-31b",
+            "per_device_batch_size=1",
+            "max_target_length=4096",
+            "ici_fsdp_parallelism=32",
+            "ici_tensor_parallelism=4",
+            "attention=flash",
+            "shard_mode=explicit",
+            "tokenizer_type=sentencepiece",
+            f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer_gemma4.model')}",
+        )
+    )
+
+  def test_gemma4_moe_explicit_sharding(self):
+    """AOT test for gemma4-26b at full size under explicit sharding.
+
+    Covers the Gemma 4 MoE block -- the scaled router, the unscaled gate norm and the
+    shared expert -- at FSDP 32 x expert 8.
+    """
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_gemma4_moe_explicit_sharding.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-512",
+            "compile_topology_num_slices=1",
+            "model_name=gemma4-26b",
+            "per_device_batch_size=1",
+            "max_target_length=4096",
+            "ici_fsdp_parallelism=32",
+            "ici_expert_parallelism=8",
+            # RoutedMoE.dense_matmul is not onboarded to explicit sharding yet.
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "shard_mode=explicit",
+            "tokenizer_type=sentencepiece",
+            f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer_gemma4.model')}",
+        )
+    )
+
+  def test_gemma4_small_explicit_sharding(self):
+    """AOT test for gemma4-e4b under explicit sharding.
+
+    The E2B/E4B block adds per-layer embeddings and KV sharing on top of gemma4, and
+    builds its stack in a Python loop rather than a scan.
+    """
+    compiled_trainstep_file = os.path.join(gettempdir(), "test_gemma4_small_explicit_sharding.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-64",
+            "compile_topology_num_slices=1",
+            "model_name=gemma4-e4b",
+            "per_device_batch_size=1",
+            "max_target_length=4096",
+            # E4B has two KV heads, which is as far as the tensor axis can split them,
+            # and a 4x4x2 physical mesh is the smallest one that can carry a two-way axis.
+            "ici_fsdp_parallelism=16",
+            "ici_tensor_parallelism=2",
+            "scan_layers=False",
+            "attention=flash",
+            "shard_mode=explicit",
+            "tokenizer_type=sentencepiece",
+            f"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer_gemma4.model')}",
+        )
+    )
+
   def test_kimi_k2_explicit_sharding(self):
     """AOT test for Kimi-K2 at full size under explicit sharding.
 


### PR DESCRIPTION
## Description

Onboards the Gemma 4 decoders to `shard_mode=explicit` (JAX sharding-in-types), continuing the series of explicit-sharding onboardings (#5064, #5066, #5099 and friends). Three decoder paths are covered:

| Block | Config | What it adds |
| --- | --- | --- |
| `gemma4` dense | `gemma4-31b` | Scanned 5x local-sliding + 1x global attention, global layers with their own head count/dim |
| `gemma4` MoE | `gemma4-26b` | Scaled router, unscaled gate norm, shared expert, per-expert scale |
| `gemma4_small` | `gemma4-e2b` / `-e4b` | Per-layer embeddings (PLE), KV sharing, unrolled (non-scan) stack |

`gemma4` and `gemma4_small` are added to `supported_decoders` in `MaxTextConfig`, so `shard_mode=explicit` is now accepted for them.

## The mechanical part

Same shape as the earlier onboardings. In each decoder layer's `__init__`:

- cache the `NamedSharding` for the activation layout (`out_sharding`) and the MLP intermediate layout (`mlp_intermediate_sharding`) via `create_sharding(...)`;
- build a `functools.partial(maybe_shard_with_logical, mesh=..., shard_mode=..., debug_sharding=..., extra_stack_level=1)` and use it in place of every `nn.with_logical_constraint`;
- pass `shard_mode=config.shard_mode` into every `RMSNorm`, and `out_sharding=` into the norms, attention and MLP calls.

Under `ShardMode.AUTO` all of this is inert: `maybe_shard_with_logical` falls back to the old logical constraint, and the callees ignore the `out_sharding` arguments, so GSPMD sees exactly what it saw before.

## Three things that needed more than that

**1. The MoE router scale is on the wrong mesh axis.** `Gemma4MoE` multiplies its normalized input by `pre_forward_scale_2`, which is stored with the `embed` logical axis, while the activation's last axis is `activation_embed`. Under the default rules those are two *different* mesh axes (`fsdp` and `tensor`), and explicit sharding rejects the broadcast.

`RMSNorm` already had a private helper for the analogous per-head QK-norm mismatch, so it is promoted to `align_scale_with_normalized_axis` (public, docstring extended to cover both cases) and reused here. It reshards the 1-D scale to whatever the activation's last axis is wearing, and is a no-op whenever they already agree.

**2. A `shard_map` cannot close over an array on explicit mesh axes.** `RoutedMoE.get_topk` reads `self.per_expert_scale` (Gemma 4 only), and on the sparse path that read happens inside `sparse_matmul_route_and_compute`'s `jax.shard_map`. The value is now threaded down as an explicit argument — `get_topk` → `permute` → `roe_ag_and_route` / `ra2a_and_route` → `route` → `moe_emb_chunking` → `_moe_body` → the shard_map — with a replicated `P()` `in_spec` (routing sees every expert) and an `EXPLICIT`-only pre-reshard at the call site, since `shard_map` will not insert a reshard for an operand that disagrees with its `in_specs`. `get_topk` still falls back to reading the module attribute when the argument is `None`, so the dense path and every other caller are unchanged.

**3. A reshape cannot split a sharded axis.** `Gemma4SmallPLE` builds both halves of the per-layer input at `[B, S, L * D_ple]` and then reshapes to `[B, S, L, D_ple]`. The flat feature axis therefore has to be replicated. Three places pin it:

- the embedding gather, which becomes `embedding.at[ids].get(out_sharding=self.flat_sharding)` — the same pattern `embeddings.py` already uses. Without this, explicit sharding infers `P('fsdp', None, 'fsdp')` and raises `DuplicateSpecError`;
- `per_layer_model_projection` and `per_layer_projection_norm`;
- `per_layer_input_gate` in `Gemma4SmallDecoderLayer`, so the gate and the PLE slice it multiplies agree.

## Tests

**`tests/integration/train_tests.py`** — two tests, each covering all three blocks:

- `test_tpu_gemma4_explicit_sharding_matches_auto`: three steps of a tiny model, auto vs. explicit. Six layers is exactly one period of the Gemma 4 attention pattern (and one whole `Gemma4ScannableBlock`), so both attention types run. MoE is paired with expert parallelism, `gemma4_small` with tensor parallelism, `gemma4` with FSDP (see below).
- `test_tpu_gemma4_zero1_gradient_accumulation`: auto + gradient accumulation vs. explicit + ZeRO-1 + gradient accumulation, mirroring the qwen3/mistral ZeRO-1 tests.

Measured behaviour: **all three blocks are bit-for-bit with auto at step 0.** The trajectory then drifts by a few parts in ten thousand (parity: 7.1e-4 / 7.7e-4 / 6.7e-4 for gemma4 / gemma4_moe / gemma4_small). The drift is float noise, not disagreement about the math — it also appears under *pure data parallelism*, where every reshard explicit sharding inserts is provably a numerical identity, so it can only be XLA reassociating reductions under a pinned layout. Gemma 4 shows it sooner than the other families because it runs its residual stream in bf16 with unscaled attention logits (`query_pre_attn_scalar=1.0`). Tolerances are `rtol=1e-3` for parity and `rtol=5e-3` for the ZeRO-1 test, which compares two runs differing in *both* shard mode and optimizer-state placement. A genuinely wrong sharding does not hide under this: it either fails the shape check outright or moves the loss by percent.

MoE runs with `sparse_matmul=True megablox=True` because `RoutedMoE.dense_matmul` is not onboarded to explicit sharding yet — a gap shared with mixtral and qwen3_moe.

**`tests/unit/pyconfig_test.py`** — `test_explicit_sharding_gemma4_decoder_support`, matching the existing qwen3/mistral/qwen2 acceptance tests.

**`tests/unit/train_compile_test.py`** — three AOT compiles at full model size, where a missing `out_sharding` fails the trace rather than silently costing a collective at a scale a test cannot run:

- `gemma4-31b` on v5p-256, FSDP 32 x tensor 4
- `gemma4-26b` on v5p-512, FSDP 32 x expert 8
- `gemma4-e4b` on v5p-64, FSDP 16 x tensor 2 (E4B has two KV heads, so the tensor axis cannot go wider)

## One pre-existing gap, documented not fixed

The `gemma4` parity test runs under FSDP rather than tensor parallelism. Under `ici_tensor_parallelism=4` + `shard_mode=explicit` + bf16 + `attention=dot_product` + `scan_layers=True`, the backward pass produces NaN gradients at step 0 — localized to the *global* attention layer's QK backward, while the forward loss is bit-identical to auto.

This is **not introduced by this PR**: `gemma3-4b`, which shares the same scanned local/global block, reproduces it identically at the same sizes. It survives every remat policy, every init seed, `matmul_precision=highest`, `weight_dtype=float32`, and both 6 and 12 layers. It goes away with `attention=flash`, `float32_qk_product=True`, `float32_logits=True`, `scan_layers=False`, `ici_tensor_parallelism=2`, or removing the global layer. Since the production path uses the splash/flash kernel and is unaffected, this PR covers `gemma4` under FSDP and leaves tensor-parallel coverage to `gemma4_small`, which builds its stack without the scan.

## Tests run

```
pytest tests/integration/train_tests.py -k test_tpu_gemma4         # 2 passed, 6 subtests
JAX_PLATFORMS=cpu pytest tests/unit/pyconfig_test.py -k explicit_sharding   # 6 passed, 11 subtests
JAX_PLATFORMS=cpu pytest tests/unit/train_compile_test.py -k gemma4         # 3 passed
```

on a TPU v4-8 host.

## Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
