### PR TITLE
fix(vllm_decode): optimize `hbm_utilization` and `ici_tensor parallelism` for Gemma4-26b

### DIFF
--- a/tests/end_to_end/tpu/gemma4/26b/test_gemma4_rl.sh
+++ b/tests/end_to_end/tpu/gemma4/26b/test_gemma4_rl.sh
@@ -30,13 +30,13 @@ python3 -m maxtext.inference.vllm_decode \
     model_name=${MODEL_NAME} \
     load_parameters_path=${UNSCANNED_CKPT_PATH} \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
-    hbm_utilization_vllm=0.85 \
+    hbm_utilization_vllm=0.75 \
     prompt="Suggest some famous landmarks in London." \
     use_chat_template=True \
     scan_layers=false \
     enable_single_controller=${use_pathways} \
     prefuse_moe_weights=True \
-    ici_tensor_parallelism=2
+    ici_tensor_parallelism=4
 
 # Step 2: Run RL on the converted checkpoint
 python3 -m maxtext.trainers.post_train.rl.train_rl \
@@ -67,10 +67,10 @@ python3 -m maxtext.inference.vllm_decode \
     model_name=${MODEL_NAME} \
     load_parameters_path=${BASE_OUTPUT_DIRECTORY}/rl/${run_id}/checkpoints/actor/2/model_params \
     vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
-    hbm_utilization_vllm=0.85 \
+    hbm_utilization_vllm=0.75 \
     prompt='Suggest some famous landmarks in London.' \
     use_chat_template=True \
     scan_layers=false \
     enable_single_controller=${use_pathways} \
     prefuse_moe_weights=True \
-    ici_tensor_parallelism=2
+    ici_tensor_parallelism=4


### PR DESCRIPTION
# Description

Fixes an HBM OOM issue during inference for `gemma4-26b` when running `vllm_decode`.

# Tests

`vllm_decode` before RL: https://paste.googleplex.com/4547572140736512
`vllm_decode` after RL: https://paste.googleplex.com/6316752972152832

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
