### PR TITLE
fix linter issues

### DIFF
--- a/src/maxtext/integration/vllm/validate_converter.py
+++ b/src/maxtext/integration/vllm/validate_converter.py
@@ -926,11 +926,10 @@ def validate_converter(argv) -> None:
   sampler = MaxTextVllmSampler(
       tokenizer=tokenizer,
       config=vllm_config,
-      converter=converter,
       direct_maxtext_sync=direct_maxtext_sync,
-      scan_axis=getattr(trainer_config, "param_scan_axis", 1),
-      layer_pattern_length=getattr(trainer_config, "inhomogeneous_layer_cycle_interval", None),
+      model_name=trainer_config.model_name,
   )
+  sampler.converter = converter
   golden_llm_state = sampler.transformer_state
   # Captured before any sync so a post-sync structural change (which will
   # otherwise surface only as an opaque PyTreeDef mismatch during generation)


### PR DESCRIPTION
# Description

[Linters failing at head](https://github.com/AI-Hypercomputer/maxtext/actions/runs/34619961698/job/103331169483):

```
************* Module maxtext.integration.vllm.validate_converter
src/maxtext/integration/vllm/validate_converter.py:926:12: E1123: Unexpected keyword argument 'converter' in constructor call (unexpected-keyword-arg)
src/maxtext/integration/vllm/validate_converter.py:926:12: E1123: Unexpected keyword argument 'scan_axis' in constructor call (unexpected-keyword-arg)
src/maxtext/integration/vllm/validate_converter.py:926:12: E1123: Unexpected keyword argument 'layer_pattern_length' in constructor call (unexpected-keyword-arg)
```

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
