### PR TITLE
Fix EOS token detection and Qwen vision model routing in multimodal_eval

### DIFF
--- a/benchmarks/multimodal/multimodal_eval.py
+++ b/benchmarks/multimodal/multimodal_eval.py
@@ -150,7 +150,7 @@ def construct_prompt(
         question=parsed_dataset_example.question,
         choices=choices_text if choices_text else "N/A",
     )
-    if config.use_multimodal and "qwen3-omni" in config.model_name:
+    if config.use_multimodal and "qwen" in str(config.decoder_block).lower():
       prompt = mm_processor.reformat_prompt(
           prompt,
           image_placeholder,
@@ -180,6 +180,16 @@ def main(config, local_args):
 
   max_prefill_predict_length = getattr(config, "max_prefill_predict_length", 1024)
   max_target_length = getattr(config, "max_target_length", 2048)
+
+  # Collect possible EOS/stop token IDs across models (Gemma, Qwen, etc.)
+  eos_token_ids = {tokenizer.eos_id} if getattr(tokenizer, "eos_id", None) is not None else set()
+  if hasattr(tokenizer, "stop_tokens"):
+    eos_token_ids.update(tokenizer.stop_tokens)
+  if hasattr(tokenizer, "tokenizer"):
+    vocab = tokenizer.tokenizer.get_vocab()
+    for token in ("<end_of_turn>", "<eos>", "<|im_end|>", "<|endoftext|>"):
+      if token in vocab:
+        eos_token_ids.add(vocab[token])
 
   # Initialize counters for overall accuracy
   correct_count = 0
@@ -278,7 +288,7 @@ def main(config, local_args):
       # Generate next token
       decode_state, sampled_token = engine.generate(params, decode_state)
       sampled_tokens.append(sampled_token.get_result_at_slot(slot).tokens.item())
-      if sampled_tokens[-1] == tokenizer.eos_id:
+      if sampled_tokens[-1] in eos_token_ids:
         break
 
     correct_answer = parsed_dataset_example.answer


### PR DESCRIPTION
# Description

This PR fixes the eval script of multimodal model in `benchmarks/multimodal/multimodal_eval.py`:
1. **Excessive Latency due to Missing EOS/Stop Tokens**: The decoding loop only checked `sampled_tokens[-1] == tokenizer.eos_id`. For tokenizers that rely on specialized stop tokens (e.g. `<end_of_turn>` for Gemma), decoding ran all the way to `max_target_length`, resulting in 60s-80s+ per sample.
2. **Missing Base Prompt Formatting for Qwen Models**: In `construct_prompt`, base prompt reformatting was restricted to `"qwen3-omni" in config.model_name`. Later when we introduced other Qwen vision models (such as `qwen3-vl-2b` and `qwen3-vl-4b`), they did not receive the required prompt structure, producing degenerate repetitive token loops (e.g., repeating `;`) and failing answer extraction.

FIXES: b/559960889

# Changes
- Replaced `"qwen3-omni" in config.model_name` with `"qwen" in str(config.decoder_block).lower()` so that we can dynamically matches all Qwen decoder variants for base prompt reformatting without hardcoding model names or accessing private attributes.
- Populates `eos_token_ids` using `tokenizer.eos_id`, `tokenizer.stop_tokens` (if available), and explicit stop tokens (`<end_of_turn>`, `<eos>`, `<|im_end|>`, `<|endoftext|>`) resolved through `tokenizer.tokenizer.get_vocab()`, and terminates generation early as soon as `sampled_tokens[-1] in eos_token_ids`.


# Tests

## 1. Gemma 3 4B (SFT Evaluation on ChartQA)

**Command:**
```bash
export PYTHONPATH=src:${PYTHONPATH:-}
export MEGASCALE_NUM_SLICES=1
export HF_TOKEN="Your-token"
export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"

python3 -m benchmarks.multimodal.multimodal_eval \
  src/maxtext/configs/base.yml \
  model_name=gemma3-4b \
  tokenizer_type=huggingface \
  tokenizer_path=google/gemma-3-4b-it \
  hf_access_token="${HF_TOKEN}" \
  load_parameters_path=gs://yuchenhou-maxtext-logs/gemma3-4b-sft-chartqa-full-decoder/gemma3_4b_sft_chartqa_5epoch_full_decoder_v4_128/checkpoints/1104/items \
  base_output_directory=gs://yuchenhou-maxtext-logs/gemma3-4b-sft-chartqa-full-decoder/eval \
  run_name=test \
  per_device_batch_size=1 \
  use_multimodal=true \
  scan_layers=true \
  attention='dot_product' \
  max_prefill_predict_length=1024 \
  max_target_length=1600 \
  hf_path=HuggingFaceM4/ChartQA \
  hf_eval_split=test \
  --ckpt_type=sft \
  --num_examples=10 \
  --tmp_results_file=test.csv
```

**Results:**
- **Before Fix**: Decoding failed to stop at `<end_of_turn>`, running to maximum length and averaging **~61s–64s/iteration** (projected >42 hours for 2500 samples).
- **After Fix**: Decoding terminates immediately on `<end_of_turn>`, reducing latency to **1.1s–5.2s/iteration** (projected ~47 minutes for 2500 samples — **>12x–50x speedup**).

<details>
<summary><b>Before fixing Gemma (Click to expand)</b></summary>

```text
INFO:absl:1 | How many food item is shown in the bar graph?
[Model output] 10
[Label answer] 14
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 1/2500
INFO:absl:Uploaded the results file to GCS bucket: gs://yuchenhou-maxtext-logs/gemma3-4b-sft-chartqa-full-decoder/eval/2026-09-11-05-32-21.csv
Evaluating HuggingFaceM4/ChartQA dataset:   0%|            | 1/2500 [01:04<44:54:14, 64.69s/it]
**************************************************
INFO:absl:2 | What is the difference in value between Lamb and Corn?
[Model output] 0.27
[Label answer] 0.57
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 2/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|            | 2/2500 [02:05<43:07:12, 62.14s/it]
**************************************************
INFO:absl:3 | How many bars are shown in the chart?
[Model output] 3
[Label answer] 3
Matching: True
INFO:absl:Running accuracy: 0.3333 | Processed: 3/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|            | 3/2500 [03:05<42:40:10, 61.52s/it]
**************************************************
INFO:absl:4 | Is the sum value of Madagascar more then Fiji?
[Model output] No
[Label answer] No
Matching: True
INFO:absl:Running accuracy: 0.5000 | Processed: 4/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|            | 4/2500 [04:06<42:17:59, 61.01s/it]
**************************************************
INFO:absl:5 | What's the value of the lowest bar?
[Model output] 23
[Label answer] 23
Matching: True
INFO:absl:Running accuracy: 0.6000 | Processed: 5/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|            | 5/2500 [05:06<42:05:07, 60.72s/it]
**************************************************
```

</details>

<details>
<summary><b>After fixing Gemma (Click to expand)</b></summary>

```text
INFO:absl:1 | How many food item is shown in the bar graph?
[Model output] 10
[Label answer] 14
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 1/2500
INFO:absl:Uploaded the results file to GCS bucket: gs://yuchenhou-maxtext-logs/gemma3-4b-sft-chartqa-full-decoder/eval/2026-09-11-05-43-04.csv
Evaluating HuggingFaceM4/ChartQA dataset:   0%|             | 1/2500 [00:05<3:36:27,  5.20s/it]
**************************************************
INFO:absl:2 | What is the difference in value between Lamb and Corn?
[Model output] 0.27
[Label answer] 0.57
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 2/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|             | 2/2500 [00:06<2:08:18,  3.08s/it]
**************************************************
INFO:absl:3 | How many bars are shown in the chart?
[Model output] 3
[Label answer] 3
Matching: True
INFO:absl:Running accuracy: 0.3333 | Processed: 3/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|             | 3/2500 [00:07<1:20:30,  1.93s/it]
**************************************************
INFO:absl:4 | Is the sum value of Madagascar more then Fiji?
[Model output] No
[Label answer] No
Matching: True
INFO:absl:Running accuracy: 0.5000 | Processed: 4/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|               | 4/2500 [00:07<58:32,  1.41s/it]
**************************************************
INFO:absl:5 | What's the value of the lowest bar?
[Model output] 23
[Label answer] 23
Matching: True
INFO:absl:Running accuracy: 0.6000 | Processed: 5/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|               | 5/2500 [00:08<47:13,  1.14s/it]
**************************************************
```

</details>


## 2. Qwen3-VL 2B (Base Evaluation on ChartQA)

**Command:**
```bash
export PYTHONPATH=src:${PYTHONPATH:-}
export MEGASCALE_NUM_SLICES=1
export HF_TOKEN="Your-token"
export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"

python3 -m benchmarks.multimodal.multimodal_eval \
  src/maxtext/configs/base.yml \
  model_name=qwen3-vl-2b \
  tokenizer_type=huggingface \
  tokenizer_path=Qwen/Qwen3-VL-2B-Instruct \
  hf_access_token="${HF_TOKEN}" \
  load_parameters_path=gs://yuchenhou-maxtext-logs/checkpoints/qwen3-vl-2b-processor/0/items \
  base_output_directory=gs://yuchenhou-maxtext-logs/qwen3-vl-2b/eval \
  run_name=eval_qwen3_vl_2b_base \
  per_device_batch_size=1 \
  use_multimodal=true \
  scan_layers=false \
  attention='dot_product' \
  max_prefill_predict_length=1024 \
  max_target_length=1600 \
  hf_path=HuggingFaceM4/ChartQA \
  hf_eval_split=test \
  --ckpt_type=base \
  --num_examples=10 \
  --tmp_results_file=qwen3_vl_2b_base_eval.csv
```

**Results:**
- **Before Fix**: Emitted repetitive garbage tokens (e.g. repeated `;`), failed answer parsing, and hung for **~83s/iteration** due to missing prompt tags and stop tokens.
- **After Fix**: Prompt formatting is applied correctly, the model outputs well-formed responses (`<answer>...</answer>`), stops at `<|im_end|>`, latency drops to **1.6s–4.9s/iteration**, and achieves much better accuracy on the ChartQA test sample.

<details>
<summary><b>Before fixing Qwen (Click to expand)</b></summary>

```text
INFO:absl:1 | How many food item is shown in the bar graph?
[Model output] ;
;
;
;
;
;
;
;
;
;
;

[Label answer] 14
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 1/2500
INFO:absl:Uploaded the results file to GCS bucket: gs://yuchenhou-maxtext-logs/qwen3-vl-2b/eval/2026-09-11-06-23-33.csv
Evaluating HuggingFaceM4/ChartQA dataset:   0%|            | 1/2500 [01:23<57:44:14, 83.18s/it]
**************************************************
INFO:absl:2 | What is the difference in value between Lamb and Corn?
[Model output]   
  <answer>100</answer>
[Label answer] 0.57
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 2/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|            | 2/2500 [01:23<24:05:27, 34.72s/it]
INFO:absl:3 | How many bars are shown in the chart?
[Model output] ;
;
;
;
;
;
;
;
;

[Label answer] 3
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 3/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|            | 3/2500 [01:49<21:16:00, 30.66s/it]
**************************************************
INFO:absl:check_correctness failed for extracted response: Yes and answers: ['No']
INFO:absl:4 | Is the sum value of Madagascar more then Fiji?
[Model output] =
<answer>Yes</answer>
[Label answer] No
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 4/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|            | 4/2500 [01:50<13:05:38, 18.89s/it]
**************************************************
INFO:absl:5 | What's the value of the lowest bar?
[Model output] =
<answer>10</answer>
[Label answer] 23
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 5/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|             | 5/2500 [01:52<8:56:37, 12.90s/it]
**************************************************
```

</details>

<details>
<summary><b>After fixing Qwen (Click to expand)</b></summary>

```text
INFO:absl:1 | How many food item is shown in the bar graph?
[Model output] <answer>12</answer>
[Label answer] 14
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 1/2500
INFO:absl:Uploaded the results file to GCS bucket: gs://yuchenhou-maxtext-logs/qwen3-vl-2b/eval/2026-09-11-06-18-13.csv
Evaluating HuggingFaceM4/ChartQA dataset:   0%|            | 1/2500 [00:51<35:34:10, 51.24s/it]
**************************************************
INFO:absl:2 | What is the difference in value between Lamb and Corn?
[Model output] <answer>0.43</answer>
[Label answer] 0.57
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 2/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|            | 2/2500 [00:52<14:57:30, 21.56s/it]
**************************************************
INFO:absl:3 | How many bars are shown in the chart?
[Model output] <answer>3</answer>
[Label answer] 3
Matching: True
INFO:absl:Running accuracy: 0.3333 | Processed: 3/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|             | 3/2500 [00:52<8:19:26, 12.00s/it]
**************************************************
INFO:absl:4 | Is the sum value of Madagascar more then Fiji?
[Model output] No
[Label answer] No
Matching: True
INFO:absl:Running accuracy: 0.5000 | Processed: 4/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|             | 4/2500 [00:53<5:09:20,  7.44s/it]
**************************************************
INFO:absl:5 | What's the value of the lowest bar?
[Model output] 23
[Label answer] 23
Matching: True
INFO:absl:Running accuracy: 0.6000 | Processed: 5/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%|             | 5/2500 [00:53<3:24:17,  4.91s/it]
**************************************************
```

</details>


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
