### PR TITLE
Use checkpoint_storage_use_ocdbt and checkpoint_storage_use_zarr3 in training_engine

### DIFF
--- a/src/maxtext/training_engine/checkpointing.py
+++ b/src/maxtext/training_engine/checkpointing.py
@@ -55,6 +55,14 @@ class CheckpointManager:
     """
     self._checkpoint_manager: ocp.CheckpointManager | None = None
     if checkpoint_dir:
+      # Use configured array format (e.g. use_ocdbt=False for Pathways).
+      # Build a fresh handler per item as Orbax handlers carry per-item state.
+      def _pytree_handler() -> ocp.PyTreeCheckpointHandler:
+        return ocp.PyTreeCheckpointHandler(
+            use_ocdbt=config.checkpoint_storage_use_ocdbt,
+            use_zarr3=config.checkpoint_storage_use_zarr3,
+        )
+
       self._checkpoint_manager = ocp.CheckpointManager(
           directory=checkpoint_dir,
           options=ocp.CheckpointManagerOptions(
@@ -62,6 +70,12 @@ class CheckpointManager:
               max_to_keep=config.max_num_checkpoints_to_keep,
               enable_async_checkpointing=config.async_checkpointing,
           ),
+          item_handlers={
+              "model_params": _pytree_handler(),
+              "optimizer_state": _pytree_handler(),
+              "accumulated_metrics": _pytree_handler(),
+              "accumulated_grads": _pytree_handler(),
+          },
       )
 
   def get_latest_step(self) -> int | None:


### PR DESCRIPTION
# Description

In MaxText's classic `train.py` workflow, `checkpoint_storage_use_ocdbt` and `checkpoint_storage_use_zarr3` are explicitly passed into `create_orbax_checkpoint_manager` (`src/maxtext/utils/train_utils.py:94-95`).

However, `src/maxtext/training_engine/checkpointing.py` constructs `ocp.CheckpointManager` directly without passing `item_handlers`. Consequently, Orbax fell back to its default handlers (`use_ocdbt=True`, `use_zarr3=False`), silently ignoring the user's config settings.

This is fatal under Pathways persistence (`ENABLE_PATHWAYS_PERSISTENCE=1`): `CloudPathwaysArrayHandler.__init__` raises:
```
ValueError: OCDBT not supported for Pathways.
```
so saving directly from TPU workers requires disabling OCDBT.

This PR configures `item_handlers` on `ocp.CheckpointManager` for `"model_params"`, `"optimizer_state"`, `"accumulated_metrics"`, and `"accumulated_grads"` using `ocp.PyTreeCheckpointHandler` instantiated with `config.checkpoint_storage_use_ocdbt` and `config.checkpoint_storage_use_zarr3`. A fresh handler is created per item as Orbax handlers maintain per-item state.

# Tests

- Verified syntax and formatting with `py_compile` and PEP 8 line length limits.
- Tested under Pathways persistence (`ENABLE_PATHWAYS_PERSISTENCE=1`, `checkpoint_storage_use_ocdbt=False`) where checkpoint saving previously failed with `ValueError: OCDBT not supported for Pathways.` and now saves successfully.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
