### PR TITLE
Fix CheckpointManager init unit test failure

### DIFF
--- a/tests/post_training/unit/maxtext_engine_test.py
+++ b/tests/post_training/unit/maxtext_engine_test.py
@@ -250,9 +250,14 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
     self.assertEqual(recorded.shape, (1,), "one norm per update, not one per micro-batch")
     np.testing.assert_allclose(recorded[0], np.sqrt(2 * 0.25**2), rtol=1e-5)
 
+  @mock.patch("orbax.checkpoint.PyTreeCheckpointHandler")
   @mock.patch("orbax.checkpoint.CheckpointManager")
-  def test_max_text_trainer_checkpoint_manager_init(self, mock_create_mgr):
-    mock_config = self.setup_config(enable_checkpointing=True)
+  def test_max_text_trainer_checkpoint_manager_init(self, mock_create_mgr, mock_handler):
+    mock_config = self.setup_config(
+        enable_checkpointing=True,
+        checkpoint_storage_use_ocdbt=False,
+        checkpoint_storage_use_zarr3=False,
+    )
 
     _ = maxtext_engine.MaxTextTrainingEngine(mock_config)
     mock_create_mgr.assert_called_once_with(
@@ -262,6 +267,16 @@ class MaxTextTrainingEngineTest(absltest.TestCase):
             max_to_keep=mock_config.max_num_checkpoints_to_keep,
             enable_async_checkpointing=mock_config.async_checkpointing,
         ),
+        item_handlers={
+            "model_params": mock_handler.return_value,
+            "optimizer_state": mock_handler.return_value,
+            "accumulated_metrics": mock_handler.return_value,
+            "accumulated_grads": mock_handler.return_value,
+        },
+    )
+    self.assertEqual(mock_handler.call_count, 4)
+    mock_handler.assert_has_calls(
+        [mock.call(use_ocdbt=False, use_zarr3=False)] * 4,
     )
 
   def test_save_checkpoint_called_after_update(self):


### PR DESCRIPTION
# Description

PR #5208 added `item_handlers` to `ocp.CheckpointManager` instantiation in `src/maxtext/training_engine/checkpointing.py` to support `checkpoint_storage_use_ocdbt` and `checkpoint_storage_use_zarr3`. 
However, `test_max_text_trainer_checkpoint_manager_init` in `tests/post_training/unit/maxtext_engine_test.py` was not updated and still expected `CheckpointManager` to be called without `item_handlers`, causing [CI failures](https://screenshot-v2.corp.google.com/0com5cmot6fs0).
This PR updates the test to:
- Patch `orbax.checkpoint.PyTreeCheckpointHandler` alongside `CheckpointManager`.
- Expect `item_handlers` with mocked handlers in `mock_create_mgr.assert_called_once_with`.
- Verify `PyTreeCheckpointHandler` is instantiated 4 times with the configured `checkpoint_storage_use_ocdbt` and `checkpoint_storage_use_zarr3` flags.

# Tests

Ran pytest on TPU VM:
- `pytest tests/post_training/unit/maxtext_engine_test.py -k test_max_text_trainer_checkpoint_manager_init` (PASSED)
- Full `maxtext_engine_test.py` suite (53 passed)


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
