### PR TITLE
Extend MoE dropless retry mechanism to eval step

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -651,6 +651,8 @@ def eval_step(model, config, state, data, dropout_rng=None):
           "evaluation/mtp_acceptance_rate_percent": mtp_acceptance_rate,
       },
   }
+  if config.retry_when_tokens_dropped:
+    metrics["has_moe_overflow"] = aux.get("has_moe_overflow", False)
 
   return metrics
 
@@ -668,6 +670,7 @@ def training_loop_iteration(
   p_train_step = jax_device_state["p_train_step"]
   p_train_step_dropless = jax_device_state.get("p_train_step_dropless", None)
   p_eval_step = jax_device_state["p_eval_step"]
+  p_eval_step_dropless = jax_device_state.get("p_eval_step_dropless", None)
 
   # Unpack python_vars
   step = python_vars["step"]
@@ -774,6 +777,16 @@ def training_loop_iteration(
         break
       with jax.set_mesh(mesh), nn_partitioning.axis_rules(logical_axis_rules_for_eval):
         eval_metrics = p_eval_step(state, eval_batch, *step_rng_args)
+        if (
+            config.retry_when_tokens_dropped
+            and p_eval_step_dropless is not None
+            and bool(eval_metrics.get("has_moe_overflow"))
+        ):
+          max_logging.log(
+              f"Eval step {eval_step_count}: MoE ragged buffer overflow detected! "
+              f"Replaying eval step with dropless buffer..."
+          )
+          eval_metrics = p_eval_step_dropless(state, eval_batch, *step_rng_args)
       eval_step_time_delta = datetime.datetime.now() - last_eval_step_completion
       last_eval_step_completion = datetime.datetime.now()
       metric_logger_instance.buffer_and_write_metrics(
@@ -857,16 +870,17 @@ def train_loop(config, recorder, state=None):
   )
 
   p_train_step_dropless = None
+  p_eval_step_dropless = None
   if jit_model_dropless is not None:
-    p_train_step_dropless, _ = train_utils.jit_train_and_eval_step(
+    p_train_step_dropless, p_eval_step_dropless = train_utils.jit_train_and_eval_step(
         config,
         jit_model_dropless,
         mesh,
         state,
         state_mesh_shardings,
         train_step,
-        eval_step=None,
-        eval_data_iterator=None,
+        eval_step=eval_step,
+        eval_data_iterator=eval_data_iterator,
         params_shardings=params_shardings,
     )
 
@@ -932,6 +946,7 @@ def train_loop(config, recorder, state=None):
       "p_train_step": p_train_step,
       "p_train_step_dropless": p_train_step_dropless,
       "p_eval_step": p_eval_step,
+      "p_eval_step_dropless": p_eval_step_dropless,
       "model": model,
   }
 

--- a/tests/unit/train_nnx_test.py
+++ b/tests/unit/train_nnx_test.py
@@ -20,8 +20,10 @@ production loss_fn uses (decoder_input_tokens, decoder_positions, ...).
 """
 
 from dataclasses import dataclass
+import datetime
 import types as pytypes
 import unittest
+from unittest import mock
 
 from flax import nnx
 from flax.nnx import variablelib
@@ -438,7 +440,7 @@ class TestTrainStepNNX(unittest.TestCase):
 
 
 class TestMoeOverflowLoggingNNX(unittest.TestCase):
-  """Covers train_step surfacing has_moe_overflow for training_loop_iteration's log line."""
+  """Covers train_step/eval_step surfacing has_moe_overflow for training_loop_iteration's retry branches."""
 
   def _build_state(self, has_overflow, retry_when_tokens_dropped):
     cfg = _Cfg(retry_when_tokens_dropped=retry_when_tokens_dropped)
@@ -455,6 +457,13 @@ class TestMoeOverflowLoggingNNX(unittest.TestCase):
     )
     return metrics
 
+  def _eval_metrics(self, has_overflow, retry_when_tokens_dropped):
+    """Runs eval_step and returns its metrics dict."""
+    cfg, ts = self._build_state(has_overflow, retry_when_tokens_dropped)
+    state_graphdef, state_pure = nnx.split(ts)
+    data = _make_data(batch=cfg.micro_batch_size_to_eval_on, vocab=cfg.vocab_size)
+    return pre_train.eval_step(state_graphdef, cfg, state_pure, data)
+
   def test_surfaces_overflow_when_flag_on(self):
     metrics = self._metrics(has_overflow=True, retry_when_tokens_dropped=True)
     self.assertTrue(bool(metrics["has_moe_overflow"]))
@@ -469,6 +478,17 @@ class TestMoeOverflowLoggingNNX(unittest.TestCase):
     change every model's compiled train_step output, even non-MoE ones.
     """
     metrics = self._metrics(has_overflow=True, retry_when_tokens_dropped=False)
+    self.assertNotIn("has_moe_overflow", metrics)
+
+  def test_eval_step_also_surfaces_overflow(self):
+    """eval_step must surface has_moe_overflow the same way train_step does -- it's what
+    training_loop_iteration's eval-retry branch checks before replaying with the dropless step.
+    """
+    metrics = self._eval_metrics(has_overflow=True, retry_when_tokens_dropped=True)
+    self.assertTrue(bool(metrics["has_moe_overflow"]))
+
+  def test_eval_step_key_absent_when_flag_off(self):
+    metrics = self._eval_metrics(has_overflow=True, retry_when_tokens_dropped=False)
     self.assertNotIn("has_moe_overflow", metrics)
 
 
@@ -647,6 +667,114 @@ class TestRecordActivationMetricsParity(unittest.TestCase):
     for key, expected in m_linen.items():
       np.testing.assert_allclose(np.asarray(m_nnx[key]), np.asarray(expected))
     np.testing.assert_allclose(np.asarray(m_nnx["activ_stdev/layer_002"]), 1.2)
+
+
+class TestTrainingLoopIterationEvalRetry(unittest.TestCase):
+  """Covers training_loop_iteration's host-side eval-retry branch: p_eval_step_dropless is
+  invoked (and its metrics used) only when retry_when_tokens_dropped is on, a dropless eval
+  step is available, and the primary eval step reports has_moe_overflow.
+  """
+
+  _PRIMARY_LOSS = 999.0
+  _DROPLESS_LOSS = -1.0
+
+  def _run(self, retry_when_tokens_dropped, has_overflow, with_dropless):
+    """Runs training_loop_iteration with fake step fns and returns (eval loss used, dropless call count)."""
+
+    def p_train_step(state, batch, *rng_args):
+      del batch, rng_args
+      return state, {"scalar": {}, "scalars": {}}
+
+    def p_eval_step(state, batch, *rng_args):
+      del state, batch, rng_args
+      metrics = {"scalar": {"evaluation/total_loss": jnp.array(self._PRIMARY_LOSS)}}
+      if retry_when_tokens_dropped:
+        metrics["has_moe_overflow"] = jnp.bool_(has_overflow)
+      return metrics
+
+    dropless_calls = []
+
+    def p_eval_step_dropless(state, batch, *rng_args):
+      del state, batch, rng_args
+      dropless_calls.append(1)
+      return {"scalar": {"evaluation/total_loss": jnp.array(self._DROPLESS_LOSS)}}
+
+    mesh = jax.sharding.Mesh(np.array(jax.devices()[:1]).reshape(1), ("data",))
+    cfg = pytypes.SimpleNamespace(
+        elastic_enabled=False,
+        enable_diloco=False,
+        retry_when_tokens_dropped=retry_when_tokens_dropped,
+        logical_axis_rules_for_eval=(),
+    )
+    metric_logger_instance = mock.MagicMock()
+    data_loader = mock.MagicMock()
+    prof = mock.MagicMock()
+
+    jax_device_state = {
+        "state": "fake_state",
+        "init_rng": None,
+        "mesh": mesh,
+        "p_train_step": p_train_step,
+        "p_train_step_dropless": None,
+        "p_eval_step": p_eval_step,
+        "p_eval_step_dropless": p_eval_step_dropless if with_dropless else None,
+    }
+    python_vars = {
+        "step": 0,
+        "last_step_completion": datetime.datetime.now(),
+        "data_loader": data_loader,
+        "rampup_manager": None,
+        "recorder": None,
+        "checkpoint_manager": None,
+        "data_iterator": None,
+        "eval_data_iterator": [jnp.zeros((1,))],
+        "metric_logger_instance": metric_logger_instance,
+        "prof": prof,
+    }
+    immutable_data = {
+        "config": cfg,
+        "logical_axis_rules_for_train": (),
+        "logical_axis_rules_for_eval": (),
+        "eval_interval": 1,
+        "eval_steps": 0,
+        "start_step": -1,  # != step, so the print_mem_stats branch is skipped
+        "eval_start_step": 0,
+        "dump_hlo": False,
+        "dump_step": -1,
+        "dump_hlo_local_dir": None,
+        "dump_hlo_gcs_dir": None,
+        "dump_hlo_module_name": None,
+        "dump_hlo_delete_local_after": False,
+        "dump_hlo_upload_all": False,
+    }
+    with mock.patch.object(pre_train.sharding, "get_input_data_sharding", return_value=None):
+      pre_train.training_loop_iteration(jax_device_state, python_vars, immutable_data)
+
+    eval_call = next(
+        c for c in metric_logger_instance.buffer_and_write_metrics.call_args_list if not c.kwargs["is_training"]
+    )
+    used_loss = float(eval_call.args[0]["scalar"]["evaluation/total_loss"])
+    return used_loss, len(dropless_calls)
+
+  def test_replays_with_dropless_metrics_on_overflow(self):
+    used_loss, dropless_call_count = self._run(retry_when_tokens_dropped=True, has_overflow=True, with_dropless=True)
+    self.assertEqual(used_loss, self._DROPLESS_LOSS)
+    self.assertEqual(dropless_call_count, 1)
+
+  def test_keeps_primary_metrics_without_overflow(self):
+    used_loss, dropless_call_count = self._run(retry_when_tokens_dropped=True, has_overflow=False, with_dropless=True)
+    self.assertEqual(used_loss, self._PRIMARY_LOSS)
+    self.assertEqual(dropless_call_count, 0)
+
+  def test_keeps_primary_metrics_when_dropless_unavailable(self):
+    used_loss, dropless_call_count = self._run(retry_when_tokens_dropped=True, has_overflow=True, with_dropless=False)
+    self.assertEqual(used_loss, self._PRIMARY_LOSS)
+    self.assertEqual(dropless_call_count, 0)
+
+  def test_keeps_primary_metrics_when_flag_off(self):
+    used_loss, dropless_call_count = self._run(retry_when_tokens_dropped=False, has_overflow=True, with_dropless=True)
+    self.assertEqual(used_loss, self._PRIMARY_LOSS)
+    self.assertEqual(dropless_call_count, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Extends the MoE dropless retry mechanism from training (PR #5080) to the evaluation pipeline.

When `retry_when_tokens_dropped=True` and `ragged_buffer_factor > 0`, tokens that exceed the ragged buffer capacity during evaluation flag `has_moe_overflow` in the eval metrics. When detected on host, `training_loop_iteration` replays the eval batch using the pre-compiled dropless fallback step (`p_eval_step_dropless`) to ensure zero token dropping during evaluation without steady-state dropless overhead.

### Key Changes:
- **`eval_step`**: Surfaces `has_moe_overflow` from `model_apply` metrics when `retry_when_tokens_dropped=True`.
- **Pre-compilation**: Compiles `p_eval_step_dropless` alongside `p_train_step_dropless` in `train_loop`.
- **Host replay**: In `training_loop_iteration`, replays eval step with `p_eval_step_dropless` upon detecting buffer overflow.
- **Unit Tests**: Added test coverage in `tests/unit/train_nnx_test.py` for eval overflow metric surfacing and host-side retry logic.

BUGS: b/555278394

# Tests

- **Unit tests**: `tests/unit/train_nnx_test.py` covering eval overflow metric surfacing and host-side replay.
- **256-chip DeepSeek-V3 MLPerf Convergence & Throughput Benchmark** (cell `yulhrp`, 64 hosts, `gf_4x8x8`):

| Config | XID | Loss at Step 86 | Average Throughput over Last 60 Steps (Tokens/s/device) | Number of Retries (Logs) | CMD (gPaste Link) |
| :--- | :---: | :---: | :---: | :---: | :--- |
| **`pr rbf = 0.125 with retry (pdbs=1)`** | [288740516](http://xids/288740516) | **3.588** *(Eliminates drop degradation: 3.588 vs 5.020)* | **275.72 Tokens/s/device** *(14.86s/step, XProf captured)* | **All 87 steps + Eval Step 0 retried** *(Every overflow caught and replayed with dropless fallback; 0 dropped tokens)* | [gPaste](https://paste.googleplex.com/5504477818388480) |
| **`pr rbf = 0.125 without retry (pdbs=2)`** *(Control)* | [288499772](http://xids/288499772) | **5.020** *(Degraded)* | **956.89 Tokens/s/device** *(8.56s/step)* | 0 *(Control: drops tokens without retry)* | [gPaste](https://paste.googleplex.com/4833127722254336) |
| **`pr rbf = 2.0 with retry (pdbs=2)`** *(Steady State)* | [288498787](http://xids/288498787) | **3.475** *(Matches baseline)* | **784.85 Tokens/s/device** *(10.40s/step)* | **0** *(0 overflows / 0 retries)* | [gPaste](https://paste.googleplex.com/5555376502734848) |
| **`pr rbf = 2.0 without retry (pdbs=2)`** *(Control)* | [288500212](http://xids/288500212) | **3.481** | **784.60 Tokens/s/device** *(10.40s/step)* | 0 *(Control: no retry code path)* | [gPaste](https://paste.googleplex.com/5238282288496640) |
| **`p4head rbf = -1.0`** *(Dropless Reference)* | [285734992](http://xids/285734992) | **3.472** | **632.08 Tokens/s/device** *(12.96s/step)* | 0 *(Dropless baseline)* | [gPaste](https://paste.googleplex.com/5604833235697664) |

### Benchmark Takeaways:
1. **Eval Dropless Retry Recovers Convergence**: At `rbf=0.125` where buffer overflows occur on every step, enabling retry (XID 288740516) achieves **Step 86 eval loss 3.588**, recovering **1.432 points of loss** compared to the unmitigated token-dropping control (**eval loss 5.020**, XID 288499772). The log confirms `Eval step 0: MoE ragged buffer overflow detected! Replaying eval step with dropless buffer...` cleanly triggered and recovered the evaluation metrics.
2. **Eval Convergence Verified at Steady State**: At steady state (`rbf=2.0 with retry`, XID 288498787), Step 86 evaluation loss is **3.475**, matching the dropless baseline (**3.472**) while providing **+24.2% higher throughput** (784.85 vs 632.08 Tokens/s/device) with 0 retries / 0 overhead.
3. **Zero Steady-State Overhead**: Comparing `rbf=2.0 with retry` (784.85 Tokens/s/device, eval loss 3.475) directly with `rbf=2.0 without retry` (784.60 Tokens/s/device, eval loss 3.481) confirms < 0.03% throughput difference, demonstrating zero runtime performance penalty for enabling the retry safety net.
4. **Replay Mechanism Verified End-to-End**: With `rbf=0.125 with retry` (XID 288740516), host-side retry successfully catches ragged buffer overflows on all 87 training steps and Eval Step 0, seamlessly replaying with the pre-compiled dropless fallback.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
