### PR TITLE
Move mmap index builder into maxtext utils

### DIFF
--- a/docs/guides/data_input_pipeline/data_input_megatron_mmap.md
+++ b/docs/guides/data_input_pipeline/data_input_megatron_mmap.md
@@ -131,7 +131,7 @@ cost, build a single dataset in advance. `--num-samples` must match the training
 sample count:
 
 ```sh
-python3 tools/data_processing/mmap_index_builder.py convert \
+python3 src/maxtext/utils/mmap_index_builder.py convert \
   --input /data/wiki_text_document \
   --output-dir /cache/wiki_indices \
   --seq-length 2048 \
@@ -142,7 +142,7 @@ python3 tools/data_processing/mmap_index_builder.py convert \
 The `blend` subcommand creates child index directories and the global dispatch:
 
 ```sh
-python3 tools/data_processing/mmap_index_builder.py blend \
+python3 src/maxtext/utils/mmap_index_builder.py blend \
   --datasets '/data/wiki_text_document,0.7;/data/code_text_document,0.3' \
   --output-dir /cache/wiki_code_blend \
   --seq-length 2048 \

--- a/src/maxtext/input_pipeline/_mmap_datasource.py
+++ b/src/maxtext/input_pipeline/_mmap_datasource.py
@@ -703,7 +703,7 @@ class MegatronNpyDataSource(grain.RandomAccessDataSource):
   """Grain-compatible data source that uses pre-built Megatron .npy indices.
 
   Loads ``document_index.npy``, ``sample_index.npy``, and
-  ``shuffle_index.npy`` (as produced by :func:`tools.data_processing.mmap_index_builder.convert`)
+  ``shuffle_index.npy`` (as produced by :func:`maxtext.utils.mmap_index_builder.convert`)
   together with one or more MMap ``.bin/.idx`` dataset shards to provide
   random access to pre-shuffled, fixed-length training samples.
 

--- a/src/maxtext/input_pipeline/_mmap_index_utils.py
+++ b/src/maxtext/input_pipeline/_mmap_index_utils.py
@@ -15,7 +15,7 @@
 """Core index-building algorithms for Megatron-LM .npy index files.
 
 Functions in this module are used both at offline build time
-(``tools/data_processing/mmap_index_builder.py``) and at training-time
+(``src/maxtext/utils/mmap_index_builder.py``) and at training-time
 auto-rebuild (``_mmap_datasource._ensure_npy_indices``).
 
 All pure-computation helpers are deterministic given the same inputs

--- a/src/maxtext/utils/mmap_index_builder.py
+++ b/src/maxtext/utils/mmap_index_builder.py
@@ -21,13 +21,13 @@ the index-building step at training initialization.
 Usage::
 
     # Single dataset
-    python tools/data_processing/mmap_index_builder.py \
+    python src/maxtext/utils/mmap_index_builder.py \
         --input /data/megatron_dataset/ \
         --output-dir /cache/indices/ \
         --seq-length 2048 --num-samples 1000000
 
     # Blending multiple datasets (concurrent build)
-    python tools/data_processing/mmap_index_builder.py blend \
+    python src/maxtext/utils/mmap_index_builder.py blend \
         --datasets '/data/ds_a,0.7;/data/ds_b,0.3' \
         --output-dir /cache/blend_indices \
         --seq-length 2048 --total-samples 1000000
@@ -37,15 +37,14 @@ import logging
 import os
 import sys
 
-# When run directly (python tools/data_processing/mmap_index_builder.py), ensure
+# When run directly (python src/maxtext/utils/mmap_index_builder.py), ensure
 # the src directory is on sys.path so the maxtext package can be resolved.
-_src_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+_src_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
 if _src_dir not in sys.path:
   sys.path.insert(0, _src_dir)
 
 # Re-export all public symbols from the canonical location so that
-# existing ``from tools.data_processing.mmap_index_builder import ...``
-# statements continue to work without changes.
+# ``from maxtext.utils.mmap_index_builder import ...`` statements work.
 from maxtext.input_pipeline._mmap_index_utils import (  # pylint: disable=unused-import  # noqa: F401 -- public re-exports
     build_document_index,
     build_indices,

--- a/tests/unit/megatron_mmap_compatibility_test.py
+++ b/tests/unit/megatron_mmap_compatibility_test.py
@@ -50,7 +50,7 @@ requires_megatron_core = pytest.mark.skipif(
 
 from maxtext.input_pipeline import _megatron_blending
 from maxtext.input_pipeline import _mmap_index_utils
-from tools.data_processing.mmap_index_builder import (
+from maxtext.utils.mmap_index_builder import (
     build_document_index,
     build_indices,
     build_sample_index,
@@ -871,8 +871,9 @@ class TestCLI:
         os.path.dirname(__file__),
         "..",
         "..",
-        "tools",
-        "data_processing",
+        "src",
+        "maxtext",
+        "utils",
         "mmap_index_builder.py",
     )
 

--- a/tests/unit/mmap_data_processing_test.py
+++ b/tests/unit/mmap_data_processing_test.py
@@ -50,7 +50,7 @@ from maxtext.input_pipeline._mmap_datasource import (
     _parse_weighted_mixture,
 )
 from tests.unit.mmap_test_utils import create_mmap_test_data
-from tools.data_processing.mmap_index_builder import convert
+from maxtext.utils.mmap_index_builder import convert
 
 pytestmark = pytest.mark.cpu_only
 


### PR DESCRIPTION
# Description

Move `mmap_index_builder.py` from `tools/data_processing` to `src/maxtext/utils` and update imports, tests, and documentation.

# Tests
https://screenshot-v2.corp.google.com/38lreoi2onha8

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
