### PR TITLE
[Raiden Weight Sync 5/7] Pass weight_dtype in Qwen3NextSparseMoeBlock shared expert gate

### DIFF
--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -1305,6 +1305,7 @@ class Qwen3NextSparseMoeBlock(nnx.Module):
           out_features_shape=1,
           use_bias=False,  # Qwen3-Next shared_expert_gate does not have a bias
           dtype=cfg.dtype,
+          weight_dtype=cfg.weight_dtype,
           kernel_init=max_initializers.nd_dense_init(cfg.dense_init_scale, "fan_in", "truncated_normal"),
           kernel_axes=("embed", None),
           matmul_precision=cfg.matmul_precision,


### PR DESCRIPTION
## Overview
Part of the stacked Raiden weight-sync enablement PR chain replacing #5089.

**Stack:**
- [M7] https://github.com/AI-Hypercomputer/maxtext/pull/5166: Cross-repo drift guard
- [M1] https://github.com/AI-Hypercomputer/maxtext/pull/5167: Inhomogeneous layer cycle support in raiden_unscan
- [M2] https://github.com/AI-Hypercomputer/maxtext/pull/5168: MoE 128-lane layout and padding (pairs with Tunix T5)
- [M3] https://github.com/AI-Hypercomputer/maxtext/pull/5169: Target-free streaming weight conversion
- **[M5] AI-Hypercomputer/maxtext (this PR)**: Shared expert gate weight_dtype fix
- [M4] AI-Hypercomputer/maxtext: TrainingEngine Raiden FFI integration (pairs with Tunix T2a)
- [M6] AI-Hypercomputer/maxtext: Rollout cleanup

## Details
- Fixes `shared_expert_gate` in `Qwen3NextSparseMoeBlock` to explicitly pass `weight_dtype=cfg.weight_dtype`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).