### PR TITLE
feat(ci): label automated GitHub Actions E2E test runs in Cloud Composer

### DIFF
--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -64,13 +64,20 @@ jobs:
         run: |
           IAP_TOKEN=$(gcloud auth print-access-token)
           PAYLOAD=$(python3 -c 'import json, os
+          from datetime import datetime, timezone
+          run_id = os.environ["RUN_ID"]
+          repo = os.environ["GITHUB_REPO"]
+          now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
           print(json.dumps({
+              "dag_run_id": f"auto_gha__{run_id}__{now}",
+              "note": f"Automated E2E TPU test suite triggered by GitHub Actions.\n\nWorkflow Run: https://github.com/{repo}/actions/runs/{run_id}",
               "conf": {
                   "build_mode": os.environ["BUILD_MODE"],
                   "commit_sha": os.environ["COMMIT_SHA"],
-                  "github_run_id": os.environ["RUN_ID"],
-                  "github_repo": os.environ["GITHUB_REPO"],
+                  "github_run_id": run_id,
+                  "github_repo": repo,
                   "github_token": os.environ["GITHUB_TOKEN"],
+                  "is_automated": True,
               }
           }))')
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \


### PR DESCRIPTION
# Description

In Cloud Composer, automated GitHub Actions E2E test runs for MaxText are currently difficult to distinguish from manual runs because Airflow defaults to generating run IDs in the format `manual__<timestamp>` with no run notes.

This PR implements CI/CD run identification when triggering the `maxtext_e2e_tests` Airflow DAG from GitHub Actions:
- Assigns an explicit `dag_run_id` prefixed with `auto_gha__` (`auto_gha__<run_id>__<iso_timestamp>`) for instant filtering in the Airflow UI DAG Runs table.
- Attaches an interactive Markdown DAG run note with a direct link back to the originating GitHub Actions workflow run.
- Adds `is_automated: true` inside the `conf` payload for downstream task visibility while preserving all existing parameters.

# Changes

- In `.github/workflows/run_e2e_tests.yml`:
  - Updated the Python payload generator in the `Trigger DAG` step to include `dag_run_id`, `note`, and `conf.is_automated: true`.
  - Maintained complete backward compatibility for all existing parameters (`build_mode`, `commit_sha`, `github_run_id`, `github_repo`, `github_token`).

# Tests

- **Cloud Composer Live API Verification**:
[Example](https://efdb2a1d6c2c435b8b7de77690c286a9-dot-us-central1.composer.googleusercontent.com/dags/maxtext_e2e_tests/grid?search=maxtext_e2e_tests&tab=details&dag_run_id=auto_gha__preview_test__2026-09-10T07%3A00%3A54Z)
  Tested the exact payload against the production Cloud Composer Airflow 2.10.5 instance (`ml-automation-solutions`):
  - Received `HTTP 200 OK` on DAG trigger.
  - Airflow created and queued the run with `dag_run_id = auto_gha__preview_test__2026-09-10T07:00:54Z`.
  - The Markdown note rendered clickably in the Airflow console with the GitHub Actions link.
  - Child TPU workloads were verified to remain decoupled (run names derive from `params.github_run_id`: `shared_run_name = "e2e-{{ params.github_run_id }}"`).
- **Downstream Callback Decoupling**:
  Verified that `.github/workflows/promote_docker_image.yml` only evaluates `state` (`success`/`failed`) and logs `DAG_RUN_ID`, with zero string parsing dependencies on the run ID format.
- **Workflow Syntax & Runtime Validation**:
  Verified clean YAML parsing (`yaml.safe_load`) and payload generation inside `google/cloud-sdk:524.0.0` container context.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
