### PR TITLE
Fix arg mismatch in _maybe_set_compact_mamba_num_blocks_override call

### DIFF
--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -606,14 +606,12 @@ def patch_kv_cache_manager():
       self._hybrid_uniform_page_size_bytes = int(uniform_page_size_bytes)
       self.runner.cache_config.mamba_page_size_padded = int(uniform_page_size_bytes)
 
+      # set mamba and attn, needs to be compatible with tpu-inference
       self._maybe_set_compact_mamba_num_blocks_override(
-          attn_page_size_bytes,
-          int(unpadded_mamba_page_size),
-          num_attn_groups,
-          num_mamba_groups,
-          num_attn,
-          num_mamba,
-          group_size,
+          attn_page_size_bytes=attn_page_size_bytes,
+          unpadded_mamba_page_size_bytes=int(unpadded_mamba_page_size),
+          num_attn_layers=num_attn,
+          num_mamba_layers=num_mamba,
       )
 
     kv_cache_spec = original_get_kv_cache_spec(self)


### PR DESCRIPTION
# Description

The vLLM adapter's patched `get_kv_cache_spec` (in `src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py`) called tpu-inference's [`_maybe_set_compact_mamba_num_blocks_override`](https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/runner/kv_cache_manager.py#L298).

```python
# tpu_inference/runner/kv_cache_manager.py
def _maybe_set_compact_mamba_num_blocks_override(
        self, attn_page_size_bytes: int,
        unpadded_mamba_page_size_bytes: int, num_attn_layers: int,
        num_mamba_layers: int) -> None:
```

As a result, any hybrid (mamba + attention) model routed through the adapter raised `TypeError` before it could build its KV cache spec.

This PR passes only the four values the method expects, by keyword, so that a
future signature change on the tpu-inference side fails loudly with an
unexpected-keyword `TypeError` instead of silently binding values to the wrong
parameters.

# Tests

- Verified against tpu-inference at HEAD
- Trellis e2e test passed [logs](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22bodaborg-v5p-nap%22%0Aresource.labels.pod_name%3D~%22yixuannwang-orch.*%22%0Aresource.labels.container_name%3D%22main%22;cursorTimestamp=2026-09-11T16:37:24.368610111Z;customDuration=today?project=cloud-tpu-shared-capacity&e=13803378&mods=logs_tg_prod) 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).


