### PR TITLE
Fix test_te_moe_block_uses_ragged_buffer_factor_validation

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -3562,7 +3562,6 @@ class MaxTextConfig(
             "use_random_routing": False,
             "use_ragged_sort": False,
             "retry_when_tokens_dropped": False,
-            "ragged_buffer_factor": -1.0,
             "use_ring_of_experts": False,
             "num_moe_emb_chunks": 0,
         }

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -129,7 +129,6 @@ class ConfigTest(absltest.TestCase):
           types.MaxTextConfig(**{**common_config, **overrides})
         self.assertIn(expected_error, str(context.exception))
 
-  @unittest.skip("b/558935791: TE MoE ragged buffer validation conflicts with the EP rank 1 restriction.")
   def test_te_moe_block_uses_ragged_buffer_factor_validation(self):
     common_config = {
         "run_name": "test",


### PR DESCRIPTION
# Description

Fixes test failure in `tests/unit/configs_value_test.py::ConfigTest::test_te_moe_block_uses_ragged_buffer_factor_validation` that was not caught previously due to unrelated build failures skipping these tests in CI. With this fix, it is now passing.

# Tests

Tested `tests/unit/configs_value_test.py::ConfigTest::test_te_moe_block_uses_ragged_buffer_factor_validation` locally before this change to reproduce the failure and then re-ran after this change it was resolved.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
